### PR TITLE
feat: public api for dismiss message

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -21,9 +21,11 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun initialize ()V
+	public static final fun instance ()Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 
 public final class io/customer/messaginginapp/ModuleMessagingInApp$Companion {
+	public final fun instance ()Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 
 public final class io/customer/messaginginapp/databinding/ActivityGistBinding : androidx/viewbinding/ViewBinding {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -37,7 +37,7 @@ public final class io/customer/messaginginapp/databinding/ActivityGistBinding : 
 }
 
 public final class io/customer/messaginginapp/di/DIGraphMessagingInAppKt {
-	public static final fun inAppMessaging (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messaginginapp/ModuleMessagingInApp;
+	public static final fun inAppMessaging (Lio/customer/sdk/CustomerIOInstance;)Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 
 public final class io/customer/messaginginapp/domain/InAppMessageReducerKt {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -90,5 +90,11 @@ class ModuleMessagingInApp(
 
     companion object {
         const val MODULE_NAME: String = "MessagingInApp"
+
+        @JvmStatic
+        fun instance(): ModuleMessagingInApp {
+            return SDKComponent.modules[MODULE_NAME] as? ModuleMessagingInApp
+                ?: throw IllegalStateException("ModuleMessagingInApp not initialized")
+        }
     }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -6,6 +6,7 @@ import io.customer.messaginginapp.provider.GistApi
 import io.customer.messaginginapp.provider.GistApiProvider
 import io.customer.messaginginapp.provider.GistInAppMessagesProvider
 import io.customer.messaginginapp.provider.InAppMessagesProvider
+import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.core.di.SDKComponent
 
 internal val SDKComponent.gistApiProvider: GistApi
@@ -14,9 +15,14 @@ internal val SDKComponent.gistApiProvider: GistApi
 internal val SDKComponent.gistProvider: InAppMessagesProvider
     get() = newInstance<InAppMessagesProvider> { GistInAppMessagesProvider(gistApiProvider) }
 
-fun SDKComponent.inAppMessaging(): ModuleMessagingInApp {
+internal fun SDKComponent.inAppMessaging(): ModuleMessagingInApp {
     return modules[ModuleMessagingInApp.MODULE_NAME] as? ModuleMessagingInApp
         ?: throw IllegalStateException("ModuleMessagingInApp not initialized")
+}
+
+@Suppress("UnusedReceiverParameter")
+fun CustomerIOInstance.inAppMessaging(): ModuleMessagingInApp {
+    return SDKComponent.inAppMessaging()
 }
 
 internal val SDKComponent.inAppMessagingManager: InAppMessagingManager

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -15,14 +15,9 @@ internal val SDKComponent.gistApiProvider: GistApi
 internal val SDKComponent.gistProvider: InAppMessagesProvider
     get() = newInstance<InAppMessagesProvider> { GistInAppMessagesProvider(gistApiProvider) }
 
-internal fun SDKComponent.inAppMessaging(): ModuleMessagingInApp {
-    return modules[ModuleMessagingInApp.MODULE_NAME] as? ModuleMessagingInApp
-        ?: throw IllegalStateException("ModuleMessagingInApp not initialized")
-}
-
 @Suppress("UnusedReceiverParameter")
 fun CustomerIOInstance.inAppMessaging(): ModuleMessagingInApp {
-    return SDKComponent.inAppMessaging()
+    return ModuleMessagingInApp.instance()
 }
 
 internal val SDKComponent.inAppMessagingManager: InAppMessagingManager

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -9,7 +9,6 @@ import io.customer.commontest.extensions.attachToSDKComponent
 import io.customer.commontest.extensions.random
 import io.customer.commontest.util.ScopeProviderStub
 import io.customer.messaginginapp.di.gistProvider
-import io.customer.messaginginapp.di.inAppMessaging
 import io.customer.messaginginapp.provider.InAppMessagesProvider
 import io.customer.messaginginapp.testutils.core.JUnitTest
 import io.customer.messaginginapp.type.InAppEventListener
@@ -144,7 +143,7 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         module.initialize()
 
         // call dismissMessage on the CustomerIO instance
-        SDKComponent.inAppMessaging().dismissMessage()
+        ModuleMessagingInApp.instance().dismissMessage()
 
         // verify that the module's dismissMessage method was called
         assertCalledOnce { inAppMessagesProviderMock.dismissMessage() }

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -115,10 +115,6 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class io/customer/messagingpush/di/DiGraphMessagingPushKt {
-	public static final fun pushMessaging (Lio/customer/sdk/CustomerIOInstance;)Lio/customer/messagingpush/ModuleMessagingPushFCM;
-}
-
 public final class io/customer/messagingpush/processor/PushMessageProcessor$Companion {
 	public static final field RECENT_MESSAGES_MAX_SIZE I
 	public final fun getRecentMessagesQueue ()Ljava/util/concurrent/LinkedBlockingDeque;

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -116,7 +116,7 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 }
 
 public final class io/customer/messagingpush/di/DiGraphMessagingPushKt {
-	public static final fun pushMessaging (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messagingpush/ModuleMessagingPushFCM;
+	public static final fun pushMessaging (Lio/customer/sdk/CustomerIOInstance;)Lio/customer/messagingpush/ModuleMessagingPushFCM;
 }
 
 public final class io/customer/messagingpush/processor/PushMessageProcessor$Companion {

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -13,6 +13,7 @@ import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
+import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 
@@ -46,7 +47,12 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
         )
     }
 
-fun SDKComponent.pushMessaging(): ModuleMessagingPushFCM {
+internal fun SDKComponent.pushMessaging(): ModuleMessagingPushFCM {
     return modules[ModuleMessagingPushFCM.MODULE_NAME] as? ModuleMessagingPushFCM
         ?: throw IllegalStateException("ModuleMessagingPushFCM not initialized")
+}
+
+@Suppress("UnusedReceiverParameter")
+fun CustomerIOInstance.pushMessaging(): ModuleMessagingPushFCM {
+    return SDKComponent.pushMessaging()
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -13,7 +13,6 @@ import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
-import io.customer.sdk.CustomerIOInstance
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 
@@ -46,13 +45,3 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
             deepLinkUtil = deepLinkUtil
         )
     }
-
-internal fun SDKComponent.pushMessaging(): ModuleMessagingPushFCM {
-    return modules[ModuleMessagingPushFCM.MODULE_NAME] as? ModuleMessagingPushFCM
-        ?: throw IllegalStateException("ModuleMessagingPushFCM not initialized")
-}
-
-@Suppress("UnusedReceiverParameter")
-fun CustomerIOInstance.pushMessaging(): ModuleMessagingPushFCM {
-    return SDKComponent.pushMessaging()
-}


### PR DESCRIPTION
### Background

Since we decoupled all modules from `CustomerIO` class and moved them to `core` module, modules were moved to the `SDKComponent` class. This broke some public APIs accessed through `SDKComponent` and made some of our documentation outdated (e.g., dismissing in-app messaging). To fix this, we had two options:

#### Option 1 - Expose in-app module through `CustomerIO` object again.

I think this is the most feasible option, so I opted for this.

#### Option 2 - Ask customers to use `SDKComponent` instead.

I don't think recommending customers to use `SDKComponent` is a very good idea, so I opted for option 1.

### Changes

- Exposed in-app module through the `CustomerIO` object for customer ease
- Exposed in-app module through module object directly to help Java customers
- Marked `SDKComponent` methods exposing these modules as internal

### Resources

- [Docs link that is currently broken](https://customer.io/docs/sdk/android/in-app/in-app-event-listeners/#dismiss-in-app-message)
- [Slack thread for the request](https://customerio.slack.com/archives/C02580R06/p1723131682532329)