### PR TITLE
chore: removed tracking usage from push

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -16,12 +16,8 @@ public class io/customer/messagingpush/CustomerIOFirebaseMessagingService : com/
 public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion {
 	public final fun onMessageReceived (Landroid/content/Context;Lcom/google/firebase/messaging/RemoteMessage;)Z
 	public final fun onMessageReceived (Landroid/content/Context;Lcom/google/firebase/messaging/RemoteMessage;Z)Z
-	public final fun onMessageReceived (Lcom/google/firebase/messaging/RemoteMessage;)Z
-	public final fun onMessageReceived (Lcom/google/firebase/messaging/RemoteMessage;Z)Z
 	public static synthetic fun onMessageReceived$default (Lio/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion;Landroid/content/Context;Lcom/google/firebase/messaging/RemoteMessage;ZILjava/lang/Object;)Z
-	public static synthetic fun onMessageReceived$default (Lio/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion;Lcom/google/firebase/messaging/RemoteMessage;ZILjava/lang/Object;)Z
 	public final fun onNewToken (Landroid/content/Context;Ljava/lang/String;)V
-	public final fun onNewToken (Ljava/lang/String;)V
 }
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
@@ -122,6 +118,7 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 }
 
 public final class io/customer/messagingpush/di/DiGraphMessagingPushKt {
+	public static final fun getAppLifecycleCallbacks (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messagingpush/util/AppLifecycleCallbacks;
 	public static final fun pushMessaging (Lio/customer/sdk/android/CustomerIO;)Lio/customer/messagingpush/ModuleMessagingPushFCM;
 }
 
@@ -131,9 +128,21 @@ public final class io/customer/messagingpush/processor/PushMessageProcessor$Comp
 }
 
 public final class io/customer/messagingpush/provider/FCMTokenProviderImpl : io/customer/sdk/device/DeviceTokenProvider {
-	public fun <init> (Lio/customer/sdk/core/util/Logger;Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;)V
 	public fun getCurrentToken (Lkotlin/jvm/functions/Function1;)V
+	public final fun getLogger ()Lio/customer/sdk/core/util/Logger;
 	public fun isValidForThisDevice (Landroid/content/Context;)Z
+}
+
+public final class io/customer/messagingpush/util/AppLifecycleCallbacks : android/app/Application$ActivityLifecycleCallbacks {
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+	public final fun registerCallback (Lio/customer/sdk/lifecycle/LifecycleCallback;)V
 }
 
 public abstract interface class io/customer/messagingpush/util/DeepLinkUtil {

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.cloudmessaging.CloudMessagingReceiver
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.extensions.getSDKInstanceOrNull
 import io.customer.messagingpush.processor.PushMessageProcessor
+import io.customer.sdk.core.di.SDKComponent
 
 /**
  * Broadcast receiver for listening to push events from GoogleCloudMessaging (GCM).
@@ -29,6 +30,6 @@ class CustomerIOCloudMessagingReceiver : BroadcastReceiver() {
         // If CustomerIO instance isn't initialized, we cannot process the notification
         val sdkInstance = context.getSDKInstanceOrNull() ?: return
 
-        sdkInstance.diGraph.pushMessageProcessor.processGCMMessageIntent(intent = intent)
+        SDKComponent.pushMessageProcessor.processGCMMessageIntent(intent = intent)
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -5,8 +5,8 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.extensions.getSDKInstanceOrNull
-import io.customer.sdk.android.CustomerIO
 import io.customer.sdk.communication.Event
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 
 open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
@@ -34,53 +34,6 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         /**
-         * Handles receiving an incoming push notification.
-         *
-         * Call this from a custom [FirebaseMessagingService] to pass push messages to
-         * CustomerIO SDK for tracking and rendering
-         * @param remoteMessage Remote message received from Firebase in
-         * [FirebaseMessagingService.onMessageReceived]
-         * @param handleNotificationTrigger indicating if the local notification should be triggered
-         * @return Boolean indicating whether this will be handled by CustomerIO
-         */
-        @Deprecated(
-            "This method is deprecated and will be removed in future releases. Use the one with context",
-            ReplaceWith("onMessageReceived(context = applicationContext, remoteMessage = remoteMessage, handleNotificationTrigger = handleNotificationTrigger)")
-        )
-        @JvmOverloads
-        fun onMessageReceived(
-            remoteMessage: RemoteMessage,
-            handleNotificationTrigger: Boolean = true
-        ): Boolean {
-            val diGraph = getInstanceOrNull()?.diGraph ?: return false
-            return handleMessageReceived(diGraph.context, remoteMessage, handleNotificationTrigger)
-        }
-
-        // Only to be used by deprecated methods relying on DI graphs from CustomerIO instance, should be removed with deprecated methods
-        private fun getInstanceOrNull(): CustomerIO? {
-            return try {
-                CustomerIO.instance()
-            } catch (e: Exception) {
-                null
-            }
-        }
-
-        /**
-         * Handles new or refreshed token
-         * Call this from [FirebaseMessagingService] to register the new device token
-         *
-         * @param token new or refreshed token
-         */
-        @Deprecated(
-            "This method is deprecated and will be removed in future releases. Use the one with context",
-            ReplaceWith("onNewToken(context = applicationContext, token = token)")
-        )
-        fun onNewToken(token: String) {
-            val diGraph = getInstanceOrNull()?.diGraph ?: return
-            handleNewToken(diGraph.context, token)
-        }
-
-        /**
          * Handles new or refreshed token
          * Call this from [FirebaseMessagingService] to register the new device token
          *
@@ -96,8 +49,6 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             eventBus.publish(
                 Event.RegisterDeviceTokenEvent(token)
             )
-            // todo: remove this
-            context.getSDKInstanceOrNull()?.registerDeviceToken(deviceToken = token)
         }
 
         private fun handleMessageReceived(
@@ -109,7 +60,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             val sdkInstance = context.getSDKInstanceOrNull() ?: return false
 
             val handler = CustomerIOPushNotificationHandler(
-                pushMessageProcessor = sdkInstance.diGraph.pushMessageProcessor,
+                pushMessageProcessor = SDKComponent.pushMessageProcessor,
                 remoteMessage = remoteMessage
             )
             return handler.handleMessage(context, handleNotificationTrigger)

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -23,11 +23,7 @@ import io.customer.messagingpush.extensions.*
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_TOKEN_KEY
-import io.customer.sdk.CustomerIOShared
-import io.customer.sdk.android.CustomerIO
-import io.customer.sdk.core.util.Logger
-import io.customer.sdk.di.CustomerIOComponent
-import io.customer.sdk.di.CustomerIOStaticComponent
+import io.customer.sdk.core.di.SDKComponent
 import java.net.URL
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
@@ -57,14 +53,8 @@ internal class CustomerIOPushNotificationHandler(
             "com.google.firebase.messaging.default_notification_color"
     }
 
-    private val diGraph: CustomerIOComponent
-        get() = CustomerIO.instance().diGraph
-
-    private val staticGraph: CustomerIOStaticComponent
-        get() = CustomerIOShared.instance().diStaticGraph
-
-    private val logger: Logger
-        get() = staticGraph.logger
+    private val diGraph = SDKComponent
+    private val logger = SDKComponent.logger
 
     private val moduleConfig: MessagingPushModuleConfig
         get() = diGraph.moduleConfig

--- a/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
@@ -4,9 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import io.customer.messagingpush.di.pushMessageProcessor
-import io.customer.sdk.CustomerIOShared
-import io.customer.sdk.android.CustomerIO
-import io.customer.sdk.core.util.Logger
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.tracking.TrackableScreen
 
 /**
@@ -16,7 +14,8 @@ import io.customer.sdk.tracking.TrackableScreen
  * metrics, handles the deep link and opens the desired activity in the host app.
  */
 class NotificationClickReceiverActivity : Activity(), TrackableScreen {
-    val logger: Logger by lazy { CustomerIOShared.instance().diStaticGraph.logger }
+    private val diGraph = SDKComponent
+    val logger = SDKComponent.logger
 
     override fun getScreenName(): String? {
         // Return null to prevent this screen from being tracked
@@ -38,15 +37,10 @@ class NotificationClickReceiverActivity : Activity(), TrackableScreen {
             // This should never happen ideally
             logger.error("Intent is null, cannot process notification click")
         } else {
-            val sdkInstance = CustomerIO.instanceOrNull(context = this)
-            if (sdkInstance == null) {
-                logger.error("SDK is not initialized, cannot handle notification intent")
-            } else {
-                sdkInstance.diGraph.pushMessageProcessor.processNotificationClick(
-                    activityContext = this,
-                    intent = data
-                )
-            }
+            diGraph.pushMessageProcessor.processNotificationClick(
+                activityContext = this,
+                intent = data
+            )
         }
         finish()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -8,13 +8,15 @@ import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
 import io.customer.messagingpush.provider.FCMTokenProviderImpl
+import io.customer.messagingpush.util.AppLifecycleCallbacks
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
 import io.customer.sdk.android.CustomerIO
+import io.customer.sdk.core.di.AndroidSDKComponent
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.device.DeviceTokenProvider
-import io.customer.sdk.di.CustomerIOComponent
 
 /*
 This file contains a series of extensions to the common module's Dependency injection (DI) graph. All extensions in this file simply add internal classes for this module into the DI graph.
@@ -22,23 +24,24 @@ This file contains a series of extensions to the common module's Dependency inje
 The use of extensions was chosen over creating a separate graph class for each module. This simplifies the SDK code as well as automated tests code dramatically.
  */
 
-internal val CustomerIOComponent.fcmTokenProvider: DeviceTokenProvider
-    get() = override() ?: FCMTokenProviderImpl(logger = logger, context = context)
+internal val AndroidSDKComponent.fcmTokenProvider: DeviceTokenProvider
+    get() = newInstance { FCMTokenProviderImpl(context = context) }
 
-internal val CustomerIOComponent.moduleConfig: MessagingPushModuleConfig
-    get() = override()
-        ?: sdkConfig.modules[ModuleMessagingPushFCM.MODULE_NAME]?.moduleConfig as? MessagingPushModuleConfig
-        ?: MessagingPushModuleConfig.default()
+internal val SDKComponent.moduleConfig: MessagingPushModuleConfig
+    get() = newInstance { modules[ModuleMessagingPushFCM.MODULE_NAME]?.moduleConfig as? MessagingPushModuleConfig ?: MessagingPushModuleConfig.default() }
 
-internal val CustomerIOComponent.deepLinkUtil: DeepLinkUtil
-    get() = override() ?: DeepLinkUtilImpl(logger, moduleConfig)
+internal val SDKComponent.deepLinkUtil: DeepLinkUtil
+    get() = newInstance { DeepLinkUtilImpl(logger, moduleConfig) }
 
 @InternalCustomerIOApi
-val CustomerIOComponent.pushTrackingUtil: PushTrackingUtil
-    get() = override() ?: PushTrackingUtilImpl()
+val SDKComponent.pushTrackingUtil: PushTrackingUtil
+    get() = newInstance { PushTrackingUtilImpl() }
 
-internal val CustomerIOComponent.pushMessageProcessor: PushMessageProcessor
-    get() = override() ?: getSingletonInstanceCreate {
+val SDKComponent.appLifecycleCallbacks: AppLifecycleCallbacks
+    get() = newInstance { AppLifecycleCallbacks() }
+
+internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
+    get() = singleton {
         PushMessageProcessorImpl(
             logger = logger,
             moduleConfig = moduleConfig,

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -25,7 +25,7 @@ The use of extensions was chosen over creating a separate graph class for each m
  */
 
 internal val AndroidSDKComponent.fcmTokenProvider: DeviceTokenProvider
-    get() = newInstance { FCMTokenProviderImpl(context = context) }
+    get() = newInstance<DeviceTokenProvider> { FCMTokenProviderImpl(context = context) }
 
 internal val SDKComponent.moduleConfig: MessagingPushModuleConfig
     get() = newInstance { modules[ModuleMessagingPushFCM.MODULE_NAME]?.moduleConfig as? MessagingPushModuleConfig ?: MessagingPushModuleConfig.default() }

--- a/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/extensions/StringExtensions.kt
@@ -3,12 +3,12 @@ package io.customer.messagingpush.extensions
 
 import android.graphics.Color
 import androidx.annotation.ColorInt
-import io.customer.sdk.CustomerIOShared
+import io.customer.sdk.core.di.SDKComponent
 
 @ColorInt
 internal fun String.toColorOrNull(): Int? = try {
     Color.parseColor(this)
 } catch (ex: IllegalArgumentException) {
-    CustomerIOShared.instance().diStaticGraph.logger.error("Invalid color string $this, ${ex.message}")
+    SDKComponent.logger.error("Invalid color string $this, ${ex.message}")
     null
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
-import io.customer.sdk.core.util.Logger
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.device.DeviceTokenProvider
 
 /**
@@ -12,9 +12,10 @@ import io.customer.sdk.device.DeviceTokenProvider
  * so we need to handle the exception manually.
  */
 class FCMTokenProviderImpl(
-    private val logger: Logger,
     private val context: Context
 ) : DeviceTokenProvider {
+
+    val logger = SDKComponent.logger
 
     override fun isValidForThisDevice(context: Context): Boolean {
         return try {

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/AppLifecycleCallbacks.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/AppLifecycleCallbacks.kt
@@ -1,0 +1,62 @@
+package io.customer.messagingpush.util
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import io.customer.sdk.lifecycle.LifecycleCallback
+
+class AppLifecycleCallbacks internal constructor() : Application.ActivityLifecycleCallbacks {
+    private val eventCallbacks = mutableMapOf<Lifecycle.Event, MutableList<LifecycleCallback>>()
+
+    fun registerCallback(callback: LifecycleCallback) {
+        for (event in callback.eventsToObserve) {
+            eventCallbacks.getOrPut(event) { mutableListOf() }.add(callback)
+        }
+    }
+
+    private fun sendEventToCallbacks(
+        event: Lifecycle.Event,
+        activity: Activity,
+        bundle: Bundle? = null
+    ) {
+        listOf(
+            eventCallbacks[event].orEmpty(),
+            eventCallbacks[Lifecycle.Event.ON_ANY].orEmpty()
+        ).flatten().forEach { callback ->
+            callback.onEventChanged(
+                event,
+                activity,
+                bundle
+            )
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+        sendEventToCallbacks(Lifecycle.Event.ON_CREATE, activity, bundle)
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        sendEventToCallbacks(Lifecycle.Event.ON_START, activity)
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        sendEventToCallbacks(Lifecycle.Event.ON_RESUME, activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        sendEventToCallbacks(Lifecycle.Event.ON_PAUSE, activity)
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        sendEventToCallbacks(Lifecycle.Event.ON_STOP, activity)
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {
+        // Not yet supported in the SDK
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        sendEventToCallbacks(Lifecycle.Event.ON_DESTROY, activity)
+    }
+}


### PR DESCRIPTION
closes: [MBL-333 : Decouple Push Module from Tracking Module](https://linear.app/customerio/issue/MBL-333/decouple-push-module-from-tracking-module)

- removes tracking modules usage from push
- remove digraph and static digraph usage from push

Not included:
- removed tracking dependency 
- update test to not utilize tracking