### PR TITLE
chore: expose console logger callback

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
@@ -10,8 +10,8 @@ import io.customer.sdk.core.util.Logger
  */
 class UnitTestLogger : Logger {
     override var logLevel: CioLogLevel = CioLogLevel.DEBUG
-    override var logDispatcher: ((CioLogLevel, String) -> Unit) = { level, message ->
-        println("[$level]: $message")
+
+    override fun setLogDispatcher(dispatcher: (CioLogLevel, String) -> Unit) {
     }
 
     override fun info(message: String) {
@@ -30,7 +30,7 @@ class UnitTestLogger : Logger {
         val shouldLog = logLevel >= levelForMessage
 
         if (shouldLog) {
-            logDispatcher.invoke(levelForMessage, message)
+            println("[$levelForMessage]: $message")
         }
     }
 }

--- a/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
@@ -10,6 +10,9 @@ import io.customer.sdk.core.util.Logger
  */
 class UnitTestLogger : Logger {
     override var logLevel: CioLogLevel = CioLogLevel.DEBUG
+    override var logDispatcher: ((CioLogLevel, String) -> Unit) = { level, message ->
+        println("[$level]: $message")
+    }
 
     override fun info(message: String) {
         log(CioLogLevel.INFO, message)
@@ -27,7 +30,7 @@ class UnitTestLogger : Logger {
         val shouldLog = logLevel >= levelForMessage
 
         if (shouldLog) {
-            println("[$levelForMessage]: $message")
+            logDispatcher.invoke(levelForMessage, message)
         }
     }
 }

--- a/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/UnitTestLogger.kt
@@ -11,7 +11,7 @@ import io.customer.sdk.core.util.Logger
 class UnitTestLogger : Logger {
     override var logLevel: CioLogLevel = CioLogLevel.DEBUG
 
-    override fun setLogDispatcher(dispatcher: (CioLogLevel, String) -> Unit) {
+    override fun setLogDispatcher(dispatcher: ((CioLogLevel, String) -> Unit)?) {
     }
 
     override fun info(message: String) {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -212,8 +212,10 @@ public final class io/customer/sdk/core/util/LogcatLogger : io/customer/sdk/core
 	public fun <init> (Lio/customer/sdk/core/environment/BuildEnvironment;)V
 	public fun debug (Ljava/lang/String;)V
 	public fun error (Ljava/lang/String;)V
+	public fun getLogDispatcher ()Lkotlin/jvm/functions/Function2;
 	public fun getLogLevel ()Lio/customer/sdk/core/util/CioLogLevel;
 	public fun info (Ljava/lang/String;)V
+	public fun setLogDispatcher (Lkotlin/jvm/functions/Function2;)V
 	public fun setLogLevel (Lio/customer/sdk/core/util/CioLogLevel;)V
 }
 
@@ -223,8 +225,10 @@ public final class io/customer/sdk/core/util/LogcatLogger$Companion {
 public abstract interface class io/customer/sdk/core/util/Logger {
 	public abstract fun debug (Ljava/lang/String;)V
 	public abstract fun error (Ljava/lang/String;)V
+	public abstract fun getLogDispatcher ()Lkotlin/jvm/functions/Function2;
 	public abstract fun getLogLevel ()Lio/customer/sdk/core/util/CioLogLevel;
 	public abstract fun info (Ljava/lang/String;)V
+	public abstract fun setLogDispatcher (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun setLogLevel (Lio/customer/sdk/core/util/CioLogLevel;)V
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -190,6 +190,7 @@ public final class io/customer/sdk/core/util/CioLogLevel : java/lang/Enum {
 	public static final field ERROR Lio/customer/sdk/core/util/CioLogLevel;
 	public static final field INFO Lio/customer/sdk/core/util/CioLogLevel;
 	public static final field NONE Lio/customer/sdk/core/util/CioLogLevel;
+	public final fun getPriority ()I
 	public static fun valueOf (Ljava/lang/String;)Lio/customer/sdk/core/util/CioLogLevel;
 	public static fun values ()[Lio/customer/sdk/core/util/CioLogLevel;
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -212,7 +212,6 @@ public final class io/customer/sdk/core/util/LogcatLogger : io/customer/sdk/core
 	public fun <init> (Lio/customer/sdk/core/environment/BuildEnvironment;)V
 	public fun debug (Ljava/lang/String;)V
 	public fun error (Ljava/lang/String;)V
-	public fun getLogDispatcher ()Lkotlin/jvm/functions/Function2;
 	public fun getLogLevel ()Lio/customer/sdk/core/util/CioLogLevel;
 	public fun info (Ljava/lang/String;)V
 	public fun setLogDispatcher (Lkotlin/jvm/functions/Function2;)V
@@ -225,7 +224,6 @@ public final class io/customer/sdk/core/util/LogcatLogger$Companion {
 public abstract interface class io/customer/sdk/core/util/Logger {
 	public abstract fun debug (Ljava/lang/String;)V
 	public abstract fun error (Ljava/lang/String;)V
-	public abstract fun getLogDispatcher ()Lkotlin/jvm/functions/Function2;
 	public abstract fun getLogLevel ()Lio/customer/sdk/core/util/CioLogLevel;
 	public abstract fun info (Ljava/lang/String;)V
 	public abstract fun setLogDispatcher (Lkotlin/jvm/functions/Function2;)V

--- a/core/src/main/kotlin/io/customer/sdk/core/util/Logger.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/Logger.kt
@@ -10,7 +10,7 @@ interface Logger {
     var logLevel: CioLogLevel
 
     /**
-     * Set the log dispatcher to handle log events based on the log level
+     * Sets the dispatcher to handle log events based on the log level
      * Default implementation is to print logs to Logcat
      * In wrapper SDKs, this will be overridden to emit logs to more user-friendly channels
      * like console, etc.
@@ -64,7 +64,7 @@ class LogcatLogger(
             preferredLogLevel = value
         }
 
-    // Hold a weak reference to the log dispatcher to avoid memory leaks
+    // Hold a weak reference to log dispatcher to avoid memory leaks
     private var logDispatcher: WeakReference<(CioLogLevel, String) -> Unit>? = null
 
     override fun setLogDispatcher(dispatcher: (CioLogLevel, String) -> Unit) {

--- a/core/src/main/kotlin/io/customer/sdk/core/util/Logger.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/Logger.kt
@@ -26,11 +26,18 @@ interface Logger {
     fun error(message: String)
 }
 
-enum class CioLogLevel {
-    NONE,
-    ERROR,
-    INFO,
-    DEBUG;
+/**
+ * Log levels for Customer.io SDK logs
+ *
+ * @property priority Priority of the log level. The higher the value, the more verbose
+ * the log level.
+ * @see shouldLog to determine if a log should be printed based on specified log level
+ */
+enum class CioLogLevel(val priority: Int) {
+    NONE(priority = 0),
+    ERROR(priority = 1),
+    INFO(priority = 2),
+    DEBUG(priority = 3);
 
     companion object {
         val DEFAULT = ERROR
@@ -42,8 +49,14 @@ enum class CioLogLevel {
     }
 }
 
+/**
+ * Determines if a log should be printed based on the specified log level
+ *
+ * @param levelForMessage Log level of the message
+ * @return true if the log should be printed, false otherwise
+ */
 internal fun CioLogLevel.shouldLog(levelForMessage: CioLogLevel): Boolean {
-    return this >= levelForMessage
+    return this.priority >= levelForMessage.priority
 }
 
 class LogcatLogger(

--- a/core/src/test/java/io/customer/sdk/core/util/CioLogLevelTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/CioLogLevelTest.kt
@@ -1,0 +1,54 @@
+package io.customer.sdk.core.util
+
+import io.customer.commontest.core.JUnit5Test
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class CioLogLevelTest : JUnit5Test() {
+    @Test
+    fun getLogLevel_givenNamesWithMatchingCase_expectCorrectLogLevel() {
+        val logLevelNone = CioLogLevel.getLogLevel("NONE")
+        val logLevelError = CioLogLevel.getLogLevel("ERROR")
+        val logLevelInfo = CioLogLevel.getLogLevel("INFO")
+        val logLevelDebug = CioLogLevel.getLogLevel("DEBUG")
+
+        logLevelNone shouldBeEqualTo CioLogLevel.NONE
+        logLevelError shouldBeEqualTo CioLogLevel.ERROR
+        logLevelInfo shouldBeEqualTo CioLogLevel.INFO
+        logLevelDebug shouldBeEqualTo CioLogLevel.DEBUG
+    }
+
+    @Test
+    fun getLogLevel_givenNamesWithDifferentCase_expectCorrectLogLevel() {
+        val logLevelNone = CioLogLevel.getLogLevel("None")
+        val logLevelError = CioLogLevel.getLogLevel("eRROR")
+        val logLevelInfo = CioLogLevel.getLogLevel("info")
+        val logLevelDebug = CioLogLevel.getLogLevel("DeBuG")
+
+        logLevelNone shouldBeEqualTo CioLogLevel.NONE
+        logLevelError shouldBeEqualTo CioLogLevel.ERROR
+        logLevelInfo shouldBeEqualTo CioLogLevel.INFO
+        logLevelDebug shouldBeEqualTo CioLogLevel.DEBUG
+    }
+
+    @Test
+    fun getLogLevel_givenInvalidValue_expectFallbackLogLevel() {
+        val parsedLogLevel = CioLogLevel.getLogLevel("invalid")
+
+        parsedLogLevel shouldBeEqualTo CioLogLevel.ERROR
+    }
+
+    @Test
+    fun getLogLevel_givenEmptyValue_expectFallbackLogLevel() {
+        val parsedLogLevel = CioLogLevel.getLogLevel("")
+
+        parsedLogLevel shouldBeEqualTo CioLogLevel.ERROR
+    }
+
+    @Test
+    fun getLogLevel_givenNull_expectFallbackLogLevel() {
+        val parsedLogLevel = CioLogLevel.getLogLevel(null)
+
+        parsedLogLevel shouldBeEqualTo CioLogLevel.ERROR
+    }
+}

--- a/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
@@ -5,6 +5,7 @@ import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.assertNoInteractions
 import io.customer.sdk.core.environment.BuildEnvironment
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -149,6 +150,7 @@ class LoggerTest : JUnit5Test() {
         assertCalledOnce { logEventListenerMock(CioLogLevel.ERROR, givenErrorMessage) }
         assertCalledNever { logEventListenerMock(CioLogLevel.INFO, givenInfoMessage) }
         assertCalledNever { logEventListenerMock(CioLogLevel.DEBUG, givenDebugMessage) }
+        confirmVerified(logEventListenerMock)
     }
 
     @Test
@@ -168,6 +170,7 @@ class LoggerTest : JUnit5Test() {
         assertCalledOnce { logEventListenerMock(CioLogLevel.ERROR, givenErrorMessage) }
         assertCalledOnce { logEventListenerMock(CioLogLevel.INFO, givenInfoMessage) }
         assertCalledNever { logEventListenerMock(CioLogLevel.DEBUG, givenDebugMessage) }
+        confirmVerified(logEventListenerMock)
     }
 
     @Test
@@ -187,5 +190,6 @@ class LoggerTest : JUnit5Test() {
         assertCalledOnce { logEventListenerMock(CioLogLevel.ERROR, givenErrorMessage) }
         assertCalledOnce { logEventListenerMock(CioLogLevel.INFO, givenInfoMessage) }
         assertCalledOnce { logEventListenerMock(CioLogLevel.DEBUG, givenDebugMessage) }
+        confirmVerified(logEventListenerMock)
     }
 }

--- a/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
@@ -124,11 +124,11 @@ class LoggerTest : JUnit5Test() {
         logger.setLogDispatcher(logEventListenerMock)
 
         val givenErrorMessage = "Test error message"
-        logger.info(givenErrorMessage)
+        logger.error(givenErrorMessage)
         val givenInfoMessage = "Test info message"
         logger.info(givenInfoMessage)
         val givenDebugMessage = "Test debug message"
-        logger.info(givenDebugMessage)
+        logger.debug(givenDebugMessage)
 
         assertNoInteractions(logEventListenerMock)
     }

--- a/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
@@ -120,7 +120,7 @@ class LoggerTest : JUnit5Test() {
         val logger = spyk(LogcatLogger(mockk(relaxed = true)))
         val logEventListenerMock = mockk<(CioLogLevel, String) -> Unit>(relaxed = true)
         logger.logLevel = CioLogLevel.NONE
-        logger.logDispatcher = logEventListenerMock
+        logger.setLogDispatcher(logEventListenerMock)
 
         val givenErrorMessage = "Test error message"
         logger.info(givenErrorMessage)
@@ -137,7 +137,7 @@ class LoggerTest : JUnit5Test() {
         val logger = spyk(LogcatLogger(mockk(relaxed = true)))
         val logEventListenerMock = mockk<(CioLogLevel, String) -> Unit>(relaxed = true)
         logger.logLevel = CioLogLevel.ERROR
-        logger.logDispatcher = logEventListenerMock
+        logger.setLogDispatcher(logEventListenerMock)
 
         val givenErrorMessage = "Test error message"
         logger.error(givenErrorMessage)
@@ -156,7 +156,7 @@ class LoggerTest : JUnit5Test() {
         val logger = spyk(LogcatLogger(mockk(relaxed = true)))
         val logEventListenerMock = mockk<(CioLogLevel, String) -> Unit>(relaxed = true)
         logger.logLevel = CioLogLevel.INFO
-        logger.logDispatcher = logEventListenerMock
+        logger.setLogDispatcher(logEventListenerMock)
 
         val givenErrorMessage = "Test error message"
         logger.error(givenErrorMessage)
@@ -175,7 +175,7 @@ class LoggerTest : JUnit5Test() {
         val logger = spyk(LogcatLogger(mockk(relaxed = true)))
         val logEventListenerMock = mockk<(CioLogLevel, String) -> Unit>(relaxed = true)
         logger.logLevel = CioLogLevel.DEBUG
-        logger.logDispatcher = logEventListenerMock
+        logger.setLogDispatcher(logEventListenerMock)
 
         val givenErrorMessage = "Test error message"
         logger.error(givenErrorMessage)


### PR DESCRIPTION
### Changes

- Updated `Logger` to expose log dispatcher, allowing wrapper SDKs to listen to it and forward logs to their relevant consoles if needed
- Added and fixed relevant tests for `Logger` and `CioLogLevel` classes