### PR TITLE
chore: fix memory leak in migration processor

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/migration/TrackingMigrationProcessor.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/migration/TrackingMigrationProcessor.kt
@@ -30,12 +30,11 @@ import sovran.kotlin.SubscriptionID
  * It implements the [MigrationProcessor] interface to process old existing tasks and migrate them to newer implementation.
  */
 internal class TrackingMigrationProcessor(
-    private val dataPipelineInstance: CustomerIO,
+    private val analytics: Analytics,
     private val migrationSiteId: String
 ) : MigrationProcessor, Subscriber {
     private val logger: Logger = SDKComponent.logger
     private val globalPreferenceStore = SDKComponent.android().globalPreferenceStore
-    private val analytics: Analytics = dataPipelineInstance.analytics
     private var subscriptionID: SubscriptionID? = null
 
     // Start the migration process in init block to start migration as soon as possible
@@ -83,14 +82,14 @@ internal class TrackingMigrationProcessor(
             return@runCatching
         }
 
-        dataPipelineInstance.identify(userId = identifier)
+        CustomerIO.instance().identify(userId = identifier)
     }
 
-    override fun processDeviceMigration(oldDeviceToken: String) = runCatching {
+    override fun processDeviceMigration(oldDeviceToken: String): Result<Unit> = runCatching {
         when (globalPreferenceStore.getDeviceToken()) {
             null -> {
                 logger.debug("Migrating existing device with token: $oldDeviceToken")
-                dataPipelineInstance.registerDeviceToken(oldDeviceToken)
+                CustomerIO.instance().registerDeviceToken(oldDeviceToken)
             }
 
             oldDeviceToken -> {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -121,8 +121,6 @@ class CustomerIO private constructor(
         subscribeToJourneyEvents()
         // if profile is already identified, republish identifier for late-added modules.
         postProfileAlreadyIdentified()
-        // Migrate unsent events from previous version
-        migrateTrackingEvents()
     }
 
     private fun postProfileAlreadyIdentified() {
@@ -152,13 +150,15 @@ class CustomerIO private constructor(
         logger.info("Migration site id found, migrating data from previous version.")
         // Initialize migration processor to perform migration
         migrationProcessor = TrackingMigrationProcessor(
-            dataPipelineInstance = this,
+            analytics = analytics,
             migrationSiteId = migrationSiteId
         )
     }
 
     override fun initialize() {
         logger.debug("CustomerIO SDK initialized with DataPipelines module.")
+        // Migrate unsent events from previous version
+        migrateTrackingEvents()
     }
 
     // Gets the userId registered by a previous identify call


### PR DESCRIPTION
### Changes

- Fixes memory leak in `TrackingMigrationProcessor` by relying on `CustomerIO.instance` instead of `this`