### PR TITLE
fix: register device tokens http request

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# Configuration for CodeCov.io service. 
+# https://docs.codecov.com/docs/codecov-yaml
+# https://docs.codecov.com/docs/common-recipe-list
+
+coverage:
+  status:
+    # rules applied to only changes in a pull request. Not changes to the test coverage of the entire project. 
+    patch: 
+      default:
+        # Do not fail CI server if pull request doesn't introduce very many tests in it. It's annoying to make a pull request blocked because 
+        # it does not contain very many tests in it. We care more about the test coverage of the whole project. For small pull requests that only 
+        # change a couple lines of code, 'patch' check is common to fail and can be more annoying then useful. 
+        informational: true 

--- a/sdk/src/main/java/io/customer/sdk/api/HttpRequestRunner.kt
+++ b/sdk/src/main/java/io/customer/sdk/api/HttpRequestRunner.kt
@@ -40,6 +40,7 @@ class HttpRequestRunnerImpl(
             response = makeRequest()
         } catch (e: Throwable) {
             // HTTP request was not able to be made. Probably an Internet connection issue
+            logger.debug("HTTP request failed. Error: ${e.message}")
         }
 
         if (response == null) {

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -154,7 +154,7 @@ class CustomerIOComponent(
         val okHttpClient = clientBuilder(timeout).build()
         return override() ?: Retrofit.Builder()
             .baseUrl(endpoint)
-            .addConverterFactory(MoshiConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
             .client(okHttpClient)
             .build()
     }


### PR DESCRIPTION
QA testing found that registering push tokens HTTP request is not happening. I was able to reproduce it and this fixed it. Retrofit was throwing an error saying it was not able to create a `@Body` request object for `DeviceRequest`. I found out that it was because none of our custom Moshi JsonAdapter classes were being added to Retrofit so our `CustomAttributesJsonAdapter` was not being used. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 