### PR TITLE
chore: java sample universal scheme deep links

### DIFF
--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -20,7 +20,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        String universalDeepLinkHost = "ciosample.page.link"
+        String universalDeepLinkHost = "www.java-sample.com"
 
         buildConfigField "String", "UNIVERSAL_DEEP_LINK_HOST", "\"${universalDeepLinkHost}\""
         buildConfigField "String", "API_KEY", "\"${localProperties["apiKey"]}\""

--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -20,8 +20,13 @@ android {
         versionCode 1
         versionName "1.0"
 
+        String universalDeepLinkHost = "ciosample.page.link"
+
+        buildConfigField "String", "UNIVERSAL_DEEP_LINK_HOST", "\"${universalDeepLinkHost}\""
         buildConfigField "String", "API_KEY", "\"${localProperties["apiKey"]}\""
         buildConfigField "String", "SITE_ID", "\"${localProperties["siteId"]}\""
+
+        manifestPlaceholders += [universalDeepLinkHost: universalDeepLinkHost]
     }
 
     buildTypes {

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -32,32 +32,62 @@
             android:name=".ui.settings.SettingsActivity"
             android:exported="true"
             android:label="@string/label_settings_activity">
-            <intent-filter android:label="deep_linking_filter">
+            <intent-filter android:label="app-scheme-links-filter">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "java-layout://settings” -->
+                <!-- Accepts URIs that begin with "java-layout://settings" -->
                 <data
                     android:host="settings"
                     android:scheme="java-layout" />
+            </intent-filter>
+            <intent-filter android:label="universal-scheme-links-filter">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "http://*" -->
+                <data android:scheme="http" />
+                <!-- Accepts URIs that begin with "https://*" -->
+                <data android:scheme="https" />
+                <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
+                <data android:host="ciosample.page.link" />
+                <!-- Accepts URIs that ends with "*://*/java-layout/settings" -->
+                <data android:pathPrefix="/java-layout/settings" />
             </intent-filter>
         </activity>
         <activity
             android:name=".ui.common.SimpleFragmentActivity"
             android:exported="true"
             android:label="@string/label_simple_fragment_activity">
-            <intent-filter android:label="deep_linking_filter">
+            <intent-filter android:label="app-scheme-links-filter">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "java-layout://*” -->
+                <!-- Accepts URIs that begin with "java-layout://*" -->
                 <data android:scheme="java-layout" />
-                <!-- Accepts URIs with host "*://events” -->
+                <!-- Accepts URIs with host "*://events" -->
                 <data android:host="events" />
-                <!-- Accepts URIs with host "*://attributes” -->
+                <!-- Accepts URIs with host "*://attributes" -->
                 <data android:host="attributes" />
+            </intent-filter>
+            <intent-filter android:label="universal-scheme-links-filter">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Accepts URIs that begin with "http://*" -->
+                <data android:scheme="http" />
+                <!-- Accepts URIs that begin with "https://*" -->
+                <data android:scheme="https" />
+                <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
+                <data android:host="ciosample.page.link" />
+                <!-- Accepts URIs that ends with "*://*/java-layout/events" -->
+                <data android:pathPrefix="/java-layout/events" />
+                <!-- Accepts URIs that ends with "*://*/java-layout/attributes" -->
+                <data android:pathPrefix="/java-layout/attributes" />
             </intent-filter>
         </activity>
 

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -53,8 +53,8 @@
                 <data android:scheme="http" />
                 <!-- Accepts URIs that begin with "https://*" -->
                 <data android:scheme="https" />
-                <!-- universalDeepLinkHost = "ciosample.page.link" -->
-                <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
+                <!-- See `samples/java_layout/build.gradle` for `universalDeepLinkHost` value -->
+                <!-- Accepts URIs that begin with "*://${universalDeepLinkHost}" -->
                 <data android:host="${universalDeepLinkHost}" />
                 <!-- Accepts URIs that ends with "*://*/java-layout/settings" -->
                 <data android:pathPrefix="/java-layout/settings" />
@@ -87,8 +87,8 @@
                 <data android:scheme="http" />
                 <!-- Accepts URIs that begin with "https://*" -->
                 <data android:scheme="https" />
-                <!-- universalDeepLinkHost = "ciosample.page.link" -->
-                <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
+                <!-- See `samples/java_layout/build.gradle` for `universalDeepLinkHost` value -->
+                <!-- Accepts URIs that begin with "*://${universalDeepLinkHost}" -->
                 <data android:host="${universalDeepLinkHost}" />
                 <!-- Accepts URIs that ends with "*://*/java-layout/events" -->
                 <data android:pathPrefix="/java-layout/events" />

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -51,8 +51,9 @@
                 <data android:scheme="http" />
                 <!-- Accepts URIs that begin with "https://*" -->
                 <data android:scheme="https" />
+                <!-- universalDeepLinkHost = "ciosample.page.link" -->
                 <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
-                <data android:host="ciosample.page.link" />
+                <data android:host="${universalDeepLinkHost}" />
                 <!-- Accepts URIs that ends with "*://*/java-layout/settings" -->
                 <data android:pathPrefix="/java-layout/settings" />
             </intent-filter>
@@ -82,8 +83,9 @@
                 <data android:scheme="http" />
                 <!-- Accepts URIs that begin with "https://*" -->
                 <data android:scheme="https" />
+                <!-- universalDeepLinkHost = "ciosample.page.link" -->
                 <!-- Accepts URIs that begin with "*://ciosample.page.link" -->
-                <data android:host="ciosample.page.link" />
+                <data android:host="${universalDeepLinkHost}" />
                 <!-- Accepts URIs that ends with "*://*/java-layout/events" -->
                 <data android:pathPrefix="/java-layout/events" />
                 <!-- Accepts URIs that ends with "*://*/java-layout/attributes" -->

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
             android:name=".ui.settings.SettingsActivity"
             android:exported="true"
             android:label="@string/label_settings_activity">
-            <intent-filter android:label="app-scheme-links-filter">
+            <intent-filter android:label="@string/filter_view_app_link">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -44,7 +44,7 @@
             </intent-filter>
             <intent-filter
                 android:autoVerify="true"
-                android:label="universal-scheme-links-filter">
+                android:label="@string/filter_view_universal_link">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -64,7 +64,7 @@
             android:name=".ui.common.SimpleFragmentActivity"
             android:exported="true"
             android:label="@string/label_simple_fragment_activity">
-            <intent-filter android:label="app-scheme-links-filter">
+            <intent-filter android:label="@string/filter_view_app_link">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -78,7 +78,7 @@
             </intent-filter>
             <intent-filter
                 android:autoVerify="true"
-                android:label="universal-scheme-links-filter">
+                android:label="@string/filter_view_universal_link">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -42,7 +42,9 @@
                     android:host="settings"
                     android:scheme="java-layout" />
             </intent-filter>
-            <intent-filter android:label="universal-scheme-links-filter">
+            <intent-filter
+                android:autoVerify="true"
+                android:label="universal-scheme-links-filter">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -74,7 +76,9 @@
                 <!-- Accepts URIs with host "*://attributes" -->
                 <data android:host="attributes" />
             </intent-filter>
-            <intent-filter android:label="universal-scheme-links-filter">
+            <intent-filter
+                android:autoVerify="true"
+                android:label="universal-scheme-links-filter">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -37,10 +37,10 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "java-layout://settings" -->
+                <!-- Accepts URIs that begin with "java-sample://settings" -->
                 <data
                     android:host="settings"
-                    android:scheme="java-layout" />
+                    android:scheme="java-sample" />
             </intent-filter>
             <intent-filter
                 android:autoVerify="true"
@@ -56,8 +56,8 @@
                 <!-- See `samples/java_layout/build.gradle` for `universalDeepLinkHost` value -->
                 <!-- Accepts URIs that begin with "*://${universalDeepLinkHost}" -->
                 <data android:host="${universalDeepLinkHost}" />
-                <!-- Accepts URIs that ends with "*://*/java-layout/settings" -->
-                <data android:pathPrefix="/java-layout/settings" />
+                <!-- Accepts URIs that ends with "*://*/settings" -->
+                <data android:pathPrefix="/settings" />
             </intent-filter>
         </activity>
         <activity
@@ -69,8 +69,8 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Accepts URIs that begin with "java-layout://*" -->
-                <data android:scheme="java-layout" />
+                <!-- Accepts URIs that begin with "java-sample://*" -->
+                <data android:scheme="java-sample" />
                 <!-- Accepts URIs with host "*://events" -->
                 <data android:host="events" />
                 <!-- Accepts URIs with host "*://attributes" -->
@@ -90,10 +90,10 @@
                 <!-- See `samples/java_layout/build.gradle` for `universalDeepLinkHost` value -->
                 <!-- Accepts URIs that begin with "*://${universalDeepLinkHost}" -->
                 <data android:host="${universalDeepLinkHost}" />
-                <!-- Accepts URIs that ends with "*://*/java-layout/events" -->
-                <data android:pathPrefix="/java-layout/events" />
-                <!-- Accepts URIs that ends with "*://*/java-layout/attributes" -->
-                <data android:pathPrefix="/java-layout/attributes" />
+                <!-- Accepts URIs that ends with "*://*/events" -->
+                <data android:pathPrefix="/events" />
+                <!-- Accepts URIs that ends with "*://*/attributes" -->
+                <data android:pathPrefix="/attributes" />
             </intent-filter>
         </activity>
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
@@ -93,10 +93,10 @@ public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentB
         // deepLinkUri contains link URI if activity is launched from deep link or url from
         // Customer.io push notification
         // e.g.
-        // java-layout://events/custom
-        // https://ciosample.page.link/java-layout/events/custom
-        // java-layout://attributes/profile
-        // https://ciosample.page.link/java-layout/attributes/profile
+        // java-sample://events/custom
+        // https://www.java-sample.com/events/custom
+        // java-sample://attributes/profile
+        // https://www.java-sample.com/attributes/profile
 
         if (deepLinkUri != null) {
             String host = deepLinkUri.getHost();
@@ -105,8 +105,8 @@ public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentB
 
             String path;
             boolean isUniversalLink = BuildConfig.UNIVERSAL_DEEP_LINK_HOST.equals(host);
-            if (isUniversalLink && segments.size() > 1) {
-                path = segments.get(1);
+            if (isUniversalLink && !segments.isEmpty()) {
+                path = segments.get(0);
             } else {
                 path = host;
             }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
@@ -9,6 +9,9 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import java.util.List;
+
+import io.customer.android.sample.java_layout.BuildConfig;
 import io.customer.android.sample.java_layout.databinding.ActivitySimpleFragmentBinding;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.android.sample.java_layout.ui.dashboard.DashboardActivity;
@@ -85,16 +88,30 @@ public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentB
 
     private boolean parseFragmentParams() {
         Intent intent = getIntent();
-        Uri deepLinkUrl = intent.getData();
+        Uri deepLinkUri = intent.getData();
 
-        // deepLinkUrl contains URI if activity is launched from deep link or url from Customer.io push notification
+        // deepLinkUri contains link URI if activity is launched from deep link or url from
+        // Customer.io push notification
         // e.g.
         // java-layout://events/custom
+        // https://ciosample.page.link/java-layout/events/custom
         // java-layout://attributes/profile
-        if (deepLinkUrl != null) {
-            String host = deepLinkUrl.getHost();
-            String lastPathSegment = deepLinkUrl.getLastPathSegment();
-            switch (host) {
+        // https://ciosample.page.link/java-layout/attributes/profile
+
+        if (deepLinkUri != null) {
+            String host = deepLinkUri.getHost();
+            List<String> segments = deepLinkUri.getPathSegments();
+            String lastPathSegment = deepLinkUri.getLastPathSegment();
+
+            String path;
+            boolean isUniversalLink = BuildConfig.UNIVERSAL_DEEP_LINK_HOST.equals(host);
+            if (isUniversalLink && segments.size() > 1) {
+                path = segments.get(1);
+            } else {
+                path = host;
+            }
+
+            switch (path) {
                 case "events":
                     if ("custom".equals(lastPathSegment)) {
                         mFragmentName = FRAGMENT_CUSTOM_TRACKING_EVENT;

--- a/samples/java_layout/src/main/res/layout/activity_dashboard.xml
+++ b/samples/java_layout/src/main/res/layout/activity_dashboard.xml
@@ -160,9 +160,10 @@
 
             <TextView
                 android:id="@+id/user_agent_text_view"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_default"
+                android:gravity="center"
                 android:textAppearance="@style/TextAppearance.Material3.BodySmall"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/samples/java_layout/src/main/res/layout/activity_login.xml
+++ b/samples/java_layout/src/main/res/layout/activity_login.xml
@@ -107,9 +107,10 @@
 
         <TextView
             android:id="@+id/user_agent_text_view"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_default"
+            android:gravity="center"
             android:textAppearance="@style/TextAppearance.Material3.BodySmall"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -57,4 +57,6 @@
     <string name="label_simple_fragment_activity">SimpleFragmentActivity</string>
     <string name="notification_permission_success">Push notifications are now enabled on this device</string>
     <string name="notification_permission_failure">Push notifications are disabled on this device</string>
+    <string name="filter_view_app_link">Java Sample App Scheme Links</string>
+    <string name="filter_view_universal_link">Java Sample Universal Scheme Links</string>
 </resources>


### PR DESCRIPTION
Part of https://github.com/customerio/issues/issues/9845

### Changes

- Deep links support for app scheme URLs
  - `java-sample://settings`
  - `java-sample://events/custom`
  - `java-sample://attributes/device`
  - `java-sample://attributes/profile`
- Deep links support for universal scheme URLs
  - https://www.java-sample.com/settings
  - https://www.java-sample.com/events/custom
  - https://www.java-sample.com/attributes/device
  - https://www.java-sample.com/attributes/profile
- Fixes and improvements in deep link handling
- Fixed user agent width and text alignment