### PR TITLE
ci: fix github ref in npm publish step of deploy action

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -16,6 +16,7 @@ jobs:
     name: Deploy git tag
     runs-on: ubuntu-latest
     outputs:
+      new_release_git_head: ${{ steps.semantic-release.outputs.new_release_git_head }}
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
@@ -127,11 +128,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.deploy-git-tag.outputs.new_release_git_head }}
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: adopt
           java-version: 11
+
       - name: Push to Sonatype servers
         run: MODULE_VERSION=${{ needs.deploy-git-tag.outputs.new_release_version }} ./scripts/deploy-code.sh
         env:


### PR DESCRIPTION
The `deploy-sonatype` job was checking out the $GITHUB_REF that triggered the workflow. The prior job (deploy-git-tag) bumps the version in the manifest and updates the changelog, which would not be picked up by the final job.

See https://github.com/customerio/customerio-reactnative/pull/100 for more information.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 