### PR TITLE
ci: build sample apps on feature branches

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -3,7 +3,7 @@ name: Build sample apps
 on: 
   pull_request: # build sample apps for every commit pushed to an open pull request (including drafts)
   push: 
-    branches: [main] 
+    branches: [main, feature/*] 
   release: # build sample apps for every git tag created. These are known as "stable" builds that are suitable for people outside the mobile team. 
     types: [published]
 


### PR DESCRIPTION
TS would like to use a sample app that points to CDP API. To help, I thought we could give them access to Android sample app builds on the cdp branch. 

IMO, even beyond this scenario, I think making builds on all feature branches for testing by the team is a good idea. 