### PR TITLE
chore: add track screen tests

### DIFF
--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -6,6 +6,7 @@ import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.getString
 import io.customer.datapipelines.core.UnitTest
 import io.customer.datapipelines.extensions.decodeJson
+import io.customer.datapipelines.extensions.shouldMatchTo
 import io.customer.datapipelines.extensions.toJsonObject
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.android.CustomerIO
@@ -14,10 +15,13 @@ import io.customer.sdk.extensions.random
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 
 class DataPipelinesCompatibilityTests : UnitTest() {
@@ -59,22 +63,25 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         return JsonArray(result)
     }
 
+    /**
+     * Identify tests
+     */
     @Test
     fun identify_givenIdentifierOnly_expectSetNewProfileWithoutAttributes() = runTest {
         val givenIdentifier = String.random
 
         sdkInstance.identify(givenIdentifier)
 
-        storage.read(Storage.Constants.UserId).shouldBeEqualTo(givenIdentifier)
-        storage.read(Storage.Constants.Traits).decodeJson().shouldBeEqualTo(emptyJsonObject)
+        storage.read(Storage.Constants.UserId) shouldBeEqualTo givenIdentifier
+        storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo emptyJsonObject
 
         val queuedEvents = getQueuedEvents()
-        queuedEvents.count().shouldBeEqualTo(1)
+        queuedEvents.count() shouldBeEqualTo 1
 
         val payload = queuedEvents.first().jsonObject
-        payload.eventType.shouldBeEqualTo("identify")
-        payload.userId.shouldBeEqualTo(givenIdentifier)
-        payload.containsKey("traits").shouldBeFalse()
+        payload.eventType shouldBeEqualTo "identify"
+        payload.userId shouldBeEqualTo givenIdentifier
+        payload.containsKey("traits") shouldBe false
     }
 
     @Test
@@ -85,21 +92,193 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.identify(givenIdentifier, givenTraits)
 
-        storage.read(Storage.Constants.UserId).shouldBeEqualTo(givenIdentifier)
-        storage.read(Storage.Constants.Traits).decodeJson().shouldBeEqualTo(givenTraitsJson)
+        storage.read(Storage.Constants.UserId) shouldBeEqualTo givenIdentifier
+        storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo givenTraitsJson
 
         val queuedEvents = getQueuedEvents()
-        queuedEvents.count().shouldBeEqualTo(1)
+        queuedEvents.count() shouldBeEqualTo 1
 
         val payload = queuedEvents.first().jsonObject
-        payload.eventType.shouldBeEqualTo("identify")
-        payload.userId.shouldBeEqualTo(givenIdentifier)
-        payload["traits"]?.jsonObject.shouldBeEqualTo(givenTraitsJson)
+        payload.eventType shouldBeEqualTo "identify"
+        payload.userId shouldBeEqualTo givenIdentifier
+        payload["traits"]?.jsonObject shouldBeEqualTo givenTraitsJson
+    }
+
+    /**
+     * Track tests
+     */
+
+    @Test
+    fun track_givenEventWithoutProperties_expectTrackWithoutProperties() = runTest {
+        val givenEvent = String.random
+
+        sdkInstance.track(givenEvent)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "track"
+        payload["properties"]?.jsonObject shouldBeEqualTo emptyJsonObject
+    }
+
+    @Test
+    fun track_givenEventWithPropertiesMap_expectTrackWithProperties() = runTest {
+        val givenEvent = String.random
+        val givenProperties: CustomAttributes = mapOf("size" to "Medium", "waist" to 32)
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "track"
+        payload.eventName shouldBeEqualTo givenEvent
+        payload["properties"]?.jsonObject!! shouldMatchTo givenProperties
+    }
+
+    @Test
+    fun track_givenEventWithPropertiesJson_expectTrackWithProperties() = runTest {
+        val givenEvent = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "track"
+        payload.eventName shouldBeEqualTo givenEvent
+        payload["properties"]?.jsonObject shouldBeEqualTo givenProperties
+    }
+
+    @Test
+    fun track_givenIdentifiedEventWithProperties_expectTrackWithProperties() = runTest {
+        sdkInstance.identify(String.random)
+        val givenEvent = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldNotBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 2
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "identify"
+        val payload2 = queuedEvents.last().jsonObject
+        payload2.eventType shouldBeEqualTo "track"
+        payload2.eventName shouldBeEqualTo givenEvent
+        payload2["properties"]?.jsonObject shouldBeEqualTo givenProperties
+    }
+
+    /**
+     * Screen tests
+     */
+
+    @Test
+    fun screen_givenEventWithoutProperties_expectTrackWithoutProperties() = runTest {
+        val givenTitle = String.random
+
+        sdkInstance.screen(givenTitle)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "screen"
+        payload.screenName shouldBeEqualTo givenTitle
+        payload["properties"]?.jsonObject shouldBeEqualTo emptyJsonObject
+    }
+
+    @Test
+    fun screen_givenEventWithPropertiesMap_expectTrackWithProperties() = runTest {
+        val givenTitle = String.random
+        val givenProperties: CustomAttributes = mapOf("width" to 11, "height" to 32)
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "screen"
+        payload.screenName shouldBeEqualTo givenTitle
+        payload["properties"]?.jsonObject!! shouldMatchTo givenProperties
+    }
+
+    @Test
+    fun screen_givenEventWithPropertiesJson_expectTrackWithProperties() = runTest {
+        val givenTitle = String.random
+        val givenProperties = buildJsonObject {
+            put("zoom", "wide")
+            put("height", 13)
+        }
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "screen"
+        payload.screenName shouldBeEqualTo givenTitle
+        payload["properties"]?.jsonObject shouldBeEqualTo givenProperties
+    }
+
+    @Test
+    fun screen_givenIdentifiedEventWithProperties_expectTrackWithProperties() = runTest {
+        sdkInstance.identify(String.random)
+        val givenTitle = String.random
+        val givenProperties = buildJsonObject {
+            put("zoom", "wide")
+            put("height", 53)
+        }
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        storage.read(Storage.Constants.UserId) shouldNotBe null
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count() shouldBeEqualTo 2
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType shouldBeEqualTo "identify"
+        val payload2 = queuedEvents.last().jsonObject
+        payload2.eventType shouldBeEqualTo "screen"
+        payload2.screenName shouldBeEqualTo givenTitle
+        payload2["properties"]?.jsonObject shouldBeEqualTo givenProperties
     }
 }
 
 private val JsonElement.eventType: String?
     get() = this.jsonObject.getString("type")
