### PR TITLE
ci: fix installing sd tool needed for deployment

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -74,7 +74,8 @@ jobs:
     # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
     # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
     - name: Install sd CLI to use later in the workflow 
-      uses: kenji-miyake/setup-sd@v1
+      # uses: kenji-miyake/setup-sd@v1
+      uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it. 
     
     - name: Install tools from Gemfile (ruby language) used for building our apps with 
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
       - name: Install sd CLI to use later in the workflow
-        uses: kenji-miyake/setup-sd@v1
+        # uses: kenji-miyake/setup-sd@v1
+        uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it. 
 
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.


### PR DESCRIPTION
The iOS SDK experienced a deployment failure on `main` because of a GH Action that we depend on. 

I installed a workaround in the iOS SDK until the GH action gets fixed. This PR applies the same workaround here. 