### PR TITLE
chore: prefer existing device token

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -127,7 +127,8 @@ public final class io/customer/datapipelines/plugins/DataPipelinePublishedEvents
 }
 
 public final class io/customer/datapipelines/plugins/PluginExtensionsKt {
-	public static final fun findInContextAtPath (Lcom/segment/analytics/kotlin/core/BaseEvent;Ljava/lang/String;)Lkotlinx/serialization/json/JsonPrimitive;
+	public static final fun findAtPath (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Ljava/util/List;
+	public static final fun findInContextAtPath (Lcom/segment/analytics/kotlin/core/BaseEvent;Ljava/lang/String;)Ljava/util/List;
 }
 
 public final class io/customer/datapipelines/plugins/StringExtensionsKt {

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -126,6 +126,10 @@ public final class io/customer/datapipelines/plugins/DataPipelinePublishedEvents
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 
+public final class io/customer/datapipelines/plugins/PluginExtensionsKt {
+	public static final fun findInContextAtPath (Lcom/segment/analytics/kotlin/core/BaseEvent;Ljava/lang/String;)Lkotlinx/serialization/json/JsonPrimitive;
+}
+
 public final class io/customer/datapipelines/plugins/StringExtensionsKt {
 	public static final fun getScreenNameFromActivity (Ljava/lang/String;)Ljava/lang/String;
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -25,7 +25,10 @@ class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
         // SDK information is being sent through user-agent
         event.removeFromContext("library")
 
-        deviceToken?.let { token ->
+        // In case of migration from older versions, the token might already be present in the context
+        // We need to ensure that the token is not overridden to avoid corruption of data
+        // If the token is not present in the context, we add current token to the context
+        event.findInContextAtPath("device.token")?.content ?: deviceToken?.let { token ->
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)
         }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -28,7 +28,7 @@ class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
         // In case of migration from older versions, the token might already be present in context
         // We need to ensure that the token is not overridden to avoid corruption of data
         // So we add current token to context only if context does not have any token already
-        event.findInContextAtPath("device.token")?.content ?: deviceToken?.let { token ->
+        event.findInContextAtPath("device.token").firstOrNull()?.content ?: deviceToken?.let { token ->
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)
         }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -25,9 +25,9 @@ class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
         // SDK information is being sent through user-agent
         event.removeFromContext("library")
 
-        // In case of migration from older versions, the token might already be present in the context
+        // In case of migration from older versions, the token might already be present in context
         // We need to ensure that the token is not overridden to avoid corruption of data
-        // If the token is not present in the context, we add current token to the context
+        // So we add current token to context only if context does not have any token already
         event.findInContextAtPath("device.token")?.content ?: deviceToken?.let { token ->
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
@@ -1,29 +1,62 @@
 package io.customer.datapipelines.plugins
 
 import com.segment.analytics.kotlin.core.BaseEvent
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Gets the value at nested path in the JSON object.
- * Example: `{"a": {"b": "c"}}.findAtPath("a.b")` returns c
+ * Gets the value(s) at nested path in the JSON object.
+ * Handles arrays by returning all matching elements.
+ * Example1: `{"a": [{"b": "c"}, {"e": "f"}]}.findAtPath("a.b")` returns [JsonPrimitive("c")]
+ * Example2: `{"a": {"b": "c"}}.findAtPath("a.b")` returns [JsonPrimitive("c")]
  */
-internal fun JsonObject.findAtPath(path: String): JsonPrimitive? = kotlin.runCatching {
-    // Split the path into keys
-    val keys = path.split(".")
-    // Start with the current JSON object
-    var currentElement = this
-    // Traverse the JSON object to find the value at the path
-    for (key in keys.dropLast(1)) {
-        // If the key does not exist, return null
-        currentElement = currentElement[key]?.jsonObject ?: return null
-    }
-    // Return the value at the last key in the path
-    return currentElement[keys.last()]?.jsonPrimitive
-}.getOrNull()
+fun JsonObject.findAtPath(path: String): List<JsonPrimitive> {
+    // Split the path into individual keys
+    val keys = path.split('.')
+    // Start the recursive search
+    return findAtPathRecursive(this, keys)
+}
 
-fun BaseEvent.findInContextAtPath(
-    path: String
-): JsonPrimitive? = context.findAtPath(path = path)
+/**
+ * Recursively searches for values at the specified path in the JSON element.
+ * @param element The current JSON element being processed.
+ * @param keys The remaining path keys to process.
+ * @return A list of JsonPrimitives found at the path.
+ */
+private fun findAtPathRecursive(element: JsonElement, keys: List<String>): List<JsonPrimitive> {
+    // Base case: If no more keys, check if the element is a JsonPrimitive
+    if (keys.isEmpty()) {
+        return if (element is JsonPrimitive) listOf(element) else emptyList()
+    }
+
+    // Extract the first key and the remaining keys
+    val key = keys.first()
+    val remainingKeys = keys.drop(1)
+
+    return when (element) {
+        is JsonObject -> {
+            // If element is a JsonObject, look up the next key
+            val nextElement = element[key]
+            // If the key exists, continue the recursive search
+            if (nextElement != null) findAtPathRecursive(nextElement, remainingKeys) else emptyList()
+        }
+        is JsonArray -> {
+            // If element is a JsonArray, apply the search to each element
+            element.flatMap { findAtPathRecursive(it, keys) }
+        }
+        else -> {
+            // If element is neither JsonObject nor JsonArray, return an empty list
+            emptyList()
+        }
+    }
+}
+
+/**
+ * Extension function for BaseEvent to search in its context at a specified path.
+ * @param path The dot-separated path to search for.
+ * @return A list of JsonPrimitives found at the path.
+ */
+fun BaseEvent.findInContextAtPath(path: String): List<JsonPrimitive> =
+    context.findAtPath(path)

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Gets the value at nested path in the JSON object.
- * Example: `{"a": {"b": "c"}}.getNestedString("a.b")` returns c
+ * Example: `{"a": {"b": "c"}}.findAtPath("a.b")` returns c
  */
 internal fun JsonObject.findAtPath(path: String): JsonPrimitive? = kotlin.runCatching {
     // Split the path into keys

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/PluginExtensions.kt
@@ -1,0 +1,29 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.BaseEvent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Gets the value at nested path in the JSON object.
+ * Example: `{"a": {"b": "c"}}.getNestedString("a.b")` returns c
+ */
+internal fun JsonObject.findAtPath(path: String): JsonPrimitive? = kotlin.runCatching {
+    // Split the path into keys
+    val keys = path.split(".")
+    // Start with the current JSON object
+    var currentElement = this
+    // Traverse the JSON object to find the value at the path
+    for (key in keys.dropLast(1)) {
+        // If the key does not exist, return null
+        currentElement = currentElement[key]?.jsonObject ?: return null
+    }
+    // Return the value at the last key in the path
+    return currentElement[keys.last()]?.jsonPrimitive
+}.getOrNull()
+
+fun BaseEvent.findInContextAtPath(
+    path: String
+): JsonPrimitive? = context.findAtPath(path = path)

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
@@ -60,8 +60,8 @@ class ContextPluginTest : JUnitTest() {
         migrationTokenPlugin.newToken = givenNewToken
         analytics.process(TrackEvent(emptyJsonObject, givenEventName))
 
-        // To avoid false positives, ensure that the original token is not null
-        // and ContextPlugin is attached later than MigrationTokenPlugin
+        // To avoid false positives, ensure that original token is not null
+        // and ContextPlugin was attached after MigrationTokenPlugin
         migrationTokenPlugin.originalToken.shouldBeNull()
 
         val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
@@ -1,0 +1,115 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.TrackEvent
+import com.segment.analytics.kotlin.core.emptyJsonObject
+import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.utilities.putInContextUnderKey
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.extensions.deviceToken
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.mockk.every
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSingleItem
+import org.junit.jupiter.api.Test
+
+class ContextPluginTest : JUnitTest() {
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        // Keep setup empty to avoid calling super.setup() as it will initialize the SDK
+        // and we want to test the SDK with different configurations in each test
+    }
+
+    private fun setupWithConfig(testConfig: DataPipelinesTestConfig = testConfiguration {}) {
+        super.setup(testConfig)
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun process_givenTokenExists_expectDoNotUpdateContextDeviceToken() {
+        val migrationTokenPlugin = MigrationTokenPlugin()
+        setupWithConfig(
+            testConfiguration {
+                analytics { add(migrationTokenPlugin) }
+            }
+        )
+
+        val givenOriginalToken = String.random
+        every { globalPreferenceStore.getDeviceToken() } returns givenOriginalToken
+        sdkInstance.registerDeviceToken(givenOriginalToken)
+        outputReaderPlugin.reset()
+
+        val givenEventName = String.random
+        val givenNewToken = String.random
+        migrationTokenPlugin.newToken = givenNewToken
+        analytics.process(TrackEvent(emptyJsonObject, givenEventName))
+
+        // To avoid false positives, ensure that the original token is not null
+        // and ContextPlugin is attached later than MigrationTokenPlugin
+        migrationTokenPlugin.originalToken.shouldBeNull()
+
+        val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
+        result.event shouldBeEqualTo givenEventName
+        result.context.deviceToken shouldBeEqualTo givenNewToken
+    }
+
+    @Test
+    fun process_givenTokenDoesNotExist_expectUpdateContextDeviceToken() {
+        setupWithConfig()
+
+        val givenOriginalToken = String.random
+        every { globalPreferenceStore.getDeviceToken() } returns givenOriginalToken
+        sdkInstance.registerDeviceToken(givenOriginalToken)
+        outputReaderPlugin.reset()
+
+        val givenEventName = String.random
+        analytics.process(TrackEvent(emptyJsonObject, givenEventName))
+
+        val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
+        result.event shouldBeEqualTo givenEventName
+        result.context.deviceToken shouldBeEqualTo givenOriginalToken
+    }
+
+    @Test
+    fun process_givenNoTokenAvailable_expectNoContextDeviceToken() {
+        setupWithConfig()
+
+        val givenEventName = String.random
+        analytics.process(TrackEvent(emptyJsonObject, givenEventName))
+
+        val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
+        result.event shouldBeEqualTo givenEventName
+        result.context.deviceToken.shouldBeNull()
+    }
+}
+
+private class MigrationTokenPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var analytics: Analytics
+    var originalToken: String? = null
+    var newToken: String? = null
+
+    override fun execute(event: BaseEvent): BaseEvent? {
+        originalToken = event.context.deviceToken
+        newToken?.let { token ->
+            event.putInContextUnderKey("device", "token", token)
+        }
+        return super.execute(event)
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExt.kt
@@ -1,6 +1,7 @@
 package io.customer.datapipelines.testutils.extensions
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
+import io.customer.datapipelines.plugins.findAtPath
 import io.customer.sdk.data.model.CustomAttributes
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -11,7 +12,6 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.amshove.kluent.internal.assertEquals
 
 /**
@@ -81,28 +81,10 @@ private fun <T> Json.encode(value: T?): JsonElement = when (value) {
 internal val JsonObject.deviceToken: String?
     get() = this.getStringAtPath("device.token")
 
-/**
- * Get the value at the nested path in the JSON object.
- * Example: `{"a": {"b": "c"}}.getNestedString("a.b")` returns c
- */
-fun JsonObject.getJsonPrimitiveAtPath(path: String): JsonPrimitive? {
-    // Split the path into keys
-    val keys = path.split(".")
-    // Start with the current JSON object
-    var currentElement = this
-    // Traverse the JSON object to find the value at the path
-    for (key in keys.dropLast(1)) {
-        // If the key does not exist, return null
-        currentElement = currentElement[key]?.jsonObject ?: return null
-    }
-    // Return the value at the last key in the path
-    return currentElement[keys.last()]?.jsonPrimitive
-}
-
 fun JsonObject.getStringAtPath(path: String): String? {
-    return getJsonPrimitiveAtPath(path)?.content
+    return findAtPath(path)?.content
 }
 
 fun JsonObject.getJsonObjectAtPath(path: String): JsonObject? {
-    return getJsonPrimitiveAtPath(path)?.jsonObject
+    return findAtPath(path)?.jsonObject
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExt.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExt.kt
@@ -82,9 +82,9 @@ internal val JsonObject.deviceToken: String?
     get() = this.getStringAtPath("device.token")
 
 fun JsonObject.getStringAtPath(path: String): String? {
-    return findAtPath(path)?.content
+    return findAtPath(path).firstOrNull()?.content
 }
 
 fun JsonObject.getJsonObjectAtPath(path: String): JsonObject? {
-    return findAtPath(path)?.jsonObject
+    return findAtPath(path).firstOrNull()?.jsonObject
 }


### PR DESCRIPTION
part of [MBL-220](https://linear.app/customerio/issue/MBL-220/migration-for-track-background-queue-identify-and-events)

### Changes

- Updated `ContextPlugin` to avoid rewriting token if one already exists
- This is to prevent data corruption with the old token already added to JSON
- Moved helpful extension from tests to production code that helps append the token to event JSON
- Added tests to validate changes