### PR TITLE
chore: fix migration json adapter

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/migration/TrackingMigrationProcessor.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/migration/TrackingMigrationProcessor.kt
@@ -123,7 +123,7 @@ internal class TrackingMigrationProcessor(
         }
 
         trackEvent.timestamp = task.timestamp.toString()
-        task.identifier?.let { trackEvent.userId = it }
+        trackEvent.userId = task.identifier
 
         logger.debug("processing migrated task: $trackEvent")
         analytics.process(trackEvent)

--- a/tracking-migration/api/tracking-migration.api
+++ b/tracking-migration/api/tracking-migration.api
@@ -111,7 +111,6 @@ public final class io/customer/tracking/migration/request/MigrationTask$Register
 
 public final class io/customer/tracking/migration/request/MigrationTask$TrackDeliveryEvent : io/customer/tracking/migration/request/MigrationTask {
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/json/JSONObject;)V
-	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/json/JSONObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -152,7 +151,6 @@ public final class io/customer/tracking/migration/request/MigrationTask$TrackEve
 
 public final class io/customer/tracking/migration/request/MigrationTask$TrackPushMetric : io/customer/tracking/migration/request/MigrationTask {
 	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/extensions/JsonExtensions.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/extensions/JsonExtensions.kt
@@ -40,13 +40,3 @@ internal inline fun <reified T : Any> JSONObject.requireField(key: String): T {
 
     return requireNotNull(value) { "Required key '$key' is missing or null in $this. Could not parse task." }
 }
-
-/**
- * Similar to [requireField] but also removes the field from the JSON object.
- * This is useful when parsing the JSON object and removing the field after parsing.
- */
-internal inline fun <reified T : Any> JSONObject.requireAndRemoveField(key: String): T {
-    val value = requireField<T>(key)
-    remove(key)
-    return value
-}

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/request/MigrationTask.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/request/MigrationTask.kt
@@ -10,7 +10,7 @@ import org.json.JSONObject
  */
 sealed interface MigrationTask {
     val timestamp: Long
-    val identifier: String?
+    val identifier: String
 
     data class IdentifyProfile(
         override val timestamp: Long,
@@ -28,7 +28,7 @@ sealed interface MigrationTask {
 
     data class TrackPushMetric(
         override val timestamp: Long,
-        override val identifier: String? = null,
+        override val identifier: String,
         val deliveryId: String,
         val deviceToken: String,
         val event: String
@@ -36,7 +36,7 @@ sealed interface MigrationTask {
 
     data class TrackDeliveryEvent(
         override val timestamp: Long,
-        override val identifier: String? = null,
+        override val identifier: String,
         val deliveryType: String,
         val deliveryId: String,
         val event: String,


### PR DESCRIPTION
part of [MBL-413](https://linear.app/customerio/issue/MBL-413/write-automated-tests-for-validating-migration-changes)

### Changes

- Update `MigrationTask` to always have an `identifier` (update for metric events mainly)
- Fixed minor parsing issues in migration `JsonAdapter`