### PR TITLE
fix: unique name for di graph singletons

### DIFF
--- a/sdk/src/main/java/io/customer/sdk/di/DiGraph.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/DiGraph.kt
@@ -46,7 +46,7 @@ abstract class DiGraph {
     inline fun <reified INST : Any> getSingletonInstanceCreate(newInstanceCreator: () -> INST): INST {
         // Use a synchronized block to prevent multiple threads from creating multiple instances of the singleton.
         synchronized(this) {
-            val singletonKey = INST::class.java.simpleName
+            val singletonKey = INST::class.java.name
 
             return singletons[singletonKey] as? INST ?: newInstanceCreator().also {
                 singletons[singletonKey] = it


### PR DESCRIPTION
closes: https://github.com/customerio/issues/issues/10311

### Changes

- Uses fully qualified name for `DiGraph` keys instead of simple name to avoid duplication