### PR TITLE
ci: make update version script easier for manual use

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,7 +28,7 @@
     [
       "@semantic-release/exec",
       {
-        "verifyReleaseCmd": "./update_version.sh ${nextRelease.version} sdk/src/main/java/io/customer/sdk/Version.kt"
+        "verifyReleaseCmd": "./scripts/update-version.sh ${nextRelease.version}"
       }
     ],
     [

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -2,12 +2,12 @@
 
 # Script that updates the Kotlin file in the SDK that contains the semantic version of the SDK.
 #
-# Use script: ./update_version.sh 0.1.1 sdk/src/main/java/io/customer/sdk/Version.kt
+# Use script: ./scripts/update-version.sh "0.1.1"
 
 set -e
 
 NEW_VERSION="$1"
-KOTLIN_SOURCE_FILE="$2"
+KOTLIN_SOURCE_FILE="sdk/src/main/java/io/customer/sdk/Version.kt"
 
 # Given line: `    static let version: String = "0.1.1"`
 # Regex string will match the line of the file that we can then substitute.
@@ -24,3 +24,5 @@ echo "Done! New version: "
 
 # print the line (/p) that is matched in the file to show the change.
 sed -n "/$LINE_PATTERN/p" $KOTLIN_SOURCE_FILE
+
+echo "\n\n Done!\n Dont forget to commit your changes. A good commit message is: \"chore: prepare for $NEW_VERSION\""


### PR DESCRIPTION
I am trying to make the deployment process better documented and resilient to problems. Part of that process is allowing the deployment process to be done manually if needed. 

This PR simply makes some naming changes to be consistent with the other SDKs. As [documented here](https://github.com/customerio/customerio-ios/pull/175/). 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 