### PR TITLE
ci: setup android for binary size gradle task

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -25,6 +25,10 @@ jobs:
         # uses: kenji-miyake/setup-sd@v1
         uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it.
 
+      # Setup Android SDK as it's needed to generate the SDK size report.
+      - name: Setup Android SDK
+        uses: ./.github/actions/setup-android
+
       # Generate SDK size report to update in main branch before deploying new release.
       # The report is pushed by semantic-release action below by including files listed in the
       # `assets` array in the `.releaserc` file.


### PR DESCRIPTION
helps: https://linear.app/customerio/issue/MBL-157/track-the-binary-size-of-our-android-sdk

### Changes 🤦🏻 

- Added `setup-android` so binary size gradle task can utilize `apkanalyzer`