-
+private val JsonElement.eventName: String?
+    get() = this.jsonObject.getString("event")
+private val JsonElement.screenName: String?
+    get() = this.jsonObject.getString("name")
 private val JsonElement.userId: String?
     get() = this.jsonObject.getString("userId")

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.put
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 
 class DataPipelinesCompatibilityTests : UnitTest() {
@@ -110,12 +111,10 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.track(givenEvent)
 
-        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
-        storage.read(Storage.Constants.UserId) shouldBe null
         storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo emptyJsonObject
 
         val queuedEvents = getQueuedEvents()
-        queuedEvents.count().shouldBeEqualTo(1)
+        queuedEvents.count() shouldBeEqualTo 1
 
         val payload = queuedEvents.first().jsonObject
         payload.eventType.shouldBeEqualTo("track")
@@ -133,9 +132,6 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         val givenEvent = String.random
 
         sdkInstance.track(givenEvent)
-
-        storage.read(Storage.Constants.UserId) shouldBe null
-        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
 
         val queuedEvents = getQueuedEvents()
         queuedEvents.count() shouldBeEqualTo 1
@@ -160,7 +156,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         val payload = queuedEvents.first().jsonObject
         payload.eventType shouldBeEqualTo "track"
         payload.eventName shouldBeEqualTo givenEvent
-        payload["properties"]?.jsonObject!! shouldMatchTo givenProperties
+        payload["properties"]?.jsonObject.shouldNotBeNull() shouldMatchTo givenProperties
     }
 
     @Test
@@ -218,9 +214,6 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.screen(givenTitle)
 
-        storage.read(Storage.Constants.UserId) shouldBe null
-        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
-
         val queuedEvents = getQueuedEvents()
         queuedEvents.count() shouldBeEqualTo 1
 
@@ -245,7 +238,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         val payload = queuedEvents.first().jsonObject
         payload.eventType shouldBeEqualTo "screen"
         payload.screenName shouldBeEqualTo givenTitle
-        payload["properties"]?.jsonObject!! shouldMatchTo givenProperties
+        payload["properties"]?.jsonObject.shouldNotBeNull() shouldMatchTo givenProperties
     }
 
     @Test
@@ -287,10 +280,10 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         val payload = queuedEvents.first().jsonObject
         payload.eventType shouldBeEqualTo "identify"
