### PR TITLE
chore: allow modifying config in data pipelines test setup

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -28,12 +28,21 @@ import io.customer.sdk.data.store.Client
  * ```
  */
 class CustomerIOBuilder(
-    private val applicationContext: Application,
+    applicationContext: Application,
     private val cdpApiKey: String
 ) {
+    // Initialize AndroidSDKComponent as soon as the builder is created so that
+    // it can be used by the modules.
+    // Also, it is needed to override test dependencies in the test environment
+    private val androidSDKComponent = SDKComponent.registerAndroidSDKComponent(
+        context = applicationContext,
+        client = Client.Android(Version.version)
+    )
 
+    // List of modules to be initialized with the SDK
     private val registeredModules: MutableList<CustomerIOModule<out CustomerIOModuleConfig>> = mutableListOf()
 
+    // Logging configuration
     private var logLevel: CioLogLevel = CioLogLevel.DEFAULT
     private val logger: Logger = SDKComponent.logger
 
@@ -166,11 +175,6 @@ class CustomerIOBuilder(
     }
 
     fun build(): CustomerIO {
-        // Register AndroidSDKComponent to fulfill the dependencies required by the SDK modules
-        val androidSDKComponent = SDKComponent.registerAndroidSDKComponent(
-            context = applicationContext,
-            client = Client.Android(Version.version)
-        )
         val modules = SDKComponent.modules
 
         // Update the log level for the SDK

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -1,7 +1,8 @@
 package io.customer.datapipelines
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
-import io.customer.datapipelines.support.core.UnitTest
+import io.customer.datapipelines.support.core.JUnitTest
+import io.customer.datapipelines.support.core.TestConfiguration
 import io.customer.datapipelines.support.data.model.UserTraits
 import io.customer.datapipelines.support.extensions.deviceToken
 import io.customer.datapipelines.support.extensions.encodeToJsonElement
@@ -28,15 +29,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-class DataPipelinesInteractionTests : UnitTest() {
+class DataPipelinesInteractionTests : JUnitTest() {
     //region Setup test environment
 
     private lateinit var outputReaderPlugin: OutputReaderPlugin
 
-    override fun initializeModule() {
-        super.initializeModule()
+    override fun setupTestEnvironment(testConfig: TestConfiguration) {
+        super.setupTestEnvironment(testConfig)
 
-        outputReaderPlugin = OutputReaderPlugin(analytics)
+        outputReaderPlugin = OutputReaderPlugin()
         analytics.add(outputReaderPlugin)
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/TrackMetricExtTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/TrackMetricExtTests.kt
@@ -1,13 +1,12 @@
 package io.customer.datapipelines.extensions
 
-import io.customer.commontest.BaseUnitTest
 import io.customer.sdk.events.Metric
 import io.customer.sdk.events.TrackMetric
 import io.customer.sdk.extensions.random
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 
-class TrackMetricExtTests : BaseUnitTest() {
+class TrackMetricExtTests {
     @Test
     fun validate_givenAnyMetric_expectCorrectSerialization() {
         for (metric in Metric.values()) {

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -46,7 +46,7 @@ class AndroidLifecyclePluginTests : RobolectricTest() {
     }
 
     private fun setupTestEnvironmentWithLifecyclePlugin() {
-        super.setupTestEnvironment(
+        setupTestEnvironment(
             testConfiguration {
                 sdkConfig {
                     setTrackApplicationLifecycleEvents(true)

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -1,21 +1,13 @@
 package io.customer.datapipelines.sdk
 
 import android.app.Activity
-import android.app.Application
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.os.Bundle
-import androidx.test.platform.app.InstrumentationRegistry
 import com.segment.analytics.kotlin.android.plugins.AndroidLifecyclePlugin
-import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.Storage
 import com.segment.analytics.kotlin.core.TrackEvent
-import io.customer.datapipelines.config.DataPipelinesModuleConfig
-import io.customer.datapipelines.support.core.UnitTest
+import io.customer.datapipelines.support.core.RobolectricTest
+import io.customer.datapipelines.support.core.testConfiguration
 import io.customer.datapipelines.support.utils.TestRunPlugin
-import io.customer.datapipelines.support.utils.createTestAnalyticsInstance
-import io.customer.datapipelines.support.utils.mockHTTPClient
-import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.extensions.random
 import io.mockk.every
 import io.mockk.mockk
@@ -31,7 +23,6 @@ import junit.framework.TestCase.assertFalse
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -39,53 +30,37 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
-class AndroidLifecyclePluginTests {
+class AndroidLifecyclePluginTests : RobolectricTest() {
     private val lifecyclePlugin = AndroidLifecyclePlugin()
 
-    private lateinit var analytics: Analytics
-    private val mockContext = spyk(InstrumentationRegistry.getInstrumentation().targetContext)
-    private val mockApplication = mockk<Application>(relaxed = true)
-
     init {
-        setupMocks()
-    }
-
-    private fun setupMocks() {
-        val packageInfo = PackageInfo().apply {
-            versionCode = 100
-            versionName = "1.0.0"
-        }
-
-        val packageManager = mockk<PackageManager> {
-            every { getPackageInfo("com.foo", 0) } returns packageInfo
-        }
-        every { mockApplication.packageName } returns "com.foo"
-        every { mockApplication.packageManager } returns packageManager
-
         mockkStatic(Instant::class)
         every { Instant.now() } returns Date(0).toInstant()
         mockkStatic(UUID::class)
         every { UUID.randomUUID().toString() } returns String.random
-
-        mockHTTPClient()
     }
 
-    private fun createModuleConfig(
-        cdpApiKey: String = UnitTest.TEST_CDP_API_KEY
-    ): DataPipelinesModuleConfig {
-        val builder = CustomerIOBuilder(mockContext as Application, cdpApiKey)
-        builder.setAutoAddCustomerIODestination(false)
-        return builder.build().moduleConfig
+    override fun setup() {
+        // Keep setup empty to avoid calling super.setup() as it will initialize the SDK
+        // and we want to test the SDK with different configurations in each test
     }
 
-    @Before
-    fun setup() {
-        analytics = createTestAnalyticsInstance(createModuleConfig(), mockApplication)
+    private fun setupTestEnvironmentWithLifecyclePlugin() {
+        super.setupTestEnvironment(
+            testConfiguration {
+                sdkConfig {
+                    setTrackApplicationLifecycleEvents(true)
+                }
+                configurePlugins {
+                    add(lifecyclePlugin)
+                }
+            }
+        )
     }
 
     @Test
     fun track_verifyApplicationOpenedIsTracked() {
-        analytics.add(lifecyclePlugin)
+        setupTestEnvironmentWithLifecyclePlugin()
 
         val mockPlugin = spyk(TestRunPlugin {})
         analytics.add(mockPlugin)
@@ -100,7 +75,9 @@ class AndroidLifecyclePluginTests {
         verify { mockPlugin.updateState(true) }
         val tracks = mutableListOf<TrackEvent>()
         verify { mockPlugin.track(capture(tracks)) }
-        assertEquals(1, tracks.size)
+        // 1. Application Installed
+        // 2. Application Opened
+        assertEquals(2, tracks.size)
         with(tracks.last()) {
             assertEquals("Application Opened", event)
             assertEquals(
@@ -116,7 +93,7 @@ class AndroidLifecyclePluginTests {
 
     @Test
     fun track_verifyApplicationBackgroundIsTracked() {
-        analytics.add(lifecyclePlugin)
+        setupTestEnvironmentWithLifecyclePlugin()
 
         val mockPlugin = spyk(TestRunPlugin {})
         analytics.add(mockPlugin)
@@ -135,7 +112,7 @@ class AndroidLifecyclePluginTests {
 
     @Test
     fun track_verifyApplicationInstalledIsTracked() = runTest {
-        analytics.add(lifecyclePlugin)
+        setupTestEnvironmentWithLifecyclePlugin()
 
         analytics.storage.remove(Storage.Constants.AppBuild)
 
@@ -165,7 +142,7 @@ class AndroidLifecyclePluginTests {
 
     @Test
     fun track_verifyApplicationUpdatedIsTracked() = runTest {
-        analytics.add(lifecyclePlugin)
+        setupTestEnvironmentWithLifecyclePlugin()
 
         analytics.storage.write(Storage.Constants.AppVersion, "0.9")
         analytics.storage.write(Storage.Constants.AppBuild, "9")
@@ -198,9 +175,17 @@ class AndroidLifecyclePluginTests {
 
     @Test
     fun track_givenApplicationLifecycleDisabled_expectPluginsNotCalled() {
-        analytics.configuration.trackApplicationLifecycleEvents = false
+        setupTestEnvironment(
+            testConfiguration {
+                sdkConfig {
+                    setTrackApplicationLifecycleEvents(false)
+                }
+                configurePlugins {
+                    add(lifecyclePlugin)
+                }
+            }
+        )
 
-        analytics.add(lifecyclePlugin)
         val mockPlugin = spyk(TestRunPlugin {})
         analytics.add(mockPlugin)
 
@@ -223,11 +208,16 @@ class AndroidLifecyclePluginTests {
         val spyLifecyclePlugin = spyk(lifecyclePlugin)
 
         // Mock analytics to use the mock application and set the lifecycle plugin
-        analytics.add(lifecyclePlugin)
-        analytics.add(spyLifecyclePlugin)
-
-        // Call setup to simulate application creation
-        spyLifecyclePlugin.setup(analytics)
+        setupTestEnvironment(
+            testConfiguration {
+                sdkConfig {
+                    setTrackApplicationLifecycleEvents(true)
+                }
+                configurePlugins {
+                    add(spyLifecyclePlugin)
+                }
+            }
+        )
 
         // Verify that registerActivityLifecycleCallbacks was called on the mock application
         verify { mockApplication.registerActivityLifecycleCallbacks(spyLifecyclePlugin) }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -1,7 +1,7 @@
 package io.customer.datapipelines.sdk
 
-import android.app.Activity
 import android.app.Application
+import androidx.test.platform.app.InstrumentationRegistry
 import io.customer.commontest.module.CustomerIOGenericModule
 import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
@@ -20,13 +20,12 @@ import org.amshove.kluent.shouldNotBeEqualTo
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class CustomerIOBuilderTest {
 
-    private val application: Application = Robolectric.buildActivity(Activity::class.java).setup().get().application
+    private val application: Application = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
 
     @After
     fun teardown() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -2,7 +2,6 @@ package io.customer.datapipelines.sdk
 
 import android.app.Activity
 import android.app.Application
-import io.customer.commontest.BaseUnitTest
 import io.customer.commontest.module.CustomerIOGenericModule
 import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
@@ -18,21 +17,21 @@ import io.mockk.verify
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class CustomerIOBuilderTest : BaseUnitTest() {
+class CustomerIOBuilderTest {
 
     private val application: Application = Robolectric.buildActivity(Activity::class.java).setup().get().application
 
-    override fun teardown() {
+    @After
+    fun teardown() {
         // Clear the instance after each test to reset SDK to initial state
         CustomerIO.clearInstance()
-
-        super.teardown()
     }
 
     private fun mockGenericModule(): CustomerIOGenericModule {

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/core/JUnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/core/JUnitTest.kt
@@ -1,0 +1,24 @@
+package io.customer.datapipelines.support.core
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+
+/**
+ * Extension of the [UnitTest] class to provide setup and teardown methods for
+ * JUnit tests using JUnit 5 annotations to setup and teardown the test environment.
+ * Thr class uses test application instance to allow running tests without depending
+ * on Android context and resources.
+ */
+open class JUnitTest : UnitTest() {
+    override var testApplication: Any = "Test"
+
+    @BeforeEach
+    open fun setup() {
+        setupTestEnvironment()
+    }
+
+    @AfterEach
+    open fun teardown() {
+        deinitializeModule()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/core/RobolectricTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/core/RobolectricTest.kt
@@ -1,0 +1,58 @@
+package io.customer.datapipelines.support.core
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import androidx.test.platform.app.InstrumentationRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.After
+import org.junit.Before
+
+/**
+ * Extension of the [UnitTest] class to provide setup and teardown methods for
+ * Robolectric tests. Since Robolectric is not compatible with JUnit 5, this class
+ * uses JUnit 4 annotations to provide setup and teardown methods for the test environment.
+ * The class uses mock application instance to allow running tests using Robolectric API for Android.
+ */
+open class RobolectricTest : UnitTest() {
+    protected val mockContext: Context = spyk(InstrumentationRegistry.getInstrumentation().targetContext)
+    protected val mockApplication: Application
+
+    init {
+        val testPackageName = "com.example.test_app"
+
+        val applicationInfoMock = mockk<ApplicationInfo>(relaxed = true)
+        val packageInfo = PackageInfo().apply {
+            versionCode = 100
+            versionName = "1.0.0"
+            applicationInfo = applicationInfoMock
+        }
+        val packageManagerMock = mockk<PackageManager>(relaxed = true) {
+            every { this@mockk.getPackageInfo(testPackageName, 0) } returns packageInfo
+            every { this@mockk.getApplicationInfo(testPackageName, 0) } returns applicationInfoMock
+        }
+
+        mockApplication = spyk(spyk<Application>(mockContext.applicationContext as Application)) {
+            every { this@spyk.packageName } returns testPackageName
+            every { this@spyk.packageManager } returns packageManagerMock
+            every { this@spyk.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE) } returns PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    override var testApplication: Any = mockApplication
+
+    @Before
+    open fun setup() {
+        setupTestEnvironment()
+    }
+
+    @After
+    open fun teardown() {
+        deinitializeModule()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/core/TestConfiguration.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/core/TestConfiguration.kt
@@ -1,0 +1,55 @@
+package io.customer.datapipelines.support.core
+
+import com.segment.analytics.kotlin.core.Analytics
+import io.customer.sdk.CustomerIOBuilder
+
+/**
+ * Test configuration for setting up the CustomerIO SDK and analytics instance.
+ *
+ * @property cdpApiKey CDP API key to be used for testing
+ * @property sdkConfig used to configure the CustomerIO SDK instance for each test separately
+ * @property configurePlugins used to configure plugins for analytics instance before
+ * we add more plugins to it in CustomerIO initialization
+ */
+class TestConfiguration private constructor(
+    val cdpApiKey: String,
+    val sdkConfig: CustomerIOBuilder.() -> Unit,
+    val configurePlugins: Analytics.() -> Unit
+) {
+    class Builder {
+        private var cdpApiKey: String = TEST_CDP_API_KEY
+        private var sdkConfig: CustomerIOBuilder.() -> Unit = {}
+        private var configurePlugins: Analytics.() -> Unit = {}
+
+        fun cdpApiKey(cdpApiKey: String) {
+            this.cdpApiKey = cdpApiKey
+        }
+
+        fun sdkConfig(block: CustomerIOBuilder.() -> Unit) {
+            sdkConfig = block
+        }
+
+        fun configurePlugins(block: Analytics.() -> Unit) {
+            configurePlugins = block
+        }
+
+        fun build(): TestConfiguration = TestConfiguration(
+            cdpApiKey = cdpApiKey,
+            sdkConfig = sdkConfig,
+            configurePlugins = configurePlugins
+        )
+
+        companion object {
+            const val TEST_CDP_API_KEY = "TESTING_API_KEY"
+        }
+    }
+}
+
+/**
+ * Creates a [TestConfiguration] using DSL builder
+ *
+ * @param block Configuration block for [TestConfiguration.Builder].
+ */
+fun testConfiguration(block: TestConfiguration.Builder.() -> Unit): TestConfiguration {
+    return TestConfiguration.Builder().apply(block).build()
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/core/TestConfiguration.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/core/TestConfiguration.kt
@@ -46,7 +46,7 @@ class TestConfiguration private constructor(
 }
 
 /**
- * Creates a [TestConfiguration] using DSL builder
+ * Creates [TestConfiguration] using DSL-like option for convenient initialization
  *
  * @param block Configuration block for [TestConfiguration.Builder].
  */

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/stubs/UnitTestLogger.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/stubs/UnitTestLogger.kt
@@ -1,0 +1,37 @@
+package io.customer.datapipelines.support.stubs
+
+import io.customer.sdk.core.util.CioLogLevel
+import io.customer.sdk.core.util.Logger
+
+/**
+ * Logger implementation for unit tests.
+ * This logger implementation logs messages messages to the console based on
+ * the log level set to help debug issues while running unit tests.
+ */
+class UnitTestLogger : Logger {
+    override var logLevel: CioLogLevel = CioLogLevel.ERROR
+
+    override fun info(message: String) {
+        runIfMeetsLogLevelCriteria(CioLogLevel.INFO) {
+            println("[INFO]: $message")
+        }
+    }
+
+    override fun debug(message: String) {
+        runIfMeetsLogLevelCriteria(CioLogLevel.DEBUG) {
+            println("[DEBUG]: $message")
+        }
+    }
+
+    override fun error(message: String) {
+        runIfMeetsLogLevelCriteria(CioLogLevel.ERROR) {
+            println("[ERROR]: $message")
+        }
+    }
+
+    private fun runIfMeetsLogLevelCriteria(levelForMessage: CioLogLevel, block: () -> Unit) {
+        val shouldLog = logLevel >= levelForMessage
+
+        if (shouldLog) block()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/stubs/UnitTestLogger.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/stubs/UnitTestLogger.kt
@@ -12,26 +12,22 @@ class UnitTestLogger : Logger {
     override var logLevel: CioLogLevel = CioLogLevel.ERROR
 
     override fun info(message: String) {
-        runIfMeetsLogLevelCriteria(CioLogLevel.INFO) {
-            println("[INFO]: $message")
-        }
+        log(CioLogLevel.INFO, message)
     }
 
     override fun debug(message: String) {
-        runIfMeetsLogLevelCriteria(CioLogLevel.DEBUG) {
-            println("[DEBUG]: $message")
-        }
+        log(CioLogLevel.DEBUG, message)
     }
 
     override fun error(message: String) {
-        runIfMeetsLogLevelCriteria(CioLogLevel.ERROR) {
-            println("[ERROR]: $message")
-        }
+        log(CioLogLevel.ERROR, message)
     }
 
-    private fun runIfMeetsLogLevelCriteria(levelForMessage: CioLogLevel, block: () -> Unit) {
+    private fun log(levelForMessage: CioLogLevel, message: String) {
         val shouldLog = logLevel >= levelForMessage
 
-        if (shouldLog) block()
+        if (shouldLog) {
+            println("[$levelForMessage]: $message")
+        }
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/utils/Plugins.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/utils/Plugins.kt
@@ -9,8 +9,9 @@ import com.segment.analytics.kotlin.core.platform.Plugin
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.Logger
 
-class OutputReaderPlugin(override var analytics: Analytics) : Plugin {
+class OutputReaderPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.After
+    override lateinit var analytics: Analytics
 
     private val logger: Logger = SDKComponent.logger
     val allEvents: MutableList<BaseEvent> = mutableListOf()


### PR DESCRIPTION
part of: [MBL-215](https://linear.app/customerio/issue/MBL-215/automatic-device-attributes-collection-and-user-agent-updates)

### Changes

- Moved the creation of `AndroidSDKComponent` earlier with `CustomerIOBuilder` initialization so tests don't have to explicitly create it and can reuse it to override dependencies before initializing the module.
- Added `JUnitTest` and `RobolectricTest` classes to avoid rewriting setup code and to make writing both types of tests easier
- Updated `UnitTest` for more flexibility. Tests should avoid directly inheriting it and use `JUnitTest` or `RobolectricTest` instead
- Added `TestConfiguration` to wrap setup parameters in a single class for flexibility
- Added a DSL-like option for convenient initialization of `TestConfiguration`
- Fixed parent classes for tests