### PR TITLE
chore: application lifecycle tests

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -32,6 +32,7 @@ object Dependencies {
         "io.github.gradle-nexus:publish-plugin:${Versions.GRADLE_NEXUS_PUBLISH_PLUGIN}"
     const val junit4 = "junit:junit:${Versions.JUNIT4}"
     const val junitBom = "org.junit:junit-bom:${Versions.JUNIT_BOM}"
+    const val junitEngine = "org.junit.vintage:junit-vintage-engine"
     const val junitJupiter = "org.junit.jupiter:junit-jupiter"
     const val kluent = "org.amshove.kluent:kluent-android:${Versions.KLUENT}"
     const val kotlinBinaryValidator =

--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -50,22 +50,7 @@ dependencies {
     testImplementation(platform(Dependencies.junitBom))
     testImplementation(Dependencies.junitJupiter)
 
-
-    // TESTING
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-
-    // Add JUnit5 dependencies.
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
-
-    // Add JUnit4 legacy dependencies.
-    testImplementation 'junit:junit:4.13.2'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
-
-    // Add Roboelectric dependencies.
-    testImplementation 'androidx.test:core:1.5.0'
+    testRuntimeOnly(Dependencies.junitEngine)
 }
 
 tasks.withType(Test).configureEach {

--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     testImplementation(platform(Dependencies.junitBom))
     testImplementation(Dependencies.junitJupiter)
 
+    // enables running JUnit 4 tests within the JUnit 5 (jupitor) platform.
     testRuntimeOnly(Dependencies.junitEngine)
 }
 

--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -49,4 +49,33 @@ dependencies {
 
     testImplementation(platform(Dependencies.junitBom))
     testImplementation(Dependencies.junitJupiter)
+
+
+    // TESTING
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+
+    // Add JUnit5 dependencies.
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
+
+    // Add JUnit4 legacy dependencies.
+    testImplementation 'junit:junit:4.13.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
+
+    // Add Roboelectric dependencies.
+    testImplementation 'androidx.test:core:1.5.0'
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+    filter {
+        excludeTestsMatching("*Integration*")
+    }
+    ignoreFailures = true
+    // https://github.com/mockk/mockk/issues/681
+    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED",
+            "--add-opens", "java.base/java.util=ALL-UNNAMED"
+    )
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
@@ -69,6 +69,6 @@ abstract class UnitTest : BaseUnitTest() {
     }
 
     companion object {
-        private const val TEST_CDP_API_KEY: String = "TESTING_API_KEY"
+        internal const val TEST_CDP_API_KEY: String = "TESTING_API_KEY"
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -1,0 +1,305 @@
+package io.customer.datapipelines.sdk
+
+import android.app.Activity
+import android.app.Application
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Bundle
+import androidx.test.platform.app.InstrumentationRegistry
+import com.segment.analytics.kotlin.android.plugins.AndroidLifecyclePlugin
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.Configuration
+import com.segment.analytics.kotlin.core.ErrorHandler
+import com.segment.analytics.kotlin.core.Storage
+import com.segment.analytics.kotlin.core.TrackEvent
+import io.customer.datapipelines.config.DataPipelinesModuleConfig
+import io.customer.datapipelines.core.UnitTest
+import io.customer.datapipelines.extensions.updateAnalyticsConfig
+import io.customer.datapipelines.stubs.TestCoroutineConfiguration
+import io.customer.datapipelines.utils.TestRunPlugin
+import io.customer.datapipelines.utils.mockHTTPClient
+import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.android.CustomerIO
+import io.customer.sdk.extensions.random
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AndroidLifecyclePluginTests {
+    private val lifecyclePlugin = AndroidLifecyclePlugin()
+
+    private lateinit var analytics: Analytics
+    private val mockContext = spyk(InstrumentationRegistry.getInstrumentation().targetContext)
+    private val mockApplication = mockk<Application>(relaxed = true)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    init {
+        val packageInfo = PackageInfo()
+        packageInfo.versionCode = 100
+        packageInfo.versionName = "1.0.0"
+
+        val packageManager = mockk<PackageManager> {
+            every { getPackageInfo("com.foo", 0) } returns packageInfo
+        }
+        every { mockApplication.packageName } returns "com.foo"
+        every { mockApplication.packageManager } returns packageManager
+
+        mockkStatic(Instant::class)
+        every { Instant.now() } returns Date(0).toInstant()
+        mockkStatic(UUID::class)
+        every { UUID.randomUUID().toString() } returns String.random
+
+        mockHTTPClient()
+    }
+
+    private fun createTestAnalyticsInstance(moduleConfig: DataPipelinesModuleConfig, testScope: TestScope, testDispatcher: TestDispatcher): Analytics {
+        val configuration = createAnalyticsConfig(moduleConfig = moduleConfig)
+        return object : Analytics(configuration, TestCoroutineConfiguration(testDispatcher, testScope)) {}
+    }
+
+    private fun createAnalyticsConfig(
+        moduleConfig: DataPipelinesModuleConfig,
+        errorHandler: ErrorHandler? = null
+    ): Configuration = Configuration(writeKey = moduleConfig.cdpApiKey, mockApplication).let { config ->
+        updateAnalyticsConfig(moduleConfig = moduleConfig, errorHandler = errorHandler).invoke(config)
+        return@let config
+    }
+
+    private fun createModuleInstance(
+        cdpApiKey: String = UnitTest.TEST_CDP_API_KEY,
+        applyConfig: CustomerIOBuilder.() -> Unit = {}
+    ): CustomerIO {
+        val builder = CustomerIOBuilder(mockContext as Application, cdpApiKey)
+        // Disable adding destination to analytics instance so events are not sent to the server by default
+        builder.setAutoAddCustomerIODestination(false)
+        // Apply custom configuration for the test
+        builder.applyConfig()
+        return builder.build()
+    }
+
+    @Before
+    fun setup() {
+        analytics = createTestAnalyticsInstance(
+            createModuleInstance().moduleConfig,
+            testScope,
+            testDispatcher
+        )
+    }
+
+    @Test
+    fun `application opened is tracked`() {
+        analytics.configuration.trackApplicationLifecycleEvents = true
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(lifecyclePlugin)
+        val mockPlugin = spyk(TestRunPlugin {})
+        analytics.add(mockPlugin)
+
+        val mockActivity = mockk<Activity>()
+        val mockBundle = mockk<Bundle>()
+
+        // Simulate activity startup
+        lifecyclePlugin.onActivityCreated(mockActivity, mockBundle)
+        lifecyclePlugin.onActivityStarted(mockActivity)
+        lifecyclePlugin.onActivityResumed(mockActivity)
+
+        verify { mockPlugin.updateState(true) }
+        val tracks = mutableListOf<TrackEvent>()
+        verify { mockPlugin.track(capture(tracks)) }
+        assertEquals(1, tracks.size)
+        with(tracks.last()) {
+            assertEquals("Application Opened", event)
+            assertEquals(
+                buildJsonObject {
+                    put("version", "1.0.0")
+                    put("build", "100")
+                    put("from_background", false)
+                },
+                properties
+            )
+        }
+    }
+
+    @Test
+    fun `application backgrounded is tracked`() {
+        analytics.configuration.trackApplicationLifecycleEvents = true
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(lifecyclePlugin)
+        val mockPlugin = spyk(TestRunPlugin {})
+        analytics.add(mockPlugin)
+
+        val mockActivity = mockk<Activity>()
+
+        // Simulate activity startup
+        lifecyclePlugin.onActivityPaused(mockActivity)
+        lifecyclePlugin.onActivityStopped(mockActivity)
+        lifecyclePlugin.onActivityDestroyed(mockActivity)
+
+        verify { mockPlugin.updateState(true) }
+        val track = slot<TrackEvent>()
+        verify { mockPlugin.track(capture(track)) }
+        with(track.captured) {
+            assertEquals("Application Backgrounded", event)
+        }
+    }
+
+    @Test
+    fun `application installed is tracked`() = runTest {
+        analytics.configuration.trackApplicationLifecycleEvents = true
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(lifecyclePlugin)
+
+        analytics.storage.remove(Storage.Constants.AppBuild)
+
+        val mockPlugin = spyk(TestRunPlugin {})
+        analytics.add(mockPlugin)
+
+        val mockActivity = mockk<Activity>()
+        val mockBundle = mockk<Bundle>()
+
+        // Simulate activity startup
+        lifecyclePlugin.onActivityCreated(mockActivity, mockBundle)
+
+        verify { mockPlugin.updateState(true) }
+        val track = slot<TrackEvent>()
+        verify { mockPlugin.track(capture(track)) }
+        with(track.captured) {
+            assertEquals("Application Installed", event)
+            assertEquals(
+                buildJsonObject {
+                    put("version", "1.0.0")
+                    put("build", "100")
+                },
+                properties
+            )
+        }
+    }
+
+    @Test
+    fun `application updated is tracked`() = runTest {
+        analytics.configuration.trackApplicationLifecycleEvents = true
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(lifecyclePlugin)
+
+        analytics.storage.write(Storage.Constants.AppVersion, "0.9")
+        analytics.storage.write(Storage.Constants.AppBuild, "9")
+
+        val mockPlugin = spyk(TestRunPlugin {})
+        analytics.add(mockPlugin)
+
+        val mockActivity = mockk<Activity>()
+        val mockBundle = mockk<Bundle>()
+
+        // Simulate activity startup
+        lifecyclePlugin.onActivityCreated(mockActivity, mockBundle)
+
+        verify { mockPlugin.updateState(true) }
+        val track = slot<TrackEvent>()
+        verify { mockPlugin.track(capture(track)) }
+        with(track.captured) {
+            assertEquals("Application Updated", event)
+            assertEquals(
+                buildJsonObject {
+                    put("version", "1.0.0")
+                    put("build", "100")
+                    put("previous_version", "0.9")
+                    put("previous_build", "9")
+                },
+                properties
+            )
+        }
+    }
+
+    @Test
+    fun `application lifecycle events not tracked when disabled`() {
+        analytics.configuration.trackApplicationLifecycleEvents = false
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(lifecyclePlugin)
+        val mockPlugin = spyk(TestRunPlugin {})
+        analytics.add(mockPlugin)
+
+        val mockActivity = mockk<Activity>()
+        val mockBundle = mockk<Bundle>()
+
+        // Simulate activity startup
+        lifecyclePlugin.onActivityCreated(mockActivity, mockBundle)
+        lifecyclePlugin.onActivityStarted(mockActivity)
+        lifecyclePlugin.onActivityResumed(mockActivity)
+
+        lifecyclePlugin.onActivityPaused(mockActivity)
+        lifecyclePlugin.onActivityStopped(mockActivity)
+        lifecyclePlugin.onActivityDestroyed(mockActivity)
+
+        assertFalse(mockPlugin.ran)
+    }
+
+    @Test
+    fun `verify all application lifecycle callbacks`() = runTest {
+        // Create a spy on the lifecycle plugin to ensure lifecycle methods are called
+        val spyLifecyclePlugin = spyk(lifecyclePlugin)
+
+        // Mock analytics to use the mock application and set the lifecycle plugin
+        analytics.configuration.trackApplicationLifecycleEvents = true
+        analytics.configuration.trackDeepLinks = false
+        analytics.configuration.useLifecycleObserver = false
+        analytics.add(spyLifecyclePlugin)
+
+        // Call setup to simulate application creation
+        spyLifecyclePlugin.setup(analytics)
+
+        // Verify that registerActivityLifecycleCallbacks was called on the mock application
+        verify { mockApplication.registerActivityLifecycleCallbacks(spyLifecyclePlugin) }
+
+        // Mock the activity and bundle
+        val mockActivity = mockk<Activity>()
+        val mockBundle = mockk<Bundle>()
+        val mockOutBundle = mockk<Bundle>()
+
+        // Simulate activity lifecycle
+        spyLifecyclePlugin.onActivityCreated(mockActivity, mockBundle)
+        spyLifecyclePlugin.onActivityStarted(mockActivity)
+        spyLifecyclePlugin.onActivityResumed(mockActivity)
+        spyLifecyclePlugin.onActivityPaused(mockActivity)
+        spyLifecyclePlugin.onActivityStopped(mockActivity)
+        spyLifecyclePlugin.onActivitySaveInstanceState(mockActivity, mockOutBundle)
+        spyLifecyclePlugin.onActivityDestroyed(mockActivity)
+
+        // Verify that the corresponding lifecycle methods of the plugin are called
+        verify { spyLifecyclePlugin.onActivityCreated(mockActivity, mockBundle) }
+        verify { spyLifecyclePlugin.onActivityStarted(mockActivity) }
+        verify { spyLifecyclePlugin.onActivityResumed(mockActivity) }
+        verify { spyLifecyclePlugin.onActivityPaused(mockActivity) }
+        verify { spyLifecyclePlugin.onActivityStopped(mockActivity) }
+        verify { spyLifecyclePlugin.onActivitySaveInstanceState(mockActivity, mockOutBundle) }
+        verify { spyLifecyclePlugin.onActivityDestroyed(mockActivity) }
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -10,12 +10,12 @@ import com.segment.analytics.kotlin.android.plugins.AndroidLifecyclePlugin
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Storage
 import com.segment.analytics.kotlin.core.TrackEvent
+import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.core.UnitTest
 import io.customer.datapipelines.utils.TestRunPlugin
 import io.customer.datapipelines.utils.createTestAnalyticsInstance
 import io.customer.datapipelines.utils.mockHTTPClient
 import io.customer.sdk.CustomerIOBuilder
-import io.customer.sdk.android.CustomerIO
 import io.customer.sdk.extensions.random
 import io.mockk.every
 import io.mockk.mockk
@@ -28,9 +28,6 @@ import java.util.Date
 import java.util.UUID
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -48,10 +45,6 @@ class AndroidLifecyclePluginTests {
     private lateinit var analytics: Analytics
     private val mockContext = spyk(InstrumentationRegistry.getInstrumentation().targetContext)
     private val mockApplication = mockk<Application>(relaxed = true)
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private val testDispatcher = UnconfinedTestDispatcher()
-    private val testScope = TestScope(testDispatcher)
 
     init {
         setupMocks()
@@ -77,19 +70,17 @@ class AndroidLifecyclePluginTests {
         mockHTTPClient()
     }
 
-    private fun createModuleInstance(
-        cdpApiKey: String = UnitTest.TEST_CDP_API_KEY,
-        applyConfig: CustomerIOBuilder.() -> Unit = {}
-    ): CustomerIO {
+    private fun createModuleConfig(
+        cdpApiKey: String = UnitTest.TEST_CDP_API_KEY
+    ): DataPipelinesModuleConfig {
         val builder = CustomerIOBuilder(mockContext as Application, cdpApiKey)
         builder.setAutoAddCustomerIODestination(false)
-        builder.applyConfig()
-        return builder.build()
+        return builder.build().moduleConfig
     }
 
     @Before
     fun setup() {
-        analytics = createTestAnalyticsInstance(createModuleInstance().moduleConfig, mockApplication, testDispatcher, testScope)
+        analytics = createTestAnalyticsInstance(createModuleConfig(), mockApplication)
     }
 
     @Test

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -14,6 +14,7 @@ import io.customer.sdk.data.model.Region
 import io.customer.sdk.extensions.random
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldNotBe
+import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -143,7 +144,7 @@ class CustomerIOBuilderTest : BaseUnitTest() {
             .setAutoTrackActivityScreens(true)
             .build()
 
-        CustomerIO.instance().analytics.find(AutomaticActivityScreenTrackingPlugin::class) shouldNotBe null
+        CustomerIO.instance().analytics.find(AutomaticActivityScreenTrackingPlugin::class) shouldNotBeEqualTo null
     }
 
     @Test

--- a/datapipelines/src/test/java/io/customer/datapipelines/utils/Analytics.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/utils/Analytics.kt
@@ -1,6 +1,5 @@
 package io.customer.datapipelines.utils
 
-import android.app.Application
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Configuration
 import com.segment.analytics.kotlin.core.Connection
@@ -20,7 +19,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import sovran.kotlin.Store
 
 val settingsDefault = """
@@ -57,14 +55,9 @@ fun spyStore(scope: TestScope, dispatcher: TestDispatcher): Store {
 fun createAnalyticsConfig(
     moduleConfig: DataPipelinesModuleConfig,
     errorHandler: ErrorHandler? = null,
-    application: Application? = null
+    application: Any? = null
 ): Configuration {
-    val configuration = if (application != null) {
-        Configuration(writeKey = moduleConfig.cdpApiKey, application = application)
-    } else {
-        Configuration(writeKey = moduleConfig.cdpApiKey)
-    }
-
+    val configuration = Configuration(writeKey = moduleConfig.cdpApiKey, application = application)
     return configuration.let { config ->
         updateAnalyticsConfig(moduleConfig = moduleConfig).invoke(config)
         config
@@ -73,18 +66,11 @@ fun createAnalyticsConfig(
 
 fun createTestAnalyticsInstance(
     moduleConfig: DataPipelinesModuleConfig,
-    application: Application? = null,
-    testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
-    testScope: TestScope = TestScope(testDispatcher)
+    application: Any = "Test",
+    testCoroutineConfiguration: TestCoroutineConfiguration = TestCoroutineConfiguration()
 ): Analytics {
-    val configuration = if (application != null) {
-        createAnalyticsConfig(moduleConfig = moduleConfig, application = application)
-    } else {
-        createAnalyticsConfig(moduleConfig = moduleConfig).apply {
-            this.application = "Test"
-        }
-    }
-    return object : Analytics(configuration, TestCoroutineConfiguration(testDispatcher, testScope)) {}
+    val configuration = createAnalyticsConfig(moduleConfig = moduleConfig, application = application)
+    return object : Analytics(configuration, testCoroutineConfiguration) {}
 }
 
 fun Analytics.clearPersistentStorage() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/utils/Analytics.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/utils/Analytics.kt
@@ -1,5 +1,6 @@
 package io.customer.datapipelines.utils
 
+import android.app.Application
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Configuration
 import com.segment.analytics.kotlin.core.Connection
@@ -19,6 +20,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import sovran.kotlin.Store
 
 val settingsDefault = """
@@ -54,16 +56,35 @@ fun spyStore(scope: TestScope, dispatcher: TestDispatcher): Store {
 
 fun createAnalyticsConfig(
     moduleConfig: DataPipelinesModuleConfig,
-    errorHandler: ErrorHandler? = null
-): Configuration = Configuration(writeKey = moduleConfig.cdpApiKey).let { config ->
-    updateAnalyticsConfig(moduleConfig = moduleConfig, errorHandler = errorHandler).invoke(config)
-    return@let config
+    errorHandler: ErrorHandler? = null,
+    application: Application? = null
+): Configuration {
+    val configuration = if (application != null) {
+        Configuration(writeKey = moduleConfig.cdpApiKey, application = application)
+    } else {
+        Configuration(writeKey = moduleConfig.cdpApiKey)
+    }
+
+    return configuration.let { config ->
+        updateAnalyticsConfig(moduleConfig = moduleConfig).invoke(config)
+        config
+    }
 }
 
-fun createTestAnalyticsInstance(moduleConfig: DataPipelinesModuleConfig): Analytics {
-    val configuration = createAnalyticsConfig(moduleConfig = moduleConfig)
-    configuration.application = "Test"
-    return object : Analytics(configuration, TestCoroutineConfiguration()) {}
+fun createTestAnalyticsInstance(
+    moduleConfig: DataPipelinesModuleConfig,
+    application: Application? = null,
+    testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+    testScope: TestScope = TestScope(testDispatcher)
+): Analytics {
+    val configuration = if (application != null) {
+        createAnalyticsConfig(moduleConfig = moduleConfig, application = application)
+    } else {
+        createAnalyticsConfig(moduleConfig = moduleConfig).apply {
+            this.application = "Test"
+        }
+    }
+    return object : Analytics(configuration, TestCoroutineConfiguration(testDispatcher, testScope)) {}
 }
 
 fun Analytics.clearPersistentStorage() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/utils/TestRunPlugin.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/utils/TestRunPlugin.kt
@@ -10,6 +10,9 @@ import com.segment.analytics.kotlin.core.TrackEvent
 import com.segment.analytics.kotlin.core.platform.EventPlugin
 import com.segment.analytics.kotlin.core.platform.Plugin
 
+/**
+ * A test plugin that can be used to test if the plugin was run
+ */
 class TestRunPlugin(var closure: (BaseEvent?) -> Unit) : EventPlugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var analytics: Analytics

--- a/datapipelines/src/test/java/io/customer/datapipelines/utils/TestRunPlugin.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/utils/TestRunPlugin.kt
@@ -1,0 +1,61 @@
+package io.customer.datapipelines.utils
+
+import com.segment.analytics.kotlin.core.AliasEvent
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.GroupEvent
+import com.segment.analytics.kotlin.core.IdentifyEvent
+import com.segment.analytics.kotlin.core.ScreenEvent
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.platform.EventPlugin
+import com.segment.analytics.kotlin.core.platform.Plugin
+
+class TestRunPlugin(var closure: (BaseEvent?) -> Unit) : EventPlugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var analytics: Analytics
+    var ran = false
+
+    override fun reset() {
+        ran = false
+    }
+
+    fun updateState(ran: Boolean) {
+        this.ran = ran
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent {
+        super.execute(event)
+        updateState(true)
+        return event
+    }
+
+    override fun track(payload: TrackEvent): BaseEvent {
+        closure(payload)
+        updateState(true)
+        return payload
+    }
+
+    override fun identify(payload: IdentifyEvent): BaseEvent {
+        closure(payload)
+        updateState(true)
+        return payload
+    }
+
+    override fun screen(payload: ScreenEvent): BaseEvent {
+        closure(payload)
+        updateState(true)
+        return payload
+    }
+
+    override fun group(payload: GroupEvent): BaseEvent {
+        closure(payload)
+        updateState(true)
+        return payload
+    }
+
+    override fun alias(payload: AliasEvent): BaseEvent {
+        closure(payload)
+        updateState(true)
+        return payload
+    }
+}

--- a/scripts/android-config.gradle
+++ b/scripts/android-config.gradle
@@ -17,7 +17,4 @@ android {
                 '-opt-in=io.customer.base.internal.InternalCustomerIOApi',
         ]
     }
-    testOptions {
-        unitTests.includeAndroidResources = true
-    }
 }

--- a/scripts/android-config.gradle
+++ b/scripts/android-config.gradle
@@ -17,4 +17,7 @@ android {
                 '-opt-in=io.customer.base.internal.InternalCustomerIOApi',
         ]
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
 }


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-309/application-lifecycle-events

tests cover:
- Verify with application state changes lifecycle callbacks are received 
- The lifecycle events are being tracked that we take responsibility of