### PR TITLE
fix: prevent register device api call when identifier is empty

### DIFF
--- a/sdk/src/main/java/io/customer/sdk/repository/DeviceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/DeviceRepository.kt
@@ -89,7 +89,7 @@ internal class DeviceRepositoryImpl(
         // once given to SDK. We need it for future profile identifications.
 
         val identifiedProfileId = sitePreferenceRepository.getIdentifier()
-        if (identifiedProfileId == null) {
+        if (identifiedProfileId.isNullOrEmpty()) {
             logger.info("no profile identified so not removing device token from profile")
             return
         }


### PR DESCRIPTION
Fixes issue for https://secure.helpscout.net/conversation/2267893231/217421/
closes : https://github.com/customerio/opsbugs/issues/3603

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 