### PR TITLE
feat: use new header to set polling interval

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
@@ -146,13 +146,14 @@ class Queue : GistListener {
     }
 
     private fun updatePollingInterval(headers: Headers) {
-        headers["X-Gist-Queue-Polling-Interval"]?.let { pollingInterval ->
-            if (pollingInterval.toInt() > 0) {
-                val newPollingInterval = (pollingInterval.toInt() * 1000).toLong()
-                if (newPollingInterval != GistSdk.pollInterval) {
-                    GistSdk.pollInterval = newPollingInterval
+        headers["X-Gist-Queue-Polling-Interval"]?.toIntOrNull()?.let { pollingIntervalSeconds ->
+            if (pollingIntervalSeconds > 0) {
+                val newPollingIntervalMilliseconds = (pollingIntervalSeconds * 1000).toLong()
+                if (newPollingIntervalMilliseconds != GistSdk.pollInterval) {
+                    GistSdk.pollInterval = newPollingIntervalMilliseconds
+                    // Queue check fetches messages again and could result in infinite loop.
                     GistSdk.observeMessagesForUser(true)
-                    Log.i(GIST_TAG, "Polling interval changed to: ${pollingInterval.toInt()} seconds")
+                    Log.i(GIST_TAG, "Polling interval changed to: $pollingIntervalSeconds seconds")
                 }
             }
         }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -25,12 +25,12 @@ const val GIST_TAG: String = "[CIO]"
 object GistSdk : Application.ActivityLifecycleCallbacks {
     private const val SHARED_PREFERENCES_NAME = "gist-sdk"
     private const val SHARED_PREFERENCES_USER_TOKEN_KEY = "userToken"
-    private const val POLL_INTERVAL = 10_000L
 
     private val sharedPreferences by lazy {
         application.getSharedPreferences(SHARED_PREFERENCES_NAME, MODE_PRIVATE)
     }
 
+    internal var pollInterval = 600_000L
     lateinit var siteId: String
     lateinit var dataCenter: String
     internal lateinit var gistEnvironment: GistEnvironment
@@ -187,16 +187,18 @@ object GistSdk : Application.ActivityLifecycleCallbacks {
 
     // Gist Message Observer
 
-    private fun observeMessagesForUser() {
+    internal fun observeMessagesForUser(skipQueueCheck: Boolean = false) {
         // Clean up any previous observers
         observeUserMessagesJob?.cancel()
 
         Log.i(GIST_TAG, "Messages timer started")
-        gistQueue.fetchUserMessages()
+        if (!skipQueueCheck) {
+            gistQueue.fetchUserMessages()
+        }
         observeUserMessagesJob = GlobalScope.launch {
             try {
                 // Poll for user messages
-                val ticker = ticker(POLL_INTERVAL, context = this.coroutineContext)
+                val ticker = ticker(pollInterval, context = this.coroutineContext)
                 for (tick in ticker) {
                     gistQueue.fetchUserMessages()
                 }


### PR DESCRIPTION
Updates the polling interval remotely through the new `X-Gist-Queue-Polling-Interval` header.

Part of: [INAPP-12243](https://linear.app/customerio/issue/INAPP-12243/update-the-in-app-sdks-to-configure-polling-based-on-remote)