### PR TITLE
chore: copy tracking classes to test migration

### DIFF
--- a/tracking-migration/build.gradle
+++ b/tracking-migration/build.gradle
@@ -1,8 +1,10 @@
 import io.customer.android.Configurations
+import io.customer.android.Dependencies
 
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'org.jetbrains.kotlin.kapt'
     id 'com.twilio.apkscale'
 }
 
@@ -34,7 +36,9 @@ dependencies {
     api project(":base")
     api project(":core")
 
-    implementation io.customer.android.Dependencies.coroutinesCore
-    implementation io.customer.android.Dependencies.coroutinesAndroid
-
+    implementation Dependencies.coroutinesCore
+    implementation Dependencies.coroutinesAndroid
+    // Only required for testing data classes from old tracking module
+    testImplementation Dependencies.moshi
+    kaptTest Dependencies.moshiCodeGen
 }

--- a/tracking-migration/src/test/java/io/customer/sdk/data/model/EventType.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/model/EventType.kt
@@ -1,0 +1,8 @@
+package io.customer.sdk.data.model
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = false)
+enum class EventType {
+    event, screen
+}

--- a/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/BigDecimalAdapter.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/BigDecimalAdapter.kt
@@ -1,0 +1,13 @@
+package io.customer.sdk.data.moshi.adapter
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.math.BigDecimal
+
+internal class BigDecimalAdapter {
+    @FromJson
+    fun fromJson(string: String) = BigDecimal(string)
+
+    @ToJson
+    fun toJson(value: BigDecimal) = value.toString()
+}

