### PR TITLE
chore: sample apps api keys with prefix

### DIFF
--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 // Include Customer.io SDK dependencies and common gradle properties for sample apps
+ext.appConfigKeyPrefix = 'javaLayout_'
 apply from: "${rootDir}/samples/sample-app.gradle"
 
 android {

--- a/samples/kotlin_compose/build.gradle.kts
+++ b/samples/kotlin_compose/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 apply {
     // Include Customer.io SDK dependencies and common gradle properties for sample apps
+    ext.set("appConfigKeyPrefix", "kotlinCompose_")
     from("$rootDir/samples/sample-app.gradle")
 }
 

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -15,6 +15,9 @@ android {
         }
 
         // Retrieve API keys using the helper method to allow key prefixing
+        // e.g. Java Layout sample app has prefix javaLayout_ for API keys
+        // javaLayout_cdpApiKey=KEY has higher priority than cdpApiKey=KEY
+        // cdpApiKey=KEY can be used as a fallback for all sample apps
         String apiKey = getConfigWithPrefix("apiKey")
         String cdpApiKey = getConfigWithPrefix("cdpApiKey")
         String siteId = getConfigWithPrefix("siteId")

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -6,9 +6,23 @@ if (localPropertiesFile.exists()) {
 
 android {
     defaultConfig {
-        buildConfigField "String", "CDP_API_KEY", "\"${localProperties["cdpApiKey"]}\""
-        buildConfigField "String", "API_KEY", "\"${localProperties["apiKey"]}\""
-        buildConfigField "String", "SITE_ID", "\"${localProperties["siteId"]}\""
+        // Sets the configuration key prefix, with fallback to empty string if not set
+        String configKeyPrefix = project.findProperty("appConfigKeyPrefix") ?: ""
+
+        // Helper method to retrieve the property with prefix or fallback to default key
+        Closure<String> getConfigWithPrefix = { String key ->
+            localProperties."${configKeyPrefix}${key}" ?: localProperties."${key}"
+        }
+
+        // Retrieve API keys using the helper method to allow key prefixing
+        String apiKey = getConfigWithPrefix("apiKey")
+        String cdpApiKey = getConfigWithPrefix("cdpApiKey")
+        String siteId = getConfigWithPrefix("siteId")
+
+        // Set build config fields for API keys
+        buildConfigField "String", "API_KEY", "\"${apiKey}\""
+        buildConfigField "String", "CDP_API_KEY", "\"${cdpApiKey}\""
+        buildConfigField "String", "SITE_ID", "\"${siteId}\""
     }
     // Avoid redefining signing configs in sample apps to avoid breaking release
     // builds (specially on CI servers)


### PR DESCRIPTION
### Background

I realized it's harder to connect both of these sample apps to different workspaces because of the way we currently fetch keys. So I made some changes that allow us to provide optional different keys for the sample apps, with fallback to current format so we can reuse the same keys as well. These changes shouldn't break anything on CI or on local machines for any developer.

### Changes

- Updated the sample apps' `build.gradle` script to prefer keys with prefix
- If the prefix is not provided or prefix keys are missing, it falls back to keys without prefix
- Both sample apps are updated to mention their prefix

### Example `local.properties` File

```
# Used by both sample apps
apiKey=API_KEY
siteId=SITE_ID

# Ignored as both sample apps have overridden the value
cdpApiKey=CDP_API_KEY

# Used by Java Layout only
javaLayout_cdpApiKey=JAVA_CDP

# Used by Kotlin Compose only
kotlinCompose_cdpApiKey=KOTLIN_CDP
```