### PR TITLE
feat: Pass options using postMessage: DO NOT MERGE

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/GistEnvironment.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/GistEnvironment.kt
@@ -10,7 +10,7 @@ enum class GistEnvironment : GistEnvironmentEndpoints {
     DEV {
         override fun getGistQueueApiUrl() = "https://gist-queue-consumer-api.cloud.dev.gist.build"
         override fun getEngineApiUrl() = "https://engine.api.dev.gist.build"
-        override fun getGistRendererUrl() = "http://192.168.2.86:8080/web"
+        override fun getGistRendererUrl() = "https://renderer.gist.build/beta"
     },
 
     LOCAL {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/GistEnvironment.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/GistEnvironment.kt
@@ -10,7 +10,7 @@ enum class GistEnvironment : GistEnvironmentEndpoints {
     DEV {
         override fun getGistQueueApiUrl() = "https://gist-queue-consumer-api.cloud.dev.gist.build"
         override fun getEngineApiUrl() = "https://engine.api.dev.gist.build"
-        override fun getGistRendererUrl() = "https://renderer.gist.build/2.0"
+        override fun getGistRendererUrl() = "http://192.168.2.86:8080/web"
     },
 
     LOCAL {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -25,7 +25,7 @@ interface GistProvider {
 class GistSdk(
     siteId: String,
     dataCenter: String,
-    environment: GistEnvironment = GistEnvironment.PROD
+    environment: GistEnvironment = GistEnvironment.DEV
 ) : GistProvider {
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
     private val state: InAppMessagingState

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistView.kt
@@ -50,7 +50,6 @@ class GistView @JvmOverloads constructor(
     }
 
     fun setup(message: Message) {
-        logger.debug("GistView setup: $message")
         currentMessage = message
         currentMessage?.let { message ->
             val engineWebConfiguration = EngineWebConfiguration(
@@ -63,6 +62,7 @@ class GistView @JvmOverloads constructor(
             )
             engineWebView?.setup(engineWebConfiguration)
         }
+        logger.debug("GistView setup: $store")
     }
 
     fun stopLoading() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -83,6 +83,7 @@ internal class EngineWebView @JvmOverloads constructor(
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageUrl = "${state.environment.getGistRendererUrl()}/index.html"
         logger.debug("Rendering message with URL: $messageUrl")
+        logger.debug("Rendering config: $configuration")
             webView?.let {
                 it.clearCache(true) // TODO: remove after debugging
                 it.settings.cacheMode = WebSettings.LOAD_NO_CACHE

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -27,6 +27,7 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.gist.utilities.ElapsedTimer
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.sdk.core.di.SDKComponent
+import org.json.JSONObject
 import java.util.Timer
 import java.util.TimerTask
 
@@ -83,7 +84,10 @@ internal class EngineWebView @JvmOverloads constructor(
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageUrl = "${state.environment.getGistRendererUrl()}/index.html"
         logger.debug("Rendering message with URL: $messageUrl")
-        logger.debug("Rendering config: $configuration")
+
+        val formattedJson = JSONObject(Gson().toJson(configuration)).toString(4)
+        logger.debug("Rendering Options: \n$formattedJson")
+
             webView?.let {
                 it.clearCache(true) // TODO: remove after debugging
                 it.settings.cacheMode = WebSettings.LOAD_NO_CACHE

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -6,7 +6,7 @@ import io.customer.messaginginapp.gist.data.model.Message
 data class InAppMessagingState(
     val siteId: String = "",
     val dataCenter: String = "",
-    val environment: GistEnvironment = GistEnvironment.PROD,
+    val environment: GistEnvironment = GistEnvironment.DEV,
     val pollInterval: Long = 600_000L,
     val userId: String? = null,
     val currentRoute: String? = null,


### PR DESCRIPTION
The idea here is to support passing the options data to the gist-web-renderer using postMessage instead of passing it as a url parameter. 

Required: gist-web-renderer PR here: https://github.com/customerio/gist-web-renderer/pull/17

This is currently working in a similar gist-web PR here: https://github.com/customerio/gist-web/pull/66

Linear issue: https://linear.app/customerio/issue/INAPP-12777/request-header-too-large-preventing-in-app-messages-from-rendering

This is work in progress. Currently on my machine with the gist-web-renderer PR I get this in my logs, which I believe is a CORS issue.

JavaScript injected for postMessage
Flutter Web Bootstrap: Auto. -- From line 7380 of http://192.168.2.86:8080/web/main.dart.js Message received base -- From line 1 of http://192.168.2.86:8080/web/main.min.js Message received json: {"isTrusted":true} -- From line 1 of http://192.168.2.86:8080/web/main.min.js Message received orig: [object Object] -- From line 1 of http://192.168.2.86:8080/web/main.min.js Options received: {"dataCenter":"us","endpoint":"https://engine.api.dev.gist.build","instanceId":"77140a57-2e78-446a-a504-b89fefa10e80","livePreview":false,"messageId":"gist-html-01J87SG3MHFFVP758GX91CFJBR","properties":{"gist":{"encodedMessageHtml":"H4sIAAAAAAAA/7x625LjyHHo+35FLjeknVEMk3W/sJujWFFHp+0YyQrL2w/7okCTRRJqEKABsC/bMV/gJ3+Bf9Gf4MgCCiDZM5IVIXfPRDezMivvmZVF4BuA62/X1ap9PgTYtfviI63QByiycruYHMv1BNZ5vZhkx7aaEJoIQrbuPgJc70ObwWqX1U1oF5Nju5m6CcwG9LfTKfxrWFX7fSjXYQ0PeXg8VHULbQWhbI51gLycZodDA80qKwIc6uoQ6uIZslVdNQ2sw0O+Cg1Mp2ci+88AZbYPi0liOxnWV1XZhrJdTB7zdbtbdGymEfgAeZm3eVZMo8gFR/YB9tlTvj/uT5eOTagjnN0VYcES79m57Z0Cq6qoiHgX9mEyCi+rep8Vpw5p87YIH69n3d+02rTPIwQwr6uqhZcBJnNG/nPo2F4N+M/fDB9j9E53Vg+hblZ1VRTTu7DLHvKqJgZluILZr85is6lq2Fd3eRHIdIrQoQ4PoWxhG5r2WIcGNnW1h331kJdbaHcpdlBtNtCs6hBK+NXsVOtj3ZC4ddhkx6I9VTh9uqvWz2f6bqqynW6yfV48z+GHOs+KD9BkZTNtQp1vrk4o91m9zcs5sNPF6WO4u8/baWTT7Kuq3eXldg5ZSRHPsyasz8j31c/Tqnl6Rb+ts+eYC6+Vvp6dhKsPHa7E/Zbd5S9FXobpLuTbXTvnqK9OzbkJxUNo81X24cSgz7hqd6tQ3L8csvWaZLvDE60e7DF/rF/22VOXtnOqwavO6GkRNu3ZQh0lxpWYK/PvTPz5sgJXl2om2UIdnoB+XVHebIrqseN5l63ut3V1LNfz7zaB/l3dVfU61NM6W+fHJip9Vz1Nm122rh7nDMThCYgZg3p7l71jH6D/j/x9R5n/TBJ7NndVNHqb1T9nxUtvgow/nQlN/nOYCxJzrrvQvQvmrPMbv1emNmq+IwteThVnTJmMwbf5nnpFVrZEnpdeZ/KlT9VDlZdtqK/WeXMosud5XkZpd0W1ur/qwsAZ+8VXDBhjFYl6K34Xf74SiNE2bg5PHfjY2WYZu2rDUztt66xsNlW9n8e6jWtZkW/L+SpEbePKOqyqOmvzquzITt2Ul7tQ5+0QZu4oMhSyM/dou1Iprp0dkeZVoD/jSptjUz2+vNalD0YUQITmvtzxl+TPTRGerv5ybNp88zzt22TaGdlM8zbsm7SUokxC+0Rvq0Pnqh6+q9q22s+nvV5RHBxSBmU8E3fi1MviwsuKsfOMOpHVFZU65YxZudpV9fSxzg6HUJ8b9gULvhiaTrkUlJF3UW2r6JUsL0P9ss0OUfjfkvE1BlBkd6H4v3PFhbTmYfvyEGpK66LPiX2+XhdhCKPotj9u/vIs/v3lizXWJducXa2K/DCvw6p9xw9PH+Ds1/urvssT0fSQtbt5XjahfafZL95ffXExqXDa2Xb5eh3KlLFTwqUCYVeHqsljxLK7piqObUjlf3i6etzlbZg2h2wV5mVFqXD1OZ0K17NxPrqOpxsMx/w6f4BVkTXNYtKfF/CUMmkC4/n/Tfx/Rt6dEYmox6bPr36lXd0ZMhkRH8ePI32c+vhXWHQd+ZTFf//Xf/4H3IRnmgDq8O31bMdHrQ5f1amj+bddVt7Dc3WM48ZqV1UNDRPVsabRb31ctQg32UOADIqquocsNieaz+4DbaubUGwga3sTdtU+QFauId9EpmUIa8jKZ8iaJm/arFyFD3AoQtYEKEILxwbuy+oRSdXZ4cyZg8Vda0uuvr47tm1V9vJoVF5MuqU0EFblqshX94vJPjRNtg24zpt93jTvXj6/n5y6enRqd+hAOqvOqFIaLKuyzctj6LSYdTLjhD5b5w+9cpuqakM98I2FOemn91D2w3vR1ml2zxLpeRubwK4Om8Vk17aHZj6brY5Ni3k1k8/h53+um8mQwYePvw1Nvi2jl9ewDkX+EOqwhse83Q0ePXfoeZuYjGl+3RyyctC96woT+Lg8Nm21DzXm1fWMSE53PGxPpjca+39TPS0mDBh4pYALPzmdJfOioCG8DKerT/uibDpb57PZ4+MjPkqs6u1MMMZmzcN2JP54su16C0NnWUyOdfHuO4LZn720f+bu/eSUmG4HWXN/tgKQrxcTWk57Jhf42EE6kill2hyK4z4vKYsvSYnmxzJvm8WE7il/ol70L+WPzStC8s7l2vMX1rp70sQrdYnpWudicuHcc+9Ek8k1sF5Mfk+xYDfslgt/45W6ZT9N+mDE1nlyIep3zsiei7VtNLJ39anbLl39ZWeP7uZfcfff5fC/w+XR6eL16vNiMuWvlwfPv4rJie/lq42XPuj9/2oV+ohwtFbClKGQXjNxI1AIIwXFiJZueorbgeKn1+rAWRRfoWev4vKFuH4psvyrkf0bVmmUSnDQyLTX9sYoFEKpW2mQWeU+JbyxyJwXn3o8eIdCSDPa3tF94sKgVHzAX/Lp5fwVz3z3A/9B/OYLwX/lm79umXJonRIgGGpm7ScpUQitBktT9JKG3KIxRoHmaBQXA/2l5Yn+gv8bWJQ0dAKNNuZTb0HvazfEotd80JBzicZexs5dWDh6oOf/BhY5zZF7dVJTTgrkt9yh01ze9Pj/VUX9o3QSXKB0EpREJqxZCsHQOZ9gEMKhYByUQ84kByEZCs9BG1RG3QjlUSixFMoi1wKkQ+OtBCE5SqlBGPRMcCAxWqoEL7lnaJUd8NwKNJ6TWG7NCBuDnmu5TLDnaLxzQPu5Bs4sGqsieyEHeJm0HPDKoGIWvEEjjIFebbAWvZH+pqdfCmHRMwnOoLXcA3nDqihWayah85ZK8FIwhs4PMHBPeAeOo1BOD/BgRg9rgc5xoO3a69HZ58F4g/BLZtA4B5aj9EouE+wUescNCO+RWUsGCi0kCM/QDeBSOI7WuBFtNVrvwGnkkvEBtgqZE+pWUHooeSO0Qa3crbUouOXLHgZvUVrKMuOQU5hj/DQIp9CQfzt4KbxCOcIgmUDKIqaQeQGSWeTSULi90OKWM4NMyhspNFrnBzV6a29769+iBXCFnJqORme5vLFeIjd+0LDH3/b4tzg4vETGxspUlqGh1O8rU2mBwmhQArX1ZoBTSifYc/TeCaD9Uoyll/in0tRcxxJKeC0l6pPKTnDin2AlUDjGgfbrk85yof9Pg0GpRpVjqIwfalRZjt5QiWplEzRY04FaoJVcA+2V3A0FmninbqkZGWMHvOYSnRepvhM42NLDjmw1GtL2QbVz1d8g+kYKqrgh+kZwNMIN3jXUkajAOEonwLC+zXu0SvKloboTFiSjs1eDpnQWZtiunUImxuTSVqKzJ3ij0RvX75egDY/zlLToGE/9gt9oJWKhdmUibojOen5rJDKpxLKHQXlqxw608ahYPE6k0A60tWiYS/BSU31xNeK9QGY9nXJOMzXAhiFTo1jDOXInBrE9DJrIlAXDHVovBraG7PSjWCM1CqZHvOKorB7EJvhSrGFohbrVlEZi2YMgNXKuDBhlUanRqRcxfYMssszFmh+yyFm0J2lgjENr9VDDCTYGrTF2mWAvyBAOtJ8LP/QIyzwyM/YQKzQ5ZsQrjtpb4Iyh1B6sMigtOIlSOntjhUVtl1ZI9B48Q8EMWG7QiShTe2WjDGN4gpfGOzRCDHjjCJ9ORjDO0aQCljqF4zeWBiDubo1Dra1Z9jAojsyRSjStsrGtXrjsp98TQyaohJBrbpckT5qYkkILDcZbdNRPOTopZWTAhEjw0lLuGTvihUEtFO23jGkgJyjuE/+bXt5bnHlMIBMGlEHDWSxqrbRZOsbQODrcUSgjwHqHV Loading message -- From line 1 of http://192.168.2.86:8080/web/main.min.js organizationId: undefined -- From line 1 of http://192.168.2.86:8080/web/main.min.js Message global timeout, cancelling display.
GistView Error loading engine
Store: action: MessageLoadingFailed(message=Message(messageId=gist-html-01J87SG3MHFFVP758GX91CFJBR, instanceId=77140a57-2e78-446a-a504-b89fefa10e80, priority=10, queueId=01e0fb5e-7117-481d-a204-d786d0669348, properties=GistProperties(routeRule=null, elementId=null, campaignId=null, position=CENTER, persistent=false)) Store: state before reducer: InAppMessagingState(siteId='0f4234d28520fd1619d0', dataCenter='us',
environment=DEV,
pollInterval=10000,
userId=stephen.pope+gist@customer.io,
currentRoute=Dashboard,
currentMessageState=Loading(message=Message(messageId=gist-html-01J87SG3MHFFVP758GX91CFJBR, instanceId=77140a57-2e78-446a-a504-b89fefa10e80, priority=10, queueId=01e0fb5e-7117-481d-a204-d786d0669348, properties=GistProperties(routeRule=null, elementId=null, campaignId=null, position=CENTER, persistent=false)), messagesInQueue=[01e0fb5e-7117-481d-a204-d786d0669348], shownMessageQueueIds=[])
Error occurred on message: Message(messageId=gist-html-01J87SG3MHFFVP758GX91CFJBR, instanceId=77140a57-2e78-446a-a504-b89fefa10e80, priority=10, queueId=01e0fb5e-7117-481d-a204-d786d0669348, properties=GistProperties(routeRule=null, elementId=null, campaignId=null, position=CENTER, persistent=false) in-app message: errorWithMessage. message: InAppMessage(messageId=gist-html-01J87SG3MHFFVP758GX91CFJBR, queueId=01e0fb5e-7117-481d-a204-d786d0669348, deliveryId=null) track an event with name in-app message action and attributes {delivery-id=NULL, event-name=errorWithMessage, message-id=gist-html-01J87SG3MHFFVP758GX91CFJBR} JavaScript injected for postMessage
Access to XMLHttpRequest at 'https://engine-consumer-api.cloud.dev.gist.build/api/v2/configuration?cioSiteId=0f4234d28520fd1619d0&cioDatacenter=us&random=0' from origin 'http://192.168.2.86:8080' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. -- From line 0 of http://192.168.2.86:8080/web/index.html#/ Uncaught  -- From line 6090 of http://192.168.2.86:8080/web/main.dart.js

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 