-        val payload2 = queuedEvents.last().jsonObject
-        payload2.eventType shouldBeEqualTo "screen"
-        payload2.screenName shouldBeEqualTo givenTitle
-        payload2["properties"]?.jsonObject shouldBeEqualTo givenProperties
+        val trackPayload = queuedEvents.last().jsonObject
+        trackPayload.eventType shouldBeEqualTo "screen"
+        trackPayload.screenName shouldBeEqualTo givenTitle
+        trackPayload["properties"]?.jsonObject shouldBeEqualTo givenProperties
     }
 }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -110,7 +110,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.track(givenEvent)
 
-        storage.read(Storage.Constants.AnonymousId) shouldBe null
+        storage.read(Storage.Constants.AnonymousId) shouldNotBe null
         storage.read(Storage.Constants.UserId) shouldBe null
         storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo emptyJsonObject
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -104,6 +104,26 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         payload["traits"]?.jsonObject shouldBeEqualTo givenTraitsJson
     }
 
+    @Test
+    fun event_withoutIdentify_expectFinalJsonHasNoUserId() = runTest {
+        val givenEvent = String.random
+
+        sdkInstance.track(givenEvent)
+
+        storage.read(Storage.Constants.AnonymousId) shouldBe null
+        storage.read(Storage.Constants.UserId) shouldBe null
+        storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo emptyJsonObject
+
+        val queuedEvents = getQueuedEvents()
+        queuedEvents.count().shouldBeEqualTo(1)
+
+        val payload = queuedEvents.first().jsonObject
+        payload.eventType.shouldBeEqualTo("track")
+        payload.jsonObject.getString("anonymousId") shouldNotBe null
+        payload.userId shouldBe null
+        payload.containsKey("traits") shouldBe false
+    }
+
     /**
      * Track tests
      */

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -4,14 +4,23 @@ import com.segment.analytics.kotlin.core.emptyJsonObject
 import io.customer.datapipelines.core.UnitTest
 import io.customer.datapipelines.extensions.shouldMatchTo
 import io.customer.datapipelines.utils.identifyEvents
