### PR TITLE
ci: remove ci bot merge functionality

### DIFF
--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Semantic PR helper 
-        uses: levibostian/action-semantic-pr@v2
+        uses: levibostian/action-semantic-pr@v3
         with:
           readToken: ${{ secrets.READ_ONLY_BOT_TOKEN }}
-          writeToken: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}
-          # Sets rules on the types of commits allowed on a specific branch. Example: {"beta": "fix,docs"} gives a warning on the pull request if a pull request is made into the beta branch with a type thats not fix.
+                    # Sets rules on the types of commits allowed on a specific branch. Example: {"beta": "fix,docs"} gives a warning on the pull request if a pull request is made into the beta branch with a type thats not fix.
           branchTypeWarning: '{"beta": "fix", "main": "fix"}'


### PR DESCRIPTION
The bot's ability to merge a PR by adding label Ready to merge has been causing issues lately because of the CI authentication problems all mobile repos have been experiencing. I am suggesting to remove the ability for a bot to merge a PR because GitHub now [offers a feature](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) that removes the need for a bot to merge PRs for us