### PR TITLE
feat: added shared instance for independent components

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/BaseTest.kt
@@ -10,6 +10,7 @@ import io.customer.sdk.data.model.Region
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.di.CustomerIOComponent
+import io.customer.sdk.di.CustomerIOSharedComponent
 import io.customer.sdk.module.CustomerIOModuleConfig
 import io.customer.sdk.util.*
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -38,6 +39,7 @@ abstract class BaseTest {
     protected lateinit var deviceStore: DeviceStore
     protected lateinit var dispatchersProviderStub: DispatchersProviderStub
 
+    protected lateinit var sharedDI: CustomerIOSharedComponent
     protected lateinit var di: CustomerIOComponent
     protected val jsonAdapter: JsonAdapter
         get() = di.jsonAdapter
@@ -96,7 +98,9 @@ abstract class BaseTest {
             throw RuntimeException("server didnt' start ${cioConfig.trackingApiUrl}")
         }
 
+        sharedDI = CustomerIOSharedComponent()
         di = CustomerIOComponent(
+            sharedComponent = sharedDI,
             sdkConfig = cioConfig,
             context = application
         )

--- a/common-test/src/main/java/io/customer/commontest/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/BaseTest.kt
@@ -112,7 +112,7 @@ abstract class BaseTest {
         }
         deviceStore = DeviceStoreStub().getDeviceStore(cioConfig)
         dispatchersProviderStub = DispatchersProviderStub().also {
-            di.overrideDependency(DispatchersProvider::class.java, it)
+            sharedDI.overrideDependency(DispatchersProvider::class.java, it)
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/ContextExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/ContextExtensions.kt
@@ -7,7 +7,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
-import io.customer.sdk.CustomerIO
+import io.customer.sdk.CustomerIOShared
 
 @DrawableRes
 internal fun Context.getDrawableByName(name: String?): Int? = if (name.isNullOrBlank()) null
@@ -20,6 +20,6 @@ else resources?.getIdentifier(name, "drawable", packageName)?.takeUnless { id ->
 internal fun Context.getColorOrNull(@ColorRes id: Int): Int? = try {
     ContextCompat.getColor(this, id)
 } catch (ex: Resources.NotFoundException) {
-    CustomerIO.instance().diGraph.logger.error("Invalid resource $id, ${ex.message}")
+    CustomerIOShared.instance().diGraph.logger.error("Invalid resource $id, ${ex.message}")
     null
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
@@ -3,12 +3,12 @@ package io.customer.messagingpush.extensions
 
 import android.graphics.Color
 import androidx.annotation.DrawableRes
-import io.customer.sdk.CustomerIO
+import io.customer.sdk.CustomerIOShared
 
 @DrawableRes
 internal fun String.toColorOrNull(): Int? = try {
     Color.parseColor(this)
 } catch (ex: IllegalArgumentException) {
-    CustomerIO.instance().diGraph.logger.error("Invalid color string $this, ${ex.message}")
+    CustomerIOShared.instance().diGraph.logger.error("Invalid color string $this, ${ex.message}")
     null
 }

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -113,6 +113,18 @@ public abstract interface class io/customer/sdk/CustomerIOInstance {
 	public abstract fun trackMetric (Ljava/lang/String;Lio/customer/sdk/data/request/MetricEvent;Ljava/lang/String;)V
 }
 
+public final class io/customer/sdk/CustomerIOShared {
+	public static final field Companion Lio/customer/sdk/CustomerIOShared$Companion;
+	public synthetic fun <init> (Lio/customer/sdk/di/CustomerIOSharedComponent;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun attachSDKConfig (Lio/customer/sdk/CustomerIOConfig;)V
+	public final fun getDiGraph ()Lio/customer/sdk/di/CustomerIOSharedComponent;
+	public static final fun instance ()Lio/customer/sdk/CustomerIOShared;
+}
+
+public final class io/customer/sdk/CustomerIOShared$Companion {
+	public final fun instance ()Lio/customer/sdk/CustomerIOShared;
+}
+
 public final class io/customer/sdk/data/model/EventType : java/lang/Enum {
 	public static final field event Lio/customer/sdk/data/model/EventType;
 	public static final field screen Lio/customer/sdk/data/model/EventType;
@@ -175,7 +187,7 @@ public abstract interface class io/customer/sdk/device/DeviceTokenProvider {
 }
 
 public final class io/customer/sdk/di/CustomerIOComponent : io/customer/sdk/di/DiGraph {
-	public fun <init> (Landroid/content/Context;Lio/customer/sdk/CustomerIOConfig;)V
+	public fun <init> (Lio/customer/sdk/di/CustomerIOSharedComponent;Landroid/content/Context;Lio/customer/sdk/CustomerIOConfig;)V
 	public final fun buildRetrofit (Ljava/lang/String;J)Lretrofit2/Retrofit;
 	public final fun buildStore ()Lio/customer/sdk/data/store/CustomerIOStore;
 	public final fun getActivityLifecycleCallbacks ()Lio/customer/sdk/CustomerIOActivityLifecycleCallbacks;
@@ -199,6 +211,12 @@ public final class io/customer/sdk/di/CustomerIOComponent : io/customer/sdk/di/D
 	public final fun getSharedPreferenceRepository ()Lio/customer/sdk/repository/PreferenceRepository;
 	public final fun getTimer ()Lio/customer/sdk/util/SimpleTimer;
 	public final fun getTrackRepository ()Lio/customer/sdk/repository/TrackRepository;
+}
+
+public final class io/customer/sdk/di/CustomerIOSharedComponent : io/customer/sdk/di/DiGraph {
+	public fun <init> ()V
+	public final fun getDispatchersProvider ()Lio/customer/sdk/util/DispatchersProvider;
+	public final fun getLogger ()Lio/customer/sdk/util/Logger;
 }
 
 public abstract class io/customer/sdk/di/DiGraph {

--- a/sdk/api/sdk.api
+++ b/sdk/api/sdk.api
@@ -217,6 +217,7 @@ public final class io/customer/sdk/di/CustomerIOSharedComponent : io/customer/sd
 	public fun <init> ()V
 	public final fun getDispatchersProvider ()Lio/customer/sdk/util/DispatchersProvider;
 	public final fun getLogger ()Lio/customer/sdk/util/Logger;
+	public final fun getStaticSettingsProvider ()Lio/customer/sdk/util/StaticSettingsProvider;
 }
 
 public abstract class io/customer/sdk/di/DiGraph {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -37,6 +37,15 @@ android {
     }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xopt-in=kotlin.RequiresOptIn',
+                '-Xopt-in=io.customer.base.internal.InternalCustomerIOApi',
+        ]
+    }
+}
+
 dependencies {
     api project(":base")
 

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -107,6 +107,9 @@ class CustomerIO internal constructor(
         fun instanceOrNull(): CustomerIO? = try {
             instance()
         } catch (ex: Exception) {
+            CustomerIOShared.instance().diGraph.logger.error(
+                "Customer.io instance not initialized: ${ex.message}"
+            )
             null
         }
 
@@ -123,6 +126,7 @@ class CustomerIO internal constructor(
         private var region: Region = Region.US,
         private val appContext: Application
     ) {
+        private val sharedInstance = CustomerIOShared.instance()
         private var client: Client = Client.Android(Version.version)
         private var timeout = 6000L
         private var shouldAutoRecordScreenViews: Boolean = false
@@ -226,7 +230,12 @@ class CustomerIO internal constructor(
                 configurations = modules.entries.associate { entry -> entry.key to entry.value.moduleConfig }
             )
 
-            val diGraph = overrideDiGraph ?: CustomerIOComponent(sdkConfig = config, context = appContext)
+            sharedInstance.attachSDKConfig(sdkConfig = config)
+            val diGraph = overrideDiGraph ?: CustomerIOComponent(
+                sharedComponent = sharedInstance.diGraph,
+                sdkConfig = config,
+                context = appContext
+            )
             val client = CustomerIO(diGraph)
             val logger = diGraph.logger
 

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOShared.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOShared.kt
@@ -2,9 +2,25 @@ package io.customer.sdk
 
 import androidx.annotation.VisibleForTesting
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.sdk.CustomerIOShared.Companion.instance
 import io.customer.sdk.di.CustomerIOSharedComponent
 import io.customer.sdk.util.LogcatLogger
 
+/**
+ * Singleton static instance of Customer.io SDK that is initialized exactly when
+ * [instance] is called the first time. The class should be lightweight and only
+ * be used to hold code that might be required before initializing the SDK.
+ * <p/>
+ * Some use cases of the class may include:
+ * - access selected SDK methods even when SDK is not initialized
+ * - contains code that cannot guarantee SDK initialization
+ * - notify user and prevent unwanted SDK crashes in case of late initialization
+ * - hold callbacks/values that might be needed post-initialization of the SDK
+ * - reduce challenges of communication when wrapping the SDK for non native
+ * platforms
+ *
+ * @property diGraph instance of DI graph to satisfy dependencies
+ */
 class CustomerIOShared private constructor(
     val diGraph: CustomerIOSharedComponent
 ) {
@@ -28,5 +44,11 @@ class CustomerIOShared private constructor(
         ): CustomerIOShared = INSTANCE ?: CustomerIOShared(
             diGraph = diGraph ?: CustomerIOSharedComponent()
         ).apply { INSTANCE = this }
+
+        @InternalCustomerIOApi
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+        fun clearInstance() {
+            INSTANCE = null
+        }
     }
 }

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOShared.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOShared.kt
@@ -1,0 +1,32 @@
+package io.customer.sdk
+
+import androidx.annotation.VisibleForTesting
+import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.sdk.di.CustomerIOSharedComponent
+import io.customer.sdk.util.LogcatLogger
+
+class CustomerIOShared private constructor(
+    val diGraph: CustomerIOSharedComponent
+) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+    fun attachSDKConfig(sdkConfig: CustomerIOConfig) {
+        (diGraph.logger as? LogcatLogger)?.setPreferredLogLevel(logLevel = sdkConfig.logLevel)
+    }
+
+    companion object {
+        private var INSTANCE: CustomerIOShared? = null
+
+        @JvmStatic
+        @OptIn(InternalCustomerIOApi::class)
+        fun instance(): CustomerIOShared = createInstance(diGraph = null)
+
+        @Synchronized
+        @InternalCustomerIOApi
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+        fun createInstance(
+            diGraph: CustomerIOSharedComponent? = null
+        ): CustomerIOShared = INSTANCE ?: CustomerIOShared(
+            diGraph = diGraph ?: CustomerIOSharedComponent()
+        ).apply { INSTANCE = this }
+    }
+}

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -6,12 +6,7 @@ import io.customer.sdk.BuildConfig
 import io.customer.sdk.CustomerIOActivityLifecycleCallbacks
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.Version
-import io.customer.sdk.api.CustomerIOApiRetryPolicy
-import io.customer.sdk.api.HttpRequestRunner
-import io.customer.sdk.api.HttpRequestRunnerImpl
-import io.customer.sdk.api.HttpRetryPolicy
-import io.customer.sdk.api.RetrofitTrackingHttpClient
-import io.customer.sdk.api.TrackingHttpClient
+import io.customer.sdk.api.*
 import io.customer.sdk.api.interceptors.HeadersInterceptor
 import io.customer.sdk.data.moshi.adapter.BigDecimalAdapter
 import io.customer.sdk.data.moshi.adapter.CustomAttributesFactory
@@ -32,6 +27,7 @@ import java.util.concurrent.TimeUnit
  * Configuration class to configure/initialize low-level operations and objects.
  */
 class CustomerIOComponent(
+    private val sharedComponent: CustomerIOSharedComponent,
     val context: Context,
     val sdkConfig: CustomerIOConfig
 ) : DiGraph() {
@@ -49,7 +45,7 @@ class CustomerIOComponent(
         get() = override() ?: QueueRunnerImpl(jsonAdapter, cioHttpClient, logger)
 
     val dispatchersProvider: DispatchersProvider
-        get() = override() ?: SdkDispatchers()
+        get() = sharedComponent.dispatchersProvider
 
     val queue: Queue
         get() = override() ?: getSingletonInstanceCreate {
@@ -71,7 +67,7 @@ class CustomerIOComponent(
         )
 
     val logger: Logger
-        get() = override() ?: LogcatLogger(sdkConfig)
+        get() = sharedComponent.logger
 
     val hooksManager: HooksManager
         get() = override() ?: getSingletonInstanceCreate { CioHooksManager() }

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -44,7 +44,7 @@ class CustomerIOComponent(
         get() = override() ?: QueueRunnerImpl(jsonAdapter, cioHttpClient, logger)
 
     val dispatchersProvider: DispatchersProvider
-        get() = sharedComponent.dispatchersProvider
+        get() = override() ?: sharedComponent.dispatchersProvider
 
     val queue: Queue
         get() = override() ?: getSingletonInstanceCreate {
@@ -66,7 +66,7 @@ class CustomerIOComponent(
         )
 
     val logger: Logger
-        get() = sharedComponent.logger
+        get() = override() ?: sharedComponent.logger
 
     val hooksManager: HooksManager
         get() = override() ?: getSingletonInstanceCreate { CioHooksManager() }

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -2,7 +2,6 @@ package io.customer.sdk.di
 
 import android.content.Context
 import com.squareup.moshi.Moshi
-import io.customer.sdk.BuildConfig
 import io.customer.sdk.CustomerIOActivityLifecycleCallbacks
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.Version
@@ -154,7 +153,7 @@ class CustomerIOComponent(
 
     private val httpLoggingInterceptor by lazy {
         override() ?: HttpLoggingInterceptor().apply {
-            if (BuildConfig.DEBUG) {
+            if (sharedComponent.staticSettingsProvider.isDebuggable) {
                 level = HttpLoggingInterceptor.Level.BODY
             }
         }

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
@@ -1,14 +1,25 @@
 package io.customer.sdk.di
 
-import io.customer.sdk.util.DispatchersProvider
-import io.customer.sdk.util.LogcatLogger
-import io.customer.sdk.util.Logger
-import io.customer.sdk.util.SdkDispatchers
+import io.customer.sdk.util.*
 
+/**
+ * Static/shared component dependency graph to satisfy independent dependencies
+ * from single place. All other graphs should never redefine dependencies defined
+ * here unless extremely necessary.
+ * <p/>
+ * The class should only contain dependencies matching the following criteria:
+ * - dependencies that may be required without SDK initialization
+ * - dependencies that are lightweight and are not dependent on SDK initialization
+ */
+@Suppress("MemberVisibilityCanBePrivate")
 class CustomerIOSharedComponent : DiGraph() {
-    val logger: Logger
-        get() = override() ?: getSingletonInstanceCreate { LogcatLogger() }
+    val staticSettingsProvider: StaticSettingsProvider by lazy {
+        override() ?: StaticSettingsProviderImpl()
+    }
 
-    val dispatchersProvider: DispatchersProvider
-        get() = override() ?: SdkDispatchers()
+    val logger: Logger by lazy {
+        override() ?: LogcatLogger(staticSettingsProvider = staticSettingsProvider)
+    }
+
+    val dispatchersProvider: DispatchersProvider by lazy { override() ?: SdkDispatchers() }
 }

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
@@ -1,0 +1,14 @@
+package io.customer.sdk.di
+
+import io.customer.sdk.util.DispatchersProvider
+import io.customer.sdk.util.LogcatLogger
+import io.customer.sdk.util.Logger
+import io.customer.sdk.util.SdkDispatchers
+
+class CustomerIOSharedComponent : DiGraph() {
+    val logger: Logger
+        get() = override() ?: getSingletonInstanceCreate { LogcatLogger() }
+
+    val dispatchersProvider: DispatchersProvider
+        get() = override() ?: SdkDispatchers()
+}

--- a/sdk/src/main/java/io/customer/sdk/util/Logger.kt
+++ b/sdk/src/main/java/io/customer/sdk/util/Logger.kt
@@ -1,7 +1,7 @@
 package io.customer.sdk.util
 
 import android.util.Log
-import io.customer.sdk.CustomerIOConfig
+import io.customer.sdk.BuildConfig
 
 interface Logger {
     fun info(message: String)
@@ -26,32 +26,40 @@ enum class CioLogLevel {
 }
 
 internal class LogcatLogger(
-    private val sdkConfig: CustomerIOConfig
+    private var preferredLogLevel: CioLogLevel? = null
 ) : Logger {
+    private val fallbackLogLevel = if (BuildConfig.DEBUG) CioLogLevel.DEBUG else CioLogLevel.ERROR
+    private val logLevel: CioLogLevel get() = preferredLogLevel ?: fallbackLogLevel
 
-    private val tag = "[CIO]"
+    fun setPreferredLogLevel(logLevel: CioLogLevel) {
+        preferredLogLevel = logLevel
+    }
 
     override fun info(message: String) {
         runIfMeetsLogLevelCriteria(CioLogLevel.INFO) {
-            Log.i(tag, message)
+            Log.i(TAG, message)
         }
     }
 
     override fun debug(message: String) {
         runIfMeetsLogLevelCriteria(CioLogLevel.DEBUG) {
-            Log.d(tag, message)
+            Log.d(TAG, message)
         }
     }
 
     override fun error(message: String) {
         runIfMeetsLogLevelCriteria(CioLogLevel.ERROR) {
-            Log.e(tag, message)
+            Log.e(TAG, message)
         }
     }
 
     private fun runIfMeetsLogLevelCriteria(levelForMessage: CioLogLevel, block: () -> Unit) {
-        val shouldLog = sdkConfig.logLevel.shouldLog(levelForMessage)
+        val shouldLog = logLevel.shouldLog(levelForMessage)
 
         if (shouldLog) block()
+    }
+
+    companion object {
+        const val TAG = "[CIO]"
     }
 }

--- a/sdk/src/main/java/io/customer/sdk/util/Logger.kt
+++ b/sdk/src/main/java/io/customer/sdk/util/Logger.kt
@@ -10,7 +10,10 @@ interface Logger {
 }
 
 enum class CioLogLevel {
-    NONE, ERROR, INFO, DEBUG;
+    NONE,
+    ERROR,
+    INFO,
+    DEBUG;
 
     fun shouldLog(levelForMessage: CioLogLevel): Boolean {
         return when (this) {

--- a/sdk/src/main/java/io/customer/sdk/util/StaticSettingsProvider.kt
+++ b/sdk/src/main/java/io/customer/sdk/util/StaticSettingsProvider.kt
@@ -1,0 +1,18 @@
+package io.customer.sdk.util
+
+import io.customer.sdk.BuildConfig
+
+/**
+ * Wrapper class to hold static/only one time defined properties from
+ * [BuildConfig] and other Android classes to achieve the following:
+ * - making it easier to test classes relying on these properties
+ * - create abstraction and reduce dependency from native Android properties;
+ * can be helpful in SDK wrappers
+ */
+interface StaticSettingsProvider {
+    val isDebuggable: Boolean
+}
+
+class StaticSettingsProviderImpl : StaticSettingsProvider {
+    override val isDebuggable: Boolean = BuildConfig.DEBUG
+}

--- a/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOSharedTest.kt
+++ b/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOSharedTest.kt
@@ -1,0 +1,46 @@
+package io.customer.sdk
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.customer.commontest.BaseTest
+import io.customer.sdk.di.CustomerIOSharedComponent
+import io.customer.sdk.util.LogcatLogger
+import io.customer.sdk.util.StaticSettingsProvider
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class CustomerIOSharedTest : BaseTest() {
+    @Test
+    fun verifyInstanceAccessedMultipleTimes_givenNoSpecialCondition_expectSameInstance() {
+        val instance1 = CustomerIOShared.instance()
+        val instance2 = CustomerIOShared.instance()
+
+        instance1 shouldBeEqualTo instance2
+    }
+
+    @Test
+    fun verifyDIGraphProvided_givenInstanceNotInitializedBefore_expectProvidedDIGraph() {
+        val instance = with(CustomerIOShared) {
+            clearInstance()
+            createInstance(diGraph = sharedDI)
+        }
+
+        instance.diGraph shouldBeEqualTo sharedDI
+    }
+
+    @Test
+    fun verifyAttachedWithSDK_givenNoSpecificEnvironment_expectProvidedLogLevel() {
+        val diGraph = CustomerIOSharedComponent()
+        val staticSettingsProvider: StaticSettingsProvider = mock()
+        diGraph.overrideDependency(StaticSettingsProvider::class.java, staticSettingsProvider)
+        whenever(staticSettingsProvider.isDebuggable).thenReturn(false)
+
+        val instance = CustomerIOShared.createInstance(diGraph = diGraph)
+        instance.attachSDKConfig(sdkConfig = cioConfig)
+
+        (instance.diGraph.logger as LogcatLogger).logLevel shouldBeEqualTo cioConfig.logLevel
+    }
+}

--- a/sdk/src/sharedTest/java/io/customer/sdk/util/LoggerTest.kt
+++ b/sdk/src/sharedTest/java/io/customer/sdk/util/LoggerTest.kt
@@ -5,6 +5,8 @@ import io.customer.commontest.BaseTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class LoggerTest : BaseTest() {
@@ -68,5 +70,49 @@ class LoggerTest : BaseTest() {
         levelSetBySdkConfig.shouldLog(CioLogLevel.ERROR) shouldBeEqualTo error
         levelSetBySdkConfig.shouldLog(CioLogLevel.INFO) shouldBeEqualTo info
         levelSetBySdkConfig.shouldLog(CioLogLevel.DEBUG) shouldBeEqualTo debug
+    }
+
+    @Test
+    fun verifySDKNotInitialized_givenDebugEnvironment_expectLogLevelDebug() {
+        val staticSettingsProvider: StaticSettingsProvider = mock()
+        whenever(staticSettingsProvider.isDebuggable).thenReturn(true)
+
+        val logger = LogcatLogger(staticSettingsProvider)
+
+        logger.logLevel shouldBeEqualTo CioLogLevel.DEBUG
+    }
+
+    @Test
+    fun verifySDKNotInitialized_givenReleaseEnvironment_expectLogLevelErrors() {
+        val staticSettingsProvider: StaticSettingsProvider = mock()
+        whenever(staticSettingsProvider.isDebuggable).thenReturn(false)
+
+        val logger = LogcatLogger(staticSettingsProvider)
+
+        logger.logLevel shouldBeEqualTo CioLogLevel.ERROR
+    }
+
+    @Test
+    fun verifySDKInitialized_givenDebugEnvironment_expectLogLevelAsDefined() {
+        val staticSettingsProvider: StaticSettingsProvider = mock()
+        whenever(staticSettingsProvider.isDebuggable).thenReturn(true)
+        val givenLogLevel = CioLogLevel.INFO
+
+        val logger = LogcatLogger(staticSettingsProvider)
+        logger.setPreferredLogLevel(givenLogLevel)
+
+        logger.logLevel shouldBeEqualTo givenLogLevel
+    }
+
+    @Test
+    fun verifySDKInitialized_givenReleaseEnvironment_expectLogLevelAsDefined() {
+        val staticSettingsProvider: StaticSettingsProvider = mock()
+        whenever(staticSettingsProvider.isDebuggable).thenReturn(false)
+        val givenLogLevel = CioLogLevel.NONE
+
+        val logger = LogcatLogger(staticSettingsProvider)
+        logger.setPreferredLogLevel(givenLogLevel)
+
+        logger.logLevel shouldBeEqualTo givenLogLevel
     }
 }


### PR DESCRIPTION
### Fall Cleaning 2022


### Changes

- Added a top level graph named `CustomerIOSharedComponent` to hold instances of classes that can be initialized without any dependency. Currently, the graph contains only following classes and can hold more where needed.
  - `Logger`
  - `DispatchersProvider`
- Added `CustomerIOShared` class to initialize our SDK on first access without any dependency and can be used to minimise challenged for delayed initializations, particularly helpful when building wrapper SDKs for non native frameworks
- Added test cases to verify log modifications and and shared instance behavior