### PR TITLE
chore: migrate data pipelines tests to junit5

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
@@ -21,13 +21,13 @@ class AndroidSDKComponent(
     val client: Client
 ) : DiGraph() {
     val applicationContext: Context
-        get() = newInstance { context.applicationContext }
+        get() = newInstance<Context> { context.applicationContext }
     val buildStore: BuildStore
-        get() = newInstance { BuildStoreImpl() }
+        get() = newInstance<BuildStore> { BuildStoreImpl() }
     val applicationStore: ApplicationStore
-        get() = newInstance { ApplicationStoreImpl(context = applicationContext) }
+        get() = newInstance<ApplicationStore> { ApplicationStoreImpl(context = applicationContext) }
     val deviceStore: DeviceStore
-        get() = newInstance {
+        get() = newInstance<DeviceStore> {
             DeviceStoreImpl(
                 buildStore = buildStore,
                 applicationStore = applicationStore,
@@ -35,5 +35,5 @@ class AndroidSDKComponent(
             )
         }
     val globalPreferenceStore: GlobalPreferenceStore
-        get() = singleton { GlobalPreferenceStoreImpl(applicationContext) }
+        get() = singleton<GlobalPreferenceStore> { GlobalPreferenceStoreImpl(applicationContext) }
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/DiGraph.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/DiGraph.kt
@@ -54,8 +54,12 @@ abstract class DiGraph {
      * Example:
      * ```
      * val logger: Logger
-     *   get() = newInstance { LoggerImpl(...) }
+     *   get() = newInstance<Logger> { LoggerImpl(...) }
      * ```
+     * If the implementation class is different from property type, please make
+     * sure to mention class type explicitly so that it can be used for type
+     * inference.
+     * e.g. use `newInstance<Logger>(...)` instead of `newInstance(...)`.
      */
     inline fun <reified Dependency : Any> newInstance(
         identifier: String? = null,
@@ -79,8 +83,12 @@ abstract class DiGraph {
      * Example:
      * ```
      * val logger: Logger
-     *   get() = singleton { LoggerImpl(...) }
+     *   get() = singleton<Logger> { LoggerImpl(...) }
      * ```
+     * If the implementation class is different from property type, please make
+     * sure to mention class type explicitly so that it can be used for type
+     * inference.
+     * e.g. use `singleton<Logger>(...)` instead of `singleton(...)`.
      */
     inline fun <reified Dependency : Any> singleton(
         identifier: String? = null,

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponent.kt
@@ -15,8 +15,8 @@ import io.customer.sdk.core.util.Logger
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 object SDKComponent : DiGraph() {
     val androidSDKComponent: AndroidSDKComponent? get() = getOrNull()
-    val buildEnvironment: BuildEnvironment get() = newInstance { DefaultBuildEnvironment() }
-    val logger: Logger get() = singleton { LogcatLogger(buildEnvironment = buildEnvironment) }
+    val buildEnvironment: BuildEnvironment get() = newInstance<BuildEnvironment> { DefaultBuildEnvironment() }
+    val logger: Logger get() = singleton<Logger> { LogcatLogger(buildEnvironment = buildEnvironment) }
     val modules: MutableMap<String, CustomerIOModule<*>> = mutableMapOf()
 
     override fun reset() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -29,7 +29,7 @@ import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DataPipelinesCompatibilityTests : UnitTest() {
     //region Setup test environment

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -20,7 +20,7 @@ import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DataPipelinesInteractionTests : UnitTest() {
     //region Setup test environment

--- a/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/core/UnitTest.kt
@@ -1,14 +1,19 @@
 package io.customer.datapipelines.core
 
 import com.segment.analytics.kotlin.core.Analytics
-import io.customer.commontest.BaseUnitTest
 import io.customer.datapipelines.extensions.registerAnalyticsFactory
 import io.customer.datapipelines.utils.clearPersistentStorage
 import io.customer.datapipelines.utils.createTestAnalyticsInstance
 import io.customer.datapipelines.utils.mockHTTPClient
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.Version
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.registerAndroidSDKComponent
+import io.customer.sdk.data.store.Client
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.mock
 
 /**
@@ -16,16 +21,16 @@ import org.mockito.kotlin.mock
  * This class provides a setup for the CustomerIO instance and analytics instance
  * along with OutputReaderPlugin to read the events sent to the analytics instance.
  */
-abstract class UnitTest : BaseUnitTest() {
+abstract class UnitTest {
     protected lateinit var sdkInstance: CustomerIO
     protected lateinit var analytics: Analytics
+    protected lateinit var globalPreferenceStore: GlobalPreferenceStore
 
     protected val cdpApiKey: String
         get() = sdkInstance.moduleConfig.cdpApiKey
 
-    override fun setup() {
-        super.setup()
-
+    @BeforeEach
+    open fun setup() {
         initializeModule()
     }
 
@@ -43,6 +48,14 @@ abstract class UnitTest : BaseUnitTest() {
         SDKComponent.registerAnalyticsFactory { moduleConfig ->
             return@registerAnalyticsFactory createTestAnalyticsInstance(moduleConfig)
         }
+        // Register Android SDK component with mocked dependencies as we are using real context in tests
+        val androidSDKComponent = SDKComponent.registerAndroidSDKComponent(
+            context = mock(),
+            client = Client.Android(Version.version)
+        )
+        // Mock global preference store to avoid reading/writing to shared preferences
+        globalPreferenceStore = mock()
+        androidSDKComponent.overrideDependency(GlobalPreferenceStore::class.java, globalPreferenceStore)
     }
 
     protected open fun createModuleInstance(
@@ -52,14 +65,15 @@ abstract class UnitTest : BaseUnitTest() {
         val builder = CustomerIOBuilder(mock(), cdpApiKey)
         // Disable adding destination to analytics instance so events are not sent to the server by default
         builder.setAutoAddCustomerIODestination(false)
+        // Disable tracking application lifecycle events by default to avoid tracking unnecessary events while testing
+        builder.setTrackApplicationLifecycleEvents(false)
         // Apply custom configuration for the test
         builder.applyConfig()
         return builder.build()
     }
 
-    override fun teardown() {
-        super.teardown()
-
+    @AfterEach
+    open fun teardown() {
         deinitializeModule()
     }
 


### PR DESCRIPTION
### Changes

- Fixed DIGraph components inferred type using explicitly mention of base classes
- Updated DIGraph function docs for clarity
- Used JUnit5 in Data Pipelines tests instead of JUnit4
- Minor improvements in Data Pipelines tests base class