### PR TITLE
fix: prevent crash for file not found exception

### DIFF
--- a/sdk/src/main/java/io/customer/sdk/data/store/FileStorage.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/store/FileStorage.kt
@@ -59,8 +59,13 @@ class FileStorage internal constructor(
 
         if (!filePath.exists()) return null
 
-        val fileContents = filePath.readText()
-        if (fileContents.isBlank()) return null
+        val fileContents = try {
+            filePath.readText()
+        } catch (ex: Exception) {
+            logger.error("error while reading file $type. path ${filePath.absolutePath}. message: ${ex.message}")
+            null
+        }
+        if (fileContents.isNullOrBlank()) return null
 
         return fileContents
     }
@@ -80,7 +85,7 @@ class FileStorage internal constructor(
     // Used for tests to run between tests for a clean file system.
     fun deleteAllSdkFiles(path: File = sdkRootDirectoryPath) {
         if (path.isDirectory) {
-            path.list().forEach { child ->
+            path.list()?.forEach { child ->
                 deleteAllSdkFiles(File(path, child))
             }
         } else {

--- a/sdk/src/main/java/io/customer/sdk/data/store/FileStorage.kt
+++ b/sdk/src/main/java/io/customer/sdk/data/store/FileStorage.kt
@@ -59,6 +59,9 @@ class FileStorage internal constructor(
 
         if (!filePath.exists()) return null
 
+        // Even though we check file existence before reading them, there were still a few instances reported where
+        // the files were deleted before they are read completely.
+        // Reading them in a try-catch block helps preventing crashes occurring in customer apps in such scenarios
         val fileContents = try {
             filePath.readText()
         } catch (ex: Exception) {


### PR DESCRIPTION
closes: https://github.com/customerio/issues/issues/9530

### Changes

- Moved reading file text code inside `try-catch` to prevent crashing the app
- Added null safety operator for recently nullable file list method

> NOTE: This method doesn't fix the root cause for files being not found. We're not yet able to reproduce this, but the code change helps preventing customer apps from crashing