### PR TITLE
refactor: datapipelines module test classes

### DIFF
--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -39,29 +39,4 @@ dependencies {
     // Use this as API so customers can provide objects serializations without
     // needing to add it as a dependency to their app
     api(Dependencies.kotlinxSerializationJson)
-
-    testImplementation(Dependencies.mockito)
-    testImplementation(Dependencies.mockitoKotlin)
-    testImplementation(Dependencies.robolectric)
-
-    testImplementation(Dependencies.mockK)
-    testImplementation(Dependencies.coroutinesTest)
-
-    testImplementation(platform(Dependencies.junitBom))
-    testImplementation(Dependencies.junitJupiter)
-
-    // enables running JUnit 4 tests within the JUnit 5 (jupiter) platform.
-    testRuntimeOnly(Dependencies.junitVintageEngine)
-}
-
-tasks.withType(Test).configureEach {
-    useJUnitPlatform()
-    filter {
-        excludeTestsMatching("*Integration*")
-    }
-    ignoreFailures = true
-    // https://github.com/mockk/mockk/issues/681
-    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED",
-            "--add-opens", "java.base/java.util=ALL-UNNAMED"
-    )
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
@@ -1,23 +1,29 @@
 package io.customer.datapipelines
 
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.Test
 
 class DataPipelineEventBusInteractionTest : JUnitTest() {
-
     private lateinit var eventBus: EventBus
 
-    override fun setupAndroidSDKComponent() {
-        eventBus = mockk(relaxed = true)
-        SDKComponent.overrideDependency(EventBus::class.java, eventBus)
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfiguration {
+                diGraph {
+                    sdk { overrideDependency<EventBus>(mockk(relaxed = true)) }
+                }
+            }
+        )
 
-        super.setupAndroidSDKComponent()
+        eventBus = SDKComponent.eventBus
     }
 
     @Test
