### PR TITLE
feat: added support to modify notification small icon

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -5,10 +5,13 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import android.os.Build
 import android.os.Bundle
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
 import androidx.core.app.TaskStackBuilder
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -16,6 +19,7 @@ import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.deepLinkUtil
 import io.customer.messagingpush.di.moduleConfig
+import io.customer.messagingpush.extensions.*
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_TOKEN_KEY
@@ -39,6 +43,10 @@ internal class CustomerIOPushNotificationHandler(private val remoteMessage: Remo
         const val BODY_KEY = "body"
 
         const val NOTIFICATION_REQUEST_CODE = "requestCode"
+        private const val FCM_METADATA_DEFAULT_NOTIFICATION_ICON =
+            "com.google.firebase.messaging.default_notification_icon"
+        private const val FCM_METADATA_DEFAULT_NOTIFICATION_COLOR =
+            "com.google.firebase.messaging.default_notification_color"
     }
 
     private val diGraph: CustomerIOComponent
@@ -111,7 +119,25 @@ internal class CustomerIOPushNotificationHandler(private val remoteMessage: Remo
 
         bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)
 
-        val icon = context.applicationInfo.icon
+        val applicationInfo = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA
+        )
+        val appMetaData = applicationInfo.metaData
+
+        @DrawableRes
+        val smallIcon: Int =
+            remoteMessage.notification?.icon?.let { iconName -> context.getDrawableByName(iconName) }
+                ?: appMetaData?.getMetaDataResource(name = FCM_METADATA_DEFAULT_NOTIFICATION_ICON)
+                ?: applicationInfo.icon
+
+        @ColorInt
+        val tintColor: Int? =
+            remoteMessage.notification?.color?.toColorOrNull()
+                ?: appMetaData?.getMetaDataResource(name = FCM_METADATA_DEFAULT_NOTIFICATION_COLOR)
+                    ?.let { id -> context.getColorOrNull(id) }
+                ?: appMetaData?.getMetaDataString(name = FCM_METADATA_DEFAULT_NOTIFICATION_COLOR)
+                    ?.toColorOrNull()
 
         // set title and body
         val title = bundle.getString(TITLE_KEY) ?: remoteMessage.notification?.title ?: ""
@@ -120,13 +146,14 @@ internal class CustomerIOPushNotificationHandler(private val remoteMessage: Remo
         val channelId = context.packageName
         val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
         val notificationBuilder = NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(icon)
+            .setSmallIcon(smallIcon)
             .setContentTitle(title)
             .setContentText(body)
             .setAutoCancel(true)
             .setSound(defaultSoundUri)
             .setTicker(applicationName)
             .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+        tintColor?.let { color -> notificationBuilder.setColor(color) }
 
         try {
             // check for image

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -119,17 +119,22 @@ internal class CustomerIOPushNotificationHandler(private val remoteMessage: Remo
 
         bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)
 
-        val applicationInfo = context.packageManager.getApplicationInfo(
-            context.packageName,
-            PackageManager.GET_META_DATA
-        )
-        val appMetaData = applicationInfo.metaData
+        val applicationInfo = try {
+            context.packageManager.getApplicationInfo(
+                context.packageName,
+                PackageManager.GET_META_DATA
+            )
+        } catch (ex: Exception) {
+            logger.error("Package not found ${ex.message}")
+            null
+        }
+        val appMetaData = applicationInfo?.metaData
 
         @DrawableRes
         val smallIcon: Int =
             remoteMessage.notification?.icon?.let { iconName -> context.getDrawableByName(iconName) }
                 ?: appMetaData?.getMetaDataResource(name = FCM_METADATA_DEFAULT_NOTIFICATION_ICON)
-                ?: applicationInfo.icon
+                ?: context.applicationInfo.icon
 
         @ColorInt
         val tintColor: Int? =

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/ApplicationInfoExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/ApplicationInfoExtensions.kt
@@ -1,0 +1,16 @@
+package io.customer.messagingpush.extensions
+
+import android.content.res.Resources
+import android.os.Build
+import android.os.Bundle
+
+private val RESOURCE_ID_NULL: Int =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) Resources.ID_NULL else 0
+
+internal fun Bundle.getMetaDataResource(name: String): Int? {
+    return getInt(name, RESOURCE_ID_NULL).takeUnless { id -> id == RESOURCE_ID_NULL }
+}
+
+internal fun Bundle.getMetaDataString(name: String): String? {
+    return getString(name, null).takeUnless { value -> value.isNullOrBlank() }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/ContextExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/ContextExtensions.kt
@@ -1,0 +1,25 @@
+package io.customer.messagingpush.extensions
+
+import android.content.Context
+import android.content.res.Resources
+import android.os.Build
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import io.customer.sdk.CustomerIO
+
+@DrawableRes
+internal fun Context.getDrawableByName(name: String?): Int? = if (name.isNullOrBlank()) null
+else resources?.getIdentifier(name, "drawable", packageName)?.takeUnless { id ->
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) id == Resources.ID_NULL
+    else id == 0
+}
+
+@ColorInt
+internal fun Context.getColorOrNull(@ColorRes id: Int): Int? = try {
+    ContextCompat.getColor(this, id)
+} catch (ex: Resources.NotFoundException) {
+    CustomerIO.instance().diGraph.logger.error("Invalid resource $id, ${ex.message}")
+    null
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
@@ -1,0 +1,14 @@
+/* ktlint-disable filename */ // until this extension file contains 2+ functions in it, we will disable this ktlint rule.
+package io.customer.messagingpush.extensions
+
+import android.graphics.Color
+import androidx.annotation.DrawableRes
+import io.customer.sdk.CustomerIO
+
+@DrawableRes
+internal fun String.toColorOrNull(): Int? = try {
+    Color.parseColor(this)
+} catch (ex: IllegalArgumentException) {
+    CustomerIO.instance().diGraph.logger.error("Invalid color string $this, ${ex.message}")
+    null
+}


### PR DESCRIPTION
Fixes: [8156](https://github.com/customerio/issues/issues/8156)

### Changes

- Following the optiones defined by [FCM](https://firebase.google.com/docs/cloud-messaging/android/receive#edit-the-app-manifest), added support to modify small icon and color for notification using `AndroidManifest`
- The preference of icon color is follows (Same as FCM)
  1. Icon defined in notification payload
  2. Icon defined in `AndroidManifest`
  3. Application Icon
- Notification color has similar preference except that no color is applied unless mentioned explicitly
  1. Color defined in notification payload
  2. Color defined in `AndroidManifest`
  3. None
- Added helper extension methods in `push-messaging` module

> **NOTE: The changes help having a similar behavior in both FCM and our SDK. Both message and data notifications have similar behavior of color and icon irrespective of the app state.**

### Sample Usage

```
<!-- Set custom default icon. This is used when no icon is set for incoming notification messages -->
<meta-data
    android:name="com.google.firebase.messaging.default_notification_icon"
    android:resource="@drawable/ic_stat_ic_notification" />

<!-- Set color used with incoming notification messages.
     This is used when no color is set for the incoming notification message -->
<meta-data
    android:name="com.google.firebase.messaging.default_notification_color"
    android:resource="@color/colorAccent" />
```