### PR TITLE
chore: expose module config

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -45,6 +45,7 @@ public final class io/customer/messaginginapp/databinding/ActivityGistBinding : 
 }
 
 public final class io/customer/messaginginapp/di/DIGraphMessagingInAppKt {
+	public static final fun getInAppModuleConfig (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public static final fun inAppMessaging (Lio/customer/sdk/CustomerIOInstance;)Lio/customer/messaginginapp/ModuleMessagingInApp;
 }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -15,14 +15,14 @@ import io.customer.sdk.core.di.SDKComponent
 internal val SDKComponent.gistQueue: GistQueue
     get() = singleton<GistQueue> { Queue() }
 
-internal val SDKComponent.moduleConfig: MessagingInAppModuleConfig
+val SDKComponent.inAppModuleConfig: MessagingInAppModuleConfig
     get() = inAppMessaging.moduleConfig
 
 internal val SDKComponent.gistProvider: GistProvider
     get() = singleton<GistProvider> {
         GistSdk(
-            siteId = moduleConfig.siteId,
-            dataCenter = moduleConfig.region.code
+            siteId = inAppModuleConfig.siteId,
+            dataCenter = inAppModuleConfig.region.code
         )
     }
 

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -115,6 +115,10 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class io/customer/messagingpush/di/DiGraphMessagingPushKt {
+	public static final fun getPushModuleConfig (Lio/customer/sdk/core/di/SDKComponent;)Lio/customer/messagingpush/MessagingPushModuleConfig;
+}
+
 public final class io/customer/messagingpush/processor/PushMessageProcessor$Companion {
 	public static final field RECENT_MESSAGES_MAX_SIZE I
 	public final fun getRecentMessagesQueue ()Ljava/util/concurrent/LinkedBlockingDeque;

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -17,7 +17,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
-import io.customer.messagingpush.di.moduleConfig
+import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.extensions.*
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
@@ -57,7 +57,7 @@ internal class CustomerIOPushNotificationHandler(
     private val logger = SDKComponent.logger
 
     private val moduleConfig: MessagingPushModuleConfig
-        get() = diGraph.moduleConfig
+        get() = diGraph.pushModuleConfig
 
     private val bundle: Bundle by lazy {
         Bundle().apply {

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -25,13 +25,13 @@ The use of extensions was chosen over creating a separate graph class for each m
 internal val AndroidSDKComponent.fcmTokenProvider: DeviceTokenProvider
     get() = newInstance<DeviceTokenProvider> { FCMTokenProviderImpl(context = applicationContext) }
 
-internal val SDKComponent.moduleConfig: MessagingPushModuleConfig
+val SDKComponent.pushModuleConfig: MessagingPushModuleConfig
     get() = newInstance {
         modules[ModuleMessagingPushFCM.MODULE_NAME]?.moduleConfig as? MessagingPushModuleConfig ?: MessagingPushModuleConfig.default()
     }
 
 internal val SDKComponent.deepLinkUtil: DeepLinkUtil
-    get() = newInstance<DeepLinkUtil> { DeepLinkUtilImpl(logger, moduleConfig) }
+    get() = newInstance<DeepLinkUtil> { DeepLinkUtilImpl(logger, pushModuleConfig) }
 
 @InternalCustomerIOApi
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
@@ -41,7 +41,7 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {
         PushMessageProcessorImpl(
             logger = logger,
-            moduleConfig = moduleConfig,
+            moduleConfig = pushModuleConfig,
             deepLinkUtil = deepLinkUtil
         )
     }


### PR DESCRIPTION
closes: [MBL-545: Push metrics tracking (iOS & Android - RN)](https://linear.app/customerio/issue/MBL-545/push-metrics-tracking-ios-and-android-rn)

exposes module config to be used in wrappers. 