### PR TITLE
fix: update CustomerIOFirebaseMessagingService to open

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -1,4 +1,4 @@
-public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService : com/google/firebase/messaging/FirebaseMessagingService {
+public class io/customer/messagingpush/CustomerIOFirebaseMessagingService : com/google/firebase/messaging/FirebaseMessagingService {
 	public static final field Companion Lio/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion;
 	public fun <init> ()V
 	public fun onMessageReceived (Lcom/google/firebase/messaging/RemoteMessage;)V

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -5,7 +5,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.sdk.CustomerIO
 
-class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
+open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
 
     companion object {
         /**


### PR DESCRIPTION
Helps: https://github.com/customerio/issues/issues/9477

### Changes

- Updated `CustomerIOFirebaseMessagingService` access to open so we can inherit it in wrapper SDKs