### PR TITLE
fix: in-app messaging proguard rules missing

### DIFF
--- a/messaginginapp/consumer-rules.pro
+++ b/messaginginapp/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Gist
+-keep class build.gist.**  { *; }

--- a/messaginginapp/consumer-rules.pro
+++ b/messaginginapp/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Gist
+-keep class io.customer.messaginginapp.**  { *; }

--- a/messaginginapp/consumer-rules.pro
+++ b/messaginginapp/consumer-rules.pro
@@ -1,2 +1,0 @@
-# Gist
--keep class build.gist.**  { *; }

--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -24,7 +24,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/samples/kotlin_compose/build.gradle.kts
+++ b/samples/kotlin_compose/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )


### PR DESCRIPTION
Gist proguard settings didn't get copied over when in-app module code was migrated from Gist SDK into the CIO SDK. This PR adds those proguard rules back. Also enables proguard on sample apps so we can better test Release builds like customers are. 

Fixes: https://github.com/customerio/opsbugs/issues/3627