@@ -27,8 +33,8 @@ class DataPipelineEventBusInteractionTest : JUnitTest() {
         every { eventBus.subscribe(Event.RegisterDeviceTokenEvent::class, any()) } returns mockk()
 
         // Verify the subscribe method is called with the correct event classes
-        verify(exactly = 1) { eventBus.subscribe(Event.TrackPushMetricEvent::class, any()) }
-        verify(exactly = 1) { eventBus.subscribe(Event.TrackInAppMetricEvent::class, any()) }
-        verify(exactly = 1) { eventBus.subscribe(Event.RegisterDeviceTokenEvent::class, any()) }
+        assertCalledOnce { eventBus.subscribe(Event.TrackPushMetricEvent::class, any()) }
+        assertCalledOnce { eventBus.subscribe(Event.TrackInAppMetricEvent::class, any()) }
+        assertCalledOnce { eventBus.subscribe(Event.RegisterDeviceTokenEvent::class, any()) }
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -4,9 +4,9 @@ import com.segment.analytics.kotlin.core.Storage
 import com.segment.analytics.kotlin.core.emptyJsonArray
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.getString
+import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.random
-import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.datapipelines.testutils.data.model.UserTraits
@@ -15,7 +15,10 @@ import io.customer.datapipelines.testutils.extensions.deviceToken
 import io.customer.datapipelines.testutils.extensions.encodeToJsonElement
 import io.customer.datapipelines.testutils.extensions.shouldMatchTo
 import io.customer.datapipelines.testutils.extensions.toJsonObject
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.CustomAttributes
+import io.customer.sdk.data.store.DeviceStore
+import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.customer.sdk.events.Metric
 import io.customer.sdk.events.TrackMetric
 import io.mockk.every
@@ -38,10 +41,12 @@ import org.junit.jupiter.api.Test
 class DataPipelinesCompatibilityTests : JUnitTest() {
     //region Setup test environment
 
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var deviceStore: DeviceStore
     private lateinit var storage: Storage
 
-    override fun setupTestEnvironment(testConfig: DataPipelinesTestConfig) {
-        super.setupTestEnvironment(
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
             testConfiguration {
                 sdkConfig {
                     // Enable adding destination so events are processed and stored in the storage
@@ -49,6 +54,10 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
                 }
             }
         )
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+        deviceStore = androidSDKComponent.deviceStore
 
         storage = analytics.storage
     }

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -1,9 +1,10 @@
 package io.customer.datapipelines
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
+import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.TestConstants
+import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
-import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.data.model.UserTraits
 import io.customer.datapipelines.testutils.extensions.deviceToken
@@ -13,9 +14,11 @@ import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.identifyEvents
 import io.customer.datapipelines.testutils.utils.screenEvents
 import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.CustomAttributes
+import io.customer.sdk.data.store.DeviceStore
+import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.mockk.every
-import io.mockk.verify
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.amshove.kluent.shouldBe
@@ -32,10 +35,16 @@ import org.junit.jupiter.params.provider.ValueSource
 class DataPipelinesInteractionTests : JUnitTest() {
     //region Setup test environment
 
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var deviceStore: DeviceStore
     private lateinit var outputReaderPlugin: OutputReaderPlugin
 
-    override fun setupTestEnvironment(testConfig: DataPipelinesTestConfig) {
-        super.setupTestEnvironment(testConfig)
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+        deviceStore = androidSDKComponent.deviceStore
 
         outputReaderPlugin = OutputReaderPlugin()
         analytics.add(outputReaderPlugin)
@@ -567,7 +576,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         sdkInstance.registerDeviceToken(givenToken)
 
-        verify(exactly = 1) { globalPreferenceStore.saveDeviceToken(givenToken) }
+        assertCalledOnce { globalPreferenceStore.saveDeviceToken(givenToken) }
 
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExtensionsTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/StringExtensionsTest.kt
@@ -2,10 +2,9 @@ package io.customer.datapipelines.extensions
 
 import io.customer.datapipelines.plugins.getScreenNameFromActivity
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-internal class StringExt {
-
+internal class StringExtensionsTest {
     @Test
     fun verify_activityScreenFormatting_expectFormattedScreenName() {
         "HomeActivity".getScreenNameFromActivity() shouldBeEqualTo "Home"

--- a/datapipelines/src/test/java/io/customer/datapipelines/extensions/TrackMetricExtensionsTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/extensions/TrackMetricExtensionsTest.kt
@@ -4,9 +4,9 @@ import io.customer.commontest.extensions.random
 import io.customer.sdk.events.Metric
 import io.customer.sdk.events.TrackMetric
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
-class TrackMetricExtTests {
+class TrackMetricExtensionsTest {
     @Test
     fun validate_givenAnyMetric_expectCorrectSerialization() {
         for (metric in Metric.values()) {

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -1,7 +1,8 @@
 package io.customer.datapipelines.sdk
 
-import android.app.Application
-import androidx.test.platform.app.InstrumentationRegistry
+import io.customer.commontest.core.RobolectricTest
+import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
 import io.customer.commontest.module.CustomerIOGenericModule
 import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
@@ -14,24 +15,21 @@ import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
-import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class CustomerIOBuilderTest {
+class CustomerIOBuilderTest : RobolectricTest() {
 
-    private val application: Application = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as Application
-
-    @After
-    fun teardown() {
+    override fun teardown() {
         // Clear the instance after each test to reset SDK to initial state
         CustomerIO.clearInstance()
+
+        super.teardown()
     }
 
     private fun mockGenericModule(): CustomerIOGenericModule {
@@ -48,7 +46,7 @@ class CustomerIOBuilderTest {
             .addCustomerIOModule(givenModule)
             .build()
 
-        verify(exactly = 1) { givenModule.initialize() }
+        assertCalledOnce { givenModule.initialize() }
     }
 
     @Test
@@ -65,8 +63,8 @@ class CustomerIOBuilderTest {
             .addCustomerIOModule(givenModule2)
             .build()
 
-        verify(exactly = 1) { givenModule1.initialize() }
-        verify(exactly = 1) { givenModule2.initialize() }
+        assertCalledOnce { givenModule1.initialize() }
+        assertCalledOnce { givenModule2.initialize() }
     }
 
     @Test
@@ -83,8 +81,8 @@ class CustomerIOBuilderTest {
             .addCustomerIOModule(givenModule2)
             .build()
 
-        verify(exactly = 0) { givenModule1.initialize() }
-        verify(exactly = 1) { givenModule2.initialize() }
+        assertCalledNever { givenModule1.initialize() }
+        assertCalledOnce { givenModule2.initialize() }
     }
 
     @Test
@@ -203,7 +201,7 @@ class CustomerIOBuilderTest {
     }
 
     private fun createCustomerIOBuilder(givenCdpApiKey: String? = null): CustomerIOBuilder = CustomerIOBuilder(
-        applicationContext = application,
+        applicationContext = applicationMock,
         cdpApiKey = givenCdpApiKey ?: String.random
     )
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/JUnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/JUnitTest.kt
@@ -1,24 +1,32 @@
 package io.customer.datapipelines.testutils.core
 
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import com.segment.analytics.kotlin.core.Analytics
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.core.JUnit5Test
+import io.customer.sdk.CustomerIO
 
 /**
- * Extension of the [UnitTestDelegate] class to provide setup and teardown methods for
- * JUnit tests using JUnit 5 annotations to setup and teardown the test environment.
- * Thr class uses test application instance to allow running tests without depending
- * on Android context and resources.
+ * Extension of [JUnit5Test] that utilizes [UnitTestDelegate] to setup test environment
+ * for running unit tests.
+ * This class should be used for running unit tests using JUnit.
  */
-open class JUnitTest : UnitTestDelegate() {
-    override var testApplication: Any = "Test"
+abstract class JUnitTest : JUnit5Test() {
+    private val delegate: UnitTestDelegate = UnitTestDelegate(applicationInstance = "Test")
+    private val defaultTestConfiguration: DataPipelinesTestConfig = testConfiguration {}
 
-    @BeforeEach
-    open fun setup() {
-        setupTestEnvironment()
+    val sdkInstance: CustomerIO get() = delegate.sdkInstance
+    val analytics: Analytics get() = delegate.analytics
+
+    override fun setup(testConfig: TestConfig) {
+        val config = defaultTestConfiguration + testConfig
+
+        super.setup(config)
+        delegate.setup(config)
     }
 
-    @AfterEach
-    open fun teardown() {
-        deinitializeModule()
+    override fun teardown() {
+        delegate.teardownSDKComponent()
+
+        super.teardown()
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
@@ -2,8 +2,8 @@ package io.customer.datapipelines.testutils.core
 
 import android.app.Application
 import com.segment.analytics.kotlin.core.Analytics
+import io.customer.commontest.config.configureAndroidSDKComponent
 import io.customer.commontest.util.DeviceStoreStub
-import io.customer.commontest.util.UnitTestLogger
 import io.customer.datapipelines.testutils.extensions.registerAnalyticsFactory
 import io.customer.datapipelines.testutils.utils.clearPersistentStorage
 import io.customer.datapipelines.testutils.utils.createTestAnalyticsInstance
@@ -11,7 +11,6 @@ import io.customer.datapipelines.testutils.utils.mockHTTPClient
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.mockk.every
@@ -19,22 +18,13 @@ import io.mockk.mockk
 import io.mockk.spyk
 
 /**
- * Base class for unit tests in the data pipelines module.
- * This class provides a setup for the CustomerIO instance and analytics instance.
- * The class is abstract and requires the test application instance to be provided
- * by child classes which allows running tests with or without depending on Android
- * context and resources.
+ * Delegate class for setting up test environment for running unit tests.
+ * The class makes it easy to setup both JUnit and Robolectric tests by delegating setup to this class.
  */
-abstract class UnitTestDelegate {
-    // Keep application instance as Any to allow using different types of
-    // application instances for tests
-    abstract var testApplication: Any
-
-    protected lateinit var sdkInstance: CustomerIO
-    protected lateinit var analytics: Analytics
-
-    protected lateinit var globalPreferenceStore: GlobalPreferenceStore
-    protected lateinit var deviceStore: DeviceStore
+class UnitTestDelegate(private val applicationInstance: Any) {
+    private lateinit var testConfig: DataPipelinesTestConfig
+    lateinit var sdkInstance: CustomerIO
+    lateinit var analytics: Analytics
 
     init {
         // Mock HTTP client to override CDP settings with test values
@@ -45,53 +35,54 @@ abstract class UnitTestDelegate {
      * Sets up test environment based on the provided [DataPipelinesTestConfig]
      * This function initializes necessary components and configurations required for running local tests
      *
-     * @param testConfig Configuration object containing all setups for the test environment
+     * @param config Configuration object containing all setups for the test environment
      */
-    protected open fun setupTestEnvironment(testConfig: DataPipelinesTestConfig = testConfiguration { }) {
-        setupSDKComponent(testConfig = testConfig)
-
-        sdkInstance = initializeSDKForTesting(testConfig = testConfig)
+    fun setup(config: DataPipelinesTestConfig) {
+        testConfig = config
+        mockAnalytics()
+        sdkInstance = initializeSDKComponent()
         analytics = sdkInstance.analytics
     }
 
-    protected open fun setupSDKComponent(testConfig: DataPipelinesTestConfig) {
+    private fun mockAnalytics() {
         // Setup analytics factory to create test analytics instance
         SDKComponent.registerAnalyticsFactory { moduleConfig ->
-            val testAnalyticsInstance = createTestAnalyticsInstance(moduleConfig, application = testApplication)
+            val testAnalyticsInstance = createTestAnalyticsInstance(moduleConfig, application = applicationInstance)
             // Configure plugins for the test analytics instance to allow adding
             // desired plugins before CustomerIO initialization
-            testConfig.configurePlugins(testAnalyticsInstance)
+            testConfig.analytics(testAnalyticsInstance)
             return@registerAnalyticsFactory testAnalyticsInstance
         }
-        // Override logger dependency with test logger so logs can be captured in tests
-        // This also makes logger independent of Android Logcat
-        SDKComponent.overrideDependency(Logger::class.java, UnitTestLogger())
     }
 
-    protected open fun setupAndroidSDKComponent() {
+    private fun overrideAndroidComponentDependencies() {
         // Setup AndroidSDKComponent by mocking dependencies that depends on Android context
         // Prefer relaxed mocks to avoid unnecessary setup for methods that are not used in the test
         val androidSDKComponent = SDKComponent.android()
         // Mock global preference store to avoid reading/writing to shared preferences
-        globalPreferenceStore = mockk<GlobalPreferenceStore>(relaxUnitFun = true).also { instance ->
-            androidSDKComponent.overrideDependency(GlobalPreferenceStore::class.java, instance)
+        val globalPreferenceStore = mockk<GlobalPreferenceStore>(relaxUnitFun = true).also { instance ->
+            androidSDKComponent.overrideDependency<GlobalPreferenceStore>(instance)
         }
         every { globalPreferenceStore.getDeviceToken() } returns null
         // Mock device store to avoid reading/writing to device store
         // Spy on the stub to provide custom implementation for the test
         val deviceStoreStub = DeviceStoreStub().getDeviceStore(androidSDKComponent.client)
-        deviceStore = spyk(deviceStoreStub).also { instance ->
-            androidSDKComponent.overrideDependency(DeviceStore::class.java, instance)
+        spyk(deviceStoreStub).also { instance ->
+            androidSDKComponent.overrideDependency<DeviceStore>(instance)
         }
+        // Apply custom configuration for the test at the end to allow overriding default configurations
+        testConfig.configureAndroidSDKComponent(androidSDKComponent)
     }
 
-    protected open fun initializeSDKForTesting(testConfig: DataPipelinesTestConfig): CustomerIO {
+    private fun initializeSDKComponent(): CustomerIO {
         // Cast application mock to reuse mocked application context if provided
         // Else create mocked application context to avoid using real context in tests
-        val applicationContext = testApplication as? Application ?: mockk(relaxed = true)
+        val applicationContext = applicationInstance as? Application ?: mockk<Application>(relaxed = true).apply {
+            every { applicationContext } returns this
+        }
         val builder = CustomerIOBuilder(applicationContext, testConfig.cdpApiKey)
         // Register AndroidSDKComponent with mocked dependencies as we are not using real context in tests
-        setupAndroidSDKComponent()
+        overrideAndroidComponentDependencies()
         // Disable adding destination to analytics instance so events are not sent to the server by default
         builder.setAutoAddCustomerIODestination(false)
         // Disable tracking application lifecycle events by default to avoid tracking unnecessary events while testing
@@ -101,7 +92,7 @@ abstract class UnitTestDelegate {
         return builder.build()
     }
 
-    protected open fun deinitializeModule() {
+    fun teardownSDKComponent() {
         analytics.clearPersistentStorage()
         CustomerIO.clearInstance()
     }


### PR DESCRIPTION
part of [MBL-394](https://linear.app/customerio/issue/MBL-394/decouple-common-tests-from-tracking-module)

### Changes

- Removed test dependencies from module's gradle file as they are now included in the common gradle file for test dependencies
- Updated tests to match package of their respective classes
- Updated tests to work with `common-test` updates
- Updated `DataPipelinesTestConfig` as an extension of `TestConfig` that helps setting up `datapipelines` tests with module specific configuration

### Test Status

All tests for `datapipelines` module are passing ✅

### Notes

See [parent PR](https://github.com/customerio/customerio-android/pull/373) for more details and context.