### PR TITLE
ci: deploy to maven central after git tag

### DIFF
--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -1,0 +1,34 @@
+name: Deploy SDK Maven Central 
+# If deployment tries to push to maven central and then push git tags
+# when git tag deployment fails, you cannot push to maven central again
+# as it doesn't allow overwriting previously deployed artifacts. Deploy 
+# tag first, then deploy to Maven Central on successful tag deployment. 
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-sonatype:
+    name: Deploy SDK to Cocoapods 
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+      - name: Build 
+        # assembleRelease for all modules, excluding non-library modules: app, docs
+        run: ./gradlew assembleRelease -x :app:assembleRelease
+      - name: Source jar and dokka
+        run: ./gradlew androidSourcesJar javadocJar
+      - name: Push to Sonatype servers 
+        run: MODULE_VERSION=${{ github.event.release.tag_name }} ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        env:
+          OSSRH_USERNAME: ${{ secrets.GRADLE_PUBLISH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.GRADLE_PUBLISH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.GRADLE_SIGNING_KEYID }}
+          SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSPHRASE }}
+          SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_PRIVATE_KEY }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -1,26 +1,15 @@
-name: Deploy SDK
+name: Deploy git tag
 on:
   push:
     branches: [ main, beta, alpha ]
 
 jobs:
-  deploy-sdk:
-    name: Deploy SDK
+  deploy-tag:
+    name: Deploy Tag
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          distribution: adopt
-          java-version: 11
-      - name: Release build
-        # assembleRelease for all modules, excluding non-library modules: app, docs
-        run: ./gradlew assembleRelease -x :app:assembleRelease
-      - name: Source jar and dokka
-        run: ./gradlew androidSourcesJar javadocJar
-
       # Perform git related tasks inside of semantic-release because `git config user...` is already setup. It's easier to run commands in there with exec plugin.
       - name: Deploy via semantic release
         uses: cycjimmy/semantic-release-action@v2
@@ -36,10 +25,4 @@ jobs:
             @semantic-release/github@7
             @semantic-release/exec@5
         env:
-          OSSRH_USERNAME: ${{ secrets.GRADLE_PUBLISH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.GRADLE_PUBLISH_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.GRADLE_SIGNING_KEYID }}
-          SIGNING_PASSWORD: ${{ secrets.GRADLE_SIGNING_PASSPHRASE }}
-          SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_PRIVATE_KEY }}
-          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GITHUB_TOKEN: ${{ secrets.REPO_PUSH_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,7 +18,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "MODULE_VERSION=${nextRelease.version} ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository",
+        "prepareCmd": "",
         "verifyReleaseCmd": "./update_version.sh ${nextRelease.version} sdk/src/main/java/io/customer/sdk/Version.kt"
       }
     ],


### PR DESCRIPTION
The way that deployments currently happen for this project are:
1. Deploy to Sonatype server (maven central)
2. Create new git tag and push to GitHub along with CHANGELOG.md file update. 

If for some reason step #2 fails, we have to run step #2 manually from a computer. You can't simply re-run the CI workflow to try to make a deployment again. 

This is because once you push the SDK to the Sonatype server in step #1, you can't push that same SDK version (1.0.0) again. The server will deny the request. 

But, if we swap the order of the steps 1 and 2 above, if there is ever an error during deployment of either step, you can simply re-run the CI step to try again. Allowing each team member to be able to fix the issues themselves. 

That's what this PR does: swaps the steps 1 and 2 above. 