### PR TITLE
ci: use intermediate env var in run

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           # Get the current branch name and replace all / characters with - as / is invalid in gradle names.
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: echo "VERSION=$(echo \"${PR_HEAD_REF}\" | sed -r 's/\//-/g')-SNAPSHOT" >> $GITHUB_OUTPUT
+        run: echo "VERSION=$(echo ${PR_HEAD_REF} | sed -r 's/\//-/g')-SNAPSHOT" >> $GITHUB_OUTPUT
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -19,8 +19,10 @@ jobs:
       # Using branch name for name of snapshot. Makes it easy to remember and can easily trigger new builds of Remote Habits. 
       - name: Set snapshot version 
         id: set-snapshot-version
+        env:
+          PR_HEAD_REF: $(echo "${{ github.event.pull_request.head.ref }}" | sed -r 's/\//-/g')-SNAPSHOT
         # Get the current branch name and replace all / characters with - as / is invalid in gradle names. 
-        run: echo "::set-output name=VERSION::$(echo '${{ github.event.pull_request.head.ref }}' | sed -r 's/\//-/g')-SNAPSHOT"
+        run: echo "VERSION=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Set snapshot version 
         id: set-snapshot-version
         env:
-          PR_HEAD_REF: $(echo "${{ github.event.pull_request.head.ref }}" | sed -r 's/\//-/g')-SNAPSHOT
-        # Get the current branch name and replace all / characters with - as / is invalid in gradle names. 
-        run: echo "VERSION=${PR_HEAD_REF}" >> $GITHUB_OUTPUT
+          # Get the current branch name and replace all / characters with - as / is invalid in gradle names.
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: echo "VERSION=$(echo \"${PR_HEAD_REF}\" | sed -r 's/\//-/g')-SNAPSHOT" >> $GITHUB_OUTPUT
 
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository


### PR DESCRIPTION
[SEC-36](https://linear.app/customerio/issue/SEC-36/gha-run-shell-injection-vulnerability)

Using `github` variables in a GHA `run` step introduces a run shell injection vulnerability.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 