### PR TITLE
feat: track device with attributes

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -21,6 +21,7 @@ public final class io/customer/sdk/core/di/AndroidSDKComponent : io/customer/sdk
 	public final fun getClient ()Lio/customer/sdk/data/store/Client;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getDeviceStore ()Lio/customer/sdk/data/store/DeviceStore;
+	public final fun getGlobalPreferenceStore ()Lio/customer/sdk/data/store/GlobalPreferenceStore;
 }
 
 public abstract class io/customer/sdk/core/di/DiGraph {

--- a/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
@@ -8,6 +8,8 @@ import io.customer.sdk.data.store.BuildStoreImpl
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.data.store.DeviceStoreImpl
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.customer.sdk.data.store.GlobalPreferenceStoreImpl
 
 /**
  * DIGraph component for Android-specific dependencies to ensure all SDK
@@ -32,4 +34,6 @@ class AndroidSDKComponent(
                 client = client
             )
         }
+    val globalPreferenceStore: GlobalPreferenceStore
+        get() = singleton { GlobalPreferenceStoreImpl(applicationContext) }
 }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
@@ -1,0 +1,36 @@
+package io.customer.sdk.data.store
+
+import android.content.Context
+import androidx.core.content.edit
+
+/**
+ * Store for global preferences that are not tied to a specific api key, user
+ * or any other entity.
+ */
+interface GlobalPreferenceStore {
+    fun saveDeviceToken(token: String)
+    fun getDeviceToken(): String?
+
+    fun clearAll()
+}
+
+internal class GlobalPreferenceStoreImpl(
+    context: Context
+) : PreferenceStore(context), GlobalPreferenceStore {
+
+    override val prefsName: String by lazy {
+        "io.customer.sdk.${context.packageName}"
+    }
+
+    override fun saveDeviceToken(token: String) = prefs.edit {
+        putString(KEY_DEVICE_TOKEN, token)
+    }
+
+    override fun getDeviceToken(): String? = prefs.read {
+        getString(KEY_DEVICE_TOKEN, null)
+    }
+
+    companion object {
+        private const val KEY_DEVICE_TOKEN = "device_token"
+    }
+}

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PreferenceStore.kt
@@ -1,0 +1,33 @@
+package io.customer.sdk.data.store
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Base preference repository that can be reused among different preference repositories.
+ */
+internal abstract class PreferenceStore(val context: Context) {
+    abstract val prefsName: String
+
+    internal val prefs: SharedPreferences
+        get() = context.applicationContext.getSharedPreferences(
+            prefsName,
+            Context.MODE_PRIVATE
+        )
+
+    /**
+     * Clear all preferences stored in associated preference file asynchronously.
+     */
+    open fun clearAll() {
+        prefs.edit().clear().apply()
+    }
+}
+
+/**
+ * Retrieves value from the preference file using the provided action.
+ * This method handles any exceptions that might occur during the retrieval
+ * process and returns null in case of an exception.
+ */
+inline fun <Value> SharedPreferences.read(
+    action: SharedPreferences.() -> Value?
+): Value? = runCatching { action(this) }.getOrNull()

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -38,7 +38,8 @@ public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrac
 }
 
 public final class io/customer/datapipelines/plugins/ContextPlugin : com/segment/analytics/kotlin/core/platform/Plugin {
-	public fun <init> (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun <init> ()V
 	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
 	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
 	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -37,6 +37,17 @@ public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrac
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 
+public final class io/customer/datapipelines/plugins/ContextPlugin : com/segment/analytics/kotlin/core/platform/Plugin {
+	public fun <init> (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
+	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
+	public final fun updateDeviceProperties (Ljava/lang/String;Ljava/util/Map;)V
+}
+
 public final class io/customer/datapipelines/plugins/CustomerIODestination : com/segment/analytics/kotlin/core/platform/DestinationPlugin, com/segment/analytics/kotlin/core/platform/VersionedPlugin, sovran/kotlin/Subscriber {
 	public fun <init> ()V
 	public fun alias (Lcom/segment/analytics/kotlin/core/AliasEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
@@ -115,17 +126,22 @@ public final class io/customer/sdk/CustomerIOBuilder {
 public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/android/CustomerIOInstance {
 	public fun <init> ()V
 	public abstract fun clearIdentify ()V
+	public abstract fun deleteDeviceToken ()V
+	public abstract fun getDeviceAttributes ()Ljava/util/Map;
 	public abstract fun getProfileAttributes ()Ljava/util/Map;
+	public abstract fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public final fun identify (Ljava/lang/String;)V
 	public abstract fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun identify (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public abstract fun registerDeviceToken (Ljava/lang/String;)V
 	public final fun screen (Ljava/lang/String;)V
 	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun screen (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public abstract fun setDeviceAttributes (Ljava/util/Map;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;)V
 	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
@@ -139,14 +155,19 @@ public final class io/customer/sdk/android/CustomerIO : io/customer/sdk/DataPipe
 	public static final field Companion Lio/customer/sdk/android/CustomerIO$Companion;
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/datapipelines/config/DataPipelinesModuleConfig;Lcom/segment/analytics/kotlin/core/Analytics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearIdentify ()V
+	public fun deleteDeviceToken ()V
+	public fun getDeviceAttributes ()Ljava/util/Map;
 	public fun getModuleConfig ()Lio/customer/datapipelines/config/DataPipelinesModuleConfig;
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun getProfileAttributes ()Ljava/util/Map;
+	public fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun initialize ()V
 	public static final fun instance ()Lio/customer/sdk/android/CustomerIO;
+	public fun registerDeviceToken (Ljava/lang/String;)V
 	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public fun setDeviceAttributes (Ljava/util/Map;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
 	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -1,0 +1,33 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.utilities.putInContextUnderKey
+import io.customer.sdk.data.model.CustomAttributes
+
+/**
+ * Plugin class responsible for updating the context properties in events
+ * tracked by Customer.io SDK.
+ */
+class ContextPlugin(override var analytics: Analytics) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+
+    internal var deviceToken: String? = null
+        private set
+    internal var attributes: CustomAttributes = emptyMap()
+        private set
+
+    fun updateDeviceProperties(deviceToken: String?, attributes: CustomAttributes) {
+        this.deviceToken = deviceToken
+        this.attributes = attributes
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent {
+        deviceToken?.let { token ->
+            // Device token is expected to be attached to device in context
+            event.putInContextUnderKey("device", "token", token)
+        }
+        return event
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -10,8 +10,9 @@ import io.customer.sdk.data.model.CustomAttributes
  * Plugin class responsible for updating the context properties in events
  * tracked by Customer.io SDK.
  */
-class ContextPlugin(override var analytics: Analytics) : Plugin {
+class ContextPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var analytics: Analytics
 
     internal var deviceToken: String? = null
         private set

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -221,4 +221,28 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param event [TrackMetric] event to be tracked.
      */
     abstract fun trackMetric(event: TrackMetric)
+
+    /**
+     * The device token that is currently registered with the push notification service.
+     */
+    abstract val registeredDeviceToken: String?
+
+    /**
+     * Use to provide additional and custom device attributes
+     * apart from the ones the SDK is programmed to send to customer workspace.
+     */
+    abstract var deviceAttributes: CustomAttributes
+
+    /**
+     * Registers a new device token with Customer.io, associated with the current
+     * profile. If there is no profile identified yet, this will store the device
+     * token and associate it with anonymous profile, and later merge it to
+     * identified profile.
+     */
+    abstract fun registerDeviceToken(deviceToken: String)
+
+    /**
+     * Delete the currently registered device token
+     */
+    abstract fun deleteDeviceToken()
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
@@ -210,9 +210,7 @@ class CustomerIO private constructor(
             return
         }
 
-        logger.info("registering device token $deviceToken for user profile: $registeredUserId")
-
-        logger.debug("storing device token to device storage")
+        logger.info("storing and registering device token $deviceToken for user profile: $registeredUserId")
         globalPreferenceStore.saveDeviceToken(deviceToken)
 
         trackDeviceAttributes(deviceToken)

--- a/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/android/CustomerIO.kt
@@ -82,7 +82,7 @@ class CustomerIO private constructor(
         )
     )
 
-    private val contextPlugin: ContextPlugin = ContextPlugin(analytics)
+    private val contextPlugin: ContextPlugin = ContextPlugin()
 
     init {
         // Set analytics logger and debug logs based on SDK logger configuration


### PR DESCRIPTION
part of [MBL-217](https://linear.app/customerio/issue/MBL-217/device-management)

### Changes

- Implemented and exposed public APIs to track device with attributes
- Added `GlobalPreferenceStore` to store common attributes e.g. device token

### Example Usage

```kotlin
CustomerIO.instance().registeredDeviceToken
CustomerIO.instance().deviceAttributes = mapOf("name" to "Brand", "os" to 33)
CustomerIO.instance().registerDeviceToken(token)
CustomerIO.instance().deleteDeviceToken
```

### Not Included

Tests and sample app updates are not included in this PR, will be added in upcoming PRs soon.