### PR TITLE
ci: better slack notifications during deployment process

### DIFF
--- a/.github/slack-payloads/deploy_code_fail.json
+++ b/.github/slack-payloads/deploy_code_fail.json
@@ -15,7 +15,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Android SDK failed deployment during step *deploy to maven central*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue."
+                "text": "Android SDK failed deployment during step *deploy to maven central*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue. <https://github.com/customerio/mobile/blob/main/GIT-WORKFLOW.md|Learn more about the deployment process and how to fix errors>."
             }
         }
     ]

--- a/.github/slack-payloads/deploy_code_fail.json
+++ b/.github/slack-payloads/deploy_code_fail.json
@@ -1,0 +1,22 @@
+{
+    "text": "Android SDK deployment failure",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Android* SDK deployment :warning: failure :warning:"
+            }
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Android SDK failed deployment during step *deploy to maven central*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue."
+            }
+        }
+    ]
+}

--- a/.github/slack-payloads/deploy_code_success.json
+++ b/.github/slack-payloads/deploy_code_success.json
@@ -1,0 +1,22 @@
+{
+    "text": "Android SDK deployed to Maven Central",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Android* SDK deployed to Maven Central! (deployment step 2 of 2)"
+            }
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Version ${{ github.event.release.tag_name }}*\n\nAndroid SDK deployment progress:\n ~1. <https://github.com/${{github.repository}}/releases/tag/${{ github.event.release.tag_name }}|create git tag>~\n~2. deploy to maven central~\n\n"
+            }
+        }
+    ]
+}

--- a/.github/slack-payloads/deploy_git_tag_fail.json
+++ b/.github/slack-payloads/deploy_git_tag_fail.json
@@ -15,7 +15,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Android SDK failed deployment during step *create git tag*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue."
+                "text": "Android SDK failed deployment during step *create git tag*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue. <https://github.com/customerio/mobile/blob/main/GIT-WORKFLOW.md|Learn more about the deployment process and how to fix errors>."
             }
         }
     ]

--- a/.github/slack-payloads/deploy_git_tag_fail.json
+++ b/.github/slack-payloads/deploy_git_tag_fail.json
@@ -1,0 +1,22 @@
+{
+    "text": "Android SDK deployment failure",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Android* SDK deployment :warning: failure :warning:"
+            }
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Android SDK failed deployment during step *create git tag*. View <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|CI server logs> to learn why and fix the issue."
+            }
+        }
+    ]
+}

--- a/.github/slack-payloads/deploy_git_tag_success.json
+++ b/.github/slack-payloads/deploy_git_tag_success.json
@@ -1,0 +1,22 @@
+{
+    "text": "Android SDK git tag created",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Android* SDK git tag created successfully! (deployment step 1 of 2)"
+            }
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Version ${{ steps.semantic-release.outputs.new_release_version }}*\nAndroid SDK deployment progress:\n ~1. <https://github.com/${{github.repository}}/releases/tag/${{steps.semantic-release.outputs.new_release_version}}|create git tag>~\n2. deploy to maven central\n\n"
+            }
+        }
+    ]
+}

--- a/.github/slack-payloads/promote_fail.json
+++ b/.github/slack-payloads/promote_fail.json
@@ -15,7 +15,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Android SDK failed deployment during step *promote*. The best way to fix this particular issue is <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|viewing the CI server logs> to learn why and fix the issue."
+                "text": "Android SDK failed deployment during step *promote*. The best way to fix this particular issue is <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|viewing the CI server logs> to learn why and fix the issue. <https://github.com/customerio/mobile/blob/main/GIT-WORKFLOW.md|Learn more about the deployment process and how to fix errors>."
             }
         }
     ]

--- a/.github/slack-payloads/promote_fail.json
+++ b/.github/slack-payloads/promote_fail.json
@@ -1,0 +1,22 @@
+{
+    "text": "Android SDK deployment failure",
+    "blocks": [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "*Android* SDK deployment :warning: failure :warning:"
+            }
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Android SDK failed deployment during step *promote*. The best way to fix this particular issue is <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|viewing the CI server logs> to learn why and fix the issue."
+            }
+        }
+    ]
+}

--- a/.github/workflows/deploy-git-tag.yml
+++ b/.github/workflows/deploy-git-tag.yml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - name: semantic-release setup
         uses: levibostian/action-semantic-release-justwork@v1
+
+      # Semantic-release tool is used to:
+      # 1. Determine the next semantic version for the software during deployment. 
+      #    For example, if the last deployment you made was version 1.3.5 and you are releasing a new feature 
+      #    in this deployment, semantic release will automatically determine the version is 1.4.0 for this new release you're doing. 
+      #    Semantic release is able to do this by viewing commit messages since the last release. That's why this project uses a 
+      #    specific commit message format during pull requests.
+      # 2. Updates metadata files. Such as updating the version number in package.json and adding entries to CHANGELOG.md file. 
+      # 3. Create git tag and push it to github. 
       - name: Deploy git tag via semantic-release 
         uses: cycjimmy/semantic-release-action@v3
         id: semantic-release
