### PR TITLE
test: migration assistant class

### DIFF
--- a/tracking-migration/api/tracking-migration.api
+++ b/tracking-migration/api/tracking-migration.api
@@ -1,6 +1,5 @@
 public final class io/customer/tracking/migration/MigrationAssistant {
 	public static final field Companion Lio/customer/tracking/migration/MigrationAssistant$Companion;
-	public synthetic fun <init> (Lio/customer/tracking/migration/MigrationProcessor;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/customer/tracking/migration/MigrationAssistant$Companion {
@@ -17,6 +16,7 @@ public abstract interface class io/customer/tracking/migration/MigrationProcesso
 public final class io/customer/tracking/migration/di/MigrationSDKComponent : io/customer/sdk/core/di/DiGraph {
 	public fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/tracking/migration/MigrationProcessor;Ljava/lang/String;)V
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/tracking/migration/MigrationProcessor;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMigrationQueueScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getQueue ()Lio/customer/tracking/migration/queue/Queue;
 	public final fun getSitePreferences ()Lio/customer/tracking/migration/repository/preference/SitePreferenceRepository;
 }

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/MigrationAssistant.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/MigrationAssistant.kt
@@ -11,18 +11,18 @@ import kotlinx.coroutines.launch
  * Class responsible for migrating the existing tracking data to the new data
  * pipelines implementation.
  */
-class MigrationAssistant private constructor(
+class MigrationAssistant internal constructor(
     private val migrationProcessor: MigrationProcessor,
-    migrationSiteId: String
-) {
-    private val migrationSDKComponent = MigrationSDKComponent(
+    migrationSiteId: String,
+    migrationSDKComponent: MigrationSDKComponent = MigrationSDKComponent(
         migrationProcessor = migrationProcessor,
         migrationSiteId = migrationSiteId
     )
+) {
     private val sitePreferences: SitePreferenceRepository = migrationSDKComponent.sitePreferences
     private val queue: Queue = migrationSDKComponent.queue
     private val logger = SDKComponent.logger
-    private val dispatchersProvider = SDKComponent.dispatchersProvider
+    private val coroutineScope: CoroutineScope = migrationSDKComponent.migrationQueueScope
 
     /**
      * Starts the migration process by migrating the existing tracking data to the new
@@ -32,7 +32,7 @@ class MigrationAssistant private constructor(
      */
     init {
         logger.debug("Starting migration tracking data...")
-        CoroutineScope(dispatchersProvider.background).launch {
+        coroutineScope.launch {
             // Re-identify old profile to new implementation
             logger.debug("Migrating existing token and profile...")
             // token goes first since it is used to identify the profile

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/di/MigrationSDKComponent.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/di/MigrationSDKComponent.kt
@@ -20,6 +20,7 @@ import io.customer.tracking.migration.repository.preference.SitePreferenceReposi
 import io.customer.tracking.migration.repository.preference.SitePreferenceRepositoryImpl
 import io.customer.tracking.migration.store.FileStorage
 import io.customer.tracking.migration.util.JsonAdapter
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Migration SDK component responsible for providing the necessary dependencies for migration.
@@ -34,6 +35,10 @@ class MigrationSDKComponent(
     private val applicationContext: Context = androidSDKComponent.applicationContext
     private val logger: Logger = SDKComponent.logger
 
+    val migrationQueueScope: CoroutineScope
+        get() = singleton<CoroutineScope> {
+            CoroutineScope(SDKComponent.dispatchersProvider.background)
+        }
     val sitePreferences: SitePreferenceRepository
         get() = singleton<SitePreferenceRepository> {
             SitePreferenceRepositoryImpl(applicationContext, migrationSiteId)

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/MigrationAssistantTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/MigrationAssistantTest.kt
@@ -1,0 +1,143 @@
+package io.customer.tracking.migration
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.core.TestConstants
+import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.commontest.extensions.random
+import io.customer.tracking.migration.di.MigrationSDKComponent
+import io.customer.tracking.migration.queue.Queue
+import io.customer.tracking.migration.repository.preference.SitePreferenceRepository
+import io.customer.tracking.migration.testutils.core.JUnitTest
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrationAssistantTest : JUnitTest() {
+    private val migrationSiteId = TestConstants.Keys.SITE_ID
+    private val testCoroutineScope: CoroutineScope = TestScope(UnconfinedTestDispatcher())
+
+    private lateinit var migrationProcessor: MigrationProcessor
+    private lateinit var sitePreferenceRepository: SitePreferenceRepository
+    private lateinit var migrationSDKComponent: MigrationSDKComponent
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+
+        // Use relaxed unit mocks instead of full relaxed mocks to minimize false positives
+        migrationProcessor = mockk(relaxUnitFun = true)
+        sitePreferenceRepository = mockk(relaxUnitFun = true)
+        every { sitePreferenceRepository.getIdentifier() } returns null
+        every { sitePreferenceRepository.getDeviceToken() } returns null
+
+        migrationSDKComponent = MigrationSDKComponent(
+            migrationProcessor = migrationProcessor,
+            migrationSiteId = migrationSiteId
+        )
+        migrationSDKComponent.overrideDependency<CoroutineScope>(testCoroutineScope)
+        migrationSDKComponent.overrideDependency<SitePreferenceRepository>(sitePreferenceRepository)
+        migrationSDKComponent.overrideDependency<Queue>(mockk(relaxed = true))
+    }
+
+    private fun initializeAssistant(): MigrationAssistant {
+        return MigrationAssistant(
+            migrationProcessor = migrationProcessor,
+            migrationSiteId = migrationSiteId,
+            migrationSDKComponent = migrationSDKComponent
+        )
+    }
+
+    @Test
+    fun initializeAssistant_givenDefaultValues_expectAssistantRunsInOrder() {
+        initializeAssistant()
+
+        coVerifySequence {
+            sitePreferenceRepository.getDeviceToken()
+            sitePreferenceRepository.getIdentifier()
+            migrationSDKComponent.queue.run()
+            migrationProcessor.onMigrationCompleted()
+        }
+    }
+
+    @Test
+    fun initializeAssistant_givenNoProfileIdentified_expectDoNotMigrateProfile() {
+        every { sitePreferenceRepository.getIdentifier() } returns null
+
+        initializeAssistant()
+
+        assertCalledNever {
+            migrationProcessor.processProfileMigration(any())
+            sitePreferenceRepository.removeIdentifier(any())
+        }
+    }
+
+    @Test
+    fun initializeAssistant_givenProfileIdentifiedAndMigrationFails_expectDoNotClearProfile() {
+        val givenIdentifier = String.random
+        every { sitePreferenceRepository.getIdentifier() } returns givenIdentifier
+        every { migrationProcessor.processProfileMigration(givenIdentifier) } returns Result.failure(mockk())
+
+        initializeAssistant()
+
+        assertCalledOnce { migrationProcessor.processProfileMigration(givenIdentifier) }
+        assertCalledNever { sitePreferenceRepository.removeIdentifier(any()) }
+    }
+
+    @Test
+    fun initializeAssistant_givenProfileIdentified_expectMigrateProfile() {
+        val givenIdentifier = String.random
+        every { sitePreferenceRepository.getIdentifier() } returns givenIdentifier
+        every { migrationProcessor.processProfileMigration(givenIdentifier) } returns Result.success(Unit)
+
+        initializeAssistant()
+
+        assertCalledOnce {
+            migrationProcessor.processProfileMigration(givenIdentifier)
+            sitePreferenceRepository.removeIdentifier(givenIdentifier)
+        }
+    }
+
+    @Test
+    fun initializeAssistant_givenNoDeviceIdentified_expectDoNotMigrateDevice() {
+        every { sitePreferenceRepository.getDeviceToken() } returns null
+
+        initializeAssistant()
+
+        assertCalledNever {
+            migrationProcessor.processDeviceMigration(any())
+            sitePreferenceRepository.removeDeviceToken()
+        }
+    }
+
+    @Test
+    fun initializeAssistant_givenDeviceIdentifiedAndMigrationFails_expectDoNotClearDevice() {
+        val givenToken = String.random
+        every { sitePreferenceRepository.getDeviceToken() } returns givenToken
+        every { migrationProcessor.processDeviceMigration(givenToken) } returns Result.failure(mockk())
+
+        initializeAssistant()
+
+        assertCalledOnce { migrationProcessor.processDeviceMigration(givenToken) }
+        assertCalledNever { sitePreferenceRepository.removeDeviceToken() }
+    }
+
+    @Test
+    fun initializeAssistant_givenDeviceIdentified_expectMigrateDevice() {
+        val givenToken = String.random
+        every { sitePreferenceRepository.getDeviceToken() } returns givenToken
+        every { migrationProcessor.processDeviceMigration(givenToken) } returns Result.success(Unit)
+
+        initializeAssistant()
+
+        assertCalledOnce {
+            migrationProcessor.processDeviceMigration(givenToken)
+            sitePreferenceRepository.removeDeviceToken()
+        }
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/JUnitTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/JUnitTest.kt
@@ -1,0 +1,18 @@
+package io.customer.tracking.migration.testutils.core
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.ClientArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.JUnit5Test
+
+abstract class JUnitTest : JUnit5Test() {
+    private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
+        argument(ApplicationArgument(applicationMock))
+        argument(ClientArgument())
+    }
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(defaultTestConfiguration + testConfig)
+    }
+}


### PR DESCRIPTION
part of [MBL-413](https://linear.app/customerio/issue/MBL-413/write-automated-tests-for-validating-migration-changes)

### Changes

- Moved `CoroutineScope` in `MigrationSDKComponent` so it can be overridden in tests
- Updated `MigrationAssistant` internal constructor to allow overriding `MigrationSDKComponent` for tests
- Added base `JUnitTest` class in migration tests for convenience
- Added tests for `MigrationAssistant`