### PR TITLE
fix: added consumer rules for R8 full mode

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -28,6 +28,6 @@ object Versions {
     internal const val MOSHI = "1.14.0"
     internal const val TIMBER = "5.0.0"
     internal const val ROBOLECTRIC = "4.9"
-    internal const val OKHTTP = "4.10.0"
+    internal const val OKHTTP = "4.11.0"
     internal const val RETROFIT = "2.9.0"
 }

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -1,0 +1,53 @@
+# Rules necessary for R8 full mode
+-keep class com.squareup.moshi.JsonReader
+-keep class com.squareup.moshi.JsonAdapter
+-keep class kotlin.reflect.jvm.internal.* { *; }
+
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep inherited services.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# With R8 full mode generic signatures are stripped for classes that are not kept.
+-keep,allowobfuscation,allowshrinking class retrofit2.Response


### PR DESCRIPTION
closes: 

Added consumer rules for following (couldn't bump their version to add rules automatically as they are compiled with Kotlin 1.9X and hence client apps needs to bump their kotlin version)
- Moshi
- Retrofit

Updated [version](https://square.github.io/okhttp/changelogs/changelog_4x/#version-4110) for OKHTTP as it contains the latest rules.