### PR TITLE
fix: remove currentRoute parameter in in-app event listener

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -26,7 +26,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 
 public abstract interface class io/customer/messaginginapp/type/InAppEventListener {
 	public abstract fun errorWithMessage (Lio/customer/messaginginapp/type/InAppMessage;)V
-	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InAppMessage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InAppMessage;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun messageDismissed (Lio/customer/messaginginapp/type/InAppMessage;)V
 	public abstract fun messageShown (Lio/customer/messaginginapp/type/InAppMessage;)V
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistInAppMessagesProvider.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/provider/GistInAppMessagesProvider.kt
@@ -74,7 +74,7 @@ internal class GistInAppMessagesProvider(private val provider: GistApi) :
     override fun embedMessage(message: Message, elementId: String) {}
 
     override fun onAction(message: Message, currentRoute: String, action: String, name: String) {
-        listener?.messageActionTaken(InAppMessage.getFromGistMessage(message), currentRoute = currentRoute, action = action, name = name)
+        listener?.messageActionTaken(InAppMessage.getFromGistMessage(message), action = action, name = name)
     }
 
     override fun onError(message: Message) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppEventListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppEventListener.kt
@@ -4,5 +4,5 @@ interface InAppEventListener {
     fun messageShown(message: InAppMessage)
     fun messageDismissed(message: InAppMessage)
     fun errorWithMessage(message: InAppMessage)
-    fun messageActionTaken(message: InAppMessage, currentRoute: String, action: String, name: String)
+    fun messageActionTaken(message: InAppMessage, action: String, name: String)
 }

--- a/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/InAppMessagesProviderTest.kt
+++ b/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/InAppMessagesProviderTest.kt
@@ -179,7 +179,7 @@ internal class InAppMessagesProviderTest : BaseTest() {
         val givenAction = String.random
         val givenName = String.random
         gistInAppMessagesProvider.onAction(givenMessage, givenCurrentRoute, givenAction, givenName)
-        verify(eventListenerMock).messageActionTaken(expectedInAppMessage, currentRoute = givenCurrentRoute, action = givenAction, name = givenName)
+        verify(eventListenerMock).messageActionTaken(expectedInAppMessage, action = givenAction, name = givenName)
     }
 
     @Test


### PR DESCRIPTION
Removing extra parameter from in-app event listener that [the team did not mention is needed](https://github.com/customerio/customerio-ios/pull/211#issuecomment-1332281565).

The parameter has also been removed in iOS SDK. 