@@ -28,26 +37,51 @@ jobs:
             @semantic-release/exec@6
         env:
           # Needs to push git commits to repo. Needs write access. 
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}
+          # github access token to Ami CI shared github account. 
+          # token scoped to just public repositories and is added as a collaborator to the project so it can push code. 
+          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }} 
 
+      # This step is required before the action-sync-branches step as a merge commit might be made. 
       - name: Prepare to sync branches 
+        # user.email is a private email address. This is required by GitHub or we will not be able to push commits to github. 
+        # Find private email address that github uses for CI account at: https://github.com/settings/emails        
         run: |
-          git config user.email "frontend@customer.io"
-          git config user.name "Ami CI"
+          git config --global user.email "21171259+ami-ci@users.noreply.github.com"
+          git config --global user.name "Ami CI" 
+
+      # After a production deployment of the software, the 'main' branch will contain some commits in it that 'develop'
+      # branch does not contain. These commits in 'main' are from all of the alpha, beta, and production deployments made. 
+      # We need these commits to be merged into 'develop'. If we do not, semantic-release tool will error. The tool requires
+      # git commits and git tags to be in the current branch in order to determine the next semantic version of the software. 
       - name: Copy commits into develop after main deployment 
         uses: levibostian/action-sync-branches@v1
         with:
           behind: develop
           ahead: main 
+          # github access token to Ami CI shared github account. 
+          # token scoped to just public repositories and is added as a collaborator to the project so it can push code. 
           githubToken: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}
-    
+
       - name: Notify team of git tag being created 
-        uses: openhousepvt/slack@v1.3.2
-        if: steps.semantic-release.outputs.new_release_published == 'true'
+        uses: slackapi/slack-github-action@v1.18.0        
+        if: steps.semantic-release.outputs.new_release_published == 'true' # only run if a git tag was made. 
         with:
-          status: 'in progress' # in progress status because need to now deploy SDK to maven central for full deployment 
-          version: ${{ steps.semantic-release.outputs.new_release_version }}
-          platform: 'Android SDK - git tag created'
-          channel: '#squad-mobile'
+          # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
+          payload-file-path: ".github/slack-payloads/deploy_git_tag_success.json"
         env:
+          # Incoming webhook URL that sends message into the correct Slack channel. 
+          # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      
+      - name: Notify team of failure 
+        uses: slackapi/slack-github-action@v1.18.0
+        if: ${{ failure() }} # only run this if any previous step failed 
+        with:
+          # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
+          payload-file-path: ".github/slack-payloads/deploy_git_tag_fail.json"
+        env:
+          # Incoming webhook URL that sends message into the correct Slack channel. 
+          # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK          

--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -33,12 +33,26 @@ jobs:
           SIGNING_KEY: ${{ secrets.GRADLE_SIGNING_PRIVATE_KEY }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
     
-      - name: Notify team of Maven Central deployment 
-        uses: openhousepvt/slack@v1.3.2
+      - name: Notify team of successful deployment 
+        uses: slackapi/slack-github-action@v1.18.0        
+        if: ${{ success() }}
         with:
-          status: 'success'
-          version: ${{ github.event.release.tag_name }}
-          platform: 'Android SDK - Deployed to Maven Central'
-          channel: '#squad-mobile'
+          # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
+          payload-file-path: ".github/slack-payloads/deploy_code_success.json"            
         env:
+          # Incoming webhook URL that sends message into the correct Slack channel. 
+          # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      
+      - name: Notify team of failure 
+        uses: slackapi/slack-github-action@v1.18.0
+        if: ${{ failure() }} # only run this if any previous step failed 
+        with:
+          # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
+          payload-file-path: ".github/slack-payloads/deploy_code_fail.json"
+        env:
+          # Incoming webhook URL that sends message into the correct Slack channel. 
+          # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK          

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -8,13 +8,23 @@ jobs:
     name: Promote a branch to the next release 
     runs-on: ubuntu-latest 
     steps:
-      - name: Prepare for release 
-        # Find private email address that github uses for CI account at: https://github.com/settings/emails
-        run: |
-          git config --global user.email "21171259+ami-ci@users.noreply.github.com"
-          git config --global user.name "Ami CI"
       - name: Promote release 
         uses: levibostian/action-promote-semantic-release@v1
         with:
           sequence: "develop,alpha,beta,main"
           githubToken: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}
+          # Find private email address that github uses for CI account at: https://github.com/settings/emails
+          gitName: "Ami CI"
+          gitEmail: "21171259+ami-ci@users.noreply.github.com"
+
+      - name: Notify team of failure 
+        uses: slackapi/slack-github-action@v1.18.0
+        if: ${{ failure() }} # only run this if any previous step failed 
+        with:
+          # Use block kit for format of the JSON payloads: https://app.slack.com/block-kit-builder
+          payload-file-path: ".github/slack-payloads/promote_fail.json"
+        env:
+          # Incoming webhook URL that sends message into the correct Slack channel. 
+          # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
I found a new Slack notification plugin that seems to be more helpful for deployment success and failures. I installed it in the React Native SDK project and wanted to do the same here. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 