### PR TITLE
refactor: move event names to constants

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/core/TestConstants.kt
+++ b/common-test/src/main/java/io/customer/commontest/core/TestConstants.kt
@@ -11,9 +11,4 @@ object TestConstants {
         const val SITE_ID = "TESTING_SITE_ID"
         const val CDP_API_KEY = "TESTING_API_KEY"
     }
-
-    object Events {
-        const val DEVICE_CREATED = "Device Created or Updated"
-        const val DEVICE_DELETED = "Device Deleted"
-    }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPlugin.kt
@@ -5,6 +5,7 @@ import com.segment.analytics.kotlin.core.BaseEvent
 import com.segment.analytics.kotlin.core.TrackEvent
 import com.segment.analytics.kotlin.core.platform.Plugin
 import com.segment.analytics.kotlin.core.utilities.putAll
+import io.customer.datapipelines.util.EventNames
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 
@@ -16,7 +17,7 @@ class AutoTrackDeviceAttributesPlugin : Plugin {
     override lateinit var analytics: Analytics
 
     override fun execute(event: BaseEvent): BaseEvent {
-        if ((event as? TrackEvent)?.event != "Device Created or Updated") {
+        if ((event as? TrackEvent)?.event != EventNames.DEVICE_UPDATE) {
             return event
         }
 

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/EventNames.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/EventNames.kt
@@ -1,0 +1,11 @@
+package io.customer.datapipelines.util
+
+/**
+ * Event names to identify specific events in data pipelines so they can be
+ * reflected on Journeys.
+ */
+internal object EventNames {
+    const val DEVICE_UPDATE = "Device Created or Updated"
+    const val DEVICE_DELETE = "Device Deleted"
+    const val METRIC_DELIVERY = "Report Delivery Event"
+}

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -17,6 +17,7 @@ import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.ContextPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.DataPipelinePublishedEvents
+import io.customer.datapipelines.util.EventNames
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
 import io.customer.sdk.core.di.AndroidSDKComponent
@@ -276,7 +277,7 @@ class CustomerIO private constructor(
         contextPlugin.deviceToken = token
 
         logger.info("updating device attributes: $attributes")
-        track("Device Created or Updated", attributes)
+        track(EventNames.DEVICE_UPDATE, attributes)
     }
 
     override fun deleteDeviceToken() {
@@ -288,14 +289,14 @@ class CustomerIO private constructor(
             return
         }
 
-        track("Device Deleted")
+        track(EventNames.DEVICE_DELETE)
     }
 
     override fun trackMetric(event: TrackMetric) {
         logger.info("${event.type} metric received for ${event.metric} event")
         logger.debug("tracking ${event.type} metric event with properties $event")
 
-        track("Report Delivery Event", event.asMap())
+        track(EventNames.METRIC_DELIVERY, event.asMap())
     }
 
     companion object {

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -5,7 +5,6 @@ import com.segment.analytics.kotlin.core.emptyJsonArray
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.getString
 import io.customer.commontest.config.TestConfig
-import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.random
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
@@ -15,6 +14,7 @@ import io.customer.datapipelines.testutils.extensions.deviceToken
 import io.customer.datapipelines.testutils.extensions.encodeToJsonElement
 import io.customer.datapipelines.testutils.extensions.shouldMatchTo
 import io.customer.datapipelines.testutils.extensions.toJsonObject
+import io.customer.datapipelines.util.EventNames
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.data.store.DeviceStore
@@ -368,7 +368,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
 
         val payload = queuedEvents.first().jsonObject
         payload.eventType shouldBeEqualTo "track"
-        payload.eventName shouldBeEqualTo "Report Delivery Event"
+        payload.eventName shouldBeEqualTo EventNames.METRIC_DELIVERY
         payload["properties"]?.jsonObject.shouldNotBeNull() shouldMatchTo mapOf(
             "metric" to "delivered",
             "deliveryId" to givenDeliveryId,
@@ -397,7 +397,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
 
         val payload = queuedEvents.first().jsonObject
         payload.eventType shouldBeEqualTo "track"
-        payload.eventName shouldBeEqualTo "Report Delivery Event"
+        payload.eventName shouldBeEqualTo EventNames.METRIC_DELIVERY
         payload["properties"]?.jsonObject.shouldNotBeNull() shouldMatchTo buildMap {
             put("metric", "clicked")
             put("deliveryId", givenDeliveryId)
@@ -424,7 +424,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
 
         val payload = queuedEvents.last().jsonObject
         payload.eventType shouldBeEqualTo "track"
-        payload.eventName shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        payload.eventName shouldBeEqualTo EventNames.DEVICE_UPDATE
 
         val payloadContext = payload["context"]?.jsonObject.shouldNotBeNull()
         payloadContext.deviceToken shouldBeEqualTo givenToken
@@ -456,7 +456,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
 
         val payload = queuedEvents.last().jsonObject
         payload.eventType shouldBeEqualTo "track"
-        payload.eventName shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        payload.eventName shouldBeEqualTo EventNames.DEVICE_UPDATE
 
         val payloadContext = payload["context"]?.jsonObject.shouldNotBeNull()
         payloadContext.deviceToken shouldBeEqualTo givenToken
@@ -486,7 +486,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
         val payload = queuedEvents.last().jsonObject
         payload.userId shouldBeEqualTo givenIdentifier
         payload.eventType shouldBeEqualTo "track"
-        payload.eventName shouldBeEqualTo TestConstants.Events.DEVICE_DELETED
+        payload.eventName shouldBeEqualTo EventNames.DEVICE_DELETE
 
         val payloadContext = payload["context"]?.jsonObject.shouldNotBeNull()
         payloadContext.deviceToken shouldBeEqualTo givenToken

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -2,7 +2,6 @@ package io.customer.datapipelines
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import io.customer.commontest.config.TestConfig
-import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
 import io.customer.datapipelines.testutils.core.JUnitTest
@@ -14,6 +13,7 @@ import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.identifyEvents
 import io.customer.datapipelines.testutils.utils.screenEvents
 import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.datapipelines.util.EventNames
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.data.store.DeviceStore
@@ -403,7 +403,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
         deviceRegisterEvent.properties.shouldBeEmpty()
     }
@@ -428,7 +428,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
         deviceRegisterEvent.properties shouldMatchTo givenAttributes
     }
@@ -450,7 +450,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceDeleteEvent = outputReaderPlugin.trackEvents.last()
         deviceDeleteEvent.userId shouldBeEqualTo givenIdentifier
-        deviceDeleteEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_DELETED
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
         deviceDeleteEvent.context.deviceToken shouldBeEqualTo givenToken
         deviceDeleteEvent.properties.shouldBeEmpty()
     }
@@ -475,12 +475,12 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceDeleteEvent = outputReaderPlugin.trackEvents.first()
         deviceDeleteEvent.userId shouldBeEqualTo givenPreviouslyIdentifiedProfile
-        deviceDeleteEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_DELETED
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
         deviceDeleteEvent.context.deviceToken shouldBeEqualTo givenToken
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
     }
 
@@ -521,12 +521,12 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceDeleteEvent = outputReaderPlugin.trackEvents.first()
         deviceDeleteEvent.userId shouldBeEqualTo givenIdentifier
-        deviceDeleteEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_DELETED
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
         deviceDeleteEvent.context.deviceToken shouldBeEqualTo givenPreviousDeviceToken
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
     }
 
@@ -546,7 +546,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
     }
 
