### PR TITLE
chore: implement auto track device attributes

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -19,6 +19,17 @@ public final class io/customer/datapipelines/extensions/RegionExtKt {
 	public static final fun cdnHost (Lio/customer/sdk/data/model/Region;)Ljava/lang/String;
 }
 
+public final class io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPlugin : com/segment/analytics/kotlin/core/platform/Plugin {
+	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun <init> ()V
+	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
+	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
+}
+
 public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin : com/segment/analytics/kotlin/android/plugins/AndroidLifecycle, com/segment/analytics/kotlin/core/platform/Plugin {
 	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
 	public fun <init> ()V
@@ -39,14 +50,13 @@ public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrac
 
 public final class io/customer/datapipelines/plugins/ContextPlugin : com/segment/analytics/kotlin/core/platform/Plugin {
 	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
-	public fun <init> ()V
+	public fun <init> (Lio/customer/sdk/data/store/DeviceStore;)V
 	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
 	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
 	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
 	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
 	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
-	public final fun updateDeviceProperties (Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public final class io/customer/datapipelines/plugins/CustomerIODestination : com/segment/analytics/kotlin/core/platform/DestinationPlugin, com/segment/analytics/kotlin/core/platform/VersionedPlugin, sovran/kotlin/Subscriber {

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPlugin.kt
@@ -1,0 +1,46 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.utilities.putAll
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Plugin class responsible for updating the device attributes in device update events.
+ */
+class AutoTrackDeviceAttributesPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var analytics: Analytics
+
+    override fun execute(event: BaseEvent): BaseEvent {
+        if ((event as? TrackEvent)?.event != "Device Created or Updated") {
+            return event
+        }
+
+        // Extract device attributes from context and merge them into event
+        // properties so they can be reflected on Dashboard
+
+        val context = event.context
+        val properties = event.properties
+
+        event.properties = buildJsonObject {
+            putAll(properties)
+            context["network"]?.jsonObject?.let { network ->
+                network["bluetooth"]?.let { value -> put("network_bluetooth", value) }
+                network["cellular"]?.let { value -> put("network_cellular", value) }
+                network["wifi"]?.let { value -> put("network_wifi", value) }
+            }
+            context["screen"]?.jsonObject?.let { screen ->
+                screen["width"]?.let { value -> put("screen_width", value) }
+                screen["height"]?.let { value -> put("screen_height", value) }
+            }
+            context["ip"]?.let { value -> put("ip", value) }
+            context["timezone"]?.let { value -> put("timezone", value) }
+        }
+
+        return event
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -3,32 +3,33 @@ package io.customer.datapipelines.plugins
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.utilities.putInContext
 import com.segment.analytics.kotlin.core.utilities.putInContextUnderKey
-import io.customer.sdk.data.model.CustomAttributes
+import com.segment.analytics.kotlin.core.utilities.removeFromContext
+import io.customer.sdk.data.store.DeviceStore
 
 /**
  * Plugin class responsible for updating the context properties in events
  * tracked by Customer.io SDK.
  */
-class ContextPlugin : Plugin {
+class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var analytics: Analytics
 
     internal var deviceToken: String? = null
-        private set
-    internal var attributes: CustomAttributes = emptyMap()
-        private set
-
-    fun updateDeviceProperties(deviceToken: String?, attributes: CustomAttributes) {
-        this.deviceToken = deviceToken
-        this.attributes = attributes
-    }
 
     override fun execute(event: BaseEvent): BaseEvent {
+        // Set user agent in context as it is required by Customer.io Data Pipelines
+        event.putInContext("userAgent", deviceStore.buildUserAgent())
+        // Remove analytics library information from context as Customer.io
+        // SDK information is being sent through user-agent
+        event.removeFromContext("library")
+
         deviceToken?.let { token ->
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)
         }
+
         return event
     }
 }


### PR DESCRIPTION
part of: [MBL-215](https://linear.app/customerio/issue/MBL-215/automatic-device-attributes-collection-and-user-agent-updates)

### Changes

- Updated `ContextPlugin` to remove undesired values from the `context` object
- Added `AutoTrackDeviceAttributesPlugin` to include auto-tracked device attributes
- Updated device update event to include auto-tracked device attributes in event properties

**_Please refer to mentioned ticket for JSON output comparison between iOS and Android_**