### PR TITLE
chore: Update JavaLayout sample app name to "Native"

### DIFF
--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">JavaLayout</string>
+    <string name="app_name">Native</string>
     <string name="app_title">Android Java Layout Ami App</string>
     <string name="display_name">First Name</string>
     <string name="email">Email</string>


### PR DESCRIPTION
Completes [Update app name to “Android Native”](https://linear.app/customerio/issue/MBL-558/update-app-name-to-android-native)

## Context
This PR changes the Android native sample app name to be "Native". This makes it easier to differentiate the app in the device launcher from other sample apps.

I've chosen to make the name "Native" instead of "Android Native" to avoid it being truncated.


| Truncated version  | Non-truncated version |
| ------------- | ------------- |
| <img width="87" alt="app-name-after-truncated" src="https://github.com/user-attachments/assets/e335fb6e-554a-4159-9f6b-394d47e87a4a"> | <img width="83" alt="app-name-after" src="https://github.com/user-attachments/assets/a40f494e-1663-4746-af16-500d80e9bb26">  |

## Final result
| Before  | After |
| ------------- | ------------- |
| <img width="94" alt="app-name-before" src="https://github.com/user-attachments/assets/12e5cb8f-dd8b-40f0-98f9-2009e0617b53"> | <img width="83" alt="app-name-after" src="https://github.com/user-attachments/assets/980011c4-72ca-484b-a146-0ef1c630cf0a"> |





