### PR TITLE
fix: allow http requests in host app

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -17,8 +17,31 @@ jobs:
           distribution: adopt
           java-version: 11
 
+      # Get just version number for semantic snapshot release. It would just dry run and not publish, release
+      - name: Run semantic release to get version
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        with:
+          # version numbers below can be in many forms: M, M.m, M.m.p
+          semantic_version: 17
+          extra_plugins: |
+            @semantic-release/commit-analyzer@8
+            @semantic-release/release-notes-generator@9
+            @semantic-release/changelog@5
+            @semantic-release/git@9
+            @semantic-release/github@7
+            @semantic-release/exec@5
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPO_PUSH_TOKEN }}
+
+      - name: Release build
+        # assembleRelease for all modules, excluding non-library modules: app, docs
+        run: ./gradlew assembleRelease -x :app:assembleRelease
+      - name: Source jar and dokka
+        run: ./gradlew androidSourcesJar javadocJar
+
       - name: Add MODULE_VERSION env property
-        run: echo "MODULE_VERSION=$(git rev-parse --short=10 HEAD)-SNAPSHOT" >> $GITHUB_ENV
+        run: echo "MODULE_VERSION=`echo ${{ steps.semantic.outputs.new_release_version }}`-SNAPSHOT" >> $GITHUB_ENV
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -17,31 +17,8 @@ jobs:
           distribution: adopt
           java-version: 11
 
-      # Get just version number for semantic snapshot release. It would just dry run and not publish, release
-      - name: Run semantic release to get version
-        uses: cycjimmy/semantic-release-action@v2
-        id: semantic
-        with:
-          # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 17
-          extra_plugins: |
-            @semantic-release/commit-analyzer@8
-            @semantic-release/release-notes-generator@9
-            @semantic-release/changelog@5
-            @semantic-release/git@9
-            @semantic-release/github@7
-            @semantic-release/exec@5
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_PUSH_TOKEN }}
-
-      - name: Release build
-        # assembleRelease for all modules, excluding non-library modules: app, docs
-        run: ./gradlew assembleRelease -x :app:assembleRelease
-      - name: Source jar and dokka
-        run: ./gradlew androidSourcesJar javadocJar
-
       - name: Add MODULE_VERSION env property
-        run: echo "MODULE_VERSION=`echo ${{ steps.semantic.outputs.new_release_version }}`-SNAPSHOT" >> $GITHUB_ENV
+        run: echo "MODULE_VERSION=$(git rev-parse --short=10 HEAD)-SNAPSHOT" >> $GITHUB_ENV
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -7,6 +7,5 @@
 
     <application
         android:hardwareAccelerated="true"
-        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="n" />
 </manifest>

--- a/sdk/src/main/res/xml/network_security_config.xml
+++ b/sdk/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">track.customer.io</domain>
-    </domain-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">track-eu.customer.io</domain>
-    </domain-config>
-</network-security-config>


### PR DESCRIPTION
Potential bug fix for a customer. 

This PR does include a modification to the snapshot deployment script as the previous script was not working (semantic-release was not running a dry run) so I changed the snapshot to use the git commit hash to always be unique. We can leave this script change in this PR, or remove it and fix that in a future fix if there is a better idea to fix it. I wanted to get a snapshot build made for the customer to test for us. 