### PR TITLE
chore: ignore close callbacks for clicked

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -83,14 +83,16 @@ class ModuleMessagingInApp(
         )
 
         GistMessageProperties.getGistProperties(message).campaignId?.let { deliveryID ->
-            logger.debug("In-app message clicked with deliveryId: $deliveryID")
-            eventBus.publish(
-                Event.TrackInAppMetricEvent(
-                    deliveryID = deliveryID,
-                    event = Metric.Clicked,
-                    params = mapOf("action_name" to name, "action_value" to action)
+            logger.debug("In-app message clicked with deliveryId: $deliveryID with action: $action and name: $name")
+            if (action != "gist://close") {
+                eventBus.publish(
+                    Event.TrackInAppMetricEvent(
+                        deliveryID = deliveryID,
+                        event = Metric.Clicked,
+                        params = mapOf("action_name" to name, "action_value" to action)
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -29,6 +29,7 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -45,8 +46,7 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
                 diGraph {
                     sdk {
                         overrideDependency<ScopeProvider>(testScopeProviderStub)
-                        val spykEventBus = spyk(eventBus)
-                        overrideDependency<EventBus>(spykEventBus)
+                        overrideDependency<EventBus>(spyk(eventBus))
                         overrideDependency(mockk<GistProvider>(relaxed = true))
                     }
                 }
@@ -215,6 +215,7 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun onAction_givenCloseAction_expectNoTrackInAppMetricEventPublished() = runTest {
         val message = createInAppMessage(campaignId = "test_campaign_id")


### PR DESCRIPTION
changes:

- Before sending click event to journeys ignore actions that are for close. 