### PR TITLE
refactor: base module and digraph classes to core

### DIFF
--- a/common-test/build.gradle
+++ b/common-test/build.gradle
@@ -13,6 +13,7 @@ android {
 }
 
 dependencies {
+    api project(":core")
     // since all modules in project inherit the base tracking SDK, add it here to our shared testing module as all modules in project should have access to this module.
     api project(':tracking')
 

--- a/common-test/src/main/java/io/customer/commontest/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/BaseTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.data.model.Region
@@ -11,7 +12,6 @@ import io.customer.sdk.data.store.Client
 import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.di.CustomerIOComponent
 import io.customer.sdk.di.CustomerIOStaticComponent
-import io.customer.sdk.module.CustomerIOModule
 import io.customer.sdk.util.*
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockWebServer

--- a/common-test/src/main/java/io/customer/commontest/module/CustomerIOGenericModule.kt
+++ b/common-test/src/main/java/io/customer/commontest/module/CustomerIOGenericModule.kt
@@ -1,0 +1,8 @@
+package io.customer.commontest.module
+
+import io.customer.android.core.module.CustomerIOModule
+
+/**
+ * Internal typealias to simplify generic types for tests
+ */
+typealias CustomerIOGenericModule = CustomerIOModule<*>

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,3 +1,11 @@
+public abstract class io/customer/android/core/di/DiGraph {
+	public fun <init> ()V
+	public final fun getOverrides ()Ljava/util/Map;
+	public final fun getSingletons ()Ljava/util/Map;
+	public final fun overrideDependency (Ljava/lang/Class;Ljava/lang/Object;)V
+	public final fun reset ()V
+}
+
 public abstract interface class io/customer/android/core/module/CustomerIOModule {
 	public abstract fun getModuleConfig ()Lio/customer/android/core/module/CustomerIOModuleConfig;
 	public abstract fun getModuleName ()Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,0 +1,13 @@
+public abstract interface class io/customer/android/core/module/CustomerIOModule {
+	public abstract fun getModuleConfig ()Lio/customer/android/core/module/CustomerIOModuleConfig;
+	public abstract fun getModuleName ()Ljava/lang/String;
+	public abstract fun initialize ()V
+}
+
+public abstract interface class io/customer/android/core/module/CustomerIOModuleConfig {
+}
+
+public abstract interface class io/customer/android/core/module/CustomerIOModuleConfig$Builder {
+	public abstract fun build ()Lio/customer/android/core/module/CustomerIOModuleConfig;
+}
+

--- a/core/src/main/kotlin/io/customer/android/core/di/DiGraph.kt
+++ b/core/src/main/kotlin/io/customer/android/core/di/DiGraph.kt
@@ -1,4 +1,4 @@
-package io.customer.sdk.di
+package io.customer.android.core.di
 
 abstract class DiGraph {
     val overrides: MutableMap<String, Any> = mutableMapOf()

--- a/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
+++ b/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
@@ -1,7 +1,0 @@
-package io.customer.android.core.module
-
-/**
- * Internal typealias to simplify generic types, used primarily for tests or
- * only where type cannot be specified
- */
-typealias CustomerIOGenericModule = CustomerIOModule<*>

--- a/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
+++ b/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
@@ -4,4 +4,4 @@ package io.customer.android.core.module
  * Internal typealias to simplify generic types, used primarily for tests or
  * only where type cannot be specified
  */
-internal typealias CustomerIOGenericModule = CustomerIOModule<*>
+typealias CustomerIOGenericModule = CustomerIOModule<*>

--- a/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
+++ b/core/src/main/kotlin/io/customer/android/core/module/CustomerIOGenericModule.kt
@@ -1,4 +1,4 @@
-package io.customer.sdk.module
+package io.customer.android.core.module
 
 /**
  * Internal typealias to simplify generic types, used primarily for tests or

--- a/core/src/main/kotlin/io/customer/android/core/module/CustomerIOModule.kt
+++ b/core/src/main/kotlin/io/customer/android/core/module/CustomerIOModule.kt
@@ -1,4 +1,4 @@
-package io.customer.sdk.module
+package io.customer.android.core.module
 
 /**
  * A module is optional Customer.io SDK that you can install in your app.

--- a/core/src/main/kotlin/io/customer/android/core/module/CustomerIOModuleConfig.kt
+++ b/core/src/main/kotlin/io/customer/android/core/module/CustomerIOModuleConfig.kt
@@ -1,4 +1,4 @@
-package io.customer.sdk.module
+package io.customer.android.core.module
 
 /**
  * Tagged interface to support dynamic configurations for Customer.io modules

--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-
     api project(":base")
+    api project(":core")
     implementation(Dependencies.segment)
 }

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -1,20 +1,20 @@
-public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/sdk/module/CustomerIOModuleConfig {
+public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/android/core/module/CustomerIOModuleConfig {
 	public static final field Companion Lio/customer/messaginginapp/MessagingInAppModuleConfig$Companion;
 	public synthetic fun <init> (Lio/customer/messaginginapp/type/InAppEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEventListener ()Lio/customer/messaginginapp/type/InAppEventListener;
 }
 
-public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder : io/customer/sdk/module/CustomerIOModuleConfig$Builder {
+public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder : io/customer/android/core/module/CustomerIOModuleConfig$Builder {
 	public fun <init> ()V
+	public synthetic fun build ()Lio/customer/android/core/module/CustomerIOModuleConfig;
 	public fun build ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
-	public synthetic fun build ()Lio/customer/sdk/module/CustomerIOModuleConfig;
 	public final fun setEventListener (Lio/customer/messaginginapp/type/InAppEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 }
 
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Companion {
 }
 
-public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer/sdk/module/CustomerIOModule {
+public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer/android/core/module/CustomerIOModule {
 	public static final field Companion Lio/customer/messaginginapp/ModuleMessagingInApp$Companion;
 	public static final field moduleName Ljava/lang/String;
 	public fun <init> ()V
@@ -24,8 +24,8 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public fun <init> (Ljava/lang/String;Lio/customer/messaginginapp/MessagingInAppModuleConfig;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/customer/messaginginapp/MessagingInAppModuleConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun dismissMessage ()V
+	public synthetic fun getModuleConfig ()Lio/customer/android/core/module/CustomerIOModuleConfig;
 	public fun getModuleConfig ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
-	public synthetic fun getModuleConfig ()Lio/customer/sdk/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun initialize ()V
 }

--- a/messaginginapp/build.gradle
+++ b/messaginginapp/build.gradle
@@ -36,6 +36,7 @@ android {
 
 dependencies {
     api project(":base")
+    api project(":core")
     api project(":tracking")
 
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
@@ -1,7 +1,7 @@
 package io.customer.messaginginapp
 
+import io.customer.android.core.module.CustomerIOModuleConfig
 import io.customer.messaginginapp.type.InAppEventListener
-import io.customer.sdk.module.CustomerIOModuleConfig
 
 /**
  * In app messaging module configurations that can be used to customize app

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -2,6 +2,7 @@ package io.customer.messaginginapp
 
 import android.app.Application
 import androidx.annotation.VisibleForTesting
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.messaginginapp.di.gistProvider
 import io.customer.messaginginapp.hook.ModuleInAppHookProvider
 import io.customer.sdk.CustomerIO
@@ -10,7 +11,6 @@ import io.customer.sdk.data.request.MetricEvent
 import io.customer.sdk.di.CustomerIOComponent
 import io.customer.sdk.hooks.HookModule
 import io.customer.sdk.hooks.HooksManager
-import io.customer.sdk.module.CustomerIOModule
 import io.customer.sdk.repository.TrackRepository
 
 class ModuleMessagingInApp

--- a/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -1,6 +1,7 @@
 package io.customer.messaginginapp
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.commontest.BaseTest
 import io.customer.messaginginapp.di.inAppMessaging
 import io.customer.messaginginapp.provider.InAppMessagesProvider
@@ -11,7 +12,6 @@ import io.customer.sdk.data.model.Region
 import io.customer.sdk.extensions.random
 import io.customer.sdk.hooks.HookModule
 import io.customer.sdk.hooks.HooksManager
-import io.customer.sdk.module.CustomerIOModule
 import io.customer.sdk.repository.preference.SitePreferenceRepository
 import java.lang.reflect.Field
 import org.amshove.kluent.shouldBe

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -24,7 +24,7 @@ public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$
 	public final fun onNewToken (Ljava/lang/String;)V
 }
 
-public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/module/CustomerIOModuleConfig {
+public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/android/core/module/CustomerIOModuleConfig {
 	public static final field Companion Lio/customer/messagingpush/MessagingPushModuleConfig$Companion;
 	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;ZLio/customer/messagingpush/config/PushClickBehavior;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoTrackPushEvents ()Z
@@ -33,10 +33,10 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig : io/cust
 	public final fun getRedirectDeepLinksToOtherApps ()Z
 }
 
-public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder : io/customer/sdk/module/CustomerIOModuleConfig$Builder {
+public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder : io/customer/android/core/module/CustomerIOModuleConfig$Builder {
 	public fun <init> ()V
+	public synthetic fun build ()Lio/customer/android/core/module/CustomerIOModuleConfig;
 	public fun build ()Lio/customer/messagingpush/MessagingPushModuleConfig;
-	public synthetic fun build ()Lio/customer/sdk/module/CustomerIOModuleConfig;
 	public final fun setAutoTrackPushEvents (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setPushClickBehavior (Lio/customer/messagingpush/config/PushClickBehavior;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
@@ -46,13 +46,13 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder :
 public final class io/customer/messagingpush/MessagingPushModuleConfig$Companion {
 }
 
-public final class io/customer/messagingpush/ModuleMessagingPushFCM : io/customer/sdk/module/CustomerIOModule {
+public final class io/customer/messagingpush/ModuleMessagingPushFCM : io/customer/android/core/module/CustomerIOModule {
 	public static final field Companion Lio/customer/messagingpush/ModuleMessagingPushFCM$Companion;
 	public fun <init> ()V
 	public fun <init> (Lio/customer/messagingpush/MessagingPushModuleConfig;)V
 	public synthetic fun <init> (Lio/customer/messagingpush/MessagingPushModuleConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun getModuleConfig ()Lio/customer/android/core/module/CustomerIOModuleConfig;
 	public fun getModuleConfig ()Lio/customer/messagingpush/MessagingPushModuleConfig;
-	public synthetic fun getModuleConfig ()Lio/customer/sdk/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun initialize ()V
 }

--- a/messagingpush/build.gradle
+++ b/messagingpush/build.gradle
@@ -33,6 +33,7 @@ android {
 
 dependencies {
     api project(":base")
+    api project(":core")
     api project(":tracking")
 
     implementation Dependencies.coroutinesCore

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -1,9 +1,9 @@
 package io.customer.messagingpush
 
+import io.customer.android.core.module.CustomerIOModuleConfig
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.config.PushClickBehavior.ACTIVITY_PREVENT_RESTART
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
-import io.customer.sdk.module.CustomerIOModuleConfig
 
 /**
  * Push messaging module configurations

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -1,13 +1,13 @@
 package io.customer.messagingpush
 
 import androidx.annotation.VisibleForTesting
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.messagingpush.di.fcmTokenProvider
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.messagingpush.lifecycle.MessagingPushLifecycleCallback
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.di.CustomerIOComponent
-import io.customer.sdk.module.CustomerIOModule
 
 class ModuleMessagingPushFCM
 @VisibleForTesting

--- a/messagingpush/src/sharedTest/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
+++ b/messagingpush/src/sharedTest/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.commontest.BaseTest
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
@@ -8,7 +9,6 @@ import io.customer.messagingpush.di.moduleConfig
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.device.DeviceTokenProvider
-import io.customer.sdk.module.CustomerIOModule
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull

--- a/messagingpush/src/sharedTest/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
+++ b/messagingpush/src/sharedTest/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.core.app.TaskStackBuilder
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.commontest.BaseTest
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
@@ -19,7 +20,6 @@ import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.data.request.MetricEvent
 import io.customer.sdk.extensions.random
-import io.customer.sdk.module.CustomerIOModule
 import io.customer.sdk.repository.TrackRepository
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse

--- a/sdk/api/tracking.api
+++ b/sdk/api/tracking.api
@@ -29,7 +29,7 @@ public final class io/customer/sdk/CustomerIO$Builder {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/sdk/data/model/Region;Landroid/app/Application;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/sdk/data/model/Region;Landroid/app/Application;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/sdk/data/model/Region;Landroid/app/Application;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun addCustomerIOModule (Lio/customer/sdk/module/CustomerIOModule;)Lio/customer/sdk/CustomerIO$Builder;
+	public final fun addCustomerIOModule (Lio/customer/android/core/module/CustomerIOModule;)Lio/customer/sdk/CustomerIO$Builder;
 	public final fun autoTrackDeviceAttributes (Z)Lio/customer/sdk/CustomerIO$Builder;
 	public final fun autoTrackScreenViews (Z)Lio/customer/sdk/CustomerIO$Builder;
 	public final fun build ()Lio/customer/sdk/CustomerIO;
@@ -324,19 +324,6 @@ public abstract interface class io/customer/sdk/lifecycle/LifecycleCallback {
 public final class io/customer/sdk/lifecycle/LifecycleCallback$DefaultImpls {
 	public static fun onEventChanged (Lio/customer/sdk/lifecycle/LifecycleCallback;Landroidx/lifecycle/Lifecycle$Event;Landroid/app/Activity;Landroid/os/Bundle;)V
 	public static synthetic fun onEventChanged$default (Lio/customer/sdk/lifecycle/LifecycleCallback;Landroidx/lifecycle/Lifecycle$Event;Landroid/app/Activity;Landroid/os/Bundle;ILjava/lang/Object;)V
-}
-
-public abstract interface class io/customer/sdk/module/CustomerIOModule {
-	public abstract fun getModuleConfig ()Lio/customer/sdk/module/CustomerIOModuleConfig;
-	public abstract fun getModuleName ()Ljava/lang/String;
-	public abstract fun initialize ()V
-}
-
-public abstract interface class io/customer/sdk/module/CustomerIOModuleConfig {
-}
-
-public abstract interface class io/customer/sdk/module/CustomerIOModuleConfig$Builder {
-	public abstract fun build ()Lio/customer/sdk/module/CustomerIOModuleConfig;
 }
 
 public abstract interface class io/customer/sdk/repository/DeviceRepository {

--- a/sdk/api/tracking.api
+++ b/sdk/api/tracking.api
@@ -235,7 +235,7 @@ public abstract interface class io/customer/sdk/device/DeviceTokenProvider {
 	public abstract fun isValidForThisDevice (Landroid/content/Context;)Z
 }
 
-public final class io/customer/sdk/di/CustomerIOComponent : io/customer/sdk/di/DiGraph {
+public final class io/customer/sdk/di/CustomerIOComponent : io/customer/android/core/di/DiGraph {
 	public fun <init> (Lio/customer/sdk/di/CustomerIOStaticComponent;Landroid/content/Context;Lio/customer/sdk/CustomerIOConfig;)V
 	public final fun getActivityLifecycleCallbacks ()Lio/customer/sdk/CustomerIOActivityLifecycleCallbacks;
 	public final fun getCioHttpRetryPolicy ()Lio/customer/sdk/api/HttpRetryPolicy;
@@ -260,23 +260,15 @@ public final class io/customer/sdk/di/CustomerIOComponent : io/customer/sdk/di/D
 	public final fun getTrackRepository ()Lio/customer/sdk/repository/TrackRepository;
 }
 
-public final class io/customer/sdk/di/CustomerIOSharedComponent : io/customer/sdk/di/DiGraph {
+public final class io/customer/sdk/di/CustomerIOSharedComponent : io/customer/android/core/di/DiGraph {
 	public fun <init> (Landroid/content/Context;)V
 }
 
-public final class io/customer/sdk/di/CustomerIOStaticComponent : io/customer/sdk/di/DiGraph {
+public final class io/customer/sdk/di/CustomerIOStaticComponent : io/customer/android/core/di/DiGraph {
 	public fun <init> ()V
 	public final fun getDispatchersProvider ()Lio/customer/sdk/util/DispatchersProvider;
 	public final fun getLogger ()Lio/customer/sdk/util/Logger;
 	public final fun getStaticSettingsProvider ()Lio/customer/sdk/util/StaticSettingsProvider;
-}
-
-public abstract class io/customer/sdk/di/DiGraph {
-	public fun <init> ()V
-	public final fun getOverrides ()Ljava/util/Map;
-	public final fun getSingletons ()Ljava/util/Map;
-	public final fun overrideDependency (Ljava/lang/Class;Ljava/lang/Object;)V
-	public final fun reset ()V
 }
 
 public final class io/customer/sdk/hooks/HookModule : java/lang/Enum {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -42,6 +42,7 @@ android {
 
 dependencies {
     api project(":base")
+    api project(":core")
 
     implementation Dependencies.coroutinesCore
     implementation Dependencies.coroutinesAndroid

--- a/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIO.kt
@@ -5,6 +5,8 @@ import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.VisibleForTesting
+import io.customer.android.core.module.CustomerIOModule
+import io.customer.android.core.module.CustomerIOModuleConfig
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.data.model.Region
@@ -12,8 +14,6 @@ import io.customer.sdk.data.request.MetricEvent
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.di.CustomerIOComponent
 import io.customer.sdk.extensions.*
-import io.customer.sdk.module.CustomerIOModule
-import io.customer.sdk.module.CustomerIOModuleConfig
 import io.customer.sdk.repository.CleanupRepository
 import io.customer.sdk.repository.DeviceRepository
 import io.customer.sdk.repository.ProfileRepository

--- a/sdk/src/main/java/io/customer/sdk/CustomerIOConfig.kt
+++ b/sdk/src/main/java/io/customer/sdk/CustomerIOConfig.kt
@@ -1,8 +1,8 @@
 package io.customer.sdk
 
+import io.customer.android.core.module.CustomerIOModule
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.data.store.Client
-import io.customer.sdk.module.CustomerIOModule
 import io.customer.sdk.util.CioLogLevel
 
 data class CustomerIOConfig(

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOComponent.kt
@@ -2,6 +2,7 @@ package io.customer.sdk.di
 
 import android.content.Context
 import com.squareup.moshi.Moshi
+import io.customer.android.core.di.DiGraph
 import io.customer.sdk.CustomerIOActivityLifecycleCallbacks
 import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.api.*

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOSharedComponent.kt
@@ -1,6 +1,7 @@
 package io.customer.sdk.di
 
 import android.content.Context
+import io.customer.android.core.di.DiGraph
 import io.customer.sdk.repository.preference.SharedPreferenceRepository
 import io.customer.sdk.repository.preference.SharedPreferenceRepositoryImp
 

--- a/sdk/src/main/java/io/customer/sdk/di/CustomerIOStaticComponent.kt
+++ b/sdk/src/main/java/io/customer/sdk/di/CustomerIOStaticComponent.kt
@@ -1,5 +1,6 @@
 package io.customer.sdk.di
 
+import io.customer.android.core.di.DiGraph
 import io.customer.sdk.util.*
 
 /**

--- a/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOTest.kt
+++ b/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOTest.kt
@@ -1,8 +1,8 @@
 package io.customer.sdk
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.customer.android.core.module.CustomerIOGenericModule
 import io.customer.commontest.BaseTest
+import io.customer.commontest.module.CustomerIOGenericModule
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.di.CustomerIOSharedComponent

--- a/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOTest.kt
+++ b/sdk/src/sharedTest/java/io/customer/sdk/CustomerIOTest.kt
@@ -1,13 +1,13 @@
 package io.customer.sdk
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.customer.android.core.module.CustomerIOGenericModule
 import io.customer.commontest.BaseTest
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.di.CustomerIOSharedComponent
 import io.customer.sdk.di.CustomerIOStaticComponent
 import io.customer.sdk.extensions.random
-import io.customer.sdk.module.CustomerIOGenericModule
 import io.customer.sdk.repository.CleanupRepository
 import io.customer.sdk.repository.DeviceRepository
 import io.customer.sdk.repository.ProfileRepository


### PR DESCRIPTION
part of [MBL-243](https://linear.app/customerio/issue/MBL-243/initialize-the-sdk)

### Changes

- Moved base module classes from `tracking` to `core`
- Moved base DiGraph class from `tracking` to `core` so we can create desired graphs in `core`
