### PR TITLE
chore: prevent error thrown when image URL cannot be composed because empty string

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -240,11 +240,14 @@ internal class CustomerIOPushNotificationHandler(
         )
     }
 
-    private fun addImage(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun addImage(
         imageUrl: String,
         builder: NotificationCompat.Builder,
         body: String
     ) = runBlocking {
+        if (imageUrl.isEmpty()) return@runBlocking
+
         val style = NotificationCompat.BigPictureStyle()
             .bigLargeIcon(null)
             .setSummaryText(body)

--- a/messagingpush/src/sharedTest/java/io/customer/messagingpush/CustomerIOPushNotificationHandlerTest.kt
+++ b/messagingpush/src/sharedTest/java/io/customer/messagingpush/CustomerIOPushNotificationHandlerTest.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush
 
 import android.os.Bundle
+import androidx.core.app.NotificationCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.commontest.BaseTest
@@ -12,7 +13,10 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.robolectric.Shadows
 
 @RunWith(AndroidJUnit4::class)
@@ -53,5 +57,14 @@ internal class CustomerIOPushNotificationHandlerTest : BaseTest() {
 
         nextStartedActivityIntent.intentClass shouldBeEqualTo NotificationClickReceiverActivity::class.java
         nextStartedActivityPayload shouldBeEqualTo pushNotificationPayload
+    }
+
+    @Test
+    fun addImage_givenEmptyStringForUrl_expectDoNotAddImageToPush() {
+        val givenPush: NotificationCompat.Builder = mock()
+
+        pushNotificationHandler.addImage("", givenPush, "")
+
+        verifyNoInteractions(givenPush)
     }
 }


### PR DESCRIPTION
Fixes: https://linear.app/customerio/issue/MBL-308/error-javanetmalformedurlexception-no-protocol-on-receive-rich

Customer shared with us a push that they composed in Fly using the rich push composer, that does not have an image specified in the editor, but a "image" field gets added to the push payload with an empty string. The SDK handled when the "image" property is null, but not empty.

Customer is not experiencing a crash of the app, but they are getting stacktraces reported to them. So, this commit is a chore instead of a fix.

Testing:
* I added a new automated test. The test passes with the bug fix code, fails without it.