+import io.customer.datapipelines.utils.screenEvents
+import io.customer.datapipelines.utils.trackEvents
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.extensions.random
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 
 class DataPipelinesInteractionTests : UnitTest() {
+    /**
+     * Identify event tests
+     */
     @Test
     fun identify_givenIdentifierOnly_expectSetNewProfileWithoutAttributes() {
         val givenIdentifier = String.random
@@ -49,9 +58,184 @@ class DataPipelinesInteractionTests : UnitTest() {
         val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
         identifyEvent.shouldNotBeNull()
 
-        identifyEvent.userId.shouldBeEqualTo(givenIdentifier)
+        identifyEvent.userId shouldBeEqualTo givenIdentifier
         identifyEvent.traits
             .shouldNotBeNull()
             .shouldMatchTo(givenTraits)
+    }
+
+    /**
+     * Track event tests
+     */
+    @Test
+    fun track_givenEventOnly_expectTrackEventWithoutProperties() {
+        val givenEvent = String.random
+
+        sdkInstance.track(givenEvent)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
+        trackEvent.shouldNotBeNull()
+
+        trackEvent.event shouldBeEqualTo givenEvent
+        trackEvent.properties shouldBeEqualTo emptyJsonObject
+    }
+
+    @Test
+    fun track_givenEventWithPropertiesMap_expectTrackEventWithProperties() {
+        val givenEvent = String.random
+        val givenProperties: CustomAttributes = mapOf("action" to "dismiss", "validity" to 30)
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
+        trackEvent.shouldNotBeNull()
+
+        trackEvent.event shouldBeEqualTo givenEvent
+        trackEvent.properties shouldMatchTo givenProperties
+    }
+
+    @Test
+    fun track_givenEventWithPropertiesJson_expectTrackEventWithProperties() {
+        val givenEvent = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
+        trackEvent.shouldNotBeNull()
+
+        trackEvent.event shouldBeEqualTo givenEvent
+        trackEvent.properties shouldBeEqualTo givenProperties
+    }
+
+    @Test
+    fun track_givenIdentifiedEventWithProperties_expectTrackEventWithProperties() {
+        val givenIdentifier = String.random
+        val givenEvent = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+        sdkInstance.identify(givenIdentifier)
+
+        sdkInstance.track(givenEvent, givenProperties)
+
+        analytics.userId() shouldBe givenIdentifier
+
+        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+
+        val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
+        identifyEvent.shouldNotBeNull()
+
+        val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
+        trackEvent.shouldNotBeNull()
+
+        identifyEvent.userId shouldBeEqualTo givenIdentifier
+        trackEvent.event shouldBeEqualTo givenEvent
+        trackEvent.properties shouldBeEqualTo givenProperties
+    }
+
+    /**
+     * Screen event tests
+     */
+
+    @Test
+    fun screen_givenEventOnly_expectScreenEventWithoutProperties() {
+        val givenTitle = String.random
+
+        sdkInstance.screen(givenTitle)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
+        screenEvent.shouldNotBeNull()
+
+        screenEvent.name shouldBeEqualTo givenTitle
+        screenEvent.properties shouldBeEqualTo emptyJsonObject
+    }
+
+    @Test
+    fun screen_givenEventWithPropertiesMap_expectScreenEventWithProperties() {
+        val givenTitle = String.random
+        val givenProperties: CustomAttributes = mapOf("action" to "dismiss", "validity" to 30)
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
+        screenEvent.shouldNotBeNull()
+
+        screenEvent.name shouldBeEqualTo givenTitle
+        screenEvent.properties shouldMatchTo givenProperties
+    }
+
+    @Test
+    fun screen_givenEventWithPropertiesJson_expectScreenEventWithProperties() {
+        val givenTitle = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        analytics.userId() shouldBe null
+        analytics.anonymousId() shouldNotBe null
+
+        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
+        screenEvent.shouldNotBeNull()
+
+        screenEvent.name shouldBeEqualTo givenTitle
+        screenEvent.properties shouldBeEqualTo givenProperties
+    }
+
+    @Test
+    fun screen_givenIdentifiedEventWithProperties_expectScreenEventWithProperties() {
+        val givenIdentifier = String.random
+        val givenTitle = String.random
+        val givenProperties = buildJsonObject {
+            put("cool", "dude")
+            put("age", 53)
+        }
+        sdkInstance.identify(givenIdentifier)
+
+        sdkInstance.screen(givenTitle, givenProperties)
+
+        analytics.userId() shouldBe givenIdentifier
+
+        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+
+        val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
+        identifyEvent.shouldNotBeNull()
+
+        val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
+        screenEvent.shouldNotBeNull()
+
+        identifyEvent.userId shouldBeEqualTo givenIdentifier
+        screenEvent.name shouldBeEqualTo givenTitle
+        screenEvent.properties shouldBeEqualTo givenProperties
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -32,7 +32,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId().shouldBeEqualTo(givenIdentifier)
         analytics.traits().shouldBeEqualTo(emptyJsonObject)
 
-        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
         val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
         identifyEvent.shouldNotBeNull()
 
@@ -54,7 +54,7 @@ class DataPipelinesInteractionTests : UnitTest() {
             .shouldNotBeNull()
             .shouldMatchTo(givenTraits)
 
-        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
         val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
         identifyEvent.shouldNotBeNull()
 
@@ -76,7 +76,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
         val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
         trackEvent.shouldNotBeNull()
 
@@ -94,7 +94,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
         val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
         trackEvent.shouldNotBeNull()
 
@@ -115,7 +115,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
         val trackEvent = outputReaderPlugin.trackEvents.lastOrNull()
         trackEvent.shouldNotBeNull()
 
@@ -137,8 +137,8 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         analytics.userId() shouldBe givenIdentifier
 
-        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
-        outputReaderPlugin.trackEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
 
         val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
         identifyEvent.shouldNotBeNull()
@@ -164,7 +164,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.screenEvents.size shouldBeEqualTo 1
         val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
         screenEvent.shouldNotBeNull()
 
@@ -182,7 +182,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.screenEvents.size shouldBeEqualTo 1
         val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
         screenEvent.shouldNotBeNull()
 
@@ -203,7 +203,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.userId() shouldBe null
         analytics.anonymousId() shouldNotBe null
 
-        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.screenEvents.size shouldBeEqualTo 1
         val screenEvent = outputReaderPlugin.screenEvents.lastOrNull()
         screenEvent.shouldNotBeNull()
 
@@ -225,8 +225,8 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         analytics.userId() shouldBe givenIdentifier
 
-        outputReaderPlugin.identifyEvents.size.shouldBeEqualTo(1)
-        outputReaderPlugin.screenEvents.size.shouldBeEqualTo(1)
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
+        outputReaderPlugin.screenEvents.size shouldBeEqualTo 1
 
         val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
         identifyEvent.shouldNotBeNull()


### PR DESCRIPTION
adds compatibility and interaction tests for `track` and `screen`

closes:
- https://linear.app/customerio/issue/MBL-212/track-an-event-manually
- https://linear.app/customerio/issue/MBL-216/track-a-screen-view-manually