### PR TITLE
ci: fix for binary size report gradle task

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -29,7 +29,9 @@ jobs:
       # The report is pushed by semantic-release action below by including files listed in the
       # `assets` array in the `.releaserc` file.
       - name: Generate SDK Size Report
-        run: ./gradlew generateSdkSizeReport -PwriteReportTo=reports/sdk-binary-size.json
+        run: |
+          ./gradlew publishToMavenLocal
+          ./gradlew generateSdkSizeReport -PwriteReportTo=reports/sdk-binary-size.json
         env:
           # Use local version to make sure the report is generated for the current changes
           IS_DEVELOPMENT: 'true'


### PR DESCRIPTION
helps: https://linear.app/customerio/issue/MBL-157/track-the-binary-size-of-our-android-sdk

### Changes 🤦🏻 

- Added `publishToMavenLocal` so local version can be fetched