### PR TITLE
chore: add logger to analytics in datapipelines module

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -57,6 +57,12 @@ public class CustomerIORepository {
         // The new method should be called after the old method till the old method is removed
         // This is because the push and in-app modules are still using properties only initialized in the old method
         CustomerIOBuilder newBuilder = new CustomerIOBuilder(application, sdkConfig.getCdpApiKey());
+
+        // Enable detailed logging for debug builds.
+        if (sdkConfig.debugModeEnabled()) {
+            newBuilder.setLogLevel(CioLogLevel.DEBUG);
+        }
+
         builder.addCustomerIOModule(new ModuleMessagingPushFCM());
         builder.addCustomerIOModule(new ModuleMessagingInApp(
                 new MessagingInAppModuleConfig.Builder()

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
@@ -52,6 +52,8 @@ class MainApplication : Application() {
             applicationContext = this,
             cdpApiKey = configuration.cdpApiKey
         ).apply {
+            configuration.setValuesFromBuilder(this)
+
             addCustomerIOModule(
                 ModuleMessagingInApp(
                     config = MessagingInAppModuleConfig.Builder()

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/models/Configuration.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/models/Configuration.kt
@@ -1,6 +1,7 @@
 package io.customer.android.sample.kotlin_compose.data.models
 
 import io.customer.sdk.CustomerIO
+import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.CustomerIOConfig.Companion.AnalyticsConstants.AUTO_TRACK_DEVICE_ATTRIBUTES
 import io.customer.sdk.CustomerIOConfig.Companion.AnalyticsConstants.BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS
 import io.customer.sdk.CustomerIOConfig.Companion.AnalyticsConstants.BACKGROUND_QUEUE_SECONDS_DELAY
@@ -32,5 +33,14 @@ fun Configuration.setValuesFromBuilder(builder: CustomerIO.Builder): CustomerIO.
     }
     builder.autoTrackDeviceAttributes(this.trackDeviceAttributes)
     builder.autoTrackScreenViews(this.trackScreen)
+    return builder
+}
+
+fun Configuration.setValuesFromBuilder(builder: CustomerIOBuilder): CustomerIOBuilder {
+    if (this.debugMode) {
+        builder.setLogLevel(CioLogLevel.DEBUG)
+    } else {
+        builder.setLogLevel(CioLogLevel.ERROR)
+    }
     return builder
 }


### PR DESCRIPTION
part of [MBL-214](https://linear.app/customerio/issue/MBL-214/identify-a-profile)

### Changes

- Added custom logger to `analytics` to ensure that log configurations align with the SDK
- Updated sample apps to set `logLevel` when initializing the SDK with new SDK builder