### PR TITLE
fix: update notification receiver activity launchMode

### DIFF
--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
             android:name=".activity.NotificationClickReceiverActivity"
             android:excludeFromRecents="true"
             android:exported="true"
+            android:launchMode="singleTop"
             android:noHistory="true"
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -226,8 +226,6 @@ internal class CustomerIOPushNotificationHandler(
     ): PendingIntent {
         val notifyIntent = Intent(context, NotificationClickReceiverActivity::class.java)
         notifyIntent.putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, payload)
-        // Without these flags, Android OS does not launch activity again in one session if the activity was recently launched
-        notifyIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         // In Android M, you must specify the mutability of each PendingIntent
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -226,6 +226,7 @@ internal class CustomerIOPushNotificationHandler(
     ): PendingIntent {
         val notifyIntent = Intent(context, NotificationClickReceiverActivity::class.java)
         notifyIntent.putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, payload)
+        notifyIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         // In Android M, you must specify the mutability of each PendingIntent
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -226,6 +226,7 @@ internal class CustomerIOPushNotificationHandler(
     ): PendingIntent {
         val notifyIntent = Intent(context, NotificationClickReceiverActivity::class.java)
         notifyIntent.putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, payload)
+        // Without these flags, Android OS does not launch activity again in one session if the activity was recently launched
         notifyIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         // In Android M, you must specify the mutability of each PendingIntent
         val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/10830

### Changes

- Added `android:launchMode="singleTop"` to `NotificationClickReceiverActivity` as without it, Android OS does not launch activity again in one session if the activity was launched recently from earlier notification