### PR TITLE
chore: use mockk instead of mockito in data pipelines

### DIFF
--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -18,6 +18,7 @@ import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.events.Metric
 import io.customer.sdk.events.TrackMetric
 import io.customer.sdk.extensions.random
+import io.mockk.every
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -33,7 +34,6 @@ import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.whenever
 
 class DataPipelinesCompatibilityTests : UnitTest() {
     //region Setup test environment
@@ -404,7 +404,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.identify(String.random)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         val queuedEvents = getQueuedEvents()
         // 1. Identify event
@@ -433,7 +433,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.identify(String.random)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.deviceAttributes = givenAttributes
 
         val queuedEvents = getQueuedEvents()
@@ -458,7 +458,7 @@ class DataPipelinesCompatibilityTests : UnitTest() {
 
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         sdkInstance.deleteDeviceToken()
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -13,6 +13,8 @@ import io.customer.datapipelines.support.utils.screenEvents
 import io.customer.datapipelines.support.utils.trackEvents
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.extensions.random
+import io.mockk.every
+import io.mockk.verify
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.amshove.kluent.shouldBe
@@ -25,9 +27,6 @@ import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 class DataPipelinesInteractionTests : UnitTest() {
     //region Setup test environment
@@ -386,7 +385,7 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
         outputReaderPlugin.trackEvents.count() shouldBeEqualTo 1
@@ -409,7 +408,7 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.deviceAttributes = givenAttributes
 
         outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
@@ -429,7 +428,7 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         outputReaderPlugin.reset()
 
         sdkInstance.clearIdentify()
@@ -450,7 +449,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         val givenPreviouslyIdentifiedProfile = String.random
         val givenToken = String.random
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         sdkInstance.identify(givenPreviouslyIdentifiedProfile)
         outputReaderPlugin.reset()
@@ -478,7 +477,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         val givenIdentifier = String.random
         val givenToken = String.random
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         sdkInstance.identify(givenIdentifier)
         outputReaderPlugin.reset()
@@ -497,11 +496,11 @@ class DataPipelinesInteractionTests : UnitTest() {
         val givenToken = String.random
 
         sdkInstance.identify(givenIdentifier)
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenPreviousDeviceToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenPreviousDeviceToken
         sdkInstance.registerDeviceToken(givenPreviousDeviceToken)
         outputReaderPlugin.reset()
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.registerDeviceToken(givenToken)
 
         // 1. Device delete event for the old token
@@ -524,7 +523,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         val givenIdentifier = String.random
         val givenToken = String.random
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.identify(givenIdentifier)
         outputReaderPlugin.reset()
 
@@ -544,7 +543,7 @@ class DataPipelinesInteractionTests : UnitTest() {
         val givenIdentifier = String.random
         val givenToken = String.random
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.registerDeviceToken(givenToken)
         outputReaderPlugin.reset()
 
@@ -565,9 +564,9 @@ class DataPipelinesInteractionTests : UnitTest() {
 
         sdkInstance.registerDeviceToken(givenToken)
 
-        verify(globalPreferenceStore, times(1)).saveDeviceToken(givenToken)
+        verify(exactly = 1) { globalPreferenceStore.saveDeviceToken(givenToken) }
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         outputReaderPlugin.trackEvents.count() shouldBeEqualTo 1
 
@@ -581,7 +580,7 @@ class DataPipelinesInteractionTests : UnitTest() {
     fun device_givenDeviceTokenStoredInStore_expectStoredValueForRegisteredToken() {
         val givenToken = String.random
 
-        whenever(globalPreferenceStore.getDeviceToken()).thenReturn(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
 
         sdkInstance.registeredDeviceToken shouldBeEqualTo givenToken
     }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -12,15 +12,14 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
 import io.customer.sdk.extensions.random
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -36,26 +35,30 @@ class CustomerIOBuilderTest : BaseUnitTest() {
         super.teardown()
     }
 
+    private fun mockGenericModule(): CustomerIOGenericModule {
+        return mockk<CustomerIOGenericModule>(relaxUnitFun = true)
+    }
+
     @Test
     fun build_givenModule_expectInitializeModule() {
-        val givenModule: CustomerIOGenericModule = mock<CustomerIOGenericModule>().apply {
-            whenever(this.moduleName).thenReturn(String.random)
+        val givenModule: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns String.random
         }
 
         createCustomerIOBuilder()
             .addCustomerIOModule(givenModule)
             .build()
 
-        verify(givenModule).initialize()
+        verify(exactly = 1) { givenModule.initialize() }
     }
 
     @Test
     fun build_givenMultipleModules_expectInitializeAllModules() {
-        val givenModule1: CustomerIOGenericModule = mock<CustomerIOGenericModule>().apply {
-            whenever(this.moduleName).thenReturn(String.random)
+        val givenModule1: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns String.random
         }
-        val givenModule2: CustomerIOGenericModule = mock<CustomerIOGenericModule>().apply {
-            whenever(this.moduleName).thenReturn(String.random)
+        val givenModule2: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns String.random
         }
 
         createCustomerIOBuilder()
@@ -63,17 +66,17 @@ class CustomerIOBuilderTest : BaseUnitTest() {
             .addCustomerIOModule(givenModule2)
             .build()
 
-        verify(givenModule1).initialize()
-        verify(givenModule2).initialize()
+        verify(exactly = 1) { givenModule1.initialize() }
+        verify(exactly = 1) { givenModule2.initialize() }
     }
 
     @Test
     fun build_givenMultipleModulesOfSameType_expectOnlyInitializeOneModuleInstance() {
-        val givenModule1: CustomerIOGenericModule = mock<CustomerIOGenericModule>().apply {
-            whenever(this.moduleName).thenReturn("shared-module-name")
+        val givenModule1: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns "shared-module-name"
         }
-        val givenModule2: CustomerIOGenericModule = mock<CustomerIOGenericModule>().apply {
-            whenever(this.moduleName).thenReturn("shared-module-name")
+        val givenModule2: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns "shared-module-name"
         }
 
         createCustomerIOBuilder()
@@ -81,8 +84,8 @@ class CustomerIOBuilderTest : BaseUnitTest() {
             .addCustomerIOModule(givenModule2)
             .build()
 
-        verify(givenModule1, never()).initialize()
-        verify(givenModule2).initialize()
+        verify(exactly = 0) { givenModule1.initialize() }
+        verify(exactly = 1) { givenModule2.initialize() }
     }
 
     @Test


### PR DESCRIPTION
part of: [MBL-215](https://linear.app/customerio/issue/MBL-215/automatic-device-attributes-collection-and-user-agent-updates)

### Background

I noticed we have been using both `Mockito` and `MockK` in Data Pipelines module. While this isn't necessarily an issue, we should only use both if needed. For functionalities that can be handled by both, we should stick to our preferred choice for consistency. I prefer `MockK` over `Mockito` because:

- Our project codebase is mostly Kotlin
- `MockK` is more Kotlin-friendly and easier to integrate
- It has a DSL-like syntax and is easy to adopt in Kotlin
- It allows mocking/spying methods for final classes

I haven't removed `Mockito` from the module yet, I only updated it to see how it works. If everything goes well, we can later remove `Mockito` from the module/project.

### Changes

- Used `MockK` for mocking objects instead of `Mockito`
- Replaced verification and mocking calls from `Mockito` with `MockK`