### PR TITLE
fix: multiple Queue instances being created

### DIFF
--- a/sdk/src/main/java/io/customer/sdk/di/DiGraph.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/DiGraph.kt
@@ -44,10 +44,13 @@ abstract class DiGraph {
      * ```
      */
     inline fun <reified INST : Any> getSingletonInstanceCreate(newInstanceCreator: () -> INST): INST {
-        val singletonKey = INST::class.java.simpleName
+        // Use a synchronized block to prevent multiple threads from creating multiple instances of the singleton.
+        synchronized(this) {
+            val singletonKey = INST::class.java.simpleName
 
-        return singletons[singletonKey] as? INST ?: newInstanceCreator().also {
-            singletons[singletonKey] = it
+            return singletons[singletonKey] as? INST ?: newInstanceCreator().also {
+                singletons[singletonKey] = it
+            }
         }
     }
 


### PR DESCRIPTION
While testing, we noticed there are multiple instances of `Queue` being created even in `Native SDK` even though it's using `getSingletonInstanceCreate` method. On further logging, it was observed, that it might be due to multithreading so we making this method `synchronized` would fix it. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 