### PR TITLE
test: migration json adapter invalid data

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
+++ b/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
@@ -8,8 +8,9 @@ inline fun <reified E : Throwable> Result<Any>.shouldBeFailure(): E {
         "Expected failure but the result was successful"
     }
 
-    return assertNotNull(exceptionOrNull() as? E) {
-        "Expected exception of type ${E::class} but was ${exceptionOrNull()?.let { it::class } ?: "null"}"
+    val exception = exceptionOrNull()
+    return assertNotNull(exception as? E) {
+        "Expected exception of type ${E::class} but was ${exception?.let { it::class } ?: "null"}"
     }
 }
 

--- a/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
+++ b/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
@@ -4,16 +4,32 @@ package io.customer.commontest.extensions
  * Extension function to assert that Result is failure and the exception is of the specified type.
  */
 inline fun <reified E : Throwable> Result<Any>.shouldBeFailure(): E {
-    if (!isFailure) {
-        throw AssertionError("Expected failure but the result was successful")
+    assertCondition(isFailure) {
+        "Expected failure but the result was successful"
     }
 
-    val exception = exceptionOrNull()
-    if (exception == null) {
-        throw AssertionError("Expected exception of type ${E::class} but was null")
-    } else if (exception !is E) {
-        throw AssertionError("Expected exception of type ${E::class} but was ${exception::class}")
+    return assertNotNull(exceptionOrNull() as? E) {
+        "Expected exception of type ${E::class} but was ${exceptionOrNull()?.let { it::class } ?: "null"}"
     }
+}
 
-    return exception
+/**
+ * Extension function to assert that Result is success and return the value.
+ * If the result is failure, it will throw an AssertionError.
+ */
+inline fun assertCondition(condition: Boolean, lazyMessage: () -> String) {
+    check(condition) {
+        throw AssertionError(lazyMessage())
+    }
+}
+
+/**
+ * Extension function to assert that the value is not null and return it.
+ * If the value is null, it will throw an AssertionError.
+ */
+inline fun <T : Any> assertNotNull(value: T?, lazyMessage: () -> String): T {
+    check(value != null) {
+        throw AssertionError(lazyMessage())
+    }
+    return value
 }

--- a/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
+++ b/common-test/src/main/java/io/customer/commontest/extensions/AssertionExtensions.kt
@@ -1,0 +1,19 @@
+package io.customer.commontest.extensions
+
+/**
+ * Extension function to assert that Result is failure and the exception is of the specified type.
+ */
+inline fun <reified E : Throwable> Result<Any>.shouldBeFailure(): E {
+    if (!isFailure) {
+        throw AssertionError("Expected failure but the result was successful")
+    }
+
+    val exception = exceptionOrNull()
+    if (exception == null) {
+        throw AssertionError("Expected exception of type ${E::class} but was null")
+    } else if (exception !is E) {
+        throw AssertionError("Expected exception of type ${E::class} but was ${exception::class}")
+    }
+
+    return exception
+}

--- a/tracking-migration/src/main/java/io/customer/tracking/migration/util/JsonAdapter.kt
+++ b/tracking-migration/src/main/java/io/customer/tracking/migration/util/JsonAdapter.kt
@@ -10,6 +10,7 @@ import io.customer.tracking.migration.request.MigrationTask
 import io.customer.tracking.migration.type.QueueTaskType
 import java.util.Date
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 
 /**
@@ -39,7 +40,7 @@ class JsonAdapter {
         requireNotNull(type) { "Queue task type is invalid for $task. Could not run task." }
 
         val taskJson = runCatching { JSONObject(data) }.getOrElse {
-            throw RuntimeException("Queue task data is invalid for $task. Could not run task.")
+            throw JSONException("Queue task data is invalid for $task. Could not run task.")
         }
         val timestamp = taskJson.longOrNull("timestamp") ?: Date().getUnixTimestamp()
 
@@ -60,7 +61,7 @@ class JsonAdapter {
                     identifier = taskJson.requireField("identifier"),
                     event = eventJson.requireField("name"),
                     type = eventJson.requireField("type"),
-                    properties = eventJson.requireField<JSONObject>("data")
+                    properties = eventJson.jsonObjectOrNull("data") ?: JSONObject()
                 )
             }
 

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/queue/QueueTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/queue/QueueTest.kt
@@ -1,0 +1,54 @@
+package io.customer.tracking.migration.queue
+
+import io.customer.commontest.config.TestConfig
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.tracking.migration.testutils.core.JUnitTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QueueTest : JUnitTest() {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testCoroutineScope: CoroutineScope = TestScope(testDispatcher)
+
+    private lateinit var queueRunRequest: QueueRunRequest
+    private lateinit var queue: QueueImpl
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+
+        queueRunRequest = mockk<QueueRunRequest>(relaxed = true)
+        queue = QueueImpl(SDKComponent.logger, queueRunRequest)
+
+        coEvery { queueRunRequest.run() } coAnswers { delay(200L) }
+    }
+
+    @Test
+    fun run_givenMultipleRunRequestsAtSameTime_expectQueueRunnerRunsOnce() = runTest(testDispatcher) {
+        testCoroutineScope.launch { queue.run() }
+        testCoroutineScope.launch { queue.run() }
+
+        queue.isRunningRequest shouldBeEqualTo true
+        coVerify(exactly = 1) { queueRunRequest.run() }
+    }
+
+    @Test
+    fun run_givenMultipleRunRequestsAfterCompletion_expectQueueRunnerRunsMultipleTimes() = runTest(testDispatcher) {
+        runBlocking { queue.run() }
+        runBlocking { queue.run() }
+
+        queue.isRunningRequest shouldBeEqualTo false
+        coVerify(exactly = 2) { queueRunRequest.run() }
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/IntegrationTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/IntegrationTest.kt
@@ -1,0 +1,18 @@
+package io.customer.tracking.migration.testutils.core
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.ClientArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+
+abstract class IntegrationTest : RobolectricTest() {
+    private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
+        argument(ApplicationArgument(applicationMock))
+        argument(ClientArgument())
+    }
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(defaultTestConfiguration + testConfig)
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/data/MigrationDataSet.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/data/MigrationDataSet.kt
@@ -224,3 +224,68 @@ sealed interface DeletePushNotificationQueueTaskData : MigrationDataSet {
         """.trimIndent()
     }
 }
+
+sealed interface InvalidMigrationDataSet : MigrationDataSet {
+    object NullType : InvalidMigrationDataSet {
+        override val rawJson: String = """
+            {
+              "storageId": "39b4f3a3-9fcf-45e5-99f6-6027fed59912",
+              "data": "{\"identifier\":\"wcjzkxfxer\",\"event\":{\"name\":\"qrorchephz\",\"type\":\"event\",\"data\":{},\"timestamp\":1721381260}}",
+              "runResults": {
+                "totalRuns": 1
+              }
+            }
+        """.trimIndent()
+    }
+
+    object UnsupportedType : InvalidMigrationDataSet {
+        override val rawJson: String = """
+            {
+              "storageId": "f7ed672b-d3c7-4f80-bf19-9addfd0c8043",
+              "type": "TrackScreen",
+              "data": "{\"identifier\":\"oqfbtoeusq\",\"event\":{\"name\":\"pvaupgtxbj\",\"type\":\"screen\",\"data\":{},\"timestamp\":1721381260}}",
+              "runResults": {
+                "totalRuns": 5
+              }
+            }
+        """.trimIndent()
+    }
+
+    object NullData : InvalidMigrationDataSet {
+        override val rawJson: String = """
+            {
+              "storageId": "c3cd6aa8-9d4c-4394-88aa-62562f2a1f1e",
+              "type": "TrackEvent",
+              "runResults": {
+                "totalRuns": 10
+              }
+            }
+        """.trimIndent()
+    }
+
+    object UnsupportedData : InvalidMigrationDataSet {
+        override val rawJson: String = """
+            {
+              "storageId": "c8568fcd-dd92-4fbb-b6c6-0cf736915984",
+              "type": "TrackEvent",
+              "data": "{\"identifier\":\"cwbukbdlqo\",\"event\":{\"name\":\"zqnrgtfrbp\",\"timestamp\":1721381260}}",
+              "runResults": {
+                "totalRuns": 4
+              }
+            }
+        """.trimIndent()
+    }
+
+    object MalformedData : InvalidMigrationDataSet {
+        override val rawJson: String = """
+            {
+              "storageId": "37e064dc-a399-4627-8f69-1658eabbf3cf",
+              "type": "TrackEvent",
+              "data": "{invalid json}",
+              "runResults": {
+                "totalRuns": 7
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/util/JsonAdapterTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/util/JsonAdapterTest.kt
@@ -2,11 +2,13 @@ package io.customer.tracking.migration.util
 
 import io.customer.base.extenstions.getUnixTimestamp
 import io.customer.commontest.config.TestConfig
-import io.customer.commontest.core.RobolectricTest
+import io.customer.commontest.extensions.shouldBeFailure
 import io.customer.tracking.migration.request.MigrationTask
+import io.customer.tracking.migration.testutils.core.IntegrationTest
 import io.customer.tracking.migration.testutils.data.DeletePushNotificationQueueTaskData
 import io.customer.tracking.migration.testutils.data.IdentifyProfileQueueTaskData
 import io.customer.tracking.migration.testutils.data.InAppDelivery
+import io.customer.tracking.migration.testutils.data.InvalidMigrationDataSet
 import io.customer.tracking.migration.testutils.data.PushMetric
 import io.customer.tracking.migration.testutils.data.RegisterPushNotificationQueueTaskData
 import io.customer.tracking.migration.testutils.data.TrackEventQueueTaskData
@@ -18,13 +20,14 @@ import java.util.Date
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldNotBeNull
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class JsonAdapterTest : RobolectricTest() {
+class JsonAdapterTest : IntegrationTest() {
     private val jsonAdapter = JsonAdapter()
     private val mockedTime: Long
     private val mockedTimestamp: Long
@@ -176,6 +179,41 @@ class JsonAdapterTest : RobolectricTest() {
         val result = decode<MigrationTask.DeletePushToken>(queueTask)
 
         result shouldMatchTo queueTask.data
+    }
+
+    @Test
+    fun parse_givenInvalidJsonNullType_expectFailureResult() {
+        val queueTask = InvalidMigrationDataSet.NullType.encodedJson()
+
+        jsonAdapter.parseMigrationTask(queueTask).shouldBeFailure<IllegalArgumentException>()
+    }
+
+    @Test
+    fun parse_givenInvalidJsonUnsupportedType_expectFailureResult() {
+        val queueTask = InvalidMigrationDataSet.UnsupportedType.encodedJson()
+
+        jsonAdapter.parseMigrationTask(queueTask).shouldBeFailure<IllegalArgumentException>()
+    }
+
+    @Test
+    fun parse_givenInvalidJsonNullData_expectFailureResult() {
+        val queueTask = InvalidMigrationDataSet.NullData.encodedJson()
+
+        jsonAdapter.parseMigrationTask(queueTask).shouldBeFailure<IllegalArgumentException>()
+    }
+
+    @Test
+    fun parse_givenInvalidJsonUnsupportedData_expectFailureResult() {
+        val queueTask = InvalidMigrationDataSet.UnsupportedData.encodedJson()
+
+        jsonAdapter.parseMigrationTask(queueTask).shouldBeFailure<IllegalArgumentException>()
+    }
+
+    @Test
+    fun parse_givenInvalidJsonMalformedData_expectFailureResult() {
+        val queueTask = InvalidMigrationDataSet.MalformedData.encodedJson()
+
+        jsonAdapter.parseMigrationTask(queueTask).shouldBeFailure<JSONException>()
     }
 
     /**


### PR DESCRIPTION
part of [MBL-425](https://linear.app/customerio/issue/MBL-425/identify-and-improve-test-coverage-in-migration-module)

### Changes

- Added more tests for `JsonAdapter` to validate error scenarios
- Added basic tests for running `Queue`
- Added helper methods, base test class and sample json for invalid data to facilitate writing tests

### Note

Queue runner tests will be added separately later.