@@ -566,7 +566,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
     }
 
@@ -584,7 +584,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.last()
         deviceRegisterEvent.userId.shouldBeEmpty()
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.pm.PackageManager
 import com.segment.analytics.kotlin.android.plugins.AndroidContextPlugin
 import io.customer.commontest.config.TestConfig
-import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.random
 import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
 import io.customer.datapipelines.testutils.core.IntegrationTest
@@ -13,6 +12,7 @@ import io.customer.datapipelines.testutils.extensions.deviceToken
 import io.customer.datapipelines.testutils.extensions.encodeToJsonValue
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.datapipelines.util.EventNames
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.mockk.every
@@ -79,7 +79,7 @@ class DeviceAttributesTests : IntegrationTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
         deviceRegisterEvent.properties.shouldBeEmpty()
     }
@@ -105,7 +105,7 @@ class DeviceAttributesTests : IntegrationTest() {
 
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
 
         val properties = deviceRegisterEvent.properties
@@ -155,7 +155,7 @@ class DeviceAttributesTests : IntegrationTest() {
         // 2. Device Updated
         val deviceRegisterEvent = outputReaderPlugin.trackEvents.shouldHaveSize(2).last()
         deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
-        deviceRegisterEvent.event shouldBeEqualTo TestConstants.Events.DEVICE_CREATED
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
         deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
 
         val properties = deviceRegisterEvent.properties


### PR DESCRIPTION
part of [MBL-220](https://linear.app/customerio/issue/MBL-220/migration-for-track-background-queue-identify-and-events)

### Changes

- Added `EventNames` to hold constants for event names so they can be reused
- Updated code and tests to use newly added constants