### PR TITLE
feat: add support for automatic activity screen tracking

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -1,8 +1,9 @@
 public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getApiHost ()Ljava/lang/String;
 	public final fun getAutoAddCustomerIODestination ()Z
+	public final fun getAutoTrackActivityScreens ()Z
 	public final fun getAutoTrackDeviceAttributes ()Z
 	public final fun getCdnHost ()Ljava/lang/String;
 	public final fun getCdpApiKey ()Ljava/lang/String;
@@ -16,6 +17,24 @@ public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : 
 public final class io/customer/datapipelines/extensions/RegionExtKt {
 	public static final fun apiHost (Lio/customer/sdk/data/model/Region;)Ljava/lang/String;
 	public static final fun cdnHost (Lio/customer/sdk/data/model/Region;)Ljava/lang/String;
+}
+
+public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin : com/segment/analytics/kotlin/android/plugins/AndroidLifecycle, com/segment/analytics/kotlin/core/platform/Plugin {
+	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun <init> ()V
+	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 
 public final class io/customer/datapipelines/plugins/CustomerIODestination : com/segment/analytics/kotlin/core/platform/DestinationPlugin, com/segment/analytics/kotlin/core/platform/VersionedPlugin, sovran/kotlin/Subscriber {
@@ -67,12 +86,21 @@ public final class io/customer/datapipelines/plugins/CustomerIOSettings$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/customer/datapipelines/plugins/StringExtensionsKt {
+	public static final fun getScreenNameFromActivity (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class io/customer/datapipelines/plugins/TrackableScreen {
+	public abstract fun getScreenName ()Ljava/lang/String;
+}
+
 public final class io/customer/sdk/CustomerIOBuilder {
 	public fun <init> (Landroid/app/Application;Ljava/lang/String;)V
 	public final fun addCustomerIOModule (Lio/customer/sdk/core/module/CustomerIOModule;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun build ()Lio/customer/sdk/android/CustomerIO;
 	public final fun setApiHost (Ljava/lang/String;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun setAutoAddCustomerIODestination (Z)Lio/customer/sdk/CustomerIOBuilder;
+	public final fun setAutoTrackActivityScreens (Z)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun setAutoTrackDeviceAttributes (Z)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun setCdnHost (Ljava/lang/String;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun setFlushAt (I)Lio/customer/sdk/CustomerIOBuilder;

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
@@ -24,6 +24,8 @@ class DataPipelinesModuleConfig(
     val trackApplicationLifecycleEvents: Boolean,
     // Track device information
     val autoTrackDeviceAttributes: Boolean,
+    // Track screen views for Activities
+    val autoTrackActivityScreens: Boolean,
     // Configuration options required for migration from earlier versions
     val migrationSiteId: String? = null
 ) : CustomerIOModuleConfig {

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
@@ -5,6 +5,8 @@ import android.content.pm.PackageManager
 import com.segment.analytics.kotlin.android.plugins.AndroidLifecycle
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.platform.Plugin
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 
 /**
  * Optional interface for activities that should be tracked using automated screen tracking.
@@ -26,6 +28,7 @@ class AutomaticActivityScreenTrackingPlugin : Plugin, AndroidLifecycle {
 
     override val type: Plugin.Type = Plugin.Type.Utility
     override lateinit var analytics: Analytics
+    private val logger: Logger = SDKComponent.logger
 
     override fun onActivityStarted(activity: Activity?) {
         val packageManager = activity?.packageManager
@@ -46,17 +49,14 @@ class AutomaticActivityScreenTrackingPlugin : Plugin, AndroidLifecycle {
                     }
                 }
             }
-            // If screen name is null, we do not track the screen
-            screenName?.let {
+            // If screen name is null or blank, we do not track the screen
+            if (!screenName.isNullOrBlank()) {
                 analytics.screen(screenName)
             }
         } catch (e: PackageManager.NameNotFoundException) {
-            // if `PackageManager.NameNotFoundException` is thrown, is that a bug in the SDK or a problem with the customer's app?
-            // We may want to decide to log this as an SDK error, log it so customer notices it to fix it themselves, or we do nothing because this exception might not be a big issue.
-            // ActionUtils.getErrorAction(ErrorResult(error = ErrorDetail(message = "Activity Not Found: $e")))
+            logger.error(e.message ?: "Unable to activity screen NameNotFoundException, $activity")
         } catch (e: Exception) {
-            // Should we log exceptions that happen? Ignore them? How rare is an exception happen in this function?
-            // ActionUtils.getErrorAction(ErrorResult(error = ErrorDetail(message = "Unable to track, $activity")))
+            logger.error(e.message ?: "Unable to activity screen, $activity")
         }
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
@@ -1,0 +1,62 @@
+package io.customer.datapipelines.plugins
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import com.segment.analytics.kotlin.android.plugins.AndroidLifecycle
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.platform.Plugin
+
+/**
+ * Optional interface for activities that should be tracked using automated screen tracking.
+ */
+interface TrackableScreen {
+    /**
+     * Retrieve the name that should be used for tracking the screen. This name
+     * should be unique for each screen.
+     *
+     * @return name for tracking the screen, or null if the screen shouldn't be tracked.
+     */
+    fun getScreenName(): String?
+}
+
+/**
+ * Plugin that automatically tracks screens via ActivityLifecycleCallbacks `onActivityStarted` event of an activity.
+ */
+class AutomaticActivityScreenTrackingPlugin : Plugin, AndroidLifecycle {
+
+    override val type: Plugin.Type = Plugin.Type.Utility
+    override lateinit var analytics: Analytics
+
+    override fun onActivityStarted(activity: Activity?) {
+        val packageManager = activity?.packageManager
+        try {
+            val screenName: String? = if (activity is TrackableScreen) {
+                // TrackableScreen takes precedence over manifest label
+                activity.getScreenName()
+            } else {
+                val info = packageManager?.getActivityInfo(
+                    activity.componentName,
+                    PackageManager.GET_META_DATA
+                )
+                val activityLabel = info?.loadLabel(packageManager)
+
+                activity?.let {
+                    activityLabel.toString().ifEmpty {
+                        activity::class.java.simpleName.getScreenNameFromActivity()
+                    }
+                }
+            }
+            // If screen name is null, we do not track the screen
+            screenName?.let {
+                analytics.screen(screenName)
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            // if `PackageManager.NameNotFoundException` is thrown, is that a bug in the SDK or a problem with the customer's app?
+            // We may want to decide to log this as an SDK error, log it so customer notices it to fix it themselves, or we do nothing because this exception might not be a big issue.
+            // ActionUtils.getErrorAction(ErrorResult(error = ErrorDetail(message = "Activity Not Found: $e")))
+        } catch (e: Exception) {
+            // Should we log exceptions that happen? Ignore them? How rare is an exception happen in this function?
+            // ActionUtils.getErrorAction(ErrorResult(error = ErrorDetail(message = "Unable to track, $activity")))
+        }
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/StringExtensions.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/StringExtensions.kt
@@ -1,0 +1,9 @@
+package io.customer.datapipelines.plugins
+
+fun String.getScreenNameFromActivity(): String {
+    val regex = Regex(
+        pattern = "Activity|ListActivity|FragmentActivity|DialogActivity",
+        option = RegexOption.IGNORE_CASE
+    )
+    return this.replace(regex, "")
+}

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -56,6 +56,9 @@ class CustomerIOBuilder(
     // Track device information
     private var autoTrackDeviceAttributes: Boolean = true
 
+    // Track screen views for Activities
+    private var autoTrackActivityScreens: Boolean = false
+
     // Configuration options required for migration from earlier versions
     private var migrationSiteId: String? = null
 
@@ -141,6 +144,15 @@ class CustomerIOBuilder(
     }
 
     /**
+     * Enable this property if you want SDK to automatic track screen views for Activities.
+     * Note: This feature is not useful for UI toolkit like Jetpack Compose as it consist of only one Activity and multiple Composable.
+     */
+    fun setAutoTrackActivityScreens(track: Boolean): CustomerIOBuilder {
+        this.autoTrackActivityScreens = track
+        return this
+    }
+
+    /**
      * Set the migration site id to migrate the events from the tracking SDK version.
      */
     fun setMigrationSiteId(migrationSiteId: String?): CustomerIOBuilder {
@@ -173,6 +185,7 @@ class CustomerIOBuilder(
             autoAddCustomerIODestination = autoAddCustomerIODestination,
             trackApplicationLifecycleEvents = trackApplicationLifecycleEvents,
             autoTrackDeviceAttributes = autoTrackDeviceAttributes,
+            autoTrackActivityScreens = autoTrackActivityScreens,
             migrationSiteId = migrationSiteId
         )
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
@@ -14,6 +14,7 @@ import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.di.analyticsFactory
 import io.customer.datapipelines.extensions.updateAnalyticsConfig
+import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.sdk.DataPipelineInstance
 import io.customer.sdk.core.di.AndroidSDKComponent
@@ -83,6 +84,10 @@ class CustomerIO private constructor(
 
         if (moduleConfig.autoAddCustomerIODestination) {
             analytics.add(CustomerIODestination())
+        }
+
+        if (moduleConfig.autoTrackActivityScreens) {
+            analytics.add(AutomaticActivityScreenTrackingPlugin())
         }
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExt.kt
@@ -1,0 +1,17 @@
+package io.customer.datapipelines.extensions
+import io.customer.datapipelines.plugins.getScreenNameFromActivity
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class StringExt {
+
+    @Test
+    fun verify_activityScreenFormatting_expectFormattedScreenName() {
+        "HomeActivity".getScreenNameFromActivity() shouldBeEqualTo "Home"
+        "ActivityHome".getScreenNameFromActivity() shouldBeEqualTo "Home"
+        "ActivityHomeActivity".getScreenNameFromActivity() shouldBeEqualTo "Home"
+        "ItemsListActivity".getScreenNameFromActivity() shouldBeEqualTo "Items"
+        "ItemsDialogActivity".getScreenNameFromActivity() shouldBeEqualTo "Items"
+        "MapFragmentActivity".getScreenNameFromActivity() shouldBeEqualTo "Map"
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExt.kt
@@ -13,5 +13,6 @@ internal class StringExt {
         "ItemsListActivity".getScreenNameFromActivity() shouldBeEqualTo "Items"
         "ItemsDialogActivity".getScreenNameFromActivity() shouldBeEqualTo "Items"
         "MapFragmentActivity".getScreenNameFromActivity() shouldBeEqualTo "Map"
+        "SplashScreen".getScreenNameFromActivity() shouldBeEqualTo "SplashScreen"
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.app.Application
 import io.customer.commontest.BaseUnitTest
 import io.customer.commontest.module.CustomerIOGenericModule
+import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
+import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.android.CustomerIO
 import io.customer.sdk.core.di.SDKComponent
@@ -11,6 +13,7 @@ import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.extensions.random
 import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -107,6 +110,7 @@ class CustomerIOBuilderTest : BaseUnitTest() {
             .setMigrationSiteId(givenMigrationSiteId)
             .setRegion(givenRegion)
             .setAutoTrackDeviceAttributes(false)
+            .setAutoTrackActivityScreens(true)
             .setTrackApplicationLifecycleEvents(false)
             .setFlushAt(100)
             .setFlushInterval(2)
@@ -118,6 +122,7 @@ class CustomerIOBuilderTest : BaseUnitTest() {
         dataPipelinesModuleConfig.cdpApiKey shouldBe givenCdpApiKey
         dataPipelinesModuleConfig.migrationSiteId shouldBe givenMigrationSiteId
         dataPipelinesModuleConfig.autoTrackDeviceAttributes shouldBe false
+        dataPipelinesModuleConfig.autoTrackActivityScreens shouldBe true
         dataPipelinesModuleConfig.trackApplicationLifecycleEvents shouldBe false
         dataPipelinesModuleConfig.flushAt shouldBe 100
         dataPipelinesModuleConfig.flushInterval shouldBe 2
@@ -126,6 +131,29 @@ class CustomerIOBuilderTest : BaseUnitTest() {
 
         // verify the shared logger has updated log level
         SDKComponent.logger.logLevel shouldBe CioLogLevel.DEBUG
+
+        // verify plugin is added
+        CustomerIO.instance().analytics.find(CustomerIODestination::class) shouldNotBe null
+    }
+
+    @Test
+    fun build_givenAutoTrackActivityScreensEnabled_expectCorrectPluginsToBeAdded() {
+        val givenCdpApiKey = String.random
+        createCustomerIOBuilder(givenCdpApiKey)
+            .setAutoTrackActivityScreens(true)
+            .build()
+
+        CustomerIO.instance().analytics.find(AutomaticActivityScreenTrackingPlugin::class) shouldNotBe null
+    }
+
+    @Test
+    fun build_givenAutoTrackActivityScreensDisabled_expectCorrectPluginsToBeAdded() {
+        val givenCdpApiKey = String.random
+        createCustomerIOBuilder(givenCdpApiKey)
+            .setAutoTrackActivityScreens(false)
+            .build()
+
+        CustomerIO.instance().analytics.find(AutomaticActivityScreenTrackingPlugin::class) shouldBe null
     }
 
     @Test

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -66,6 +66,8 @@ public class CustomerIORepository {
             newBuilder.setFlushInterval(sdkConfig.getBackgroundQueueSecondsDelay().intValue());
         }
         newBuilder.setAutoTrackDeviceAttributes(Boolean.TRUE.equals(sdkConfig.isDeviceAttributesTrackingEnabled()));
+        newBuilder.setAutoTrackActivityScreens(Boolean.TRUE.equals(sdkConfig.isScreenTrackingEnabled()));
+
         // Enable detailed logging for debug builds.
         if (sdkConfig.debugModeEnabled()) {
             newBuilder.setLogLevel(CioLogLevel.DEBUG);

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/models/Configuration.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/models/Configuration.kt
@@ -39,6 +39,7 @@ fun Configuration.setValuesFromBuilder(builder: CustomerIO.Builder): CustomerIO.
 fun Configuration.setValuesFromBuilder(builder: CustomerIOBuilder): CustomerIOBuilder {
     builder.setMigrationSiteId(this.siteId)
     builder.setAutoTrackDeviceAttributes(this.trackDeviceAttributes)
+    builder.setAutoTrackActivityScreens(this.trackScreen)
     builder.setFlushAt(this.backgroundQueueMinNumTasks)
     builder.setFlushInterval(this.backgroundQueueSecondsDelay.toInt())
     builder.setLogLevel(if (this.debugMode) CioLogLevel.DEBUG else CioLogLevel.ERROR)


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-286/expose-plugin-for-automatic-screen-tracking

Includes:
- Config to enable/disable feature
- Plugin to fire events based on activity lifecycle
- Sample app changes