### PR TITLE
ci: remove workaround for semantic-release issue skipping deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -39,11 +39,11 @@ jobs:
           dry_run: false
           # version numbers below can be in many forms: M, M.m, M.m.p
           extra_plugins: |
-            conventional-changelog-conventionalcommits@4
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/github@8
-            @semantic-release/exec@6
+            conventional-changelog-conventionalcommits
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
+            @semantic-release/exec
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           dry_run: false
           # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 18
           extra_plugins: |
             conventional-changelog-conventionalcommits@4
             @semantic-release/changelog@6


### PR DESCRIPTION
semantic-release has fixed the conventional-commits issue in v22. Therefore, we can remove the workaround from our CI configurations and use the latest version of semantic-release for deployments. 

This PR updates the CI config to have the latest version of semantic-release. 