### PR TITLE
refactor: core module test classes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,12 +37,5 @@ android {
 dependencies {
     api project(":base")
     api Dependencies.androidxCoreKtx
-
     implementation Dependencies.coroutinesAndroid
-
-    testImplementation(Dependencies.mockK)
-    testImplementation(Dependencies.coroutinesTest)
-
-    testImplementation(platform(Dependencies.junitBom))
-    testImplementation(Dependencies.junitJupiter)
 }

--- a/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
+++ b/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
@@ -1,10 +1,10 @@
-package io.customer.sdk.core.di
+package io.customer.sdk.communication
 
-import io.customer.commontest.core.BaseUnitTest
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.JUnit5Test
 import io.customer.commontest.util.ScopeProviderStub
-import io.customer.sdk.communication.Event
-import io.customer.sdk.communication.EventBus
-import io.customer.sdk.communication.subscribe
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.ScopeProvider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -13,20 +13,27 @@ import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldHaveSingleItem
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-class EventBusTest : BaseUnitTest() {
-
+class EventBusTest : JUnit5Test() {
     private lateinit var eventBus: EventBus
     private val testScopeProvider = ScopeProviderStub()
 
-    override fun setup() {
-        SDKComponent.overrideDependency(ScopeProvider::class.java, testScopeProvider)
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk { overrideDependency<ScopeProvider>(testScopeProvider) }
+                }
+            }
+        )
+
         eventBus = SDKComponent.eventBus
     }
 
     override fun teardown() {
         eventBus.removeAllSubscriptions()
+
         super.teardown()
     }
 

--- a/core/src/test/java/io/customer/sdk/core/di/DiGraphTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/di/DiGraphTest.kt
@@ -1,6 +1,7 @@
 package io.customer.sdk.core.di
 
