### PR TITLE
feat: added screen APIs

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -93,6 +93,11 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/and
 	public final fun identify (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public final fun screen (Ljava/lang/String;)V
+	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public final fun screen (Ljava/lang/String;Ljava/util/Map;)V
+	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;)V
 	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
@@ -112,6 +117,7 @@ public final class io/customer/sdk/android/CustomerIO : io/customer/sdk/DataPipe
 	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun initialize ()V
 	public static final fun instance ()Lio/customer/sdk/android/CustomerIO;
+	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
 	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -154,6 +154,57 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     }
 
     /**
+     * The screen methods represents screen views in your mobile apps
+     *
+     * @param name A name for the screen.
+     * @param properties Additional details about the screen.
+     * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
+     */
+    @JvmOverloads
+    fun screen(name: String, properties: JsonObject = emptyJsonObject) {
+        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+    }
+
+    /**
+     * The screen methods represents screen views in your mobile apps
+     *
+     * @param name A name for the screen.
+     * @param properties Additional details about the screen in Map <String, Any> format.
+     * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
+     */
+    fun screen(name: String, properties: CustomAttributes) {
+        // Method needed for Java interop as inline doesn't work with Java
+        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+    }
+
+    /**
+     * The screen methods represents screen views in your mobile apps
+     *
+     * @param name A name for the screen.
+     * @param properties Additional details about the screen.
+     * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
+     */
+    abstract fun <T> screen(
+        name: String,
+        properties: T,
+        serializationStrategy: SerializationStrategy<T>
+    )
+
+    /**
+     * The screen methods represents screen views in your mobile apps
+     *
+     * @param name A name for the screen.
+     * @param properties Additional details about the screen.
+     * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
+     */
+    inline fun <reified T> screen(
+        name: String,
+        properties: T
+    ) {
+        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+    }
+
+    /**
      * Stop identifying the currently persisted customer. All future calls to the SDK will no longer
      * be associated with the previously identified customer.
      * Note: If you simply want to identify a *new* customer, this function call is optional. Simply

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -156,36 +156,36 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     /**
      * The screen methods represents screen views in your mobile apps
      *
-     * @param name A name for the screen.
+     * @param title A name for the screen.
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
     @JvmOverloads
-    fun screen(name: String, properties: JsonObject = emptyJsonObject) {
-        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+    fun screen(title: String, properties: JsonObject = emptyJsonObject) {
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
      * The screen methods represents screen views in your mobile apps
      *
-     * @param name A name for the screen.
+     * @param title A name for the screen.
      * @param properties Additional details about the screen in Map <String, Any> format.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    fun screen(name: String, properties: CustomAttributes) {
+    fun screen(title: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
      * The screen methods represents screen views in your mobile apps
      *
-     * @param name A name for the screen.
+     * @param title A name for the screen.
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
     abstract fun <T> screen(
-        name: String,
+        title: String,
         properties: T,
         serializationStrategy: SerializationStrategy<T>
     )
@@ -193,15 +193,15 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     /**
      * The screen methods represents screen views in your mobile apps
      *
-     * @param name A name for the screen.
+     * @param title A name for the screen.
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
     inline fun <reified T> screen(
-        name: String,
+        title: String,
         properties: T
     ) {
-        screen(name, properties, JsonAnySerializer.serializersModule.serializer())
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
     }
 
     /**

--- a/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
@@ -147,9 +147,9 @@ class CustomerIO private constructor(
      * Common method to track an screen with properties.
      * All other screen methods should call this method to ensure consistency.
      */
-    override fun <T> screen(name: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
-        logger.debug("track a screen with title $name, properties $properties")
-        analytics.screen(title = name, properties = properties, serializationStrategy = serializationStrategy)
+    override fun <T> screen(title: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
+        logger.debug("track a screen with title $title, properties $properties")
+        analytics.screen(title = title, properties = properties, serializationStrategy = serializationStrategy)
     }
 
     override fun clearIdentify() {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
@@ -143,6 +143,15 @@ class CustomerIO private constructor(
         analytics.track(name = name, properties = properties, serializationStrategy = serializationStrategy)
     }
 
+    /**
+     * Common method to track an screen with properties.
+     * All other screen methods should call this method to ensure consistency.
+     */
+    override fun <T> screen(name: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
+        logger.debug("track a screen with title $name, properties $properties")
+        analytics.screen(title = name, properties = properties, serializationStrategy = serializationStrategy)
+    }
+
     override fun clearIdentify() {
         val userId = registeredUserId ?: "anonymous"
         logger.debug("resetting user profile with id $userId")

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/customTrack/CustomEvent.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/customTrack/CustomEvent.kt
@@ -44,7 +44,7 @@ fun CustomEventRoute(
     val context = LocalContext.current
 
     TrackScreenLifecycle(lifecycleOwner = LocalLifecycleOwner.current, onScreenEnter = {
-        CustomerIO.instance().screen("Custom Event")
+        io.customer.sdk.android.CustomerIO.instance().screen("Custom Event")
     })
 
     Column(

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
@@ -45,7 +45,7 @@ fun DashboardRoute(
     val userState = viewModel.uiState.collectAsState()
 
     TrackScreenLifecycle(lifecycleOwner = LocalLifecycleOwner.current, onScreenEnter = {
-        CustomerIO.instance().screen("Dashboard")
+        io.customer.sdk.android.CustomerIO.instance().screen("Dashboard")
     })
 
     DashboardScreen(

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/login/Login.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/login/Login.kt
@@ -46,7 +46,7 @@ fun LoginRoute(
     TrackScreenLifecycle(
         lifecycleOwner = LocalLifecycleOwner.current,
         onScreenEnter = {
-            CustomerIO.instance().screen("Login")
+            io.customer.sdk.android.CustomerIO.instance().screen("Login")
         }
     )
 

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/settings/Settings.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/settings/Settings.kt
@@ -62,7 +62,7 @@ fun SettingsRoute(
     val state by settingsViewModel.uiState.collectAsState()
 
     TrackScreenLifecycle(lifecycleOwner = LocalLifecycleOwner.current, onScreenEnter = {
-        CustomerIO.instance().screen("Settings")
+        io.customer.sdk.android.CustomerIO.instance().screen("Settings")
     })
 
     SettingsScreen(


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-216/track-a-screen-view-manually

- Added public APIs to track screen events
- Update sample apps to utilize the new APIs

Tests are going to follow in the next PR when the base setup PR is merged.