### PR TITLE
chore: add site pref repo to migration module

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PreferenceStore.kt
@@ -6,10 +6,10 @@ import android.content.SharedPreferences
 /**
  * Base preference repository that can be reused among different preference repositories.
  */
-internal abstract class PreferenceStore(val context: Context) {
+abstract class PreferenceStore(val context: Context) {
     abstract val prefsName: String
 
-    internal val prefs: SharedPreferences
+    protected val prefs: SharedPreferences
         get() = context.applicationContext.getSharedPreferences(
             prefsName,
             Context.MODE_PRIVATE

--- a/tracking-migration/api/tracking-migration.api
+++ b/tracking-migration/api/tracking-migration.api
@@ -20,6 +20,15 @@ public abstract interface class io/customer/tracking/migration/queue/QueueStorag
 	public abstract fun getInventory ()Ljava/util/List;
 }
 
+public abstract interface class io/customer/tracking/migration/repository/preference/SitePreferenceRepository {
+	public abstract fun clearAll ()V
+	public abstract fun getDeviceToken ()Ljava/lang/String;
+	public abstract fun getIdentifier ()Ljava/lang/String;
+	public abstract fun removeIdentifier (Ljava/lang/String;)V
+	public abstract fun saveDeviceToken (Ljava/lang/String;)V
+	public abstract fun saveIdentifier (Ljava/lang/String;)V
+}
+
 public final class io/customer/tracking/migration/request/Device {
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/repository/preference/SitePreferenceRepository.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/repository/preference/SitePreferenceRepository.kt
@@ -1,0 +1,52 @@
+package io.customer.tracking.migration.repository.preference
+
+import android.content.Context
+import androidx.core.content.edit
+import io.customer.sdk.data.store.PreferenceStore
+import io.customer.sdk.data.store.read
+
+interface SitePreferenceRepository {
+    fun saveIdentifier(identifier: String)
+    fun removeIdentifier(identifier: String)
+    fun getIdentifier(): String?
+
+    fun saveDeviceToken(token: String)
+    fun getDeviceToken(): String?
+
+    fun clearAll()
+}
+
+internal class SitePreferenceRepositoryImpl(
+    context: Context,
+    private val siteId: String
+) : PreferenceStore(context), SitePreferenceRepository {
+
+    override val prefsName: String by lazy {
+        "io.customer.sdk.${context.packageName}.$siteId"
+    }
+
+    companion object {
+        private const val KEY_IDENTIFIER = "identifier"
+        private const val KEY_DEVICE_TOKEN = "device_token"
+    }
+
+    override fun saveIdentifier(identifier: String) = prefs.edit {
+        putString(KEY_IDENTIFIER, identifier)
+    }
+
+    override fun removeIdentifier(identifier: String) = prefs.edit {
+        remove(KEY_IDENTIFIER)
+    }
+
+    override fun getIdentifier(): String? = prefs.read {
+        getString(KEY_IDENTIFIER, null)
+    }
+
+    override fun saveDeviceToken(token: String) = prefs.edit {
+        putString(KEY_DEVICE_TOKEN, token)
+    }
+
+    override fun getDeviceToken(): String? = prefs.read {
+        getString(KEY_DEVICE_TOKEN, null)
+    }
+}


### PR DESCRIPTION
part of [MBL-220](https://linear.app/customerio/issue/MBL-220/migration-for-track-background-queue-identify-and-events)

### Changes

- Updated core `PreferenceStore` to allow extending in other modules
- Refactored and added `SitePreferenceRepository` to `migration` module to fetch values added by `tracking` module in older releases