### PR TITLE
fix: added support for big decimal

### DIFF
--- a/app/src/main/java/io/customer/example/MainActivity.kt
+++ b/app/src/main/java/io/customer/example/MainActivity.kt
@@ -48,11 +48,15 @@ class MainActivity : AppCompatActivity() {
         ).enqueue(outputCallback)
         CustomerIO.instance().track(
             name = "int event",
-            attributes = mapOf("value" to 1)
+            attributes = mapOf("value" to 1388377266772)
         ).enqueue(outputCallback)
         CustomerIO.instance().track(
             name = "long event",
-            attributes = mapOf("value" to 1L)
+            attributes = mapOf("value" to 1653L)
+        ).enqueue(outputCallback)
+        CustomerIO.instance().track(
+            name = "double event",
+            attributes = mapOf("value" to 133333.882)
         ).enqueue(outputCallback)
         CustomerIO.instance().track(
             name = "array event",
@@ -87,9 +91,10 @@ class MainActivity : AppCompatActivity() {
         CoroutineScope(Dispatchers.IO).launch {
             when (
                 val result =
-                    CustomerIO.instance()
-                        .identify("sample@email.com@email.com", mapOf("speed" to "slow"))
-                        .execute()
+                    CustomerIO.instance().identify(
+                        identifier = "support-ticket-test",
+                        mapOf("created_at" to 1642659790)
+                    ).execute()
             ) {
                 is ErrorResult -> Log.v("ErrorResult", result.error.cause.toString())
                 is Success -> Log.v("Success", "Success")

--- a/sdk/src/main/java/io/customer/sdk/data/moshi/CustomerIOParser.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/moshi/CustomerIOParser.kt
@@ -3,6 +3,7 @@ package io.customer.sdk.data.moshi
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import io.customer.sdk.data.moshi.adapter.BigDecimalAdapter
 import io.customer.sdk.data.moshi.adapter.SupportedAttributesFactory
 
 internal interface CustomerIOParser {
@@ -14,6 +15,7 @@ internal class CustomerIOParserImpl : CustomerIOParser {
 
     private val moshi by lazy {
         Moshi.Builder()
+            .add(BigDecimalAdapter())
             .add(SupportedAttributesFactory())
             .build()
     }

--- a/sdk/src/main/java/io/customer/sdk/data/moshi/adapter/BigDecimalAdapter.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/moshi/adapter/BigDecimalAdapter.kt
@@ -1,0 +1,13 @@
+package io.customer.sdk.data.moshi.adapter
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+class BigDecimalAdapter {
+    @FromJson
+    fun fromJson(string: String) = BigDecimal(string)
+
+    @ToJson
+    fun toJson(value: BigDecimal) = value.toString()
+}

--- a/sdk/src/main/java/io/customer/sdk/data/moshi/adapter/SupportedAttributesAdapter.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/moshi/adapter/SupportedAttributesAdapter.kt
@@ -2,6 +2,7 @@ package io.customer.sdk.data.moshi.adapter
 
 import com.squareup.moshi.*
 import java.lang.reflect.Type
+import java.math.BigDecimal
 
 internal class SupportedAttributesFactory : JsonAdapter.Factory {
     override fun create(
@@ -20,6 +21,8 @@ internal class SupportedAttributesAdapter(moshi: Moshi) :
     JsonAdapter<Map<String, Any>>() {
 
     private val elementAdapter: JsonAdapter<Any> = moshi.adapter(Any::class.java)
+    private val elementBigDecimalAdapter: JsonAdapter<BigDecimal> =
+        moshi.adapter(BigDecimal::class.java)
 
     private val mapAdapter: JsonAdapter<Map<String, Any?>> =
         moshi.adapter(
@@ -37,7 +40,11 @@ internal class SupportedAttributesAdapter(moshi: Moshi) :
             try {
                 val name = reader.nextName()
                 val peeked = reader.peekJson()
-                result[name] = elementAdapter.fromJson(peeked)!!
+                if (peeked.peek() == JsonReader.Token.NUMBER) {
+                    result[name] = elementBigDecimalAdapter.fromJson(peeked)!!
+                } else {
+                    result[name] = elementAdapter.fromJson(peeked)!!
+                }
             } catch (ignored: JsonDataException) {
             }
             reader.skipValue()

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -1,6 +1,7 @@
 package io.customer.sdk.di
 
 import android.content.Context
+import com.squareup.moshi.Moshi
 import io.customer.sdk.BuildConfig
 import io.customer.sdk.CustomerIOClient
 import io.customer.sdk.CustomerIOConfig
@@ -12,6 +13,7 @@ import io.customer.sdk.api.service.CustomerService
 import io.customer.sdk.api.service.PushService
 import io.customer.sdk.data.moshi.CustomerIOParser
 import io.customer.sdk.data.moshi.CustomerIOParserImpl
+import io.customer.sdk.data.moshi.adapter.BigDecimalAdapter
 import io.customer.sdk.data.store.*
 import io.customer.sdk.repository.*
 import okhttp3.OkHttpClient
@@ -88,6 +90,14 @@ internal class CustomerIOComponent(
         }
     }
 
+    private val retrofitMoshiConverterFactory by lazy {
+        MoshiConverterFactory.create(
+            Moshi.Builder()
+                .add(BigDecimalAdapter())
+                .build()
+        )
+    }
+
     private fun buildRetrofit(
         endpoint: String,
         timeout: Long
@@ -96,7 +106,7 @@ internal class CustomerIOComponent(
         return Retrofit.Builder()
             .baseUrl(endpoint)
             .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(retrofitMoshiConverterFactory)
             .addCallAdapterFactory(CustomerIoCallAdapterFactory.create())
             .build()
     }

--- a/sdk/src/test/java/io/customer/sdk/repositories/AttributesRepositoryTest.kt
+++ b/sdk/src/test/java/io/customer/sdk/repositories/AttributesRepositoryTest.kt
@@ -35,16 +35,18 @@ internal class AttributesRepositoryTest {
         val result = attributesRepository.mapToJson(mapOf("key" to 1, "key2" to 2))
 
         // JSON only has numbers. Not integers or doubles. And since numbers can have decimals they are always represented as doubles in Java.
-        val expected = mapOf("key" to 1, "key2" to 2).mapValues { it.value.toDouble() }
+        val expected = mapOf("key" to 1, "key2" to 2).mapValues { it.value.toBigDecimal() }
 
         (result == expected).shouldBeTrue()
     }
 
     @Test
     fun `Verify Long attributes are mapped correctly`() {
-        val expected = mapOf("key" to 1.0, "key2" to 2.0)
+        val expected =
+            sortedMapOf("key" to 1.0, "key2" to 2.0).mapValues { it.value.toBigDecimal() }
 
-        val result = attributesRepository.mapToJson(mapOf("key" to 1.0, "key2" to 2.0))
+        val result =
+            attributesRepository.mapToJson(mutableMapOf("key" to 1.0, "key2" to 2.0)).toSortedMap()
 
         (result == expected).shouldBeTrue()
     }
@@ -53,7 +55,7 @@ internal class AttributesRepositoryTest {
     fun `Verify Date attributes are mapped correctly`() {
 
         val date = Date()
-        val expected = mapOf("key" to date.getUnixTimestamp().toDouble())
+        val expected = mapOf("key" to date.getUnixTimestamp().toBigDecimal())
 
         // even if Date is sent, unix timestamp should be mapped
         val result = attributesRepository.mapToJson(mapOf("key" to date))


### PR DESCRIPTION
SDK was adding scientific notation in numbers because the JSON parser library would convert it into `double`. This is the known behavior of the [library](https://github.com/square/moshi/issues/192). 

Updating default behavior to convert all numbers into BigDecimal, with this we can avoid the use of scientific notation and resolve our issue.

Helpscout [ticket](https://secure.helpscout.net/conversation/1761542700/147582) 