### PR TITLE
fix: encrypt stored sdk config

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -3,6 +3,8 @@ package io.customer.android
 object Dependencies {
     const val androidGradlePlugin =
         "com.android.tools.build:gradle:${Versions.ANDROID_GRADLE_PLUGIN}"
+    const val androidxSecurityCrypto =
+        "androidx.security:security-crypto:${Versions.ANDROIDX_SECURITY_CRYPTO}"
     const val androidxTestJunit = "androidx.test.ext:junit:${Versions.ANDROIDX_TEST_JUNIT}"
     const val androidxTestRunner = "androidx.test:runner:${Versions.ANDROIDX_TEST_RUNNER}"
     const val androidxTestRules = "androidx.test:rules:${Versions.ANDROIDX_TEST_RULES}"

--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -2,6 +2,9 @@ package io.customer.android
 
 object Versions {
     internal const val ANDROID_GRADLE_PLUGIN = "7.2.0"
+
+    // Using alpha version as current stable version (1.0.0) has minSdkVersion 23
+    internal const val ANDROIDX_SECURITY_CRYPTO = "1.1.0-alpha06"
     internal const val ANDROIDX_TEST_JUNIT = "1.1.4"
     internal const val ANDROIDX_TEST_RUNNER = "1.4.0"
     internal const val ANDROIDX_TEST_RULES = "1.4.0"

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application>
+    <application android:fullBackupContent="@xml/backup_rules">
         <service
             android:name=".CustomerIOFirebaseMessagingService"
             android:exported="false">

--- a/messagingpush/src/main/res/xml/backup_rules.xml
+++ b/messagingpush/src/main/res/xml/backup_rules.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!-- Prevent EncryptedSharedPreferences file from being backed up -->
+    <!-- Encrypted preferences should not be backed up as the key used to encrypt it will no
+    longer be present when backup is restored -->
     <exclude
         domain="sharedpref"
-        path="io.customer.sdk.SECURE_PREFERENCE_FILE_KEY.xml" />
+        path="io.customer.sdk.EncryptedConfigCache.xml" />
 </full-backup-content>

--- a/messagingpush/src/main/res/xml/backup_rules.xml
+++ b/messagingpush/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Prevent EncryptedSharedPreferences file from being backed up -->
+    <exclude
+        domain="sharedpref"
+        path="io.customer.sdk.SECURE_PREFERENCE_FILE_KEY.xml" />
+</full-backup-content>

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
     implementation Dependencies.coroutinesCore
     implementation Dependencies.coroutinesAndroid
-    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
+    implementation Dependencies.androidxSecurityCrypto
     implementation Dependencies.retrofit
     implementation Dependencies.moshi
     implementation Dependencies.retrofitMoshiConverter

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 
     implementation Dependencies.coroutinesCore
     implementation Dependencies.coroutinesAndroid
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
     implementation Dependencies.retrofit
     implementation Dependencies.moshi
     implementation Dependencies.retrofitMoshiConverter

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
@@ -9,6 +9,8 @@ import android.content.SharedPreferences
 internal abstract class BasePreferenceRepository(val context: Context) {
 
     abstract val prefsName: String
+
+    // Making this abstract so base class has option to use encrypted shared prefs
     internal abstract val prefs: SharedPreferences
 
     // this would clear the prefs asynchronously

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
@@ -9,12 +9,7 @@ import android.content.SharedPreferences
 internal abstract class BasePreferenceRepository(val context: Context) {
 
     abstract val prefsName: String
-
-    internal val prefs: SharedPreferences
-        get() = context.applicationContext.getSharedPreferences(
-            prefsName,
-            Context.MODE_PRIVATE
-        )
+    protected abstract val prefs: SharedPreferences
 
     // this would clear the prefs asynchronously
     open fun clearAll() {

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/BasePreferenceRepository.kt
@@ -9,7 +9,7 @@ import android.content.SharedPreferences
 internal abstract class BasePreferenceRepository(val context: Context) {
 
     abstract val prefsName: String
-    protected abstract val prefs: SharedPreferences
+    internal abstract val prefs: SharedPreferences
 
     // this would clear the prefs asynchronously
     open fun clearAll() {

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/SharedPreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/SharedPreferenceRepository.kt
@@ -1,6 +1,9 @@
 package io.customer.sdk.repository.preference
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import io.customer.sdk.Version
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.data.store.Client
@@ -17,7 +20,23 @@ internal class SharedPreferenceRepositoryImp(context: Context) : SharedPreferenc
     BasePreferenceRepository(context) {
 
     override val prefsName: String by lazy {
-        "io.customer.sdk.${context.packageName}.PREFERENCE_FILE_KEY"
+        "io.customer.sdk.SECURE_PREFERENCE_FILE_KEY"
+    }
+
+    override val prefs: SharedPreferences
+
+    init {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            prefsName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     override fun saveSettings(

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/SharedPreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/SharedPreferenceRepository.kt
@@ -19,8 +19,13 @@ internal interface SharedPreferenceRepository {
 internal class SharedPreferenceRepositoryImp(context: Context) : SharedPreferenceRepository,
     BasePreferenceRepository(context) {
 
+    // The file name used for storing shared preferences.
+    // This preference file should not be included in Auto Backup.
+    // Upon restoration, the encryption key originally used may no longer be present.
+    // To prevent this, ensure the file name matches the one excluded in backup_rules.xml.
+    // Read more: https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences
     override val prefsName: String by lazy {
-        "io.customer.sdk.SECURE_PREFERENCE_FILE_KEY"
+        "io.customer.sdk.EncryptedConfigCache"
     }
 
     override val prefs: SharedPreferences

--- a/sdk/src/main/java/io/customer/sdk/repository/preference/SitePreferenceRepository.kt
+++ b/sdk/src/main/java/io/customer/sdk/repository/preference/SitePreferenceRepository.kt
@@ -1,6 +1,7 @@
 package io.customer.sdk.repository.preference
 
 import android.content.Context
+import android.content.SharedPreferences
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.extensions.getDate
 import io.customer.sdk.extensions.putDate
@@ -27,6 +28,12 @@ internal class SitePreferenceRepositoryImpl(
     override val prefsName: String by lazy {
         "io.customer.sdk.${context.packageName}.${config.siteId}"
     }
+
+    override val prefs: SharedPreferences
+        get() = context.applicationContext.getSharedPreferences(
+            prefsName,
+            Context.MODE_PRIVATE
+        )
 
     companion object {
         private const val KEY_IDENTIFIER = "identifier"


### PR DESCRIPTION
### Background

Following the [Slack discussion](https://customerio.slack.com/archives/C02580R06/p1698523559693929), we realized that we should encrypt the SDK config to prevent possible reverse engineering and unauthorized extraction of keys.

### Changes

- Utilized [EncryptedSharedPreferences](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences) for secure storage of the SDK config
- Renamed the existing preferences file for the SDK config to avoid corrupt values
- Disabled backup for encrypted preferences, as recommended in the [Android docs](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences).

### Testing

- Native SDK users will not experience any impact, as they initialize the SDK in the Application class, eliminating the need for auto-initialization
- For existing wrapper customers, the SDK won't be auto-initialized from the killed state until the app is launched after this update. As soon as the app is launched, stored config values will be updated, and everything will proceed as expected.
- To test auto backup changes, enable `allowBackup` in the app and run the following command:

```
adb shell bmgr backupnow <app-package-name>
```