### PR TITLE
test: identify user profile

### DIFF
--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -30,6 +30,8 @@ import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 
 class DataPipelinesCompatibilityTests : UnitTest() {
+    //region Setup test environment
+
     private lateinit var storage: Storage
 
     override fun initializeModule() {
@@ -68,9 +70,9 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         return JsonArray(result)
     }
 
-    /**
-     * Identify tests
-     */
+    //endregion
+    //region Identify
+
     @Test
     fun identify_givenIdentifierOnly_expectFinalJsonHasNewProfile() = runTest {
         val givenIdentifier = String.random
@@ -132,6 +134,9 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         payload["traits"]?.jsonObject.shouldBeEqualTo(givenTraitsJson)
     }
 
+    //endregion
+    //region Clear identify
+
     @Test
     fun identify_clearIdentify_givenPreviouslyIdentifiedProfile_expectUserReset() {
         val previousAnonymousId = storage.read(Storage.Constants.AnonymousId)
@@ -143,6 +148,9 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         storage.read(Storage.Constants.UserId).shouldBeNull()
         storage.read(Storage.Constants.Traits).decodeJson() shouldBeEqualTo emptyJsonObject
     }
+
+    //endregion
+    //region Anonymous user
 
     @Test
     fun event_withoutIdentify_expectFinalJsonHasNoUserId() = runTest {
@@ -162,9 +170,8 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         payload.containsKey("traits") shouldBe false
     }
 
-    /**
-     * Track tests
-     */
+    //endregion
+    //region Track event
 
     @Test
     fun track_givenEventWithoutProperties_expectTrackWithoutProperties() = runTest {
@@ -243,9 +250,8 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         payload2["properties"]?.jsonObject shouldBeEqualTo givenProperties
     }
 
-    /**
-     * Screen tests
-     */
+    //endregion
+    //region Track screen
 
     @Test
     fun screen_givenEventWithoutProperties_expectTrackWithoutProperties() = runTest {
@@ -324,7 +330,11 @@ class DataPipelinesCompatibilityTests : UnitTest() {
         trackPayload.screenName shouldBeEqualTo givenTitle
         trackPayload["properties"]?.jsonObject shouldBeEqualTo givenProperties
     }
+
+    //endregion
 }
+
+//region Json extensions
 
 private val JsonElement.eventType: String?
     get() = this.jsonObject.getString("type")
@@ -334,3 +344,5 @@ private val JsonElement.screenName: String?
     get() = this.jsonObject.getString("name")
 private val JsonElement.userId: String?
     get() = this.jsonObject.getString("userId")
+
+//endregion

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -23,6 +23,8 @@ import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 
 class DataPipelinesInteractionTests : UnitTest() {
+    //region Setup test environment
+
     private lateinit var outputReaderPlugin: OutputReaderPlugin
 
     override fun initializeModule() {
@@ -32,9 +34,9 @@ class DataPipelinesInteractionTests : UnitTest() {
         analytics.add(outputReaderPlugin)
     }
 
-    /**
-     * Identify event tests
-     */
+    //endregion
+    //region Identify
+
     @Test
     fun identify_givenIdentifierOnly_expectSetNewProfileWithoutAttributes() {
         val givenIdentifier = String.random
@@ -158,6 +160,9 @@ class DataPipelinesInteractionTests : UnitTest() {
         outputReaderPlugin.allEvents.shouldBeEmpty()
     }
 
+    //endregion
+    //region Clear identify
+
     @Test
     fun identify_clearIdentify_givenPreviouslyIdentifiedProfile_expectUserReset() {
         val previousAnonymousId = analytics.anonymousId()
@@ -173,9 +178,9 @@ class DataPipelinesInteractionTests : UnitTest() {
         outputReaderPlugin.allEvents.shouldBeEmpty()
     }
 
-    /**
-     * Track event tests
-     */
+    //endregion
+    //region Track event
+
     @Test
     fun track_givenEventOnly_expectTrackEventWithoutProperties() {
         val givenEvent = String.random
@@ -260,9 +265,8 @@ class DataPipelinesInteractionTests : UnitTest() {
         trackEvent.properties shouldBeEqualTo givenProperties
     }
 
-    /**
-     * Screen event tests
-     */
+    //endregion
+    //region Track screen
 
     @Test
     fun screen_givenEventOnly_expectScreenEventWithoutProperties() {
@@ -347,4 +351,6 @@ class DataPipelinesInteractionTests : UnitTest() {
         screenEvent.name shouldBeEqualTo givenTitle
         screenEvent.properties shouldBeEqualTo givenProperties
     }
+
+    //endregion
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -160,6 +160,23 @@ class DataPipelinesInteractionTests : UnitTest() {
         outputReaderPlugin.allEvents.shouldBeEmpty()
     }
 
+    @Test
+    fun identify_givenEmptyIdentifier_givenProfileAlreadyIdentifiedWithTraits_expectRequestIgnored() {
+        val givenIdentifier = ""
+        val givenPreviouslyIdentifiedProfile = String.random
+        val givenPreviouslyIdentifiedTraits: CustomAttributes = mapOf("first_name" to "Dana", "ageInYears" to 30)
+
+        sdkInstance.identify(givenPreviouslyIdentifiedProfile, givenPreviouslyIdentifiedTraits)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier, emptyMap())
+
+        analytics.userId() shouldBeEqualTo givenPreviouslyIdentifiedProfile
+        analytics.traits().shouldNotBeNull() shouldMatchTo givenPreviouslyIdentifiedTraits
+
+        outputReaderPlugin.allEvents.shouldBeEmpty()
+    }
+
     //endregion
     //region Clear identify
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -2,16 +2,32 @@ package io.customer.datapipelines
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import io.customer.datapipelines.core.UnitTest
+import io.customer.datapipelines.extensions.encodeToJsonElement
 import io.customer.datapipelines.extensions.shouldMatchTo
+import io.customer.datapipelines.support.UserTraits
+import io.customer.datapipelines.utils.OutputReaderPlugin
 import io.customer.datapipelines.utils.identifyEvents
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.extensions.random
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 
 class DataPipelinesInteractionTests : UnitTest() {
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun initializeModule() {
+        super.initializeModule()
+
+        outputReaderPlugin = OutputReaderPlugin(analytics)
+        analytics.add(outputReaderPlugin)
+    }
+
     @Test
     fun identify_givenIdentifierOnly_expectSetNewProfileWithoutAttributes() {
         val givenIdentifier = String.random
@@ -53,5 +69,100 @@ class DataPipelinesInteractionTests : UnitTest() {
         identifyEvent.traits
             .shouldNotBeNull()
             .shouldMatchTo(givenTraits)
+    }
+
+    @Test
+    fun identify_givenIdentifierWithJson_expectSetNewProfileWithAttributes() {
+        val givenIdentifier = String.random
+        val givenFirstNamePair = "first_name" to "Dana"
+        val givenAgePair = "ageInYears" to 30
+        val givenTraits = mapOf(givenFirstNamePair, givenAgePair)
+
+        analytics.userId().shouldBeNull()
+
+        sdkInstance.identify(
+            givenIdentifier,
+            buildJsonObject {
+                put(givenFirstNamePair.first, givenFirstNamePair.second)
+                put(givenAgePair.first, givenAgePair.second)
+            }
+        )
+
+        analytics.userId() shouldBeEqualTo (givenIdentifier)
+        analytics.traits().shouldNotBeNull() shouldMatchTo givenTraits
+
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
+        val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
+        identifyEvent.shouldNotBeNull()
+
+        identifyEvent.userId shouldBeEqualTo givenIdentifier
+        identifyEvent.traits.shouldNotBeNull() shouldMatchTo givenTraits
+    }
+
+    @Test
+    fun identify_givenIdentifierWithTraits_expectSetNewProfileWithAttributes() {
+        val givenIdentifier = String.random
+        val givenTraits = UserTraits(
+            firstName = "Dana",
+            ageInYears = 30
+        )
+        val givenTraitsJson = givenTraits.encodeToJsonElement()
+
+        analytics.userId().shouldBeNull()
+
+        sdkInstance.identify(givenIdentifier, givenTraits)
+
+        analytics.userId() shouldBeEqualTo givenIdentifier
+        analytics.traits().shouldNotBeNull() shouldBeEqualTo givenTraitsJson
+
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
+        val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
+        identifyEvent.shouldNotBeNull()
+
+        identifyEvent.userId shouldBeEqualTo givenIdentifier
+        identifyEvent.traits.shouldNotBeNull() shouldBeEqualTo givenTraitsJson
+    }
+
+    @Test
+    fun identify_givenEmptyIdentifier_givenNoProfilePreviouslyIdentified_expectRequestIgnored() {
+        val givenIdentifier = ""
+
+        sdkInstance.identify(givenIdentifier)
+
+        analytics.userId().shouldBeNull()
+        analytics.traits() shouldBeEqualTo emptyJsonObject
+
+        outputReaderPlugin.allEvents.shouldBeEmpty()
+    }
+
+    @Test
+    fun identify_givenEmptyIdentifier_givenProfileAlreadyIdentified_expectRequestIgnored() {
+        val givenIdentifier = ""
+        val givenPreviouslyIdentifiedProfile = String.random
+
+        sdkInstance.identify(givenPreviouslyIdentifiedProfile)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier)
+
+        analytics.userId() shouldBeEqualTo givenPreviouslyIdentifiedProfile
+        analytics.traits() shouldBeEqualTo emptyJsonObject
+
+        outputReaderPlugin.allEvents.shouldBeEmpty()
+    }
+
+    @Test
+    fun identify_clearIdentify_givenPreviouslyIdentifiedProfile_expectUserReset() {
+        val previousAnonymousId = analytics.anonymousId()
+        sdkInstance.identify(String.random)
+        outputReaderPlugin.reset()
+
+        sdkInstance.clearIdentify()
+
+        analytics.anonymousId().shouldNotBeNull() shouldNotBeEqualTo previousAnonymousId
+        analytics.userId().shouldBeNull()
+        analytics.traits().shouldBeNull()
+
+        outputReaderPlugin.allEvents.shouldBeEmpty()
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
@@ -3,7 +3,6 @@ package io.customer.datapipelines.core
 import com.segment.analytics.kotlin.core.Analytics
 import io.customer.commontest.BaseUnitTest
 import io.customer.datapipelines.extensions.registerAnalyticsFactory
-import io.customer.datapipelines.utils.OutputReaderPlugin
 import io.customer.datapipelines.utils.clearPersistentStorage
 import io.customer.datapipelines.utils.createTestAnalyticsInstance
 import io.customer.datapipelines.utils.mockHTTPClient
@@ -20,7 +19,6 @@ import org.mockito.kotlin.mock
 abstract class UnitTest : BaseUnitTest() {
     protected lateinit var sdkInstance: CustomerIO
     protected lateinit var analytics: Analytics
-    protected lateinit var outputReaderPlugin: OutputReaderPlugin
 
     protected val cdpApiKey: String
         get() = sdkInstance.moduleConfig.cdpApiKey
@@ -36,9 +34,6 @@ abstract class UnitTest : BaseUnitTest() {
 
         sdkInstance = createModuleInstance()
         analytics = sdkInstance.analytics
-
-        outputReaderPlugin = OutputReaderPlugin(analytics)
-        analytics.add(outputReaderPlugin)
     }
 
     protected open fun setupDependencies() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/JsonExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/JsonExt.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
 import org.amshove.kluent.internal.assertEquals
 
 /**
@@ -40,6 +41,13 @@ fun CustomAttributes?.toJsonObject(): JsonObject {
 fun String?.decodeJson(): JsonObject = this?.let { json ->
     Json.decodeFromString(json)
 } ?: emptyJsonObject
+
+/**
+ * Encodes a serializable object to a JSON element.
+ */
+inline fun <reified T> T.encodeToJsonElement(): JsonElement {
+    return Json.encodeToJsonElement(this)
+}
 
 @OptIn(ExperimentalSerializationApi::class)
 private fun <T> Json.encode(value: T?): JsonElement = when (value) {

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/UserTraits.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/UserTraits.kt
@@ -1,0 +1,15 @@
+package io.customer.datapipelines.support
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Serializable data class representing user traits.
+ * The class is helpful for testing purposes as it can be serialized and can be used as user traits.
+ */
+@Serializable
+data class UserTraits(
+    @SerialName("first_name")
+    val firstName: String,
+    val ageInYears: Int
+)


### PR DESCRIPTION
part of [MBL-214](https://linear.app/customerio/issue/MBL-214/identify-a-profile)

### Changes

- Added more tests to `DataPipelinesInteractionTests` and `DataPipelinesCompatibilityTests` for identify profile
- Moved `OutputReaderPlugin` out of `UnitTest` to avoid being misused
- Added helper extensions and `UserTraits` class to test package