### PR TITLE
fix: added cleanup of previously instance before creating new one

### DIFF
--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -337,6 +337,12 @@ class CustomerIO internal constructor(
             val client = CustomerIO(diGraph)
             val logger = diGraph.logger
 
+            // cleanups
+            instance?.let {
+                appContext.unregisterActivityLifecycleCallbacks(it.diGraph.activityLifecycleCallbacks)
+                instance = null
+            }
+
             instance = client
 
             appContext.registerActivityLifecycleCallbacks(diGraph.activityLifecycleCallbacks)

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -337,8 +337,10 @@ class CustomerIO internal constructor(
             val client = CustomerIO(diGraph)
             val logger = diGraph.logger
 
-            // cleanups
+            // cleanup of old reference if it exists
             instance?.let {
+                // we need to unregister the previous activity lifecycle because it doesn't get garbage collected
+                // and will continue to hold a reference to the previous app context and return callbacks
                 appContext.unregisterActivityLifecycleCallbacks(it.diGraph.activityLifecycleCallbacks)
                 instance = null
             }


### PR DESCRIPTION
Due to lifecycle differences, multiple instances of the `application` lifecycle would be added. So we need to unregister old instances of callbacks and also garbage collect any other instance of before. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 