--- a/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/CustomAttributesAdapter.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/CustomAttributesAdapter.kt
@@ -1,0 +1,107 @@
+package io.customer.sdk.data.moshi.adapter
+
+import com.squareup.moshi.*
+import io.customer.base.extenstions.getUnixTimestamp
+import io.customer.sdk.data.model.CustomAttributes
+import java.lang.reflect.Type
+import java.math.BigDecimal
+import java.util.*
+
+internal class CustomAttributesFactory : JsonAdapter.Factory {
+    override fun create(
+        type: Type,
+        annotations: MutableSet<out Annotation>,
+        moshi: Moshi
+    ): JsonAdapter<*>? {
+        if (Types.getRawType(type) != Map::class.java) {
+            return null
+        }
+        return CustomAttributesAdapter(moshi).nullSafe()
+    }
+}
+
+/**
+ * Moshi [JsonAdapter] for supporting [CustomAttributes] for the SDK.
+ *
+ * Duties of the JsonAdapter to support:
+ * * For numbers inside of JSON, parse them to [BigDecimal]. Moshi by default uses [Double] which may not be big enough for a customer's use.
+ * * Convert [Date] to [Long] (unix timestamp) as that's what the Customer.IO API expects.
+ * * Convert [Enum] to [String] data type.
+ * * Because the Map allows Any, filter out values that Moshi does not support. This lessons the chance of sending attributes to the API that the API cannot understand. This filtering is done *before* JSON parsing. Therefore, use the included [CustomAttributes.verify] extensions before using the [io.customer.sdk.util.JsonAdapter].
+ */
+internal class CustomAttributesAdapter(moshi: Moshi) :
+    JsonAdapter<CustomAttributes>() {
+
+    private val elementAdapter: JsonAdapter<Any> = moshi.adapter(Any::class.java)
+    private val elementBigDecimalAdapter: JsonAdapter<BigDecimal> =
+        moshi.adapter(BigDecimal::class.java)
+
+    override fun fromJson(reader: JsonReader): CustomAttributes {
+        val result = mutableMapOf<String, Any>()
+        reader.beginObject()
+        while (reader.peek() != JsonReader.Token.END_OBJECT) {
+            try {
+                val name = reader.nextName()
+                val peeked = reader.peekJson()
+                if (peeked.peek() == JsonReader.Token.NUMBER) {
+                    result[name] = elementBigDecimalAdapter.fromJson(peeked)!!
+                } else {
+                    result[name] = elementAdapter.fromJson(peeked)!!
+                }
+            } catch (ignored: JsonDataException) {
+            }
+            reader.skipValue()
+        }
+        reader.endObject()
+        return result
+    }
+
+    override fun toJson(writer: JsonWriter, value: CustomAttributes?) {
+        if (value == null) {
+            throw NullPointerException("value was null! Wrap in .nullSafe() to write nullable values.")
+        }
+        val value = verifyCustomAttributes(value)
+
+        writer.beginObject()
+
+        value.forEach {
+            try {
+                /**
+                 * If moshi can't serialize an object, it will throw an exception and crash the SDK.
+                 * To avoid the SDK crashing, try to see if Moshi is able to serialize the object.
+                 * If it is able to, then let's use the JSON writer to write the object to the JSON string. Else, ignore the attribute.
+                 */
+                elementAdapter.toJson(it.value) // our test. will throw exception if can't serialize.
+
+                // Write to json string since we are confident that it's able to be serialized now.
+                writer.name(it.key)
+                elementAdapter.toJson(writer, it.value)
+            } catch (e: Throwable) {
+                // Ignore element if it can't be serialized.
+                // Have automated tests written against SDK objects to assert the SDK models are able to
+                // serialize.
+            }
+        }
+
+        writer.endObject()
+    }
+
+    /**
+     * Convert data types of the Map to data types the Customer.io API can understand. We want to run this function before Moshi converts our Map into a JSON string that then gets sent to theAPI.
+     */
+    private fun verifyCustomAttributes(value: CustomAttributes): CustomAttributes {
+        fun getValidValue(any: Any): Any {
+            return when (any) {
+                is Date -> any.getUnixTimestamp() // The API expects dates to be in Unix time format.
+                is Enum<*> -> any.name // Convert Enum data types to String.
+                else -> any
+            }
+        }
+
+        val validMap = mutableMapOf<String, Any>()
+        value.entries.forEach {
+            validMap[it.key] = getValidValue(it.value)
+        }
+        return validMap.toMap()
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/UnixDateAdapter.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/moshi/adapter/UnixDateAdapter.kt
@@ -1,0 +1,34 @@
+package io.customer.sdk.data.moshi.adapter
+
+import com.squareup.moshi.*
+import io.customer.base.extenstions.getUnixTimestamp
+import io.customer.base.extenstions.unixTimeToDate
+import java.io.IOException
+import java.util.*
+import org.json.JSONObject.NULL
+
+// Help from: https://github.com/square/moshi/blob/fd128875c308a90288e705162e03a835220a74d9/moshi-adapters/src/main/java/com/squareup/moshi/adapters/Rfc3339DateJsonAdapter.kt
+// The Customer.io API uses unix date format. Use this date format for all Dates with JSON.
+internal class UnixDateAdapter : JsonAdapter<Date>() {
+    @Synchronized
+    @Throws(IOException::class)
+    @FromJson
+    override fun fromJson(reader: JsonReader): Date? {
+        if (reader.peek() == NULL) {
+            return reader.nextNull()
+        }
+        val string = reader.nextString()
+        return string.toLongOrNull()?.unixTimeToDate()
+    }
+
+    @Synchronized
+    @Throws(IOException::class)
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: Date?) {
+        if (value == null) {
+            writer.nullValue()
+        } else {
+            writer.value(value.getUnixTimestamp())
+        }
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/sdk/data/request/DeliveryEvent.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/request/DeliveryEvent.kt
@@ -1,0 +1,24 @@
+package io.customer.sdk.data.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.util.Date
+
+@JsonClass(generateAdapter = false)
+internal enum class DeliveryType {
+    in_app
+}
+
+@JsonClass(generateAdapter = true)
+internal data class DeliveryPayload(
+    @field:Json(name = "delivery_id") val deliveryID: String,
+    val event: MetricEvent,
+    val timestamp: Date,
+    @field:Json(name = "metadata") val metaData: Map<String, String>
+)
+
+@JsonClass(generateAdapter = true)
+internal data class DeliveryEvent(
+    val type: DeliveryType,
+    val payload: DeliveryPayload
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/data/request/Device.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/request/Device.kt
@@ -1,0 +1,20 @@
+package io.customer.sdk.data.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import io.customer.sdk.data.model.CustomAttributes
+import java.util.Date
+
+@JsonClass(generateAdapter = true)
+data class Device(
+    @field:Json(name = "id") val token: String,
+    val platform: String = "android",
+    @field:Json(name = "last_used") val lastUsed: Date?, // nullable to cater for `lastUsed` field in older versions of the SDK
+    @field:Json(name = "lastUsed") val lastUsedDeprecated: Date? = null, // additional field to cater for `lastUsed` field in older versions of the SDK
+    val attributes: CustomAttributes
+)
+
+@JsonClass(generateAdapter = true)
+internal data class DeviceRequest(
+    val device: Device
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/data/request/Event.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/request/Event.kt
@@ -1,0 +1,13 @@
+package io.customer.sdk.data.request
+
+import com.squareup.moshi.JsonClass
+import io.customer.sdk.data.model.CustomAttributes
+import io.customer.sdk.data.model.EventType
+
+@JsonClass(generateAdapter = true)
+internal data class Event(
+    val name: String,
+    val type: EventType,
+    val data: CustomAttributes,
+    val timestamp: Long? = null
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/data/request/Metric.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/data/request/Metric.kt
@@ -1,0 +1,28 @@
+package io.customer.sdk.data.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.util.Date
+
+@JsonClass(generateAdapter = false)
+enum class MetricEvent {
+    delivered, opened, converted, clicked;
+
+    companion object {
+        fun getEvent(event: String?): MetricEvent? {
+            return if (event.isNullOrBlank()) {
+                null
+            } else {
+                values().find { value -> value.name.equals(event, ignoreCase = true) }
+            }
+        }
+    }
+}
+
+@JsonClass(generateAdapter = true)
+internal data class Metric(
+    @field:Json(name = "delivery_id") val deliveryID: String,
+    @field:Json(name = "device_id") val deviceToken: String,
+    val event: MetricEvent,
+    val timestamp: Date
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/DeletePushNotificationQueueTaskData.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/DeletePushNotificationQueueTaskData.kt
@@ -1,0 +1,9 @@
+package io.customer.sdk.queue.taskdata
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class DeletePushNotificationQueueTaskData(
+    val profileIdentified: String,
+    val deviceToken: String
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/IdentifyProfileQueueTaskData.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/IdentifyProfileQueueTaskData.kt
@@ -1,0 +1,9 @@
+package io.customer.sdk.queue.taskdata
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class IdentifyProfileQueueTaskData(
+    val identifier: String,
+    val attributes: Map<String, Any>
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/RegisterPushNotificationQueueTaskData.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/RegisterPushNotificationQueueTaskData.kt
@@ -1,0 +1,10 @@
+package io.customer.sdk.queue.taskdata
+
+import com.squareup.moshi.JsonClass
+import io.customer.sdk.data.request.Device
+
+@JsonClass(generateAdapter = true)
+internal data class RegisterPushNotificationQueueTaskData(
+    val profileIdentified: String,
+    val device: Device
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/TrackEventQueueTaskData.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/taskdata/TrackEventQueueTaskData.kt
@@ -1,0 +1,10 @@
+package io.customer.sdk.queue.taskdata
+
+import com.squareup.moshi.JsonClass
+import io.customer.sdk.data.request.Event
+
+@JsonClass(generateAdapter = true)
+internal data class TrackEventQueueTaskData(
+    val identifier: String,
+    val event: Event
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/type/QueueTask.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/type/QueueTask.kt
@@ -1,0 +1,11 @@
+package io.customer.sdk.queue.type
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class QueueTask(
+    val storageId: String,
+    val type: String,
+    val data: String,
+    val runResults: QueueTaskRunResults
+)

--- a/tracking-migration/src/test/java/io/customer/sdk/queue/type/QueueTaskRunResults.kt
+++ b/tracking-migration/src/test/java/io/customer/sdk/queue/type/QueueTaskRunResults.kt
@@ -1,0 +1,11 @@
+package io.customer.sdk.queue.type
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * Metadata about a task in the background queue and it's execution history in the queue. Used, for example, to see how many times a task has failed running in the queue.
+ */
+@JsonClass(generateAdapter = true)
+data class QueueTaskRunResults(
+    val totalRuns: Int
+)


### PR DESCRIPTION
part of [MBL-413](https://linear.app/customerio/issue/MBL-413/write-automated-tests-for-validating-migration-changes)

### Changes

This PR copies all data classes from the deprecated `tracking` module to test directory of `migration` module. This allows us to write automated tests that closely match original data generated for those classes. The classes are copied to test directory to avoid including any changes in release build. Since `tracking` module used `Moshi` to parse data classes to JSON, the dependency is copied as well but only as `testImplementation` to allow writing tests that provide more confidence.