### PR TITLE
chore: fix memory leak in lifecycle listener

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -313,6 +313,7 @@ public final class io/customer/sdk/events/TrackMetric$Push : io/customer/sdk/eve
 
 public final class io/customer/sdk/lifecycle/CustomerIOActivityLifecycleCallbacks : android/app/Application$ActivityLifecycleCallbacks {
 	public fun <init> ()V
+	public final fun currentLifecycleState ()Lio/customer/sdk/lifecycle/LifecycleStateChange;
 	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
 	public fun onActivityDestroyed (Landroid/app/Activity;)V
 	public fun onActivityPaused (Landroid/app/Activity;)V

--- a/core/src/main/kotlin/io/customer/sdk/lifecycle/CustomerIOActivityLifecycleCallbacks.kt
+++ b/core/src/main/kotlin/io/customer/sdk/lifecycle/CustomerIOActivityLifecycleCallbacks.kt
@@ -43,6 +43,12 @@ class CustomerIOActivityLifecycleCallbacks : Application.ActivityLifecycleCallba
         currentLifecycleStateRef = null
     }
 
+    /**
+     * Returns last emitted lifecycle state.
+     * The function returns null if no event has been emitted yet.
+     * New subscribers can use this function to get current state after subscribing
+     * to simulate behavior of replaying events.
+     */
     fun currentLifecycleState(): LifecycleStateChange? {
         return currentLifecycleStateRef?.get()
     }


### PR DESCRIPTION
### Changes

- Used `WeakReference` instead of `replay` to prevent holding strong activity references and avoid memory leaks
- Exposed `currentLifecycleState` which wrappers can use to get current state and act accordingly

### Testing

`MemoryLeakageInstrumentedTest` which was previously failing now passes after the changes.
