### PR TITLE
chore: use meta-data for user agent client

### DIFF
--- a/common-test/src/main/AndroidManifest.xml
+++ b/common-test/src/main/AndroidManifest.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <!--
+        Meta-data tags added here to test challenges that may arise when merging multiple
+        AndroidManifest.xml files with same meta-data tags.
+        See AndroidManifest.xml in androidTest directory of core module for more details.
+        -->
+        <meta-data
+            android:name="io.customer.sdk.android.core.SDK_SOURCE"
+            android:value="CommonTestAndroidSDK" />
+        <meta-data
+            android:name="io.customer.sdk.android.core.SDK_VERSION"
+            android:value="0.1.0" />
+    </application>
 </manifest>

--- a/common-test/src/main/java/io/customer/commontest/config/TestArgument.kt
+++ b/common-test/src/main/java/io/customer/commontest/config/TestArgument.kt
@@ -1,7 +1,6 @@
 package io.customer.commontest.config
 
 import android.app.Application
-import io.customer.sdk.data.store.Client
 
 /**
  * Base interface for all test arguments.
@@ -16,11 +15,4 @@ interface TestArgument
  */
 data class ApplicationArgument(
     val value: Application
-) : TestArgument
-
-/**
- * Argument for passing client instance to test configuration.
- */
-data class ClientArgument(
-    val value: Client = Client.Android(sdkVersion = "3.0.0")
 ) : TestArgument

--- a/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
@@ -45,6 +45,6 @@ abstract class BaseTest {
         val application = testConfig.argumentOrNull<ApplicationArgument>()?.value ?: return
         val client = testConfig.argumentOrNull<ClientArgument>()?.value ?: return
 
-        testConfig.configureAndroidSDKComponent(SDKComponent.registerAndroidSDKComponent(application, client))
+        testConfig.configureAndroidSDKComponent(SDKComponent.registerAndroidSDKComponent(application))
     }
 }

--- a/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
@@ -1,7 +1,6 @@
 package io.customer.commontest.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.argumentOrNull
 import io.customer.commontest.config.configureAndroidSDKComponent
