### PR TITLE
fix: ensure messages are only shown once

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
@@ -23,6 +23,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class Queue : GistListener {
 
     private var localMessageStore: MutableList<Message> = mutableListOf()
+    private var shownMessageQueueIds = mutableSetOf<String>()
 
     init {
         GistSdk.addListener(this)
@@ -149,6 +150,11 @@ class Queue : GistListener {
     }
 
     private fun processMessage(message: Message) {
+        if (message.queueId != null && shownMessageQueueIds.contains(message.queueId)) {
+            Log.i(GIST_TAG, "Duplicate message ${message.queueId} skipped")
+            return
+        }
+
         val gistProperties = GistMessageProperties.getGistProperties(message)
         gistProperties.routeRule?.let { routeRule ->
             try {
@@ -218,6 +224,10 @@ class Queue : GistListener {
             Log.i(GIST_TAG, "Persistent message shown: ${message.messageId}, skipping logging view")
         } else {
             logView(message)
+        }
+
+        if (message.queueId != null) {
+            shownMessageQueueIds.add(message.queueId)
         }
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
@@ -194,6 +194,7 @@ class Queue : GistListener {
                         GIST_TAG,
                         "Logging view for user message: ${message.messageId}, with queue id: ${message.queueId}"
                     )
+                    shownMessageQueueIds.add(message.queueId)
                     removeMessageFromLocalStore(message)
                     gistQueueService.logUserMessageView(message.queueId)
                 } else {
@@ -224,10 +225,6 @@ class Queue : GistListener {
             Log.i(GIST_TAG, "Persistent message shown: ${message.messageId}, skipping logging view")
         } else {
             logView(message)
-        }
-
-        if (message.queueId != null) {
-            shownMessageQueueIds.add(message.queueId)
         }
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -46,6 +46,7 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
 
     private var gistModalManager: GistModalManager = GistModalManager()
     internal var currentRoute: String = ""
+    private var shownMessageQueueIds = mutableSetOf<String>()
 
     @JvmStatic
     fun getInstance() = this
@@ -145,15 +146,26 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
     fun showMessage(message: Message, position: MessagePosition? = null): String? {
         ensureInitialized()
         var messageShown = false
+        val queueId = message.queueId
 
-        GlobalScope.launch {
-            try {
-                messageShown = gistModalManager.showModalMessage(message, position)
-            } catch (e: Exception) {
-                Log.e(GIST_TAG, "Failed to show message: ${e.message}", e)
+        if (shownMessageQueueIds.contains(queueId)) {
+            Log.i(GIST_TAG,"Duplicate message $queueId skipped")
+        } else {
+            GlobalScope.launch {
+                try {
+                    messageShown = gistModalManager.showModalMessage(message, position)
+                } catch (e: Exception) {
+                    Log.e(GIST_TAG, "Failed to show message: ${e.message}", e)
+                }
             }
         }
-        return if (messageShown) message.instanceId else null
+
+        if (messageShown) {
+            shownMessageQueueIds.add(queueId!!)
+            return message.instanceId
+        } else {
+            return null
+        }
     }
 
     fun dismissMessage() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -46,7 +46,6 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
 
     private var gistModalManager: GistModalManager = GistModalManager()
     internal var currentRoute: String = ""
-    private var shownMessageQueueIds = mutableSetOf<String>()
 
     @JvmStatic
     fun getInstance() = this
@@ -146,26 +145,16 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
     fun showMessage(message: Message, position: MessagePosition? = null): String? {
         ensureInitialized()
         var messageShown = false
-        val queueId = message.queueId
 
-        if (shownMessageQueueIds.contains(queueId)) {
-            Log.i(GIST_TAG, "Duplicate message $queueId skipped")
-        } else {
-            GlobalScope.launch {
-                try {
-                    messageShown = gistModalManager.showModalMessage(message, position)
-                } catch (e: Exception) {
-                    Log.e(GIST_TAG, "Failed to show message: ${e.message}", e)
-                }
+        GlobalScope.launch {
+            try {
+                messageShown = gistModalManager.showModalMessage(message, position)
+            } catch (e: Exception) {
+                Log.e(GIST_TAG, "Failed to show message: ${e.message}", e)
             }
         }
 
-        if (messageShown) {
-            shownMessageQueueIds.add(queueId!!)
-            return message.instanceId
-        } else {
-            return null
-        }
+        return if (messageShown) message.instanceId else null
     }
 
     fun dismissMessage() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -149,7 +149,7 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
         val queueId = message.queueId
 
         if (shownMessageQueueIds.contains(queueId)) {
-            Log.i(GIST_TAG,"Duplicate message $queueId skipped")
+            Log.i(GIST_TAG, "Duplicate message $queueId skipped")
         } else {
             GlobalScope.launch {
                 try {


### PR DESCRIPTION
The idea is to keep track of the shown messages by queueId (which is unique per message) and skip the shown ones

This is based on the same solution applied for gist-web: https://github.com/customerio/gist-web/pull/26

Task: https://github.com/customerio/issues/issues/11967

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 