### PR TITLE
fix: add userId for deleteToken

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -144,7 +144,7 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public static final field Companion Lio/customer/sdk/CustomerIO$Companion;
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/datapipelines/config/DataPipelinesModuleConfig;Lcom/segment/analytics/kotlin/core/Analytics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearIdentify ()V
-	public fun deleteDeviceToken ()V
+	public fun deleteDeviceToken (Lkotlin/jvm/functions/Function1;)V
 	public fun getAnonymousId ()Ljava/lang/String;
 	public fun getDeviceAttributes ()Ljava/util/Map;
 	public fun getModuleConfig ()Lio/customer/datapipelines/config/DataPipelinesModuleConfig;
@@ -153,15 +153,15 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public fun getProfileAttributes ()Ljava/util/Map;
 	public fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public fun getUserId ()Ljava/lang/String;
-	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
 	public fun initialize ()V
 	public static final fun instance ()Lio/customer/sdk/CustomerIO;
-	public fun registerDeviceToken (Ljava/lang/String;)V
-	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public fun registerDeviceToken (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
 	public fun setDeviceAttributes (Ljava/util/Map;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
-	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
-	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
+	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/customer/sdk/CustomerIO$Companion {
@@ -189,30 +189,42 @@ public final class io/customer/sdk/CustomerIOBuilder {
 public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/CustomerIOInstance {
 	public fun <init> ()V
 	public abstract fun clearIdentify ()V
-	public abstract fun deleteDeviceToken ()V
+	public abstract fun deleteDeviceToken (Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun deleteDeviceToken$default (Lio/customer/sdk/DataPipelineInstance;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public abstract fun getAnonymousId ()Ljava/lang/String;
 	public abstract fun getDeviceAttributes ()Ljava/util/Map;
 	public abstract fun getProfileAttributes ()Ljava/util/Map;
 	public abstract fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public abstract fun getUserId ()Ljava/lang/String;
 	public final fun identify (Ljava/lang/String;)V
-	public abstract fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
-	public final fun identify (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public final fun identify (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
-	public abstract fun registerDeviceToken (Ljava/lang/String;)V
+	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun registerDeviceToken (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun registerDeviceToken$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun screen (Ljava/lang/String;)V
-	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
-	public final fun screen (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public final fun screen (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public abstract fun setDeviceAttributes (Ljava/util/Map;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;)V
-	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
-	public final fun track (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public final fun track (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
-	public abstract fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
+	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun trackMetric (Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun trackMetric$default (Lio/customer/sdk/DataPipelineInstance;Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -153,15 +153,15 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public fun getProfileAttributes ()Ljava/util/Map;
 	public fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public fun getUserId ()Ljava/lang/String;
-	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun initialize ()V
 	public static final fun instance ()Lio/customer/sdk/CustomerIO;
-	public fun registerDeviceToken (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public fun registerDeviceToken (Ljava/lang/String;)V
+	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun setDeviceAttributes (Ljava/util/Map;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
 	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
-	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;)V
+	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
 }
 
 public final class io/customer/sdk/CustomerIO$Companion {
@@ -197,34 +197,24 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public abstract fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public abstract fun getUserId ()Ljava/lang/String;
 	public final fun identify (Ljava/lang/String;)V
-	public abstract fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
-	public final fun identify (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public final fun identify (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public abstract fun registerDeviceToken (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun registerDeviceToken$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public abstract fun registerDeviceToken (Ljava/lang/String;)V
 	public final fun screen (Ljava/lang/String;)V
-	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
-	public final fun screen (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
+	public final fun screen (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
 	public abstract fun setDeviceAttributes (Ljava/util/Map;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;)V
 	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
-	public final fun track (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public final fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public abstract fun trackMetric (Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun trackMetric$default (Lio/customer/sdk/DataPipelineInstance;Lio/customer/sdk/events/TrackMetric;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public abstract fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
 }
 

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -144,7 +144,7 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public static final field Companion Lio/customer/sdk/CustomerIO$Companion;
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/datapipelines/config/DataPipelinesModuleConfig;Lcom/segment/analytics/kotlin/core/Analytics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearIdentify ()V
-	public fun deleteDeviceToken (Lkotlin/jvm/functions/Function1;)V
+	public fun deleteDeviceToken ()V
 	public fun getAnonymousId ()Ljava/lang/String;
 	public fun getDeviceAttributes ()Ljava/util/Map;
 	public fun getModuleConfig ()Lio/customer/datapipelines/config/DataPipelinesModuleConfig;
@@ -160,7 +160,7 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun setDeviceAttributes (Ljava/util/Map;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
-	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
 }
 
@@ -189,8 +189,7 @@ public final class io/customer/sdk/CustomerIOBuilder {
 public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/CustomerIOInstance {
 	public fun <init> ()V
 	public abstract fun clearIdentify ()V
-	public abstract fun deleteDeviceToken (Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun deleteDeviceToken$default (Lio/customer/sdk/DataPipelineInstance;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun deleteDeviceToken ()V
 	public abstract fun getAnonymousId ()Ljava/lang/String;
 	public abstract fun getDeviceAttributes ()Ljava/util/Map;
 	public abstract fun getProfileAttributes ()Ljava/util/Map;
@@ -210,10 +209,9 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public abstract fun setDeviceAttributes (Ljava/util/Map;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;)V
-	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
 	public abstract fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -228,7 +228,12 @@ class CustomerIO private constructor(
      * Common method to track an event with traits.
      * All other track methods should call this method to ensure consistency.
      */
-    override fun <T> track(name: String, properties: T, serializationStrategy: SerializationStrategy<T>, enrichment: EnrichmentClosure?) {
+    override fun <T> track(name: String, properties: T, serializationStrategy: SerializationStrategy<T>) = track(name, properties, serializationStrategy, null)
+
+    /**
+     * Private method that support enrichment of generated track events.
+     */
+    private fun <T> track(name: String, properties: T, serializationStrategy: SerializationStrategy<T>, enrichment: EnrichmentClosure?) {
         logger.debug("track an event with name $name and attributes $properties")
         analytics.track(name = name, properties = properties, serializationStrategy = serializationStrategy, enrichment = enrichment)
     }
@@ -314,7 +319,9 @@ class CustomerIO private constructor(
         )
     }
 
-    override fun deleteDeviceToken(enrichment: EnrichmentClosure?) {
+    override fun deleteDeviceToken() = deleteDeviceToken(null)
+
+    private fun deleteDeviceToken(enrichment: EnrichmentClosure?) {
         logger.info("deleting device token")
 
         val deviceToken = contextPlugin.deviceToken
@@ -323,11 +330,7 @@ class CustomerIO private constructor(
             return
         }
 
-        trackDelete(enrichmentClosure = enrichment)
-    }
-
-    private fun trackDelete(enrichmentClosure: EnrichmentClosure?) {
-        track(name = EventNames.DEVICE_DELETE, properties = emptyJsonObject, serializationStrategy = JsonAnySerializer.serializersModule.serializer(), enrichment = enrichmentClosure)
+        track(name = EventNames.DEVICE_DELETE, properties = emptyJsonObject, serializationStrategy = JsonAnySerializer.serializersModule.serializer(), enrichment = enrichment)
     }
 
     override fun trackMetric(event: TrackMetric) {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -4,9 +4,11 @@ import androidx.annotation.VisibleForTesting
 import com.segment.analytics.kotlin.android.Analytics
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.ErrorHandler
+import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.platform.EnrichmentClosure
 import com.segment.analytics.kotlin.core.platform.plugins.logger.LogKind
 import com.segment.analytics.kotlin.core.platform.plugins.logger.LogMessage
+import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.di.analyticsFactory
@@ -31,6 +33,7 @@ import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.events.TrackMetric
 import io.customer.tracking.migration.MigrationProcessor
 import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.serializer
 
 /**
  * Welcome to the Customer.io Android SDK!
@@ -183,8 +186,7 @@ class CustomerIO private constructor(
     override fun <Traits> identify(
         userId: String,
         traits: Traits,
-        serializationStrategy: SerializationStrategy<Traits>,
-        enrichment: EnrichmentClosure?
+        serializationStrategy: SerializationStrategy<Traits>
     ) {
         if (userId.isBlank()) {
             logger.debug("Profile cannot be identified: Identifier is blank. Please retry with a valid, non-empty identifier.")
@@ -208,8 +210,7 @@ class CustomerIO private constructor(
         analytics.identify(
             userId = userId,
             traits = traits,
-            serializationStrategy = serializationStrategy,
-            enrichment = enrichment
+            serializationStrategy = serializationStrategy
         )
 
         if (isFirstTimeIdentifying || isChangingIdentifiedProfile) {
@@ -236,9 +237,9 @@ class CustomerIO private constructor(
      * Common method to track an screen with properties.
      * All other screen methods should call this method to ensure consistency.
      */
-    override fun <T> screen(title: String, properties: T, serializationStrategy: SerializationStrategy<T>, enrichment: EnrichmentClosure?) {
+    override fun <T> screen(title: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
         logger.debug("track a screen with title $title, properties $properties")
-        analytics.screen(title = title, properties = properties, serializationStrategy = serializationStrategy, enrichment = enrichment)
+        analytics.screen(title = title, properties = properties, serializationStrategy = serializationStrategy)
     }
 
     override fun clearIdentify() {
@@ -246,8 +247,11 @@ class CustomerIO private constructor(
 
         logger.debug("deleting device token to remove device from user profile")
 
+        // since the tasks are asynchronous, we need to store the userId before deleting the device token
+        // otherwise, the userId could be null when the delete task is executed
+        val existingUserId = userId
         deleteDeviceToken { event ->
-            event?.apply { userId = this@CustomerIO.userId.toString() }
+            event?.apply { userId = existingUserId.toString() }
         }
 
         logger.debug("resetting user profile")
@@ -269,7 +273,7 @@ class CustomerIO private constructor(
             trackDeviceAttributes(registeredDeviceToken, value)
         }
 
-    override fun registerDeviceToken(deviceToken: String, enrichment: EnrichmentClosure?) {
+    override fun registerDeviceToken(deviceToken: String) {
         if (deviceToken.isBlank()) {
             logger.debug("device token cannot be blank. ignoring request to register device token")
             return
@@ -278,10 +282,10 @@ class CustomerIO private constructor(
         logger.info("storing and registering device token $deviceToken for user profile: ${this.userId}")
         globalPreferenceStore.saveDeviceToken(deviceToken)
 
-        trackDeviceAttributes(token = deviceToken, enrichment = enrichment)
+        trackDeviceAttributes(token = deviceToken)
     }
 
-    private fun trackDeviceAttributes(token: String?, customAddedAttributes: CustomAttributes = emptyMap(), enrichment: EnrichmentClosure? = null) {
+    private fun trackDeviceAttributes(token: String?, customAddedAttributes: CustomAttributes = emptyMap()) {
         if (token.isNullOrBlank()) {
             logger.debug("no device token found. ignoring request to track device.")
             return
@@ -306,10 +310,7 @@ class CustomerIO private constructor(
         logger.info("updating device attributes: $attributes")
         track(
             name = EventNames.DEVICE_UPDATE,
-            properties = attributes,
-            enrichment = enrichment ?: { event ->
-                event?.apply { userId = this@CustomerIO.userId.toString() }
-            }
+            properties = attributes
         )
     }
 
@@ -322,14 +323,18 @@ class CustomerIO private constructor(
             return
         }
 
-        track(name = EventNames.DEVICE_DELETE, enrichment = enrichment)
+        trackDelete(enrichmentClosure = enrichment)
     }
 
-    override fun trackMetric(event: TrackMetric, enrichment: EnrichmentClosure?) {
+    private fun trackDelete(enrichmentClosure: EnrichmentClosure?) {
+        track(name = EventNames.DEVICE_DELETE, properties = emptyJsonObject, serializationStrategy = JsonAnySerializer.serializersModule.serializer(), enrichment = enrichmentClosure)
+    }
+
+    override fun trackMetric(event: TrackMetric) {
         logger.info("${event.type} metric received for ${event.metric} event")
         logger.debug("tracking ${event.type} metric event with properties $event")
 
-        track(name = EventNames.METRIC_DELIVERY, properties = event.asMap(), enrichment = enrichment)
+        track(name = EventNames.METRIC_DELIVERY, properties = event.asMap())
     }
 
     companion object {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -1,7 +1,6 @@
 package io.customer.sdk
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
-import com.segment.analytics.kotlin.core.platform.EnrichmentClosure
 import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.events.TrackMetric
@@ -128,14 +127,12 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param name Name of the action
      * @param properties to describe the action. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      * @param serializationStrategy strategy to serialize [properties]
-     * @param enrichment closure to enrich the generated event
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
     abstract fun <T> track(
         name: String,
         properties: T,
-        serializationStrategy: SerializationStrategy<T>,
-        enrichment: EnrichmentClosure? = null
+        serializationStrategy: SerializationStrategy<T>
     )
 
     /**
@@ -256,5 +253,5 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     /**
      * Delete the currently registered device token
      */
-    abstract fun deleteDeviceToken(enrichment: EnrichmentClosure? = null)
+    abstract fun deleteDeviceToken()
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -1,6 +1,7 @@
 package io.customer.sdk
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
+import com.segment.analytics.kotlin.core.platform.EnrichmentClosure
 import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.events.TrackMetric
@@ -30,8 +31,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits [Traits] about the user. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      */
-    inline fun <reified Traits> identify(userId: String, traits: Traits) {
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer())
+    inline fun <reified Traits> identify(userId: String, traits: Traits, noinline enrichment: EnrichmentClosure? = null) {
+        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -46,8 +47,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param traits JsonObject about the user.
      */
     @JvmOverloads
-    fun identify(userId: String, traits: JsonObject = emptyJsonObject) {
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer())
+    fun identify(userId: String, traits: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
+        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -61,9 +62,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits Map of <String, Any> to be added
      */
-    fun identify(userId: String, traits: CustomAttributes) {
+    fun identify(userId: String, traits: CustomAttributes, enrichment: EnrichmentClosure? = null) {
         // Method needed for Java interop as inline doesn't work with Java
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer())
+        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -82,7 +83,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     abstract fun <Traits> identify(
         userId: String,
         traits: Traits,
-        serializationStrategy: SerializationStrategy<Traits>
+        serializationStrategy: SerializationStrategy<Traits>,
+        enrichment: EnrichmentClosure? = null
     )
 
     /**
@@ -97,8 +99,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
     @JvmOverloads
-    fun track(name: String, properties: JsonObject = emptyJsonObject) {
-        track(name, properties, JsonAnySerializer.serializersModule.serializer())
+    fun track(name: String, properties: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
+        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -112,9 +114,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Map of <String, Any> to be added
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
-    fun track(name: String, properties: CustomAttributes) {
+    fun track(name: String, properties: CustomAttributes, enrichment: EnrichmentClosure? = null) {
         // Method needed for Java interop as inline doesn't work with Java
-        track(name, properties, JsonAnySerializer.serializersModule.serializer())
+        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -132,7 +134,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     abstract fun <T> track(
         name: String,
         properties: T,
-        serializationStrategy: SerializationStrategy<T>
+        serializationStrategy: SerializationStrategy<T>,
+        enrichment: EnrichmentClosure? = null
     )
 
     /**
@@ -148,9 +151,10 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     inline fun <reified T> track(
         name: String,
-        properties: T
+        properties: T,
+        noinline enrichment: EnrichmentClosure? = null
     ) {
-        track(name, properties, JsonAnySerializer.serializersModule.serializer())
+        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -161,8 +165,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
     @JvmOverloads
-    fun screen(title: String, properties: JsonObject = emptyJsonObject) {
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
+    fun screen(title: String, properties: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -172,9 +176,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen in Map <String, Any> format.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    fun screen(title: String, properties: CustomAttributes) {
+    fun screen(title: String, properties: CustomAttributes, enrichment: EnrichmentClosure? = null) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -187,7 +191,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     abstract fun <T> screen(
         title: String,
         properties: T,
-        serializationStrategy: SerializationStrategy<T>
+        serializationStrategy: SerializationStrategy<T>,
+        enrichment: EnrichmentClosure? = null
     )
 
     /**
@@ -199,9 +204,10 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     inline fun <reified T> screen(
         title: String,
-        properties: T
+        properties: T,
+        noinline enrichment: EnrichmentClosure? = null
     ) {
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer())
+        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
     }
 
     /**
@@ -219,7 +225,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      *
      * @param event [TrackMetric] event to be tracked.
      */
-    abstract fun trackMetric(event: TrackMetric)
+    abstract fun trackMetric(event: TrackMetric, enrichment: EnrichmentClosure? = null)
 
     /**
      * The device token that is currently registered with the push notification service.
@@ -248,10 +254,10 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * token and associate it with anonymous profile, and later merge it to
      * identified profile.
      */
-    abstract fun registerDeviceToken(deviceToken: String)
+    abstract fun registerDeviceToken(deviceToken: String, enrichment: EnrichmentClosure? = null)
 
     /**
      * Delete the currently registered device token
      */
-    abstract fun deleteDeviceToken()
+    abstract fun deleteDeviceToken(enrichment: EnrichmentClosure? = null)
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -31,8 +31,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits [Traits] about the user. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      */
-    inline fun <reified Traits> identify(userId: String, traits: Traits, noinline enrichment: EnrichmentClosure? = null) {
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
+    inline fun <reified Traits> identify(userId: String, traits: Traits) {
+        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -47,8 +47,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param traits JsonObject about the user.
      */
     @JvmOverloads
-    fun identify(userId: String, traits: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
+    fun identify(userId: String, traits: JsonObject = emptyJsonObject) {
+        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -62,9 +62,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits Map of <String, Any> to be added
      */
-    fun identify(userId: String, traits: CustomAttributes, enrichment: EnrichmentClosure? = null) {
+    fun identify(userId: String, traits: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        identify(userId, traits, JsonAnySerializer.serializersModule.serializer(), enrichment)
+        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -83,8 +83,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     abstract fun <Traits> identify(
         userId: String,
         traits: Traits,
-        serializationStrategy: SerializationStrategy<Traits>,
-        enrichment: EnrichmentClosure? = null
+        serializationStrategy: SerializationStrategy<Traits>
     )
 
     /**
@@ -99,8 +98,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
     @JvmOverloads
-    fun track(name: String, properties: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
-        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+    fun track(name: String, properties: JsonObject = emptyJsonObject) {
+        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -114,9 +113,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Map of <String, Any> to be added
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
-    fun track(name: String, properties: CustomAttributes, enrichment: EnrichmentClosure? = null) {
+    fun track(name: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -129,6 +128,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param name Name of the action
      * @param properties to describe the action. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      * @param serializationStrategy strategy to serialize [properties]
+     * @param enrichment closure to enrich the generated event
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
     abstract fun <T> track(
@@ -151,10 +151,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     inline fun <reified T> track(
         name: String,
-        properties: T,
-        noinline enrichment: EnrichmentClosure? = null
+        properties: T
     ) {
-        track(name, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -165,8 +164,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
     @JvmOverloads
-    fun screen(title: String, properties: JsonObject = emptyJsonObject, enrichment: EnrichmentClosure? = null) {
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+    fun screen(title: String, properties: JsonObject = emptyJsonObject) {
+        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -176,9 +175,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen in Map <String, Any> format.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    fun screen(title: String, properties: CustomAttributes, enrichment: EnrichmentClosure? = null) {
+    fun screen(title: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -191,8 +190,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
     abstract fun <T> screen(
         title: String,
         properties: T,
-        serializationStrategy: SerializationStrategy<T>,
-        enrichment: EnrichmentClosure? = null
+        serializationStrategy: SerializationStrategy<T>
     )
 
     /**
@@ -204,10 +202,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     inline fun <reified T> screen(
         title: String,
-        properties: T,
-        noinline enrichment: EnrichmentClosure? = null
+        properties: T
     ) {
-        screen(title, properties, JsonAnySerializer.serializersModule.serializer(), enrichment)
+        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -225,7 +222,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      *
      * @param event [TrackMetric] event to be tracked.
      */
-    abstract fun trackMetric(event: TrackMetric, enrichment: EnrichmentClosure? = null)
+    abstract fun trackMetric(event: TrackMetric)
 
     /**
      * The device token that is currently registered with the push notification service.
@@ -254,7 +251,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * token and associate it with anonymous profile, and later merge it to
      * identified profile.
      */
-    abstract fun registerDeviceToken(deviceToken: String, enrichment: EnrichmentClosure? = null)
+    abstract fun registerDeviceToken(deviceToken: String)
 
     /**
      * Delete the currently registered device token

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -598,6 +598,20 @@ class DataPipelinesInteractionTests : JUnitTest() {
     }
 
     @Test
+    fun device_givenDeleteDeviceWithIdentifiedUser_expectUserIdWithTrackRequest() {
+        val givenIdentifier = String.random
+
+        every { globalPreferenceStore.getDeviceToken() } returns String.random
+
+        sdkInstance.identify(givenIdentifier)
+
+        sdkInstance.clearIdentify()
+
+        val event = outputReaderPlugin.trackEvents.last()
+        event.userId shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
     fun device_givenDeleteDeviceWhenNoExistingPushToken_expectNoEventDispatched() {
         sdkInstance.deleteDeviceToken()
 


### PR DESCRIPTION
closes: [MBL-528: Android SDK should consistently add userId in delete token payload](https://linear.app/customerio/issue/MBL-528/android-sdk-should-consistently-add-userid-in-delete-token-payload)

Since event are asynchronous, we can have `userId` null before `deleteDevice` access the value of `userId`. So we should enrich the delete device event with `userId` so it always have that value. 