### PR TITLE
fix: cio sdk version attribute using client value

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/DeviceStoreStub.kt
+++ b/common-test/src/main/java/io/customer/commontest/DeviceStoreStub.kt
@@ -34,7 +34,7 @@ class DeviceStoreStub {
                 override val isPushEnabled: Boolean
                     get() = true
             },
-            version = cioConfig.client.sdkVersion
+            version = "1.0.0-alpha.6"
         )
     }
 }

--- a/sdk/src/main/java/io/customer/sdk/data/store/Client.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/store/Client.kt
@@ -32,6 +32,11 @@ sealed class Client(
     class Expo(sdkVersion: String) : Client(source = SOURCE_EXPO, sdkVersion = sdkVersion)
 
     /**
+     * Simpler class for Flutter clients.
+     */
+    class Flutter(sdkVersion: String) : Client(source = SOURCE_FLUTTER, sdkVersion = sdkVersion)
+
+    /**
      * Other class to allow adding custom sources for clients that are not
      * supported above.
      * <p/>
@@ -46,6 +51,7 @@ sealed class Client(
         internal const val SOURCE_ANDROID = "Android"
         internal const val SOURCE_REACT_NATIVE = "ReactNative"
         internal const val SOURCE_EXPO = "Expo"
+        internal const val SOURCE_FLUTTER = "Flutter"
 
         /**
          * Helper method to create client from raw values
@@ -67,6 +73,10 @@ sealed class Client(
                 other = SOURCE_EXPO,
                 ignoreCase = true
             ) -> Expo(sdkVersion = sdkVersion)
+            source.equals(
+                other = SOURCE_FLUTTER,
+                ignoreCase = true
+            ) -> Flutter(sdkVersion = sdkVersion)
             else -> Other(source = source, sdkVersion = sdkVersion)
         }
     }

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.squareup.moshi.Moshi
 import io.customer.sdk.CustomerIOActivityLifecycleCallbacks
 import io.customer.sdk.CustomerIOConfig
-import io.customer.sdk.Version
 import io.customer.sdk.api.*
 import io.customer.sdk.api.interceptors.HeadersInterceptor
 import io.customer.sdk.data.moshi.adapter.BigDecimalAdapter
@@ -157,7 +156,7 @@ class CustomerIOComponent(
                     sdkConfig = sdkConfig,
                     buildStore = BuildStoreImp(),
                     applicationStore = ApplicationStoreImp(context),
-                    version = Version.version
+                    version = sdkConfig.client.sdkVersion
                 )
             }
         }

--- a/sdk/src/sharedTest/java/io/customer/sdk/data/store/ClientTest.kt
+++ b/sdk/src/sharedTest/java/io/customer/sdk/data/store/ClientTest.kt
@@ -30,6 +30,13 @@ class ClientTest : BaseTest() {
     }
 
     @Test
+    fun initialize_givenFlutter_expectFlutterClient() {
+        val flutterClient = Client.Flutter(sdkVersion = "3.5.8")
+
+        flutterClient.toString().shouldBeEqualTo(expected = "Flutter Client/3.5.8")
+    }
+
+    @Test
     fun initialize_givenOther_expectOtherClient() {
         val iOSClient = Client.fromRawValue(source = "iOS", sdkVersion = "4.6.7")
 
@@ -73,6 +80,19 @@ class ClientTest : BaseTest() {
         upperCaseClient.toString().shouldBeEqualTo(expected = "Expo Client/2.3.4")
         titleCaseClient.toString().shouldBeEqualTo(expected = "Expo Client/3.4.5")
         mixedCaseClient.toString().shouldBeEqualTo(expected = "Expo Client/4.5.6")
+    }
+
+    @Test
+    fun initialize_givenRawValueFlutter_expectFlutterClient() {
+        val lowerCaseClient = Client.fromRawValue(source = "flutter", sdkVersion = "1.2.3")
+        val upperCaseClient = Client.fromRawValue(source = "FLUTTER", sdkVersion = "2.3.4")
+        val titleCaseClient = Client.fromRawValue(source = "Flutter", sdkVersion = "3.4.5")
+        val mixedCaseClient = Client.fromRawValue(source = "FlutTer", sdkVersion = "4.5.6")
+
+        lowerCaseClient.toString().shouldBeEqualTo(expected = "Flutter Client/1.2.3")
+        upperCaseClient.toString().shouldBeEqualTo(expected = "Flutter Client/2.3.4")
+        titleCaseClient.toString().shouldBeEqualTo(expected = "Flutter Client/3.4.5")
+        mixedCaseClient.toString().shouldBeEqualTo(expected = "Flutter Client/4.5.6")
     }
 
     @Test


### PR DESCRIPTION
Helps: [8515](https://github.com/customerio/issues/issues/8515)

### Changes

- Uses wrapper SDK version from client value attributes passed in `DeviceStore`
- Added support for Flutter client