### PR TITLE
chore: inapp config builder

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -37,7 +37,7 @@ public final class io/customer/messaginginapp/databinding/ActivityGistBinding : 
 }
 
 public final class io/customer/messaginginapp/di/DIGraphMessagingInAppKt {
-	public static final fun inAppMessaging (Lio/customer/sdk/android/CustomerIO;)Lio/customer/messaginginapp/ModuleMessagingInApp;
+	public static final fun inAppMessaging (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 
 public abstract class io/customer/messaginginapp/gist/GistEnvironment : java/lang/Enum, io/customer/messaginginapp/gist/GistEnvironmentEndpoints {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -1,28 +1,21 @@
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public static final field Companion Lio/customer/messaginginapp/MessagingInAppModuleConfig$Companion;
-	public synthetic fun <init> (Lio/customer/messaginginapp/type/InAppEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEventListener ()Lio/customer/messaginginapp/type/InAppEventListener;
+	public final fun getRegion ()Lio/customer/sdk/data/model/Region;
+	public final fun getSiteId ()Ljava/lang/String;
 }
 
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder : io/customer/sdk/core/module/CustomerIOModuleConfig$Builder {
-	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;)V
 	public fun build ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public final fun setEventListener (Lio/customer/messaginginapp/type/InAppEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 }
 
-public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Companion {
-}
-
 public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer/sdk/core/module/CustomerIOModule {
 	public static final field Companion Lio/customer/messaginginapp/ModuleMessagingInApp$Companion;
-	public static final field moduleName Ljava/lang/String;
-	public fun <init> ()V
+	public static final field MODULE_NAME Ljava/lang/String;
 	public fun <init> (Lio/customer/messaginginapp/MessagingInAppModuleConfig;)V
-	public synthetic fun <init> (Lio/customer/messaginginapp/MessagingInAppModuleConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lio/customer/messaginginapp/MessagingInAppModuleConfig;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/messaginginapp/MessagingInAppModuleConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun dismissMessage ()V
 	public fun getModuleConfig ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
@@ -43,8 +36,8 @@ public final class io/customer/messaginginapp/databinding/ActivityGistBinding : 
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lio/customer/messaginginapp/databinding/ActivityGistBinding;
 }
 
-public final class io/customer/messaginginapp/di/DIGraphMessaginIAppKt {
-	public static final fun inAppMessaging (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messaginginapp/ModuleMessagingInApp;
+public final class io/customer/messaginginapp/di/DIGraphMessagingInAppKt {
+	public static final fun inAppMessaging (Lio/customer/sdk/android/CustomerIO;)Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 
 public abstract class io/customer/messaginginapp/gist/GistEnvironment : java/lang/Enum, io/customer/messaginginapp/gist/GistEnvironmentEndpoints {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
@@ -2,15 +2,21 @@ package io.customer.messaginginapp
 
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.sdk.core.module.CustomerIOModuleConfig
+import io.customer.sdk.data.model.Region
 
 /**
  * In app messaging module configurations that can be used to customize app
  * experience based on the provided configurations
  */
 class MessagingInAppModuleConfig private constructor(
+    val siteId: String,
+    val region: Region,
     val eventListener: InAppEventListener?
 ) : CustomerIOModuleConfig {
-    class Builder : CustomerIOModuleConfig.Builder<MessagingInAppModuleConfig> {
+    class Builder(
+        private val siteId: String,
+        private val region: Region
+    ) : CustomerIOModuleConfig.Builder<MessagingInAppModuleConfig> {
         private var eventListener: InAppEventListener? = null
 
         fun setEventListener(eventListener: InAppEventListener): Builder {
@@ -20,12 +26,10 @@ class MessagingInAppModuleConfig private constructor(
 
         override fun build(): MessagingInAppModuleConfig {
             return MessagingInAppModuleConfig(
+                siteId = siteId,
+                region = region,
                 eventListener = eventListener
             )
         }
-    }
-
-    companion object {
-        internal fun default(): MessagingInAppModuleConfig = Builder().build()
     }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -5,6 +5,7 @@ import io.customer.messaginginapp.provider.GistApi
 import io.customer.messaginginapp.provider.GistApiProvider
 import io.customer.messaginginapp.provider.GistInAppMessagesProvider
 import io.customer.messaginginapp.provider.InAppMessagesProvider
+import io.customer.sdk.android.CustomerIO
 import io.customer.sdk.core.di.SDKComponent
 
 internal val SDKComponent.gistApiProvider: GistApi
@@ -13,7 +14,10 @@ internal val SDKComponent.gistApiProvider: GistApi
 internal val SDKComponent.gistProvider: InAppMessagesProvider
     get() = newInstance<InAppMessagesProvider> { GistInAppMessagesProvider(gistApiProvider) }
 
-fun SDKComponent.inAppMessaging(): ModuleMessagingInApp {
-    return modules[ModuleMessagingInApp.moduleName] as? ModuleMessagingInApp
+// We need to add extension functions to the CustomerIO class as this is how
+// customers will interact with in-app messaging module.
+@Suppress("UnusedReceiverParameter")
+fun CustomerIO.inAppMessaging(): ModuleMessagingInApp {
+    return SDKComponent.modules[ModuleMessagingInApp.MODULE_NAME] as? ModuleMessagingInApp
         ?: throw IllegalStateException("ModuleMessagingInApp not initialized")
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -5,7 +5,6 @@ import io.customer.messaginginapp.provider.GistApi
 import io.customer.messaginginapp.provider.GistApiProvider
 import io.customer.messaginginapp.provider.GistInAppMessagesProvider
 import io.customer.messaginginapp.provider.InAppMessagesProvider
-import io.customer.sdk.android.CustomerIO
 import io.customer.sdk.core.di.SDKComponent
 
 internal val SDKComponent.gistApiProvider: GistApi
@@ -14,10 +13,7 @@ internal val SDKComponent.gistApiProvider: GistApi
 internal val SDKComponent.gistProvider: InAppMessagesProvider
     get() = newInstance<InAppMessagesProvider> { GistInAppMessagesProvider(gistApiProvider) }
 
-// We need to add extension functions to the CustomerIO class as this is how
-// customers will interact with in-app messaging module.
-@Suppress("UnusedReceiverParameter")
-fun CustomerIO.inAppMessaging(): ModuleMessagingInApp {
-    return SDKComponent.modules[ModuleMessagingInApp.MODULE_NAME] as? ModuleMessagingInApp
+fun SDKComponent.inAppMessaging(): ModuleMessagingInApp {
+    return modules[ModuleMessagingInApp.MODULE_NAME] as? ModuleMessagingInApp
         ?: throw IllegalStateException("ModuleMessagingInApp not initialized")
 }

--- a/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/sharedTest/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -13,8 +13,6 @@ import io.customer.sdk.extensions.random
 import io.customer.sdk.hooks.HookModule
 import io.customer.sdk.hooks.HooksManager
 import io.customer.sdk.repository.preference.SitePreferenceRepository
-import java.lang.reflect.Field
-import org.amshove.kluent.shouldBe
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,11 +42,12 @@ internal class ModuleMessagingInAppTest : BaseTest() {
         di.overrideDependency(HooksManager::class.java, hooksManager)
 
         module = ModuleMessagingInApp(
-            moduleConfig = MessagingInAppModuleConfig.Builder().setEventListener(eventListenerMock)
-                .build(),
-            overrideDiGraph = di
+            config = MessagingInAppModuleConfig.Builder(
+                siteId = siteId,
+                region = Region.US
+            ).setEventListener(eventListenerMock).build()
         )
-        modules[ModuleMessagingInApp.moduleName] = module
+        modules[ModuleMessagingInApp.MODULE_NAME] = module
     }
 
     @Test
@@ -102,27 +101,6 @@ internal class ModuleMessagingInAppTest : BaseTest() {
 
         // verify gist doesn't userToken
         verify(gistInAppMessagesProvider, never()).setUserToken(any())
-    }
-
-    @Test
-    fun initialize_givenComponentInitializedWithOrganizationId_expectOrganizationIdToBeIgnored() {
-        // since `organizationId` is a private member, to check if its being used we have to use reflection
-        // this test will be deleted when the deprecated variable is removed
-
-        val orgId = String.random
-        val module = ModuleMessagingInApp(
-            organizationId = orgId
-        )
-        val fields = ModuleMessagingInApp::class.java.declaredFields
-        var organizationId: Field? = null
-        for (field in fields) {
-            if (field.name == "organizationId") {
-                organizationId = field
-                break
-            }
-        }
-        organizationId?.isAccessible = true
-        (organizationId?.get(module)) shouldBe null
     }
 
     @Test

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -20,6 +20,7 @@ import io.customer.messagingpush.ModuleMessagingPushFCM;
 import io.customer.sdk.CustomerIO;
 import io.customer.sdk.CustomerIOBuilder;
 import io.customer.sdk.core.util.CioLogLevel;
+import io.customer.sdk.data.model.Region;
 
 /**
  * Repository class to hold all Customer.io related operations at single place
@@ -56,7 +57,7 @@ public class CustomerIORepository {
         builder.addCustomerIOModule(new ModuleMessagingPushFCM());
         // Enables in-app messages
         builder.addCustomerIOModule(new ModuleMessagingInApp(
-                new MessagingInAppModuleConfig.Builder()
+                new MessagingInAppModuleConfig.Builder(sdkConfig.getSiteId(), Region.US.INSTANCE)
                         .setEventListener(new InAppMessageEventListener(appGraph.getLogger()))
                         .build()
         ));

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
@@ -12,6 +12,7 @@ import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.data.model.Region
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -52,8 +53,10 @@ class MainApplication : Application() {
 
             addCustomerIOModule(
                 ModuleMessagingInApp(
-                    config = MessagingInAppModuleConfig.Builder()
-                        .setEventListener(InAppMessageEventListener()).build()
+                    config = MessagingInAppModuleConfig.Builder(
+                        siteId = configuration.siteId,
+                        region = Region.US
+                    ).setEventListener(InAppMessageEventListener()).build()
                 )
             )
             addCustomerIOModule(ModuleMessagingPushFCM())


### PR DESCRIPTION
part of: [MBL-377](https://linear.app/customerio/issue/MBL-377/decouple-tests-from-tracking)

### Changes

- Updated `MessagingInAppModuleConfig.Builder` to include required options (i.e. `siteId` and `region`)
- Removed unused code from `ModuleMessagingInApp`
- Updated sample apps
- Minor improvements in related code