### PR TITLE
chore: add static and android di graphs

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,9 +1,25 @@
+public final class io/customer/android/core/di/AndroidSDKComponent : io/customer/android/core/di/DiGraph {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun getApplicationContext ()Landroid/content/Context;
+	public final fun getContext ()Landroid/content/Context;
+}
+
 public abstract class io/customer/android/core/di/DiGraph {
 	public fun <init> ()V
 	public final fun getOverrides ()Ljava/util/Map;
 	public final fun getSingletons ()Ljava/util/Map;
 	public final fun overrideDependency (Ljava/lang/Class;Ljava/lang/Object;)V
 	public final fun reset ()V
+}
+
+public final class io/customer/android/core/di/SDKComponent : io/customer/android/core/di/DiGraph {
+	public static final field INSTANCE Lio/customer/android/core/di/SDKComponent;
+	public final fun getAndroidSDKComponent ()Lio/customer/android/core/di/AndroidSDKComponent;
+	public final fun getModules ()Ljava/util/Map;
+}
+
+public final class io/customer/android/core/di/SDKComponentExtKt {
+	public static final fun registerAndroidSDKComponent (Lio/customer/android/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/android/core/di/AndroidSDKComponent;
 }
 
 public abstract interface class io/customer/android/core/module/CustomerIOModule {

--- a/core/src/main/kotlin/io/customer/android/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/android/core/di/AndroidSDKComponent.kt
@@ -1,0 +1,15 @@
+package io.customer.android.core.di
+
+import android.content.Context
+
+/**
+ * DIGraph component for Android-specific dependencies to ensure all SDK
+ * modules can access them.
+ * Integrate this graph at SDK startup using from Android entry point.
+ */
+class AndroidSDKComponent(
+    val context: Context
+) : DiGraph() {
+    val applicationContext: Context
+        get() = newInstance { context.applicationContext }
+}

--- a/core/src/main/kotlin/io/customer/android/core/di/SDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/android/core/di/SDKComponent.kt
@@ -1,0 +1,14 @@
+package io.customer.android.core.di
+
+import io.customer.android.core.module.CustomerIOModule
+
+/**
+ * Object level DiGraph for the SDK. Provides a centralized way to manage all
+ * dependencies in the SDK in a single place.
+ * The object can be accessed from anywhere in the SDK and can be used to provide
+ * a consistent and efficient way to access them throughout the SDK.
+ */
+object SDKComponent : DiGraph() {
+    val androidSDKComponent: AndroidSDKComponent? get() = getOrNull()
+    val modules: MutableMap<String, CustomerIOModule<*>> = mutableMapOf()
+}

--- a/core/src/main/kotlin/io/customer/android/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/android/core/di/SDKComponentExt.kt
@@ -1,0 +1,15 @@
+package io.customer.android.core.di
+
+import android.content.Context
+
+/**
+ * The file contains extension functions for the SDKComponent object and its dependencies.
+ */
+
+/**
+ * Create and register an instance of AndroidSDKComponent with the provided context,
+ * only if it is not already initialized.
+ */
+fun SDKComponent.registerAndroidSDKComponent(context: Context) = registerDependency {
+    AndroidSDKComponent(context)
+}


### PR DESCRIPTION
part of [MBL-273](https://linear.app/customerio/issue/MBL-273/enhance-digraph-for-improved-dependency-management)

### Changes

- Introduced `SDKComponent` static DI graph to decouple dependencies from SDK initialization
- Added `AndroidSDKComponent` to hold dependencies specific to Android OS and context