### PR TITLE
chore: updated constructor to not account for task builder

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -22,11 +22,10 @@ public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
 	public static final field Companion Lio/customer/messagingpush/MessagingPushModuleConfig$Companion;
-	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;ZLio/customer/messagingpush/config/PushClickBehavior;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoTrackPushEvents ()Z
 	public final fun getNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;
 	public final fun getPushClickBehavior ()Lio/customer/messagingpush/config/PushClickBehavior;
-	public final fun getRedirectDeepLinksToOtherApps ()Z
 }
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder : io/customer/sdk/core/module/CustomerIOModuleConfig$Builder {
@@ -36,7 +35,6 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder :
 	public final fun setAutoTrackPushEvents (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setPushClickBehavior (Lio/customer/messagingpush/config/PushClickBehavior;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
-	public final fun setRedirectDeepLinksToOtherApps (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 }
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig$Companion {
@@ -76,12 +74,12 @@ public final class io/customer/messagingpush/config/PushClickBehavior : java/lan
 }
 
 public abstract interface class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback {
-	public abstract fun createTaskStackFromPayload (Landroid/content/Context;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;)Landroidx/core/app/TaskStackBuilder;
+	public abstract fun onNotificationClicked (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public abstract fun onNotificationComposed (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
 
 public final class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback$DefaultImpls {
-	public static fun createTaskStackFromPayload (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Landroid/content/Context;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;)Landroidx/core/app/TaskStackBuilder;
+	public static fun onNotificationClicked (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public static fun onNotificationComposed (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -10,21 +10,17 @@ import io.customer.sdk.core.module.CustomerIOModuleConfig
  *
  * @property notificationCallback callback to override default sdk behaviour for
  * notifications
- * @property redirectDeepLinksToOtherApps flag to support opening urls from
- * notification to other native apps or browsers; default true
  * @property pushClickBehavior defines the behavior when a push notification
  * is clicked
  */
 class MessagingPushModuleConfig private constructor(
     val autoTrackPushEvents: Boolean,
     val notificationCallback: CustomerIOPushNotificationCallback?,
-    val redirectDeepLinksToOtherApps: Boolean,
     val pushClickBehavior: PushClickBehavior
 ) : CustomerIOModuleConfig {
     class Builder : CustomerIOModuleConfig.Builder<MessagingPushModuleConfig> {
         private var autoTrackPushEvents: Boolean = true
         private var notificationCallback: CustomerIOPushNotificationCallback? = null
-        private var redirectDeepLinksToOtherApps: Boolean = true
         private var pushClickBehavior: PushClickBehavior = ACTIVITY_PREVENT_RESTART
 
         /**
@@ -50,21 +46,6 @@ class MessagingPushModuleConfig private constructor(
         }
 
         /**
-         * Allows to enable/disable opening non app links outside the app
-         * <p>
-         * true: links not supported by apps will be opened in other matching apps,
-         * if no matching apps are found, host app will be launched to default landing page
-         * false: links not supported will only open the host app to its default landing page
-         *
-         * @param redirectDeepLinksToOtherApps flag to support opening urls from
-         * notification to other native apps or browsers; default true
-         */
-        fun setRedirectDeepLinksToOtherApps(redirectDeepLinksToOtherApps: Boolean): Builder {
-            this.redirectDeepLinksToOtherApps = redirectDeepLinksToOtherApps
-            return this
-        }
-
-        /**
          * Defines the behavior when a notification is clicked.
          *
          * @param pushClickBehavior the behavior when a notification is clicked; default [PushClickBehavior.ACTIVITY_PREVENT_RESTART].
@@ -79,7 +60,6 @@ class MessagingPushModuleConfig private constructor(
             return MessagingPushModuleConfig(
                 autoTrackPushEvents = autoTrackPushEvents,
                 notificationCallback = notificationCallback,
-                redirectDeepLinksToOtherApps = redirectDeepLinksToOtherApps,
                 pushClickBehavior = pushClickBehavior
             )
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
@@ -20,7 +20,9 @@ interface CustomerIOPushNotificationCallback {
     fun onNotificationClicked(
         payload: CustomerIOParsedPushPayload,
         context: Context
-    ): Unit? = null
+    ): Unit? {
+        return null
+    }
 
     /**
      * Called when all attributes for the notification has been set by the SDK

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
@@ -2,7 +2,6 @@ package io.customer.messagingpush.data.communication
 
 import android.content.Context
 import androidx.core.app.NotificationCompat
-import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 
 interface CustomerIOPushNotificationCallback {
@@ -11,17 +10,17 @@ interface CustomerIOPushNotificationCallback {
      *
      * @param context reference to application context
      * @param payload data received for the notification
-     * @return [TaskStackBuilder] to launch activities on notification click;
-     * null to let the SDK handle this
+     * @return [Unit] non null, depicting that customer is going to launch activities on notification click;
+     * and null to let the SDK handle this
      *
      * NOTE: If your app is targeting Android 12 or greater, be careful of
      * launching intents outside the app as it can affect the notification
      * open metrics tracking
      */
-    fun createTaskStackFromPayload(
-        context: Context,
-        payload: CustomerIOParsedPushPayload
-    ): TaskStackBuilder? = null
+    fun onNotificationClicked(
+        payload: CustomerIOParsedPushPayload,
+        context: Context
+    ): Unit? = null
 
     /**
      * Called when all attributes for the notification has been set by the SDK
@@ -29,9 +28,9 @@ interface CustomerIOPushNotificationCallback {
      * <p/>
      * Please note that overriding the pending intent for notification is not
      * allowed as it can affect tracking and other metrics. Please override
-     * [createTaskStackFromPayload] instead to launch desired intent(s).
+     * [onNotificationClicked] instead to launch desired intent(s).
      * <p/>
-     * @see [createTaskStackFromPayload] to override click action
+     * @see [onNotificationClicked] to override click action
      *
      * @param payload data received for the notification
      * @param builder notification builder that is being used to build

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -145,7 +145,7 @@ internal class PushMessageProcessorImpl(
         )
 
         if (wasClicked != null) {
-            logger.info("Notification target overridden by createTaskStackFromPayload, starting new stack for link $deepLink")
+            logger.info("Notification target overridden by onNotificationClicked, link $deepLink handled by host app")
             return
         }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -139,13 +139,13 @@ internal class PushMessageProcessorImpl(
 
         // check if host app overrides the handling of deeplink
         val notificationCallback = moduleConfig.notificationCallback
-        val taskStackFromPayload = notificationCallback?.createTaskStackFromPayload(
+        val wasClicked = notificationCallback?.onNotificationClicked(
             context = activityContext,
             payload = payload
         )
-        if (taskStackFromPayload != null) {
+
+        if (wasClicked != null) {
             logger.info("Notification target overridden by createTaskStackFromPayload, starting new stack for link $deepLink")
-            taskStackFromPayload.startActivities()
             return
         }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/DeepLinkUtil.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/DeepLinkUtil.kt
@@ -61,11 +61,6 @@ class DeepLinkUtilImpl(
     }
 
     override fun createDeepLinkExternalIntent(context: Context, link: String): Intent? {
-        // check config if the deep link should be opened by any other app or not
-        if (!moduleConfig.redirectDeepLinksToOtherApps) {
-            return null
-        }
-
         val linkUri = Uri.parse(link)
         val intent = queryDeepLinksForThirdPartyApps(context = context, uri = linkUri)
         if (intent == null) {

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
@@ -1,8 +1,10 @@
 package io.customer.messagingpush
 
 import android.app.Application
+import android.content.Context
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.communication.EventBus
@@ -87,7 +89,11 @@ internal class ModuleMessagingConfigTest : JUnitTest() {
         module = ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder().apply {
                 setAutoTrackPushEvents(false)
-                setNotificationCallback(object : CustomerIOPushNotificationCallback {})
+                setNotificationCallback(object : CustomerIOPushNotificationCallback {
+                    override fun onNotificationClicked(payload: CustomerIOParsedPushPayload, context: Context) {
+                        println("")
+                    }
+                })
                 setRedirectDeepLinksToOtherApps(false)
                 setPushClickBehavior(PushClickBehavior.RESET_TASK_STACK)
             }.build()

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingConfigTest.kt
@@ -1,10 +1,8 @@
 package io.customer.messagingpush
 
 import android.app.Application
-import android.content.Context
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
-import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.communication.EventBus
@@ -89,11 +87,7 @@ internal class ModuleMessagingConfigTest : JUnitTest() {
         module = ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder().apply {
                 setAutoTrackPushEvents(false)
-                setNotificationCallback(object : CustomerIOPushNotificationCallback {
-                    override fun onNotificationClicked(payload: CustomerIOParsedPushPayload, context: Context) {
-                        println("")
-                    }
-                })
+                setNotificationCallback(object : CustomerIOPushNotificationCallback {})
                 setRedirectDeepLinksToOtherApps(false)
                 setPushClickBehavior(PushClickBehavior.RESET_TASK_STACK)
             }.build()


### PR DESCRIPTION
closes: [MBL-396 : Revisit Push Module Config to Eliminate Redundant Configurations](https://linear.app/customerio/issue/MBL-396/revisit-push-module-config-to-eliminate-redundant-configurations)

improves customer experience and dev experience.  