### PR TITLE
feat: added option to customize push notification from app

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -162,6 +162,11 @@ internal class CustomerIOPushNotificationHandler(private val remoteMessage: Remo
             title = title,
             body = body
         )
+
+        moduleConfig.notificationCallback?.onNotificationComposed(
+            payload = payload,
+            builder = notificationBuilder
+        )
         createIntentFromLink(
             context,
             requestCode,

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush.data.communication
 
 import android.content.Context
+import androidx.core.app.NotificationCompat
 import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 
@@ -20,5 +21,24 @@ interface CustomerIOPushNotificationCallback {
     fun createTaskStackFromPayload(
         context: Context,
         payload: CustomerIOParsedPushPayload
-    ): TaskStackBuilder?
+    ): TaskStackBuilder? = null
+
+    /**
+     * Called when all attributes for the notification has been set by the SDK
+     * and the notification is about to be pushed to system tray.
+     * <p/>
+     * Please note that overriding the pending intent for notification is not
+     * allowed as it can affect tracking and other metrics. Please override
+     * [createTaskStackFromPayload] instead to launch desired intent(s).
+     * <p/>
+     * @see [createTaskStackFromPayload] to override click action
+     *
+     * @param payload data received for the notification
+     * @param builder notification builder that is being used to build
+     * notification attributes
+     */
+    fun onNotificationComposed(
+        payload: CustomerIOParsedPushPayload,
+        builder: NotificationCompat.Builder
+    ) = Unit
 }

--- a/messagingpush/src/sharedTest/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
+++ b/messagingpush/src/sharedTest/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
@@ -1,11 +1,8 @@
 package io.customer.messagingpush
 
-import android.content.Context
-import androidx.core.app.TaskStackBuilder
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.customer.commontest.BaseTest
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
-import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.moduleConfig
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.CustomerIOInstance
@@ -78,14 +75,7 @@ internal class ModuleMessagingConfigTest : BaseTest() {
         val module = ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder().apply {
                 setAutoTrackPushEvents(false)
-                setNotificationCallback(
-                    object : CustomerIOPushNotificationCallback {
-                        override fun createTaskStackFromPayload(
-                            context: Context,
-                            payload: CustomerIOParsedPushPayload
-                        ): TaskStackBuilder? = null
-                    }
-                )
+                setNotificationCallback(object : CustomerIOPushNotificationCallback {})
                 setRedirectDeepLinksToOtherApps(false)
             }.build(),
             overrideCustomerIO = customerIOMock,


### PR DESCRIPTION
Closes: [83](https://github.com/customerio/customerio-android/issues/83)

### Changes

- Added `onNotificationComposed` to `CustomerIOPushNotificationCallback` that notifies client app whenever notification composition is complete (except `PendingIntent`)
- Added docs

### Sample Usage

```
addCustomerIOModule(ModuleMessagingPushFCM(
    MessagingPushModuleConfig.Builder().apply {
        this.setNotificationCallback(object : CustomerIOPushNotificationCallback {
            override fun onNotificationComposed(
                payload: CustomerIOParsedPushPayload,
                builder: NotificationCompat.Builder
            ) {
                // Do whatever you want to do with NotificationBuilder, e.g.
                builder.setSmallIcon(R.drawable.ic_small_push_notification)
            }
        })
    }.build()
))
```

---

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 