### PR TITLE
fix: push opened metrics tracked on Android 12

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -86,8 +86,19 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             handleNewToken(context = context, token = token)
         }
 
+        /**
+         * Gets initialized instance of SDK. If the SDK is not initialized, it
+         * attempts to initialize with messaging push module so the module classes
+         * are initialized as well.
+         */
+        private fun getSDKInstanceOrNull(context: Context): CustomerIO? = try {
+            CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))
+        } catch (e: Exception) {
+            null
+        }
+
         private fun handleNewToken(context: Context, token: String) {
-            CustomerIO.instanceOrNull(context)?.registerDeviceToken(deviceToken = token)
+            getSDKInstanceOrNull(context = context)?.registerDeviceToken(deviceToken = token)
         }
 
         private fun handleMessageReceived(
@@ -96,9 +107,8 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             handleNotificationTrigger: Boolean = true
         ): Boolean {
             // if CustomerIO instance isn't initialized, we can't handle the notification
-            if (CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM())) == null) {
-                return false
-            }
+            getSDKInstanceOrNull(context = context) ?: return false
+
             val handler = CustomerIOPushNotificationHandler(remoteMessage = remoteMessage)
             return handler.handleMessage(context, handleNotificationTrigger)
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -87,9 +87,14 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         /**
-         * Gets initialized instance of SDK. If the SDK is not initialized, it
-         * attempts to initialize with messaging push module so the module classes
-         * are initialized as well.
+         * Gets initialized instance of SDK. If the SDK is not initialized, we
+         * try to initialize the SDK and messaging push module earlier than requested
+         * by wrapper SDKs using stored values if available.
+         *
+         * By initializing the module early, we can register activity lifecycle callback
+         * required by messaging push module whenever we initialize the SDK using context.
+         * This helps us tracking metrics in wrapper SDKs for notifications received when
+         * app was in terminated state.
          */
         private fun getSDKInstanceOrNull(context: Context): CustomerIO? {
             return CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -91,11 +91,9 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
          * attempts to initialize with messaging push module so the module classes
          * are initialized as well.
          */
-        private fun getSDKInstanceOrNull(context: Context): CustomerIO? = try {
-            CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))
-        } catch (e: Exception) {
-            null
-        }
+private fun getSDKInstanceOrNull(context: Context): CustomerIO? {
+    return CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))
+}
 
         private fun handleNewToken(context: Context, token: String) {
             getSDKInstanceOrNull(context = context)?.registerDeviceToken(deviceToken = token)

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -91,9 +91,9 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
          * attempts to initialize with messaging push module so the module classes
          * are initialized as well.
          */
-private fun getSDKInstanceOrNull(context: Context): CustomerIO? {
-    return CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))
-}
+        private fun getSDKInstanceOrNull(context: Context): CustomerIO? {
+            return CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM()))
+        }
 
         private fun handleNewToken(context: Context, token: String) {
             getSDKInstanceOrNull(context = context)?.registerDeviceToken(deviceToken = token)

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -96,7 +96,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             handleNotificationTrigger: Boolean = true
         ): Boolean {
             // if CustomerIO instance isn't initialized, we can't handle the notification
-            if (CustomerIO.instanceOrNull(context) == null) {
+            if (CustomerIO.instanceOrNull(context, listOf(ModuleMessagingPushFCM())) == null) {
                 return false
             }
             val handler = CustomerIOPushNotificationHandler(remoteMessage = remoteMessage)

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -344,7 +344,8 @@ class CustomerIO internal constructor(
             val client = CustomerIO(diGraph)
             val logger = diGraph.logger
 
-            // cleanup of old reference if it exists
+            // cleanup of old reference if it exists, so that if the SDK is re-initialized (due to wrappers different lifecycle),
+            // the old instance is not kept in memory and any callbacks are unregistered
             instance?.let {
                 // we need to unregister the previous activity lifecycle because it doesn't get garbage collected
                 // and will continue to hold a reference to the previous app context and return callbacks

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -344,6 +344,14 @@ class CustomerIO internal constructor(
             val client = CustomerIO(diGraph)
             val logger = diGraph.logger
 
+            // cleanup of old reference if it exists
+            instance?.let {
+                // we need to unregister the previous activity lifecycle because it doesn't get garbage collected
+                // and will continue to hold a reference to the previous app context and return callbacks
+                appContext.unregisterActivityLifecycleCallbacks(it.diGraph.activityLifecycleCallbacks)
+                instance = null
+            }
+
             instance = client
 
             appContext.registerActivityLifecycleCallbacks(diGraph.activityLifecycleCallbacks)

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -350,6 +350,10 @@ class CustomerIO internal constructor(
                 // we need to unregister the previous activity lifecycle because it doesn't get garbage collected
                 // and will continue to hold a reference to the previous app context and return callbacks
                 appContext.unregisterActivityLifecycleCallbacks(it.diGraph.activityLifecycleCallbacks)
+                // Cancelling queue timer as the new queue timer will take care of running queue tasks.
+                // If we do not cancel old timer, it results in multiple timers being run and accessing
+                // the same tasks.
+                it.diGraph.queue.cancelTimer()
                 instance = null
             }
 

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -115,14 +115,17 @@ class CustomerIO internal constructor(
         @InternalCustomerIOApi
         @JvmStatic
         @Synchronized
-        fun instanceOrNull(context: Context): CustomerIO? = try {
+        fun instanceOrNull(
+            context: Context,
+            modules: List<CustomerIOModule<*>> = emptyList()
+        ): CustomerIO? = try {
             instance()
         } catch (ex: Exception) {
             val customerIOShared = CustomerIOShared.instance()
             customerIOShared.initializeAndGetSharedComponent(context).let {
                 val storedValues = it.sharedPreferenceRepository.loadSettings()
                 if (storedValues.doesExist()) {
-                    return@let createInstanceFromStoredValues(storedValues, context)
+                    return@let createInstanceFromStoredValues(storedValues, context, modules)
                 } else {
                     customerIOShared.diStaticGraph.logger.error(
                         "Customer.io instance not initialized: ${ex.message}"
@@ -135,7 +138,8 @@ class CustomerIO internal constructor(
         @Throws(IllegalArgumentException::class)
         private fun createInstanceFromStoredValues(
             customerIOStoredValues: CustomerIOStoredValues,
-            context: Context
+            context: Context,
+            modules: List<CustomerIOModule<*>>
         ): CustomerIO {
             return Builder(
                 siteId = customerIOStoredValues.siteId,
@@ -149,6 +153,9 @@ class CustomerIO internal constructor(
                 autoTrackDeviceAttributes(shouldTrackDeviceAttributes = customerIOStoredValues.autoTrackDeviceAttributes)
                 setBackgroundQueueMinNumberOfTasks(backgroundQueueMinNumberOfTasks = customerIOStoredValues.backgroundQueueMinNumberOfTasks)
                 setBackgroundQueueSecondsDelay(backgroundQueueSecondsDelay = customerIOStoredValues.backgroundQueueSecondsDelay)
+                for (module in modules) {
+                    addCustomerIOModule(module)
+                }
             }.build()
         }
 

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.lifecycle.LifecycleCallback
 
 class CustomerIOActivityLifecycleCallbacks internal constructor(
@@ -16,6 +17,23 @@ class CustomerIOActivityLifecycleCallbacks internal constructor(
         for (event in callback.eventsToObserve) {
             eventCallbacks.getOrPut(event) { mutableListOf() }.add(callback)
         }
+    }
+
+    /**
+     * In non-native/wrapper SDKs, module listeners are attached after the
+     * activity has been created which results in missing initial lifecycle
+     * events. This method helps completing any pending actions by emitting
+     * those events manually. This method should be called as soon as SDK is
+     * initialized in wrapper SDKs by client app.
+     */
+    @InternalCustomerIOApi
+    fun postDelayedEventsForNonNativeActivity(activity: Activity) {
+        val bundle = activity.intent?.extras
+        sendEventToCallbacks(
+            event = Lifecycle.Event.ON_CREATE,
+            activity = activity,
+            bundle = bundle
+        )
     }
 
     private fun sendEventToCallbacks(

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.lifecycle.LifecycleCallback
 
 class CustomerIOActivityLifecycleCallbacks internal constructor(
@@ -15,6 +17,45 @@ class CustomerIOActivityLifecycleCallbacks internal constructor(
     fun registerCallback(callback: LifecycleCallback) {
         for (event in callback.eventsToObserve) {
             eventCallbacks.getOrPut(event) { mutableListOf() }.add(callback)
+        }
+    }
+
+    /**
+     * In non-native/wrapper SDKs, module listeners are attached after the
+     * activity has been created which results in missing initial lifecycle
+     * events. This method helps completing any pending actions by emitting
+     * those events manually. This method should be called as soon as SDK is
+     * initialized in wrapper SDKs by client app.
+     */
+    @InternalCustomerIOApi
+    fun postDelayedEventsForNonNativeActivity(activity: Activity) {
+        val lifecycleAwareActivity = activity as? LifecycleOwner ?: return
+
+        val currentState = lifecycleAwareActivity.lifecycle.currentState
+        val bundle = activity.intent?.extras
+        val pendingEvents = mutableListOf<Lifecycle.Event>()
+
+        when {
+            currentState.isAtLeast(Lifecycle.State.RESUMED) -> {
+                pendingEvents.add(Lifecycle.Event.ON_CREATE)
+                pendingEvents.add(Lifecycle.Event.ON_START)
+                pendingEvents.add(Lifecycle.Event.ON_RESUME)
+            }
+            currentState.isAtLeast(Lifecycle.State.STARTED) -> {
+                pendingEvents.add(Lifecycle.Event.ON_CREATE)
+                pendingEvents.add(Lifecycle.Event.ON_START)
+            }
+            currentState.isAtLeast(Lifecycle.State.CREATED) -> {
+                pendingEvents.add(Lifecycle.Event.ON_CREATE)
+            }
+        }
+
+        for (event in pendingEvents) {
+            sendEventToCallbacks(
+                event = event,
+                activity = activity,
+                bundle = bundle
+            )
         }
     }
 

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOActivityLifecycleCallbacks.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
-import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.lifecycle.LifecycleCallback
 
 class CustomerIOActivityLifecycleCallbacks internal constructor(
@@ -17,23 +16,6 @@ class CustomerIOActivityLifecycleCallbacks internal constructor(
         for (event in callback.eventsToObserve) {
             eventCallbacks.getOrPut(event) { mutableListOf() }.add(callback)
         }
-    }
-
-    /**
-     * In non-native/wrapper SDKs, module listeners are attached after the
-     * activity has been created which results in missing initial lifecycle
-     * events. This method helps completing any pending actions by emitting
-     * those events manually. This method should be called as soon as SDK is
-     * initialized in wrapper SDKs by client app.
-     */
-    @InternalCustomerIOApi
-    fun postDelayedEventsForNonNativeActivity(activity: Activity) {
-        val bundle = activity.intent?.extras
-        sendEventToCallbacks(
-            event = Lifecycle.Event.ON_CREATE,
-            activity = activity,
-            bundle = bundle
-        )
     }
 
     private fun sendEventToCallbacks(

--- a/sdk/src/main/java/io/customer/sdk/queue/Queue.kt
+++ b/sdk/src/main/java/io/customer/sdk/queue/Queue.kt
@@ -55,6 +55,8 @@ interface Queue {
     suspend fun run()
 
     fun deleteExpiredTasks()
+
+    fun cancelTimer()
 }
 
 internal class QueueImpl internal constructor(
@@ -258,5 +260,9 @@ internal class QueueImpl internal constructor(
 
     override fun deleteExpiredTasks() {
         storage.deleteExpired()
+    }
+
+    override fun cancelTimer() {
+        queueTimer.cancel()
     }
 }


### PR DESCRIPTION
fixes: https://github.com/customerio/issues/issues/9483

### Changes

- Updated `instanceOrNull` method to support modules initialization
- Updated `CustomerIOFirebaseMessagingService` to initialize push module when we initialize SDK using `context`