-import io.customer.commontest.core.BaseUnitTest
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.core.JUnit5Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
@@ -9,27 +10,27 @@ import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-// Custom data class to test dependency injection with the same class name.
-private data class Pair(val value: Int)
-class DiGraphTest : BaseUnitTest() {
+class DiGraphTest : JUnit5Test() {
     private lateinit var diGraph: DiGraph
 
-    override fun setup() {
-        super.setup()
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+
         diGraph = object : DiGraph() {}
     }
 
     override fun teardown() {
         diGraph.reset()
+
         super.teardown()
     }
 
     @Test
     fun newInstance_givenDependencyOverridden_expectOverriddenInstanceRetrieved() {
         val givenInstance = "OverriddenString"
-        diGraph.overrideDependency(String::class.java, givenInstance)
+        diGraph.overrideDependency<String>(givenInstance)
 
         val actualInstance = diGraph.newInstance { "NewInstance" }
 
@@ -39,7 +40,7 @@ class DiGraphTest : BaseUnitTest() {
     @Test
     fun getOrNull_givenDependencyOverridden_expectOverriddenInstanceRetrieved() {
         val givenInstance = "OverriddenString"
-        diGraph.overrideDependency(String::class.java, givenInstance)
+        diGraph.overrideDependency<String>(givenInstance)
 
         val actualInstance = diGraph.getOrNull<String>()
 
@@ -49,7 +50,7 @@ class DiGraphTest : BaseUnitTest() {
     @Test
     fun singletonInstance_givenDependencyOverridden_expectOverriddenInstanceRetrieved() {
         val givenInstance = "OverriddenString"
-        diGraph.overrideDependency(String::class.java, givenInstance)
+        diGraph.overrideDependency<String>(givenInstance)
 
         val actualInstance = diGraph.singleton { "NewInstance" }
 
@@ -59,9 +60,9 @@ class DiGraphTest : BaseUnitTest() {
     @Test
     fun getOrNull_givenDependencySameClassName_expectDifferentInstancesRetrieved() {
         val givenNativePairInstance = "value" to 1
-        diGraph.overrideDependency(kotlin.Pair::class.java, givenNativePairInstance)
+        diGraph.overrideDependency<kotlin.Pair<*, *>>(givenNativePairInstance)
         val givenCustomPairInstance = Pair(value = 2)
-        diGraph.overrideDependency(Pair::class.java, givenCustomPairInstance)
+        diGraph.overrideDependency<Pair>(givenCustomPairInstance)
 
         val actualNativePairInstance = diGraph.getOrNull<kotlin.Pair<String, Int>>()
         val actualCustomPairInstance = diGraph.getOrNull<Pair>()
@@ -85,9 +86,9 @@ class DiGraphTest : BaseUnitTest() {
     @Test
     fun singletonInstanceWithOverride_givenDependencySameClassName_expectDifferentInstancesRetrieved() {
         val givenNativePairInstance = "value" to 1
-        diGraph.overrideDependency(kotlin.Pair::class.java, givenNativePairInstance)
+        diGraph.overrideDependency<kotlin.Pair<*, *>>(givenNativePairInstance)
         val givenCustomPairInstance = Pair(value = 2)
-        diGraph.overrideDependency(Pair::class.java, givenCustomPairInstance)
+        diGraph.overrideDependency<Pair>(givenCustomPairInstance)
 
         val actualNativePairInstance = diGraph.singleton { "value" to 3 }
         val actualCustomPairInstance = diGraph.singleton { Pair(value = 4) }
@@ -218,7 +219,7 @@ class DiGraphTest : BaseUnitTest() {
 
     @Test
     fun reset_givenDependenciesSet_expectDependenciesCleared() {
-        diGraph.overrideDependency(String::class.java, "OverriddenString")
+        diGraph.overrideDependency<String>("OverriddenString")
         diGraph.newInstance<Int> { 1 }
         diGraph.singleton<Float> { 2.0F }
 
@@ -231,3 +232,6 @@ class DiGraphTest : BaseUnitTest() {
         diGraph.getOrNull<Float>().shouldBeNull()
     }
 }
+
+// Custom data class to test dependency injection with the same class name.
+private data class Pair(val value: Int)

--- a/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
@@ -1,16 +1,13 @@
 package io.customer.sdk.core.util
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.customer.commontest.core.BaseTest
+import io.customer.commontest.core.JUnit5Test
 import io.customer.sdk.core.environment.BuildEnvironment
+import io.mockk.every
+import io.mockk.mockk
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
-class LoggerTest : BaseTest() {
+class LoggerTest : JUnit5Test() {
 
     // Test log levels
 
@@ -75,8 +72,8 @@ class LoggerTest : BaseTest() {
 
     @Test
     fun verifySDKNotInitialized_givenDebugEnvironment_expectLogLevelDebug() {
-        val buildEnvironment: BuildEnvironment = mock()
-        whenever(buildEnvironment.debugModeEnabled).thenReturn(true)
+        val buildEnvironment: BuildEnvironment = mockk(relaxed = true)
+        every { buildEnvironment.debugModeEnabled } returns true
 
         val logger = LogcatLogger(buildEnvironment)
 
@@ -85,8 +82,8 @@ class LoggerTest : BaseTest() {
 
     @Test
     fun verifySDKNotInitialized_givenReleaseEnvironment_expectLogLevelErrors() {
-        val buildEnvironment: BuildEnvironment = mock()
-        whenever(buildEnvironment.debugModeEnabled).thenReturn(false)
+        val buildEnvironment: BuildEnvironment = mockk(relaxed = true)
+        every { buildEnvironment.debugModeEnabled } returns false
 
         val logger = LogcatLogger(buildEnvironment)
 
@@ -95,8 +92,8 @@ class LoggerTest : BaseTest() {
 
     @Test
     fun verifySDKInitialized_givenDebugEnvironment_expectLogLevelAsDefined() {
-        val buildEnvironment: BuildEnvironment = mock()
-        whenever(buildEnvironment.debugModeEnabled).thenReturn(true)
+        val buildEnvironment: BuildEnvironment = mockk(relaxed = true)
+        every { buildEnvironment.debugModeEnabled } returns true
         val givenLogLevel = CioLogLevel.INFO
 
         val logger = LogcatLogger(buildEnvironment)
@@ -107,8 +104,8 @@ class LoggerTest : BaseTest() {
 
     @Test
     fun verifySDKInitialized_givenReleaseEnvironment_expectLogLevelAsDefined() {
-        val buildEnvironment: BuildEnvironment = mock()
-        whenever(buildEnvironment.debugModeEnabled).thenReturn(false)
+        val buildEnvironment: BuildEnvironment = mockk(relaxed = true)
+        every { buildEnvironment.debugModeEnabled } returns false
         val givenLogLevel = CioLogLevel.NONE
 
         val logger = LogcatLogger(buildEnvironment)


### PR DESCRIPTION
part of [MBL-394](https://linear.app/customerio/issue/MBL-394/decouple-common-tests-from-tracking-module)

### Changes

- Removed test dependencies from module's gradle file as they are now included in the common gradle file for test dependencies
- Updated tests to match package of their respective classes
- Updated tests to work with `common-test` updates

### Test Status

All tests for `core` module are passing ✅

### Notes

See [parent PR](https://github.com/customerio/customerio-android/pull/373) for more details and context.