@@ -43,7 +42,6 @@ abstract class BaseTest {
      */
     private fun registerAndroidSDKComponent(testConfig: TestConfig) {
         val application = testConfig.argumentOrNull<ApplicationArgument>()?.value ?: return
-        val client = testConfig.argumentOrNull<ClientArgument>()?.value ?: return
 
         testConfig.configureAndroidSDKComponent(SDKComponent.registerAndroidSDKComponent(application))
     }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -122,7 +122,7 @@ public abstract class io/customer/sdk/core/di/AndroidSDKComponent : io/customer/
 }
 
 public final class io/customer/sdk/core/di/AndroidSDKComponentImpl : io/customer/sdk/core/di/AndroidSDKComponent {
-	public fun <init> (Landroid/content/Context;Lio/customer/sdk/data/store/Client;)V
+	public fun <init> (Landroid/content/Context;)V
 	public fun getApplication ()Landroid/app/Application;
 	public fun getApplicationContext ()Landroid/content/Context;
 	public fun getApplicationStore ()Lio/customer/sdk/data/store/ApplicationStore;
@@ -155,7 +155,7 @@ public final class io/customer/sdk/core/di/SDKComponent : io/customer/sdk/core/d
 }
 
 public final class io/customer/sdk/core/di/SDKComponentExtKt {
-	public static final fun registerAndroidSDKComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;Lio/customer/sdk/data/store/Client;)Lio/customer/sdk/core/di/AndroidSDKComponent;
+	public static final fun registerAndroidSDKComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/sdk/core/di/AndroidSDKComponent;
 }
 
 public abstract interface class io/customer/sdk/core/environment/BuildEnvironment {
@@ -165,6 +165,10 @@ public abstract interface class io/customer/sdk/core/environment/BuildEnvironmen
 public final class io/customer/sdk/core/environment/DefaultBuildEnvironment : io/customer/sdk/core/environment/BuildEnvironment {
 	public fun <init> ()V
 	public fun getDebugModeEnabled ()Z
+}
+
+public final class io/customer/sdk/core/extensions/ContextExtensionsKt {
+	public static final fun applicationMetaData (Landroid/content/Context;)Landroid/os/Bundle;
 }
 
 public abstract interface class io/customer/sdk/core/module/CustomerIOModule {

--- a/core/src/androidTest/AndroidManifest.xml
+++ b/core/src/androidTest/AndroidManifest.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application>
+        <!--
+        This is how wrapper SDKs can provide their own values for the SDK_SOURCE and SDK_VERSION meta-data.
+        tools:replace="android:value" is used to replace the value of the meta-data.
+        tools:node="replace" is used to replace the entire meta-data tag.
+        Either of these attributes can be used to resolve any conflicts that may arise when merging
+        multiple AndroidManifest.xml files with the same meta-data tags.
+        -->
         <meta-data
-            android:name="io.customer.sdk.android.core.USER_AGENT"
-            android:value="TestUserAgent" />
+            android:name="io.customer.sdk.android.core.SDK_SOURCE"
+            android:value="TestUserAgent"
+            tools:replace="android:value" />
         <meta-data
             android:name="io.customer.sdk.android.core.SDK_VERSION"
-            android:value="1.3.5" />
+            android:value="1.3.5"
+            tools:node="replace" />
     </application>
-
 </manifest>

--- a/core/src/androidTest/AndroidManifest.xml
+++ b/core/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="io.customer.sdk.android.core.USER_AGENT"
+            android:value="TestUserAgent" />
+        <meta-data
+            android:name="io.customer.sdk.android.core.SDK_VERSION"
+            android:value="1.3.5" />
+    </application>
+
+</manifest>

--- a/core/src/androidTest/java/io/customer/sdk/data/store/AndroidManifestClientTest.kt
+++ b/core/src/androidTest/java/io/customer/sdk/data/store/AndroidManifestClientTest.kt
@@ -1,0 +1,15 @@
+package io.customer.sdk.data.store
+
+import io.customer.commontest.core.AndroidTest
+import io.customer.sdk.core.extensions.applicationMetaData
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class AndroidManifestClientTest : AndroidTest() {
+    @Test
+    fun fromManifest_givenTestMetaData_expectClientWithTestMetaData() {
+        val client = Client.fromMetadata(application.applicationMetaData())
+
+        client.toString() shouldBeEqualTo "TestUserAgent Client/1.3.5"
+    }
+}

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application>
-        <meta-data
-            android:name="io.customer.sdk.android.core.USER_AGENT"
-            android:value="TestUserAgent" />
-        <meta-data
-            android:name="io.customer.sdk.android.core.SDK_VERSION"
-            android:value="1.3.5" />
-    </application>
-
 </manifest>

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <meta-data
+            android:name="io.customer.sdk.android.core.USER_AGENT"
+            android:value="TestUserAgent" />
+        <meta-data
+            android:name="io.customer.sdk.android.core.SDK_VERSION"
+            android:value="1.3.5" />
+    </application>
+
 </manifest>

--- a/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
@@ -28,11 +28,13 @@ abstract class AndroidSDKComponent : DiGraph() {
  * Integrate this graph at SDK startup using from Android entry point.
  */
 class AndroidSDKComponentImpl(
-    private val context: Context,
-    override val client: Client
+    private val context: Context
 ) : AndroidSDKComponent() {
     override val application: Application
         get() = newInstance<Application> { context.applicationContext as Application }
+
+    override val client: Client
+        get() = singleton<Client> { Client.fromManifest(context = context) }
 
     init {
         SDKComponent.activityLifecycleCallbacks.register(application)

--- a/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
@@ -2,6 +2,7 @@ package io.customer.sdk.core.di
 
 import android.app.Application
 import android.content.Context
+import io.customer.sdk.core.extensions.applicationMetaData
 import io.customer.sdk.data.store.ApplicationStore
 import io.customer.sdk.data.store.ApplicationStoreImpl
 import io.customer.sdk.data.store.BuildStore
@@ -34,7 +35,7 @@ class AndroidSDKComponentImpl(
         get() = newInstance<Application> { context.applicationContext as Application }
 
     override val client: Client
-        get() = singleton<Client> { Client.fromManifest(context = context) }
+        get() = singleton<Client> { Client.fromMetadata(context.applicationMetaData()) }
 
     init {
         SDKComponent.activityLifecycleCallbacks.register(application)

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -1,7 +1,6 @@
 package io.customer.sdk.core.di
 
 import android.content.Context
-import io.customer.sdk.data.store.Client
 
 /**
  * The file contains extension functions for the SDKComponent object and its dependencies.
@@ -12,8 +11,7 @@ import io.customer.sdk.data.store.Client
  * only if it is not already initialized.
  */
 fun SDKComponent.registerAndroidSDKComponent(
-    context: Context,
-    client: Client
+    context: Context
 ) = registerDependency<AndroidSDKComponent> {
-    AndroidSDKComponentImpl(context, client)
+    AndroidSDKComponentImpl(context)
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/extensions/ContextExtensions.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/extensions/ContextExtensions.kt
@@ -1,0 +1,29 @@
+package io.customer.sdk.core.extensions
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import io.customer.sdk.core.di.SDKComponent
+
+/**
+ * Gets meta-data from AndroidManifest.xml file.
+ *
+ * @return The meta-data bundle from application info.
+ */
+fun Context.applicationMetaData(): Bundle? = runCatching {
+    val appInfo: ApplicationInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.getApplicationInfo(
+            packageName,
+            PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
+        )
+    } else {
+        @Suppress("DEPRECATION")
+        packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+    }
+
+    return@runCatching appInfo.metaData
+}.onFailure { ex ->
+    SDKComponent.logger.error("Failed to get application meta-data: ${ex.message}")
+}.getOrNull()

--- a/core/src/main/kotlin/io/customer/sdk/core/extensions/ContextExtensions.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/extensions/ContextExtensions.kt
@@ -1,46 +1,31 @@
 package io.customer.sdk.core.extensions
 
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import io.customer.sdk.core.di.SDKComponent
 
 /**
- * Retrieves application info from the package manager for given package name.
- *
- * @throws PackageManager.NameNotFoundException If the package name is not found.
- * @return The application info for the given package name.
- */
-@Throws
-private fun PackageManager.packageApplicationInfo(packageName: String): ApplicationInfo {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getApplicationInfo(
-            packageName,
-            PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
-        )
-    } else {
-        getApplicationInfo(
-            packageName,
-            PackageManager.GET_META_DATA
-        )
-    }
-}
-
-/**
  * Retrieves application meta-data from AndroidManifest.xml file.
  *
  * @return The meta-data bundle from application info.
  */
-fun Context.applicationMetaData(): Bundle? {
-    var applicationPackageName = ""
-    return runCatching {
-        applicationPackageName = packageName
-        return@runCatching packageManager.packageApplicationInfo(applicationPackageName)
-    }.onFailure { ex ->
-        SDKComponent.logger.error(
-            "Failed to get ApplicationInfo for package: $applicationPackageName with error: ${ex.message}"
+fun Context.applicationMetaData(): Bundle? = try {
+    val applicationInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        packageManager.getApplicationInfo(
+            packageName,
+            PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
         )
-    }.getOrNull()?.metaData
+    } else {
+        @Suppress("DEPRECATION")
+        packageManager.getApplicationInfo(
+            packageName,
+            PackageManager.GET_META_DATA
+        )
+    }
+    applicationInfo.metaData
+} catch (ex: Exception) {
+    SDKComponent.logger.error("Failed to get ApplicationInfo with error: ${ex.message}")
+    null
 }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
@@ -1,8 +1,7 @@
 package io.customer.sdk.data.store
 
-import android.content.Context
+import android.os.Bundle
 import io.customer.sdk.Version
-import io.customer.sdk.core.extensions.applicationMetaData
 
 /**
  * Represents the client information to append with user-agent.
@@ -19,23 +18,21 @@ class Client(
 
     companion object {
         private const val SOURCE_ANDROID = "Android"
-        private const val META_DATA_USER_AGENT = "io.customer.sdk.android.core.USER_AGENT"
-        private const val META_DATA_SDK_VERSION = "io.customer.sdk.android.core.SDK_VERSION"
+        internal const val META_DATA_USER_AGENT = "io.customer.sdk.android.core.USER_AGENT"
+        internal const val META_DATA_SDK_VERSION = "io.customer.sdk.android.core.SDK_VERSION"
 
         /**
          * Creates a new [Client] instance from the manifest meta-data.
          * If the user-agent or SDK version is not found, the default client is returned.
          * Default client is created with [SOURCE_ANDROID] and SDK version mentioned in [Version] class.
          *
-         * @param context The context to retrieve the meta-data from.
+         * @param metadata Android application meta-data to retrieve the user-agent and SDK version from.
          * @return The client instance created from the manifest meta-data.
          * If not found, the default client is returned.
          */
-        fun fromManifest(context: Context): Client {
-            // Retrieve user agent and SDK version from manifest
-            val appMetaData = context.applicationMetaData()
-            val userAgent = appMetaData?.getString(META_DATA_USER_AGENT)
-            val sdkVersion = appMetaData?.getString(META_DATA_SDK_VERSION)
+        fun fromMetadata(metadata: Bundle?): Client {
+            val userAgent = metadata?.getString(META_DATA_USER_AGENT)
+            val sdkVersion = metadata?.getString(META_DATA_SDK_VERSION)
 
             // If either value is null or blank, return the default client
             return if (userAgent.isNullOrBlank() || sdkVersion.isNullOrBlank()) {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
@@ -18,7 +18,7 @@ class Client(
 
     companion object {
         private const val SOURCE_ANDROID = "Android"
-        internal const val META_DATA_USER_AGENT = "io.customer.sdk.android.core.USER_AGENT"
+        internal const val META_DATA_SDK_SOURCE = "io.customer.sdk.android.core.SDK_SOURCE"
         internal const val META_DATA_SDK_VERSION = "io.customer.sdk.android.core.SDK_VERSION"
 
         /**
@@ -31,7 +31,7 @@ class Client(
          * If not found, the default client is returned.
          */
         fun fromMetadata(metadata: Bundle?): Client {
-            val userAgent = metadata?.getString(META_DATA_USER_AGENT)
+            val userAgent = metadata?.getString(META_DATA_SDK_SOURCE)
             val sdkVersion = metadata?.getString(META_DATA_SDK_VERSION)
 
             // If either value is null or blank, return the default client

--- a/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/Client.kt
@@ -1,83 +1,48 @@
 package io.customer.sdk.data.store
 
+import android.content.Context
+import io.customer.sdk.Version
+import io.customer.sdk.core.extensions.applicationMetaData
+
 /**
- * Sealed class to hold information about the SDK wrapper and package that the
- * client app is using.
+ * Represents the client information to append with user-agent.
  *
  * @property source name of the client to append with user-agent.
  * @property sdkVersion version of the SDK used.
  */
-sealed class Client(
+@Suppress("MemberVisibilityCanBePrivate")
+class Client(
     val source: String,
     val sdkVersion: String
 ) {
     override fun toString(): String = "$source Client/$sdkVersion"
 
-    /**
-     * Simpler class for Android clients.
-     */
-    class Android(sdkVersion: String) : Client(source = SOURCE_ANDROID, sdkVersion = sdkVersion)
-
-    /**
-     * Simpler class for ReactNative clients.
-     */
-    class ReactNative(sdkVersion: String) : Client(
-        source = SOURCE_REACT_NATIVE,
-        sdkVersion = sdkVersion
-    )
-
-    /**
-     * Simpler class for Expo clients.
-     */
-    class Expo(sdkVersion: String) : Client(source = SOURCE_EXPO, sdkVersion = sdkVersion)
-
-    /**
-     * Simpler class for Flutter clients.
-     */
-    class Flutter(sdkVersion: String) : Client(source = SOURCE_FLUTTER, sdkVersion = sdkVersion)
-
-    /**
-     * Other class to allow adding custom sources for clients that are not
-     * supported above.
-     * <p/>
-     * Use this only if the client platform is not available in the above list.
-     */
-    class Other internal constructor(
-        source: String,
-        sdkVersion: String
-    ) : Client(source = source, sdkVersion = sdkVersion)
-
     companion object {
-        internal const val SOURCE_ANDROID = "Android"
-        internal const val SOURCE_REACT_NATIVE = "ReactNative"
-        internal const val SOURCE_EXPO = "Expo"
-        internal const val SOURCE_FLUTTER = "Flutter"
+        private const val SOURCE_ANDROID = "Android"
+        private const val META_DATA_USER_AGENT = "io.customer.sdk.android.core.USER_AGENT"
+        private const val META_DATA_SDK_VERSION = "io.customer.sdk.android.core.SDK_VERSION"
 
         /**
-         * Helper method to create client from raw values
+         * Creates a new [Client] instance from the manifest meta-data.
+         * If the user-agent or SDK version is not found, the default client is returned.
+         * Default client is created with [SOURCE_ANDROID] and SDK version mentioned in [Version] class.
          *
-         * @param source raw string of client source (case insensitive)
-         * @param sdkVersion version of the SDK used
-         * @return [Client] created from provided values
+         * @param context The context to retrieve the meta-data from.
+         * @return The client instance created from the manifest meta-data.
+         * If not found, the default client is returned.
          */
-        fun fromRawValue(source: String, sdkVersion: String): Client = when {
-            source.equals(
-                other = SOURCE_ANDROID,
-                ignoreCase = true
-            ) -> Android(sdkVersion = sdkVersion)
-            source.equals(
-                other = SOURCE_REACT_NATIVE,
-                ignoreCase = true
-            ) -> ReactNative(sdkVersion = sdkVersion)
-            source.equals(
-                other = SOURCE_EXPO,
-                ignoreCase = true
-            ) -> Expo(sdkVersion = sdkVersion)
-            source.equals(
-                other = SOURCE_FLUTTER,
-                ignoreCase = true
-            ) -> Flutter(sdkVersion = sdkVersion)
-            else -> Other(source = source, sdkVersion = sdkVersion)
+        fun fromManifest(context: Context): Client {
+            // Retrieve user agent and SDK version from manifest
+            val appMetaData = context.applicationMetaData()
+            val userAgent = appMetaData?.getString(META_DATA_USER_AGENT)
+            val sdkVersion = appMetaData?.getString(META_DATA_SDK_VERSION)
+
+            // If either value is null or blank, return the default client
+            return if (userAgent.isNullOrBlank() || sdkVersion.isNullOrBlank()) {
+                Client(source = SOURCE_ANDROID, sdkVersion = Version.version)
+            } else {
+                Client(source = userAgent, sdkVersion = sdkVersion)
+            }
         }
     }
 }

--- a/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
@@ -10,7 +10,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ClientTest : RobolectricTest() {
-    private val defaultClientString: String = Client("Android", Version.version).toString()
+    private val defaultClientString: String = "Android Client/${Version.version}"
 
     private fun createMetadata(
         userAgent: String?,

--- a/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
@@ -1,0 +1,85 @@
+package io.customer.sdk.data.store
+
+import android.os.Bundle
+import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.Version
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ClientTest : RobolectricTest() {
+    private val defaultClientString: String = Client("Android", Version.version).toString()
+
+    private fun createMetadata(
+        userAgent: String?,
+        sdkVersion: String?
+    ) = Bundle().apply {
+        userAgent?.let { putString(Client.META_DATA_USER_AGENT, it) }
+        sdkVersion?.let { putString(Client.META_DATA_SDK_VERSION, it) }
+    }
+
+    @Test
+    fun fromManifest_givenValidMetaData_expectClientWithMetaData() {
+        val metadata = createMetadata("ReactNative", "1.2.3")
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo "ReactNative Client/1.2.3"
+    }
+
+    @Test
+    fun fromManifest_givenNullUserAgent_expectDefaultSourceUsed() {
+        val metadata = createMetadata(null, "1.2.3")
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+
+    @Test
+    fun fromManifest_givenEmptyUserAgent_expectDefaultSourceUsed() {
+        val metadata = createMetadata("", "1.2.3")
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+
+    @Test
+    fun fromManifest_givenNullSdkVersion_expectDefaultSdkVersionUsed() {
+        val metadata = createMetadata("ReactNative", null)
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+
+    @Test
+    fun fromManifest_givenEmptySdkVersion_expectDefaultSdkVersionUsed() {
+        val metadata = createMetadata("ReactNative", "")
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+
+    @Test
+    fun fromManifest_givenNullMetaData_expectDefaultValuesUsed() {
+        val metadata = createMetadata(null, null)
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+
+    @Test
+    fun fromManifest_givenEmptyMetaData_expectDefaultValuesUsed() {
+        val metadata = createMetadata("", "")
+
+        val client = Client.fromMetadata(metadata)
+
+        client.toString() shouldBeEqualTo defaultClientString
+    }
+}

--- a/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/ClientTest.kt
@@ -16,7 +16,7 @@ class ClientTest : RobolectricTest() {
         userAgent: String?,
         sdkVersion: String?
     ) = Bundle().apply {
-        userAgent?.let { putString(Client.META_DATA_USER_AGENT, it) }
+        userAgent?.let { putString(Client.META_DATA_SDK_SOURCE, it) }
         sdkVersion?.let { putString(Client.META_DATA_SDK_VERSION, it) }
     }
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -10,7 +10,6 @@ import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.model.Region
-import io.customer.sdk.data.store.Client
 
 /**
  * Creates a new instance of builder for CustomerIO SDK.
@@ -35,8 +34,7 @@ class CustomerIOBuilder(
     // it can be used by the modules.
     // Also, it is needed to override test dependencies in the test environment
     private val androidSDKComponent = SDKComponent.registerAndroidSDKComponent(
-        context = applicationContext,
-        client = Client.Android(Version.version)
+        context = applicationContext
     )
 
     // List of modules to be initialized with the SDK

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/core/IntegrationTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/core/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package io.customer.messaginginapp.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
@@ -9,7 +8,6 @@ import io.customer.commontest.core.RobolectricTest
 abstract class IntegrationTest : RobolectricTest() {
     private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
     }
 
     override fun setup(testConfig: TestConfig) {

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/core/JUnitTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/core/JUnitTest.kt
@@ -1,7 +1,6 @@
 package io.customer.messaginginapp.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.JUnit5Test
@@ -10,7 +9,6 @@ import io.customer.messaginginapp.testutils.mocks.mockAndroidLog
 abstract class JUnitTest : JUnit5Test() {
     private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
 
         diGraph {
             sdk {

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -5,7 +5,6 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import android.os.Build
@@ -24,6 +23,7 @@ import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_TOKEN_KEY
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.extensions.applicationMetaData
 import java.net.URL
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
@@ -114,16 +114,7 @@ internal class CustomerIOPushNotificationHandler(
 
         bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)
 
-        val applicationInfo = try {
-            context.packageManager.getApplicationInfo(
-                context.packageName,
-                PackageManager.GET_META_DATA
-            )
-        } catch (ex: Exception) {
-            logger.error("Package not found ${ex.message}")
-            null
-        }
-        val appMetaData = applicationInfo?.metaData
+        val appMetaData = context.applicationMetaData()
 
         @DrawableRes
         val smallIcon: Int =

--- a/messagingpush/src/test/java/io/customer/messagingpush/testutils/core/IntegrationTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/testutils/core/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package io.customer.messagingpush.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
@@ -9,7 +8,6 @@ import io.customer.commontest.core.RobolectricTest
 abstract class IntegrationTest : RobolectricTest() {
     private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
     }
 
     override fun setup(testConfig: TestConfig) {

--- a/messagingpush/src/test/java/io/customer/messagingpush/testutils/core/JUnitTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/testutils/core/JUnitTest.kt
@@ -1,7 +1,6 @@
 package io.customer.messagingpush.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.JUnit5Test
@@ -9,7 +8,6 @@ import io.customer.commontest.core.JUnit5Test
 abstract class JUnitTest : JUnit5Test() {
     private val defaultTestConfiguration: TestConfig = testConfigurationDefault {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
     }
 
     override fun setup(testConfig: TestConfig) {

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/IntegrationTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package io.customer.tracking.migration.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.RobolectricTest
 import io.customer.sdk.core.di.SDKComponent
@@ -11,7 +10,6 @@ import io.customer.tracking.migration.testutils.extensions.migrationSDKComponent
 abstract class IntegrationTest : RobolectricTest() {
     private val defaultTestConfiguration: TrackingMigrationTestConfig = testConfiguration {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
     }
 
     override fun setup(testConfig: TestConfig) {

--- a/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/JUnitTest.kt
+++ b/tracking-migration/src/test/java/io/customer/tracking/migration/testutils/core/JUnitTest.kt
@@ -1,7 +1,6 @@
 package io.customer.tracking.migration.testutils.core
 
 import io.customer.commontest.config.ApplicationArgument
-import io.customer.commontest.config.ClientArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.JUnit5Test
 import io.customer.sdk.core.di.SDKComponent
@@ -11,7 +10,6 @@ import io.customer.tracking.migration.testutils.extensions.migrationSDKComponent
 abstract class JUnitTest : JUnit5Test() {
     private val defaultTestConfiguration: TrackingMigrationTestConfig = testConfiguration {
         argument(ApplicationArgument(applicationMock))
-        argument(ClientArgument())
     }
 
     override fun setup(testConfig: TestConfig) {


### PR DESCRIPTION
part of [MBL-522](https://linear.app/customerio/issue/MBL-522/user-agent-rn-android)

### Changes

- Moved `Client` class out of `AndroidSDKComponent` constructor and made it a singular dependency, allowing for decoupling
- Simplified `Client` class by removing sealed implementation
- Updated `Client` class to create user-agent client based on meta-data provided in `AndroidManifest`
- Added and used extensions to fetch meta-data from `AndroidManifest` and fixed the deprecated method warning for `ApplicationInfo`
- Added tests to verify the changes
- Removed `ClientArgument` from `TestArgument` as it is no longer needed

### Benefits of this approach

- `Client` is no longer dependent on SDK initialization
- `Client` will always remain the same, regardless of which classes initialize the SDK and register `AndroidSDKComponent`
- `Client` can still be overridden in `AndroidSDKComponent`

### User agent sent from Android SDK

```
Customer.io Android Client/4.2.0 (Google Pixel 6; 34) io.customer.android.sample.java_layout/1.0
```

### User agent sent from React Native SDK (Pending changes)

```
Customer.io ReactNative Client/3.8.0 (Google sdk_gphone64_arm64; 33) io.customer.rn_sample.fcm/1.0
```