### PR TITLE
chore: java sample appium tags

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
@@ -15,6 +15,7 @@ import io.customer.android.sample.java_layout.ui.login.LoginActivity;
 import io.customer.android.sample.java_layout.ui.tracking.AttributesTrackingFragment;
 import io.customer.android.sample.java_layout.ui.tracking.CustomEventTrackingFragment;
 import io.customer.android.sample.java_layout.ui.user.AuthViewModel;
+import io.customer.android.sample.java_layout.utils.ViewUtils;
 
 public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentBinding> {
 
@@ -66,6 +67,7 @@ public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentB
             throw new IllegalStateException("Fragment name cannot be null");
         }
 
+        ViewUtils.prepareForAutomatedTests(binding.topAppBar);
         binding.topAppBar.setNavigationOnClickListener(view -> navigateUp());
         authViewModel.getUserLoggedInStateObservable().observe(this, isLoggedIn -> {
             if (isLoggedIn) {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/common/SimpleFragmentActivity.java
@@ -69,6 +69,7 @@ public class SimpleFragmentActivity extends BaseActivity<ActivitySimpleFragmentB
 
         ViewUtils.prepareForAutomatedTests(binding.topAppBar);
         binding.topAppBar.setNavigationOnClickListener(view -> navigateUp());
+
         authViewModel.getUserLoggedInStateObservable().observe(this, isLoggedIn -> {
             if (isLoggedIn) {
                 replaceFragment();

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
@@ -71,6 +71,7 @@ public class DashboardActivity extends BaseActivity<ActivityDashboardBinding> {
     @Override
     protected void setupContent() {
         validateAuth();
+        prepareViewsForAutomatedTests();
         setupViews();
         setupObservers();
     }
@@ -92,6 +93,16 @@ public class DashboardActivity extends BaseActivity<ActivityDashboardBinding> {
                     }
                 }
         );
+    }
+
+    private void prepareViewsForAutomatedTests() {
+        ViewUtils.prepareForAutomatedTests(binding.settingsButton, R.string.acd_settings_icon);
+        ViewUtils.prepareForAutomatedTests(binding.sendRandomEventButton, R.string.acd_random_event_button);
+        ViewUtils.prepareForAutomatedTests(binding.sendCustomEventButton, R.string.acd_custom_event_button);
+        ViewUtils.prepareForAutomatedTests(binding.setDeviceAttributesButton, R.string.acd_device_attribute_button);
+        ViewUtils.prepareForAutomatedTests(binding.setProfileAttributesButton, R.string.acd_profile_attribute_button);
+        ViewUtils.prepareForAutomatedTests(binding.showPushPromptButton, R.string.acd_push_prompt_button);
+        ViewUtils.prepareForAutomatedTests(binding.logoutButton, R.string.acd_logout_button);
     }
 
     private void setupViews() {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
@@ -97,6 +97,7 @@ public class DashboardActivity extends BaseActivity<ActivityDashboardBinding> {
 
     private void prepareViewsForAutomatedTests() {
         ViewUtils.prepareForAutomatedTests(binding.settingsButton, R.string.acd_settings_icon);
+        ViewUtils.prepareForAutomatedTests(binding.userEmailTextView, R.string.acd_email_id_text);
         ViewUtils.prepareForAutomatedTests(binding.sendRandomEventButton, R.string.acd_random_event_button);
         ViewUtils.prepareForAutomatedTests(binding.sendCustomEventButton, R.string.acd_custom_event_button);
         ViewUtils.prepareForAutomatedTests(binding.setDeviceAttributesButton, R.string.acd_device_attribute_button);

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/login/LoginActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/login/LoginActivity.java
@@ -38,7 +38,7 @@ public class LoginActivity extends BaseActivity<ActivityLoginBinding> {
     private void prepareViewsForAutomatedTests() {
         ViewUtils.prepareForAutomatedTests(binding.settingsButton, R.string.acd_settings_icon);
         ViewUtils.prepareForAutomatedTests(binding.displayNameTextInput, R.string.acd_first_name_input);
-        ViewUtils.prepareForAutomatedTests(binding.emailInputLayout, R.string.acd_email_input);
+        ViewUtils.prepareForAutomatedTests(binding.emailTextInput, R.string.acd_email_input);
         ViewUtils.prepareForAutomatedTests(binding.loginButton, R.string.acd_login_button);
         ViewUtils.prepareForAutomatedTests(binding.randomLoginButton, R.string.acd_random_login_button);
     }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/login/LoginActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/login/LoginActivity.java
@@ -30,8 +30,17 @@ public class LoginActivity extends BaseActivity<ActivityLoginBinding> {
 
     @Override
     protected void setupContent() {
+        prepareViewsForAutomatedTests();
         setupViews();
         setupObservers();
+    }
+
+    private void prepareViewsForAutomatedTests() {
+        ViewUtils.prepareForAutomatedTests(binding.settingsButton, R.string.acd_settings_icon);
+        ViewUtils.prepareForAutomatedTests(binding.displayNameTextInput, R.string.acd_first_name_input);
+        ViewUtils.prepareForAutomatedTests(binding.emailInputLayout, R.string.acd_email_input);
+        ViewUtils.prepareForAutomatedTests(binding.loginButton, R.string.acd_login_button);
+        ViewUtils.prepareForAutomatedTests(binding.randomLoginButton, R.string.acd_random_login_button);
     }
 
     private void setupObservers() {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -59,6 +59,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
 
     @Override
     protected void setupContent() {
+        prepareViewsForAutomatedTests();
         setupViews();
         setupObservers();
     }
@@ -87,6 +88,21 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
             }
         }
         isLinkParamsPopulated = true;
+    }
+
+    private void prepareViewsForAutomatedTests() {
+        ViewUtils.prepareForAutomatedTests(binding.topAppBar);
+        ViewUtils.prepareForAutomatedTests(binding.deviceTokenTextInput, R.string.acd_device_token_input);
+        ViewUtils.prepareForAutomatedTests(binding.trackingUrlTextInput, R.string.acd_tracking_url_input);
+        ViewUtils.prepareForAutomatedTests(binding.siteIdTextInput, R.string.acd_site_id_input);
+        ViewUtils.prepareForAutomatedTests(binding.apiKeyTextInput, R.string.acd_api_key_input);
+        ViewUtils.prepareForAutomatedTests(binding.bqDelayTextInput, R.string.acd_bq_seconds_delay_input);
+        ViewUtils.prepareForAutomatedTests(binding.bqTasksTextInput, R.string.acd_bq_min_tasks_input);
+        ViewUtils.prepareForAutomatedTests(binding.trackScreensSwitch, R.string.acd_track_screens_switch);
+        ViewUtils.prepareForAutomatedTests(binding.trackDeviceAttributesSwitch, R.string.acd_track_device_attributes_switch);
+        ViewUtils.prepareForAutomatedTests(binding.debugModeSwitch, R.string.acd_debug_mode_switch);
+        ViewUtils.prepareForAutomatedTests(binding.saveButton, R.string.acd_save_settings_button);
+        ViewUtils.prepareForAutomatedTests(binding.restoreDefaultsButton, R.string.acd_restore_default_settings_button);
     }
 
     private void setupViews() {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/tracking/AttributesTrackingFragment.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/tracking/AttributesTrackingFragment.java
@@ -60,6 +60,24 @@ public class AttributesTrackingFragment extends BaseFragment<FragmentAttributesT
 
     @Override
     protected void setupContent() {
+        prepareViewsForAutomatedTests();
+        setupViews();
+    }
+
+    private void prepareViewsForAutomatedTests() {
+        ViewUtils.prepareForAutomatedTests(binding.attributeNameTextInput, R.string.acd_attribute_name_input);
+        ViewUtils.prepareForAutomatedTests(binding.attributeValueTextInput, R.string.acd_attribute_value_input);
+        switch (mAttributeType) {
+            case ATTRIBUTE_TYPE_DEVICE:
+                ViewUtils.prepareForAutomatedTests(binding.sendEventButton, R.string.acd_send_device_attribute_button);
+                break;
+            case ATTRIBUTE_TYPE_PROFILE:
+                ViewUtils.prepareForAutomatedTests(binding.sendEventButton, R.string.acd_send_profile_attribute_button);
+                break;
+        }
+    }
+
+    private void setupViews() {
         switch (mAttributeType) {
             case ATTRIBUTE_TYPE_DEVICE:
                 binding.screenTitleTextView.setText(R.string.screen_title_device_attributes);

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/tracking/CustomEventTrackingFragment.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/tracking/CustomEventTrackingFragment.java
@@ -39,6 +39,18 @@ public class CustomEventTrackingFragment extends BaseFragment<FragmentCustomEven
 
     @Override
     protected void setupContent() {
+        prepareViewsForAutomatedTests();
+        setupViews();
+    }
+
+    private void prepareViewsForAutomatedTests() {
+        ViewUtils.prepareForAutomatedTests(binding.eventNameTextInput, R.string.acd_event_name_input);
+        ViewUtils.prepareForAutomatedTests(binding.propertyNameTextInput, R.string.acd_property_name_input);
+        ViewUtils.prepareForAutomatedTests(binding.propertyValueTextInput, R.string.acd_property_value_input);
+        ViewUtils.prepareForAutomatedTests(binding.sendEventButton, R.string.acd_send_event_button);
+    }
+
+    private void setupViews() {
         binding.sendEventButton.setOnClickListener(view -> {
             boolean isFormValid = true;
             String eventName = ViewUtils.getText(binding.eventNameTextInput);

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/utils/ViewUtils.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/utils/ViewUtils.java
@@ -2,11 +2,14 @@ package io.customer.android.sample.java_layout.utils;
 
 import android.app.Activity;
 import android.text.TextUtils;
+import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.widget.Toolbar;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputLayout;
@@ -14,9 +17,18 @@ import com.google.android.material.textfield.TextInputLayout;
 import java.util.Locale;
 
 import io.customer.android.sample.java_layout.BuildConfig;
+import io.customer.android.sample.java_layout.R;
 import io.customer.sdk.CustomerIO;
 
 public class ViewUtils {
+    public static void prepareForAutomatedTests(@NonNull View view, @StringRes int contentDescResId) {
+        view.setContentDescription(view.getContext().getString(contentDescResId));
+    }
+
+    public static void prepareForAutomatedTests(@NonNull Toolbar toolbar) {
+        toolbar.setNavigationContentDescription(R.string.acd_back_button_icon);
+    }
+
     @NonNull
     public static String getText(@NonNull EditText editText) {
         return editText.getText().toString();

--- a/samples/resources/values/appium.xml
+++ b/samples/resources/values/appium.xml
@@ -20,6 +20,7 @@
     <string name="acd_debug_mode_switch">Debug Mode Toggle</string>
     <string name="acd_save_settings_button">Save Settings Button</string>
     <string name="acd_restore_default_settings_button">Restore Default Settings Button</string>
+    <string name="acd_email_id_text">Email ID Text</string>
     <string name="acd_random_event_button">Random Event Button</string>
     <string name="acd_custom_event_button">Custom Event Button</string>
     <string name="acd_device_attribute_button">Device Attribute Button</string>

--- a/samples/resources/values/appium.xml
+++ b/samples/resources/values/appium.xml
@@ -1,0 +1,37 @@
+<resources>
+    <!--
+    Adding a prefix "acd_" to all the strings helps us avoid any conflicts with the app strings.
+    ACD here is used as short form Appium Content Description.
+    -->
+    <string name="acd_settings_icon">Settings</string>
+    <string name="acd_back_button_icon">Back Button</string>
+    <string name="acd_first_name_input">First Name Input</string>
+    <string name="acd_email_input">Email Input</string>
+    <string name="acd_login_button">Login Button</string>
+    <string name="acd_random_login_button">Random Login Button</string>
+    <string name="acd_device_token_input">Device Token Input</string>
+    <string name="acd_tracking_url_input">Track URL Input</string>
+    <string name="acd_site_id_input">Site ID Input</string>
+    <string name="acd_api_key_input">API Key Input</string>
+    <string name="acd_bq_seconds_delay_input">BQ Seconds Delay Input</string>
+    <string name="acd_bq_min_tasks_input">BQ Min Number of Tasks Input</string>
+    <string name="acd_track_screens_switch">Track Screens Toggle</string>
+    <string name="acd_track_device_attributes_switch">Track Device Attributes Toggle</string>
+    <string name="acd_debug_mode_switch">Debug Mode Toggle</string>
+    <string name="acd_save_settings_button">Save Settings Button</string>
+    <string name="acd_restore_default_settings_button">Restore Default Settings Button</string>
+    <string name="acd_random_event_button">Random Event Button</string>
+    <string name="acd_custom_event_button">Custom Event Button</string>
+    <string name="acd_device_attribute_button">Device Attribute Button</string>
+    <string name="acd_profile_attribute_button">Profile Attribute Button</string>
+    <string name="acd_push_prompt_button">Show Push Prompt Button</string>
+    <string name="acd_logout_button">Log Out Button</string>
+    <string name="acd_event_name_input">Event Name Input</string>
+    <string name="acd_property_name_input">Property Name Input</string>
+    <string name="acd_property_value_input">Property Value Input</string>
+    <string name="acd_send_event_button">Send Event Button</string>
+    <string name="acd_attribute_name_input">Attribute Name Input</string>
+    <string name="acd_attribute_value_input">Attribute Value Input</string>
+    <string name="acd_send_device_attribute_button">Set Device Attribute Button</string>
+    <string name="acd_send_profile_attribute_button">Set Profile Attribute Button</string>
+</resources>

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -33,6 +33,13 @@ android {
         // For snapshot builds
         maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
     }
+    sourceSets {
+        main {
+            res.srcDirs += [
+                    "${rootDir}/samples/resources",
+            ]
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
part of: https://github.com/customerio/issues/issues/9845
helps: https://github.com/customerio/issues/issues/9844

### Changes

- Sets content description for views which is common practice for automation tests, in case we need to changes this later because of some technical limitation, we can do it in a separate PR
- Added `appium.xml` containing tags for all views
- Added `appium.xml` as resource for all sample app so it can be reused