### PR TITLE
test: auto track device attributes

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/BaseTest.kt
@@ -119,7 +119,7 @@ abstract class BaseTest {
         dateUtilStub = DateUtilStub().also {
             di.overrideDependency(DateUtil::class.java, it)
         }
-        deviceStore = DeviceStoreStub().getDeviceStore(cioConfig)
+        deviceStore = DeviceStoreStub().getDeviceStore(cioConfig.client)
         dispatchersProviderStub = DispatchersProviderStub().also {
             staticDIComponent.overrideDependency(DispatchersProvider::class.java, it)
         }

--- a/common-test/src/main/java/io/customer/commontest/DeviceStoreStub.kt
+++ b/common-test/src/main/java/io/customer/commontest/DeviceStoreStub.kt
@@ -1,15 +1,15 @@
 package io.customer.commontest
 
-import io.customer.sdk.CustomerIOConfig
 import io.customer.sdk.data.store.ApplicationStore
 import io.customer.sdk.data.store.BuildStore
+import io.customer.sdk.data.store.Client
 import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.data.store.DeviceStoreImpl
 import java.util.*
 
 class DeviceStoreStub {
 
-    fun getDeviceStore(cioConfig: CustomerIOConfig): DeviceStore {
+    fun getDeviceStore(client: Client): DeviceStore {
         return DeviceStoreImpl(
             buildStore = object : BuildStore {
                 override val deviceBrand: String
@@ -33,7 +33,7 @@ class DeviceStoreStub {
                 override val isPushEnabled: Boolean
                     get() = true
             },
-            client = cioConfig.client,
+            client = client,
             version = "1.0.0-alpha.6"
         )
     }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -403,6 +403,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
     fun device_givenTokenRegistered_expectFinalJSONHasCorrectDeviceAttributes() = runTest {
         val givenToken = String.random
 
+        every { deviceStore.buildDeviceAttributes() } returns emptyMap()
         sdkInstance.identify(String.random)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
@@ -427,15 +428,16 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
     @Test
     fun device_givenAttributesUpdated_expectFinalJSONHasCustomDeviceAttributes() = runTest {
         val givenToken = String.random
-        val givenAttributes = mapOf(
+        val customAttributes = mapOf(
             "source" to "test",
-            "debugMode" to true
+            "debugMode" to true,
+            "device_model" to "Test Device"
         )
 
         sdkInstance.identify(String.random)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
-        sdkInstance.deviceAttributes = givenAttributes
+        sdkInstance.deviceAttributes = customAttributes
 
         val queuedEvents = getQueuedEvents()
         // 1. Identify
@@ -449,6 +451,8 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
 
         val payloadContext = payload["context"]?.jsonObject.shouldNotBeNull()
         payloadContext.deviceToken shouldBeEqualTo givenToken
+
+        val givenAttributes = deviceStore.buildDeviceAttributes() + customAttributes
         payload["properties"]?.jsonObject.shouldNotBeNull() shouldMatchTo givenAttributes
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -384,6 +384,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
         val givenIdentifier = String.random
         val givenToken = String.random
 
+        every { deviceStore.buildDeviceAttributes() } returns emptyMap()
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
@@ -407,6 +408,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
             "debugMode" to true
         )
 
+        every { deviceStore.buildDeviceAttributes() } returns emptyMap()
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken

--- a/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
@@ -1,0 +1,131 @@
+package io.customer.datapipelines
+
+import android.Manifest
+import android.content.pm.PackageManager
+import com.segment.analytics.kotlin.android.plugins.AndroidContextPlugin
+import io.customer.datapipelines.support.core.RobolectricTest
+import io.customer.datapipelines.support.core.TestConfiguration
+import io.customer.datapipelines.support.core.testConfiguration
+import io.customer.datapipelines.support.extensions.deviceToken
+import io.customer.datapipelines.support.extensions.encodeToJsonValue
+import io.customer.datapipelines.support.utils.OutputReaderPlugin
+import io.customer.datapipelines.support.utils.TestConstants
+import io.customer.datapipelines.support.utils.trackEvents
+import io.customer.sdk.extensions.random
+import io.mockk.every
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldHaveSingleItem
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldNotBeNullOrBlank
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class DeviceAttributesTests : RobolectricTest() {
+    //region Setup test environment
+
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    init {
+        every { mockApplication.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE) } returns PackageManager.PERMISSION_GRANTED
+    }
+
+    @Before
+    override fun setup() {
+        // Keep setup empty to avoid calling super.setup() as it will initialize the SDK
+        // and we want to test the SDK with different configurations in each test
+    }
+
+    override fun setupTestEnvironment(testConfig: TestConfiguration) {
+        super.setupTestEnvironment(testConfig)
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun track_givenAutoTrackDeviceAttributesDisabled_expectNoDeviceAttributesInProperties() {
+        setupTestEnvironment(
+            testConfiguration {
+                sdkConfig {
+                    // Disable auto tracking of device attributes
+                    setAutoTrackDeviceAttributes(false)
+                }
+                configurePlugins {
+                    // Add Android context plugin so that device attributes can be tracked by analytics
+                    add(AndroidContextPlugin())
+                }
+            }
+        )
+
+        val givenIdentifier = String.random
+        val givenToken = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+        sdkInstance.registerDeviceToken(givenToken)
+
+        val deviceRegisterEvent = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
+        println(deviceRegisterEvent.toString())
+        println(deviceRegisterEvent.properties)
+        println(deviceRegisterEvent.context)
+        deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
+        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
+        deviceRegisterEvent.properties.shouldBeEmpty()
+    }
+
+    @Test
+    fun track_givenAutoTrackDeviceAttributesEnabled_expectDeviceAttributesInContextNotProperties() {
+        setupTestEnvironment(
+            testConfiguration {
+                sdkConfig {
+                    setAutoTrackDeviceAttributes(true)
+                }
+                configurePlugins {
+                    // Add Android context plugin so that device attributes can be tracked by analytics
+                    add(AndroidContextPlugin())
+                }
+            }
+        )
+
+        val givenIdentifier = String.random
+        val givenToken = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+        sdkInstance.registerDeviceToken(givenToken)
+
+        val deviceRegisterEvent = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
+        deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
+        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
+
+        val properties = deviceRegisterEvent.properties
+        println(deviceRegisterEvent.properties)
+        properties.keys shouldHaveSize 13
+        properties shouldContain ("device_os" to 30).encodeToJsonValue()
+        properties shouldContain ("device_model" to "Pixel 6").encodeToJsonValue()
+        properties shouldContain ("device_manufacturer" to "Google").encodeToJsonValue()
+        properties shouldContain ("app_version" to "1.0").encodeToJsonValue()
+        properties shouldContain ("cio_sdk_version" to "1.0.0-alpha.6").encodeToJsonValue()
+        properties shouldContain ("device_locale" to "en-US").encodeToJsonValue()
+        properties shouldContain ("push_enabled" to true).encodeToJsonValue()
+        properties["timezone"]?.jsonPrimitive?.content.shouldNotBeNullOrBlank()
+        properties["screen_width"]?.jsonPrimitive?.intOrNull.shouldNotBeNull()
+        properties["screen_height"]?.jsonPrimitive?.intOrNull.shouldNotBeNull()
+        properties["network_wifi"]?.jsonPrimitive?.booleanOrNull.shouldNotBeNull()
+        properties["network_cellular"]?.jsonPrimitive?.booleanOrNull.shouldNotBeNull()
+        properties["network_bluetooth"]?.jsonPrimitive?.booleanOrNull.shouldNotBeNull()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/support/extensions/JsonExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/support/extensions/JsonExt.kt
@@ -22,6 +22,13 @@ infix fun JsonObject.shouldMatchTo(expected: CustomAttributes): JsonObject {
 }
 
 /**
+ * Encodes pair of key and value to pair of key and JSON element by encoding the value.
+ */
+inline fun <K, reified V> Pair<K, V>.encodeToJsonValue(): Pair<K, JsonElement> {
+    return first to second.encodeToJsonElement()
+}
+
+/**
  * Converts a map of custom attributes to a JSON object.
  * If the map is empty, it returns an empty JSON object.
  */


### PR DESCRIPTION
part of: [MBL-215](https://linear.app/customerio/issue/MBL-215/automatic-device-attributes-collection-and-user-agent-updates)

### Changes

- Fixed tests breaking in `DataPipelinesCompatibilityTests` for device registration
- Added tests for auto track device attributes in `DeviceAttributesTests`
- Updated `DeviceStoreStub` and helper extensions to help writing tests