### PR TITLE
ci: snapshot release on each branch

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -2,8 +2,7 @@ name: Publish Snapshot builds
 
 on:
   push:
-    branches:
-      - develop
+    branches-ignore: [ main, beta, alpha ] # skip for deployment branches.
 
 jobs:
   publish:


### PR DESCRIPTION
- Get rid of the `develop` branch and make a snapshot release on each feature branch