### PR TITLE
fix: image not shown when image url in notification payload

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -168,13 +168,9 @@ internal class CustomerIOPushNotificationHandler(
             .setStyle(NotificationCompat.BigTextStyle().bigText(body))
         tintColor?.let { color -> notificationBuilder.setColor(color) }
 
-        // This is custom logic to add images to a push notification. Some image URLs have not
-        // been able to display an image in a push. https://github.com/customerio/issues/issues/7293
-        // Instead, we recommend customers use `notification.image` in the FCM payload to bypass
-        // our logic and use the logic from FCM's SDK for image handling instead.
         try {
-            // check for image
-            val notificationImage = bundle.getString(IMAGE_KEY)
+            // check for image in data and notification payload
+            val notificationImage = bundle.getString(IMAGE_KEY) ?: remoteMessage.notification?.imageUrl?.toString()
             if (notificationImage != null) {
                 addImage(notificationImage, notificationBuilder, body)
             }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -169,7 +169,9 @@ internal class CustomerIOPushNotificationHandler(
         tintColor?.let { color -> notificationBuilder.setColor(color) }
 
         try {
-            // check for image in data and notification payload
+            // check for image in data and notification payload to cater for both simple and rich push
+            // data only payload (foreground and background)
+            // notification + data payload (foreground)
             val notificationImage = bundle.getString(IMAGE_KEY) ?: remoteMessage.notification?.imageUrl?.toString()
             if (notificationImage != null) {
                 addImage(notificationImage, notificationBuilder, body)


### PR DESCRIPTION
In the case of custom payload, 

```
{
  "message":{
    "notification": {
      "body" : "Meet scientific Yogi & Empathy Expert Thiemo️",
      "title" : "Yoga + Meditation + Science = :bulb:️️",
      "image": "https://userimg-assets.customeriomail.com/images/client-env-101262/1676545327104_thiemo_01GSCY703G786FJE0F5FT34H0N.jpeg"
    },
    "data": {
      "screen": "/users/9b906b6c-3152-4083-87d4-455d9d6e4e13?utm_source=cio&utm_medium=push&utm_campaign=thiemo_push&utm_content=9b906b6c-3152-4083-87d4-455d9d6e4e13&utm_term={{delivery_id}}"
    }
  }
}
```

If the app is in the foreground, `Service` would receive payload, and we need to check for `notification.image`. 

More information : https://customerio.slack.com/archives/C02580R06/p1676625992450419


Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 