### PR TITLE
fix: in-app messages instant delivery

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -15,7 +15,7 @@ object Versions {
     internal const val FIREBASE_MESSAGING = "22.0.0"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
     internal const val GRADLE_VERSIONS_PLUGIN = "0.39.0"
-    internal const val GIST = "2.1.5"
+    internal const val GIST = "2.3.0"
     internal const val GOOGLE_PLAY_SERVICES_BASE = "17.6.0"
     internal const val KLUENT = "1.68"
     internal const val KOTLIN_BINARY_VALIDATOR = "0.10.1"

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -57,7 +57,7 @@ class ModuleMessagingInApp internal constructor(
                     event = MetricEvent.opened
                 )
             },
-            onAction = { deliveryID: String, _: String, _: String ->
+            onAction = { deliveryID: String, _: String, _: String, _: String ->
                 logger.debug("in-app message clicked $deliveryID")
                 trackRepository.trackInAppMetric(
                     deliveryID = deliveryID,

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistApiProvider.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistApiProvider.kt
@@ -16,7 +16,7 @@ internal interface GistApi {
     fun clearUserToken()
     fun subscribeToEvents(
         onMessageShown: (deliveryId: String) -> Unit,
-        onAction: (deliveryId: String?, currentRoute: String, action: String) -> Unit,
+        onAction: (deliveryId: String?, currentRoute: String, action: String, name: String) -> Unit,
         onError: (errorMessage: String) -> Unit
     )
 }
@@ -43,16 +43,16 @@ internal class GistApiProvider : GistApi {
 
     override fun subscribeToEvents(
         onMessageShown: (String) -> Unit,
-        onAction: (deliveryId: String?, currentRoute: String, action: String) -> Unit,
+        onAction: (deliveryId: String?, currentRoute: String, action: String, name: String) -> Unit,
         onError: (message: String) -> Unit
     ) {
         GistSdk.addListener(object : GistListener {
             override fun embedMessage(message: Message, elementId: String) {
             }
 
-            override fun onAction(message: Message, currentRoute: String, action: String) {
+            override fun onAction(message: Message, currentRoute: String, action: String, name: String) {
                 val deliveryID = GistMessageProperties.getGistProperties(message).campaignId
-                onAction(deliveryID, currentRoute, action)
+                onAction(deliveryID, currentRoute, action, name)
             }
 
             override fun onError(message: Message) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistInAppMessagesProvider.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistInAppMessagesProvider.kt
@@ -9,7 +9,7 @@ internal interface InAppMessagesProvider {
     fun clearUserToken()
     fun subscribeToEvents(
         onMessageShown: (deliveryId: String) -> Unit,
-        onAction: (deliveryId: String, currentRoute: String, action: String) -> Unit,
+        onAction: (deliveryId: String, currentRoute: String, action: String, name: String) -> Unit,
         onError: (errorMessage: String) -> Unit
     )
 }
@@ -38,16 +38,16 @@ internal class GistInAppMessagesProvider(private val provider: GistApi) :
 
     override fun subscribeToEvents(
         onMessageShown: (String) -> Unit,
-        onAction: (deliveryId: String, currentRoute: String, action: String) -> Unit,
+        onAction: (deliveryId: String, currentRoute: String, action: String, name: String) -> Unit,
         onError: (message: String) -> Unit
     ) {
         provider.subscribeToEvents(
             onMessageShown = { deliveryID ->
                 onMessageShown(deliveryID)
             },
-            onAction = { deliveryID: String?, currentRoute: String, action: String ->
+            onAction = { deliveryID: String?, currentRoute: String, action: String, name: String ->
                 if (deliveryID != null && action != "gist://close") {
-                    onAction(deliveryID, currentRoute, action)
+                    onAction(deliveryID, currentRoute, action, name)
                 }
             },
             onError = { errorMessage ->

--- a/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/InAppMessagesProviderTest.kt
+++ b/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/InAppMessagesProviderTest.kt
@@ -41,7 +41,7 @@ internal class InAppMessagesProviderTest : BaseTest() {
                 wasOnMessageShownCalled = true
                 assertEquals("test-deliveryId", deliveryID)
             },
-            onAction = { _: String?, _: String, _: String ->
+            onAction = { _: String?, _: String, _: String, _: String ->
                 wasOnActionCalled = true
             },
             onError = {
@@ -57,10 +57,11 @@ internal class InAppMessagesProviderTest : BaseTest() {
     @Test
     fun whenSubscribedToEvents_expectOnActionWithDeliveryIdCurrentRouteAndAction() {
         whenever(gistApiProvider.subscribeToEvents(any(), any(), any())).then { invocation ->
-            (invocation.arguments[1] as (deliveryId: String, currentRoute: String, action: String) -> Unit).invoke(
+            (invocation.arguments[1] as (deliveryId: String, currentRoute: String, action: String, name: String) -> Unit).invoke(
                 "test-deliveryId",
                 "test-route",
-                "test-action"
+                "test-action",
+                "test-name"
             )
         }
 
@@ -72,11 +73,12 @@ internal class InAppMessagesProviderTest : BaseTest() {
             onMessageShown = {
                 wasOnMessageShownCalled = true
             },
-            onAction = { deliveryID: String?, currentRoute: String, action: String ->
+            onAction = { deliveryID: String?, currentRoute: String, action: String, name: String ->
                 wasOnActionCalled = true
                 assertEquals("test-deliveryId", deliveryID)
                 assertEquals("test-route", currentRoute)
                 assertEquals("test-action", action)
+                assertEquals("test-name", name)
             },
             onError = {
                 wasOnErrorCalled = true
@@ -91,10 +93,11 @@ internal class InAppMessagesProviderTest : BaseTest() {
     @Test
     fun whenSubscribedToEvents_expectOnActionWithCloseAction_expectOnActionCallbackToBeIgnored() {
         whenever(gistApiProvider.subscribeToEvents(any(), any(), any())).then { invocation ->
-            (invocation.arguments[1] as (deliveryId: String, currentRoute: String, action: String) -> Unit).invoke(
+            (invocation.arguments[1] as (deliveryId: String, currentRoute: String, action: String, name: String) -> Unit).invoke(
                 "test-deliveryId",
                 "test-route",
-                "gist://close"
+                "gist://close",
+                "test-name"
             )
         }
 
@@ -106,7 +109,7 @@ internal class InAppMessagesProviderTest : BaseTest() {
             onMessageShown = {
                 wasOnMessageShownCalled = true
             },
-            onAction = { _: String?, _: String, _: String ->
+            onAction = { _: String?, _: String, _: String, _: String ->
                 wasOnActionCalled = true
             },
             onError = {
@@ -134,7 +137,7 @@ internal class InAppMessagesProviderTest : BaseTest() {
             onMessageShown = { deliveryID ->
                 wasOnMessageShownCalled = true
             },
-            onAction = { _: String?, _: String, _: String ->
+            onAction = { _: String?, _: String, _: String, _: String ->
                 wasOnActionCalled = true
             },
             onError = { errorMessage ->


### PR DESCRIPTION
Closes: [8614](https://github.com/customerio/issues/issues/8614)

### Changes

- Updates Gist SDK version to `2.3.0`
- Updated `InAppMessagesProvider` and `GistApiProvider` to support changes from Gist SDK
- Fixed test cases