### PR TITLE
test: data pipelines object support

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/extensions/LongExtensions.kt
+++ b/common-test/src/main/java/io/customer/commontest/extensions/LongExtensions.kt
@@ -1,0 +1,10 @@
+package io.customer.commontest.extensions
+
+import kotlin.random.Random
+
+fun Long.Companion.random(min: Long, max: Long): Long {
+    require(min < max) { "max must be greater than min" }
+
+    val maxExclusive = max + 1
+    return Random.nextLong(from = min, until = maxExclusive)
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -528,7 +528,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
         val givenGroupId = String.random
         val givenCompanyName = "name" to "RandomCompany"
         val givenIsActive = "isActive" to true
-        val givenObjectTypeId = Long.random(min = 0, max = 1000)
+        val givenObjectTypeId = String.random
 
         val givenTraitsBuilder: TraitsBuilder = TraitsBuilder()
             .addTrait(givenCompanyName)

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -700,7 +700,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
         val givenGroupId = String.random
         val givenCompanyName = "name" to "RandomCompany"
         val givenIsActive = "isActive" to true
-        val givenObjectTypeId = Long.random(min = 0, max = 1000)
+        val givenObjectTypeId = String.random
         val givenRelationshipAttributes = buildMap {
             put("manager", "jane@ceo.com")
             put("department", "Engineering")

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/utils/Plugins.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/utils/Plugins.kt
@@ -2,6 +2,7 @@ package io.customer.datapipelines.testutils.utils
 
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.GroupEvent
 import com.segment.analytics.kotlin.core.IdentifyEvent
 import com.segment.analytics.kotlin.core.ScreenEvent
 import com.segment.analytics.kotlin.core.TrackEvent
@@ -36,3 +37,5 @@ val OutputReaderPlugin.screenEvents: List<ScreenEvent>
     get() = allEvents.filterIsInstance<ScreenEvent>()
 val OutputReaderPlugin.trackEvents: List<TrackEvent>
     get() = allEvents.filterIsInstance<TrackEvent>()
+val OutputReaderPlugin.groupEvents: List<GroupEvent>
+    get() = allEvents.filterIsInstance<GroupEvent>()


### PR DESCRIPTION
part of [MBL-407](https://linear.app/customerio/issue/MBL-407/android-sdk-object-support)

### Changes

- Added tests for validating group calls without traits
- Added tests for validating group calls with traits using:
  - `JsonObject`
  - `Map<String, Any>` (`CustomAttributes`)
  - Custom `Serializable` object
  - `TraitsBuilder`