### PR TITLE
ci: sample apps local props path

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -85,9 +85,9 @@ jobs:
 
     - name: Setup build environment with Customer.io workspace credentials 
       run: |
-        touch "samples/${{ matrix.sample-app }}/local.properties"
-        echo "siteId=${{ secrets.CIO_SITE_ID }}" >> "samples/${{ matrix.sample-app }}/local.properties"
-        echo "apiKey=${{ secrets.CIO_API_KEY }}" >> "samples/${{ matrix.sample-app }}/local.properties"          
+        touch "samples/local.properties"
+        echo "siteId=${{ secrets.CIO_SITE_ID }}" >> "samples/local.properties"
+        echo "apiKey=${{ secrets.CIO_API_KEY }}" >> "samples/local.properties"          
     
     - name: Verify gradle scripts are not modified 
       uses: gradle/wrapper-validation-action@v1

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -1,5 +1,5 @@
 Properties localProperties = new Properties()
-File localPropertiesFile = rootProject.file('local.properties')
+File localPropertiesFile = file("${rootDir}/samples/local.properties")
 if (localPropertiesFile.exists()) {
     localProperties.load(new FileInputStream(localPropertiesFile))
 }


### PR DESCRIPTION
### Background

Sample apps builds generated by actions used `local.properties` inside the app, but the code assumed the `local.properties` file should be used from root project which resulted in inconsistency and apps failing to load properties when uploaded for distribution

### Changes

- Updated gradle file to use `local.properties` located in `samples` folder so same file can be reused by all apps and can be kept separate from SDK properties 