### PR TITLE
chore: ignore embed and cleanup properties

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -92,15 +92,6 @@ public final class io/customer/messaginginapp/gist/data/listeners/Queue : io/cus
 	public fun logView (Lio/customer/messaginginapp/gist/data/model/Message;)V
 }
 
-public final class io/customer/messaginginapp/gist/data/model/GistMessageProperties {
-	public static final field Companion Lio/customer/messaginginapp/gist/data/model/GistMessageProperties$Companion;
-	public fun <init> ()V
-}
-
-public final class io/customer/messaginginapp/gist/data/model/GistMessageProperties$Companion {
-	public final fun getGistProperties (Lio/customer/messaginginapp/gist/data/model/Message;)Lio/customer/messaginginapp/gist/data/model/GistProperties;
-}
-
 public final class io/customer/messaginginapp/gist/data/model/GistProperties {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/data/model/MessagePosition;Z)V
 	public final fun component1 ()Ljava/lang/String;
@@ -137,6 +128,7 @@ public final class io/customer/messaginginapp/gist/data/model/Message {
 	public final fun getPriority ()Ljava/lang/Integer;
 	public final fun getProperties ()Ljava/util/Map;
 	public final fun getQueueId ()Ljava/lang/String;
+	public final fun gistProperties ()Lio/customer/messaginginapp/gist/data/model/GistProperties;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -133,10 +133,6 @@ public final class io/customer/messaginginapp/gist/data/model/Message {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/customer/messaginginapp/gist/data/model/MessageKt {
-	public static final fun getRouteRule (Lio/customer/messaginginapp/gist/data/model/Message;)Ljava/lang/String;
-}
-
 public final class io/customer/messaginginapp/gist/data/model/MessagePosition : java/lang/Enum {
 	public static final field BOTTOM Lio/customer/messaginginapp/gist/data/model/MessagePosition;
 	public static final field CENTER Lio/customer/messaginginapp/gist/data/model/MessagePosition;

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -123,12 +123,12 @@ public final class io/customer/messaginginapp/gist/data/model/Message {
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lio/customer/messaginginapp/gist/data/model/Message;
 	public static synthetic fun copy$default (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/messaginginapp/gist/data/model/Message;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGistProperties ()Lio/customer/messaginginapp/gist/data/model/GistProperties;
 	public final fun getInstanceId ()Ljava/lang/String;
 	public final fun getMessageId ()Ljava/lang/String;
 	public final fun getPriority ()Ljava/lang/Integer;
 	public final fun getProperties ()Ljava/util/Map;
 	public final fun getQueueId ()Ljava/lang/String;
-	public final fun gistProperties ()Lio/customer/messaginginapp/gist/data/model/GistProperties;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -52,7 +52,7 @@ class ModuleMessagingInApp(
     override fun onMessageShown(message: Message) {
         moduleConfig.eventListener?.messageShown(InAppMessage.getFromGistMessage(message))
 
-        message.gistProperties().campaignId?.let { deliveryID ->
+        message.gistProperties.campaignId?.let { deliveryID ->
             logger.debug("In-app message shown with deliveryId $deliveryID")
             eventBus.publish(
                 Event.TrackInAppMetricEvent(
@@ -81,7 +81,7 @@ class ModuleMessagingInApp(
             actionName = name
         )
 
-        message.gistProperties().campaignId?.let { deliveryID ->
+        message.gistProperties.campaignId?.let { deliveryID ->
             logger.debug("In-app message clicked with deliveryId: $deliveryID with action: $action and name: $name")
             if (action != "gist://close") {
                 eventBus.publish(

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -1,7 +1,6 @@
 package io.customer.messaginginapp
 
 import io.customer.messaginginapp.di.gistProvider
-import io.customer.messaginginapp.gist.data.model.GistMessageProperties
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.presentation.GistListener
 import io.customer.messaginginapp.gist.presentation.GistProvider
@@ -53,7 +52,7 @@ class ModuleMessagingInApp(
     override fun onMessageShown(message: Message) {
         moduleConfig.eventListener?.messageShown(InAppMessage.getFromGistMessage(message))
 
-        GistMessageProperties.getGistProperties(message).campaignId?.let { deliveryID ->
+        message.gistProperties().campaignId?.let { deliveryID ->
             logger.debug("In-app message shown with deliveryId $deliveryID")
             eventBus.publish(
                 Event.TrackInAppMetricEvent(
@@ -82,7 +81,7 @@ class ModuleMessagingInApp(
             actionName = name
         )
 
-        GistMessageProperties.getGistProperties(message).campaignId?.let { deliveryID ->
+        message.gistProperties().campaignId?.let { deliveryID ->
             logger.debug("In-app message clicked with deliveryId: $deliveryID with action: $action and name: $name")
             if (action != "gist://close") {
                 eventBus.publish(

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -70,7 +70,3 @@ data class Message(
         return "Message(messageId=$messageId, instanceId=$instanceId, priority=$priority, queueId=$queueId, properties=$gistProperties"
     }
 }
-
-fun Message.getRouteRule(): String? {
-    return gistProperties.routeRule
-}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -22,53 +22,54 @@ data class Message(
     val priority: Int? = null,
     val queueId: String? = null,
     val properties: Map<String, Any?>? = null
-)
+) {
 
-fun Message.getRouteRule(): String? {
-    return GistMessageProperties.getGistProperties(this).routeRule
-}
+    fun gistProperties(): GistProperties {
+        var routeRule: String? = null
+        var elementId: String? = null
+        var campaignId: String? = null
+        var position: MessagePosition = MessagePosition.CENTER
+        var persistent = false
 
-class GistMessageProperties {
-    companion object {
-        fun getGistProperties(message: Message): GistProperties {
-            var routeRule: String? = null
-            var elementId: String? = null
-            var campaignId: String? = null
-            var position: MessagePosition = MessagePosition.CENTER
-            var persistent = false
-
-            message.properties?.let { properties ->
-                properties["gist"]?.let { gistProperties ->
-                    (gistProperties as Map<String, Any?>).let { gistProperties ->
-                        gistProperties["routeRuleAndroid"]?.let { rule ->
-                            (rule as String).let { stringRule ->
-                                routeRule = stringRule
-                            }
+        this.properties?.let { properties ->
+            properties["gist"]?.let { gistProperties ->
+                (gistProperties as Map<String, Any?>).let { gistProperties ->
+                    gistProperties["routeRuleAndroid"]?.let { rule ->
+                        (rule as String).let { stringRule ->
+                            routeRule = stringRule
                         }
-                        gistProperties["campaignId"]?.let { id ->
-                            (id as String).let { stringId ->
-                                campaignId = stringId
-                            }
+                    }
+                    gistProperties["campaignId"]?.let { id ->
+                        (id as String).let { stringId ->
+                            campaignId = stringId
                         }
-                        gistProperties["elementId"]?.let { id ->
-                            (id as String).let { stringId ->
-                                elementId = stringId
-                            }
+                    }
+                    gistProperties["elementId"]?.let { id ->
+                        (id as String).let { stringId ->
+                            elementId = stringId
                         }
-                        gistProperties["position"]?.let { messagePosition ->
-                            (messagePosition as String).let { stringPosition ->
-                                position = MessagePosition.valueOf(stringPosition.uppercase())
-                            }
+                    }
+                    gistProperties["position"]?.let { messagePosition ->
+                        (messagePosition as String).let { stringPosition ->
+                            position = MessagePosition.valueOf(stringPosition.uppercase())
                         }
-                        gistProperties["persistent"]?.let { id ->
-                            (id as? Boolean)?.let { persistentValue ->
-                                persistent = persistentValue
-                            }
+                    }
+                    gistProperties["persistent"]?.let { id ->
+                        (id as? Boolean)?.let { persistentValue ->
+                            persistent = persistentValue
                         }
                     }
                 }
             }
-            return GistProperties(routeRule = routeRule, elementId = elementId, campaignId = campaignId, position = position, persistent = persistent)
         }
+        return GistProperties(routeRule = routeRule, elementId = elementId, campaignId = campaignId, position = position, persistent = persistent)
     }
+
+    override fun toString(): String {
+        return "Message(messageId=$messageId, instanceId=$instanceId, priority=$priority, queueId=$queueId, properties=${gistProperties()}"
+    }
+}
+
+fun Message.getRouteRule(): String? {
+    return gistProperties().routeRule
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -23,8 +23,9 @@ data class Message(
     val queueId: String? = null,
     val properties: Map<String, Any?>? = null
 ) {
+    val gistProperties: GistProperties = convertToGistProperties()
 
-    fun gistProperties(): GistProperties {
+    private fun convertToGistProperties(): GistProperties {
         var routeRule: String? = null
         var elementId: String? = null
         var campaignId: String? = null
@@ -66,10 +67,10 @@ data class Message(
     }
 
     override fun toString(): String {
-        return "Message(messageId=$messageId, instanceId=$instanceId, priority=$priority, queueId=$queueId, properties=${gistProperties()}"
+        return "Message(messageId=$messageId, instanceId=$instanceId, priority=$priority, queueId=$queueId, properties=$gistProperties"
     }
 }
 
 fun Message.getRouteRule(): String? {
-    return gistProperties().routeRule
+    return gistProperties.routeRule
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -14,7 +14,6 @@ import com.google.gson.Gson
 import io.customer.messaginginapp.R
 import io.customer.messaginginapp.databinding.ActivityGistBinding
 import io.customer.messaginginapp.di.inAppMessagingManager
-import io.customer.messaginginapp.gist.data.model.GistMessageProperties
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.MessagePosition
 import io.customer.messaginginapp.gist.utilities.ElapsedTimer
@@ -75,7 +74,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
                 binding.gistView.listener = this
                 binding.gistView.setup(message)
                 val messagePosition = if (modalPositionStr == null) {
-                    GistMessageProperties.getGistProperties(message).position
+                    message.gistProperties().position
                 } else {
                     MessagePosition.valueOf(modalPositionStr.uppercase())
                 }
@@ -162,11 +161,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
 
     private fun isPersistentMessage(message: Message? = null): Boolean {
         val currentMessage = message ?: currentMessageState?.message
-        return currentMessage?.let {
-            GistMessageProperties.getGistProperties(
-                it
-            ).persistent
-        } ?: false
+        return currentMessage?.gistProperties()?.persistent ?: false
     }
 
     private fun onMessageShown(message: Message) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -74,7 +74,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
                 binding.gistView.listener = this
                 binding.gistView.setup(message)
                 val messagePosition = if (modalPositionStr == null) {
-                    message.gistProperties().position
+                    message.gistProperties.position
                 } else {
                     MessagePosition.valueOf(modalPositionStr.uppercase())
                 }
@@ -161,7 +161,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
 
     private fun isPersistentMessage(message: Message? = null): Boolean {
         val currentMessage = message ?: currentMessageState?.message
-        return currentMessage?.gistProperties()?.persistent ?: false
+        return currentMessage?.gistProperties?.persistent ?: false
     }
 
     private fun onMessageShown(message: Message) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import com.google.gson.Gson
 import io.customer.messaginginapp.di.gistQueue
 import io.customer.messaginginapp.gist.data.model.Message
-import io.customer.messaginginapp.gist.data.model.getRouteRule
 import io.customer.messaginginapp.gist.presentation.GIST_MESSAGE_INTENT
 import io.customer.messaginginapp.gist.presentation.GIST_MODAL_POSITION_INTENT
 import io.customer.messaginginapp.gist.presentation.GistListener
@@ -122,7 +121,7 @@ internal fun routeChangeMiddleware() = middleware<InAppMessagingState> { store, 
 
         // if there is no active message or the message route matches the current route, continue
         if (currentMessage != null) {
-            val currentMessageRouteRule = currentMessage.getRouteRule()
+            val currentMessageRouteRule = currentMessage.gistProperties.routeRule
             val isCurrentMessageRouteAllowedOnNewRoute = currentMessageRouteRule == null || runCatching { currentMessageRouteRule.toRegex().matches(action.route) }.getOrNull() ?: true
             if (!isCurrentMessageRouteAllowedOnNewRoute) {
                 SDKComponent.logger.debug("Dismissing message: ${currentMessage.queueId} because route does not match current route: ${action.route}")

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -55,7 +55,7 @@ private fun handleMessageDismissal(action: InAppMessagingAction.DismissMessage, 
 }
 
 private fun handleMessageDisplay(action: InAppMessagingAction.DisplayMessage, next: (Any) -> Any) {
-    val gistProperties = action.message.gistProperties()
+    val gistProperties = action.message.gistProperties
     if (!gistProperties.persistent) {
         SDKComponent.gistQueue.logView(action.message)
     }
@@ -146,13 +146,13 @@ internal fun processMessages() = middleware<InAppMessagingState> { store, next, 
             .filter { message ->
                 // filter out the messages that are already shown
                 // and the messages that have an elementId because we are not handling embedded messages
-                message.queueId != null && !store.state.shownMessageQueueIds.contains(message.queueId) && message.gistProperties().elementId != null
+                message.queueId != null && !store.state.shownMessageQueueIds.contains(message.queueId) && message.gistProperties.elementId == null
             }
             .distinctBy(Message::queueId)
             .sortedWith(compareBy(nullsLast()) { it.priority })
 
         val messageToBeShownWithProperties = notShownMessages.firstOrNull { message ->
-            val routeRule = message.gistProperties().routeRule
+            val routeRule = message.gistProperties.routeRule
             val currentRoute = store.state.currentRoute
             when {
                 // If the route rule is null, the message should be shown

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -3,7 +3,6 @@ package io.customer.messaginginapp.state
 import android.content.Intent
 import com.google.gson.Gson
 import io.customer.messaginginapp.di.gistQueue
-import io.customer.messaginginapp.gist.data.model.GistMessageProperties
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.getRouteRule
 import io.customer.messaginginapp.gist.presentation.GIST_MESSAGE_INTENT
@@ -56,7 +55,7 @@ private fun handleMessageDismissal(action: InAppMessagingAction.DismissMessage, 
 }
 
 private fun handleMessageDisplay(action: InAppMessagingAction.DisplayMessage, next: (Any) -> Any) {
-    val gistProperties = GistMessageProperties.getGistProperties(action.message)
+    val gistProperties = action.message.gistProperties()
     if (!gistProperties.persistent) {
         SDKComponent.gistQueue.logView(action.message)
     }
@@ -145,19 +144,15 @@ internal fun processMessages() = middleware<InAppMessagingState> { store, next, 
     if (action is InAppMessagingAction.ProcessMessageQueue && action.messages.isNotEmpty()) {
         val notShownMessages = action.messages
             .filter { message ->
-                message.queueId != null && !store.state.shownMessageQueueIds.contains(message.queueId)
+                // filter out the messages that are already shown
+                // and the messages that have an elementId because we are not handling embedded messages
+                message.queueId != null && !store.state.shownMessageQueueIds.contains(message.queueId) && message.gistProperties().elementId != null
             }
             .distinctBy(Message::queueId)
             .sortedWith(compareBy(nullsLast()) { it.priority })
 
-        val notShownMessagesWithProperties = notShownMessages
-            .map { message ->
-                val properties = GistMessageProperties.getGistProperties(message)
-                Pair(message, properties)
-            }
-
-        val messageToBeShownWithProperties = notShownMessagesWithProperties.firstOrNull { message ->
-            val routeRule = GistMessageProperties.getGistProperties(message.first).routeRule
+        val messageToBeShownWithProperties = notShownMessages.firstOrNull { message ->
+            val routeRule = message.gistProperties().routeRule
             val currentRoute = store.state.currentRoute
             when {
                 // If the route rule is null, the message should be shown
@@ -177,14 +172,8 @@ internal fun processMessages() = middleware<InAppMessagingState> { store, next, 
         next(InAppMessagingAction.ProcessMessageQueue(notShownMessages))
 
         if (messageToBeShownWithProperties != null && !isCurrentMessageDisplaying && !isCurrentMessageBeingProcessed) {
-            val message = messageToBeShownWithProperties.first
-            val properties = messageToBeShownWithProperties.second
-
-            if (properties.elementId != null) {
-                store.dispatch(InAppMessagingAction.EmbedMessage(message, properties.elementId))
-            } else {
-                store.dispatch(InAppMessagingAction.LoadMessage(message))
-            }
+            // Load the message to be shown
+            store.dispatch(InAppMessagingAction.LoadMessage(messageToBeShownWithProperties))
         } else {
             // Handle the case where no message matches the criteria.
             // This might involve logging, dispatching another action, or simply doing nothing.

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessage.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessage.kt
@@ -9,7 +9,7 @@ data class InAppMessage(
 ) {
     companion object {
         internal fun getFromGistMessage(gistMessage: Message): InAppMessage {
-            val gistProperties = gistMessage.gistProperties()
+            val gistProperties = gistMessage.gistProperties
             val campaignId = gistProperties.campaignId
 
             return InAppMessage(

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessage.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessage.kt
@@ -1,6 +1,5 @@
 package io.customer.messaginginapp.type
 
-import io.customer.messaginginapp.gist.data.model.GistMessageProperties
 import io.customer.messaginginapp.gist.data.model.Message
 
 data class InAppMessage(
@@ -10,7 +9,7 @@ data class InAppMessage(
 ) {
     companion object {
         internal fun getFromGistMessage(gistMessage: Message): InAppMessage {
-            val gistProperties = GistMessageProperties.getGistProperties(gistMessage)
+            val gistProperties = gistMessage.gistProperties()
             val campaignId = gistProperties.campaignId
 
             return InAppMessage(

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -9,7 +9,6 @@ import io.customer.commontest.extensions.attachToSDKComponent
 import io.customer.commontest.extensions.random
 import io.customer.commontest.util.ScopeProviderStub
 import io.customer.messaginginapp.di.gistProvider
-import io.customer.messaginginapp.gist.data.model.GistMessageProperties
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.MessagePosition
 import io.customer.messaginginapp.gist.presentation.GistProvider
@@ -160,7 +159,7 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         val messageSlot = slot<Message>()
         verify { InAppMessage.getFromGistMessage(capture(messageSlot)) }
         val capturedMessage = messageSlot.captured
-        val gistProperties = GistMessageProperties.getGistProperties(capturedMessage)
+        val gistProperties = capturedMessage.gistProperties
         assert(gistProperties.position == MessagePosition.TOP)
     }
 
@@ -184,7 +183,7 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         val messageSlot = slot<Message>()
         verify { InAppMessage.getFromGistMessage(capture(messageSlot)) }
         val capturedMessage = messageSlot.captured
-        val gistProperties = GistMessageProperties.getGistProperties(capturedMessage)
+        val gistProperties = capturedMessage.gistProperties
         assert(gistProperties.position == MessagePosition.CENTER)
     }
 


### PR DESCRIPTION
changes:
- ignore embedded messages that were blocking the queue from being processed
- move GistProperties as part of `Message`