### PR TITLE
chore: ensure Android component is initialized from services

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
@@ -7,7 +7,7 @@ import io.customer.commontest.config.configureAndroidSDKComponent
 import io.customer.commontest.config.configureSDKComponent
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.ensureAndroidComponent
+import io.customer.sdk.core.di.setupAndroidComponent
 import io.mockk.clearAllMocks
 
 /**
@@ -43,6 +43,6 @@ abstract class BaseTest {
     private fun registerAndroidSDKComponent(testConfig: TestConfig) {
         val application = testConfig.argumentOrNull<ApplicationArgument>()?.value ?: return
 
-        testConfig.configureAndroidSDKComponent(SDKComponent.ensureAndroidComponent(application))
+        testConfig.configureAndroidSDKComponent(SDKComponent.setupAndroidComponent(application))
     }
 }

--- a/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
+++ b/common-test/src/main/java/io/customer/commontest/core/BaseTest.kt
@@ -7,7 +7,7 @@ import io.customer.commontest.config.configureAndroidSDKComponent
 import io.customer.commontest.config.configureSDKComponent
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.registerAndroidSDKComponent
+import io.customer.sdk.core.di.ensureAndroidComponent
 import io.mockk.clearAllMocks
 
 /**
@@ -43,6 +43,6 @@ abstract class BaseTest {
     private fun registerAndroidSDKComponent(testConfig: TestConfig) {
         val application = testConfig.argumentOrNull<ApplicationArgument>()?.value ?: return
 
-        testConfig.configureAndroidSDKComponent(SDKComponent.registerAndroidSDKComponent(application))
+        testConfig.configureAndroidSDKComponent(SDKComponent.ensureAndroidComponent(application))
     }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -154,7 +154,7 @@ public final class io/customer/sdk/core/di/SDKComponent : io/customer/sdk/core/d
 }
 
 public final class io/customer/sdk/core/di/SDKComponentExtKt {
-	public static final fun ensureAndroidComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/sdk/core/di/AndroidSDKComponent;
+	public static final fun setupAndroidComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/sdk/core/di/AndroidSDKComponent;
 }
 
 public abstract interface class io/customer/sdk/core/environment/BuildEnvironment {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -137,7 +137,6 @@ public abstract class io/customer/sdk/core/di/DiGraph {
 	public fun <init> ()V
 	public final fun getOverrides ()Ljava/util/concurrent/ConcurrentHashMap;
 	public final fun getSingletons ()Ljava/util/concurrent/ConcurrentHashMap;
-	public final fun overrideDependency (Ljava/lang/Class;Ljava/lang/Object;)V
 	public fun reset ()V
 }
 
@@ -155,7 +154,7 @@ public final class io/customer/sdk/core/di/SDKComponent : io/customer/sdk/core/d
 }
 
 public final class io/customer/sdk/core/di/SDKComponentExtKt {
-	public static final fun registerAndroidSDKComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/sdk/core/di/AndroidSDKComponent;
+	public static final fun ensureAndroidComponent (Lio/customer/sdk/core/di/SDKComponent;Landroid/content/Context;)Lio/customer/sdk/core/di/AndroidSDKComponent;
 }
 
 public abstract interface class io/customer/sdk/core/environment/BuildEnvironment {

--- a/core/src/main/kotlin/io/customer/sdk/core/di/DiGraph.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/DiGraph.kt
@@ -133,18 +133,4 @@ abstract class DiGraph {
         overrides.clear()
         singletons.clear()
     }
-
-    // TODO: Remove deprecated functions after all usages are removed.
-    @Deprecated("Use overrideDependency<Dependency> instead", ReplaceWith("overrideDependency<Dependency>(value)"))
-    fun <Dependency : Any> overrideDependency(dependency: Class<Dependency>, value: Dependency) {
-        overrides[dependency.name] = value as Any
-    }
-
-    @Deprecated("Use newInstance or singleton instead", ReplaceWith("newInstance()"))
-    inline fun <reified DEP : Any> override(): DEP? = overrides[dependencyKey<DEP>(identifier = null)] as? DEP
-
-    @Deprecated("Use singleton instead", ReplaceWith("singleton(newInstanceCreator)"))
-    inline fun <reified INST : Any> getSingletonInstanceCreate(newInstanceCreator: () -> INST): INST {
-        return getOrCreateSingletonInstance(identifier = null, newInstanceCreator = newInstanceCreator)
-    }
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -12,7 +12,7 @@ import android.content.Context
  * This function should be called from all entry points of the SDK to ensure that
  * AndroidSDKComponent is initialized before accessing any of its dependencies.
  */
-fun SDKComponent.ensureAndroidComponent(
+fun SDKComponent.setupAndroidComponent(
     context: Context
 ) = registerDependency<AndroidSDKComponent> {
     AndroidSDKComponentImpl(context)

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -9,8 +9,10 @@ import android.content.Context
 /**
  * Create and register an instance of AndroidSDKComponent with the provided context,
  * only if it is not already initialized.
+ * This function should be called from all entry points of the SDK to ensure that
+ * AndroidSDKComponent is initialized before accessing any of its dependencies.
  */
-fun SDKComponent.registerAndroidSDKComponent(
+fun SDKComponent.ensureAndroidComponent(
     context: Context
 ) = registerDependency<AndroidSDKComponent> {
     AndroidSDKComponentImpl(context)

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.ensureAndroidComponent
+import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.CioLogLevel
@@ -33,7 +33,7 @@ class CustomerIOBuilder(
     // Initialize AndroidSDKComponent as soon as the builder is created so that
     // it can be used by the modules.
     // Also, it is needed to override test dependencies in the test environment
-    private val androidSDKComponent = SDKComponent.ensureAndroidComponent(
+    private val androidSDKComponent = SDKComponent.setupAndroidComponent(
         context = applicationContext
     )
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.registerAndroidSDKComponent
+import io.customer.sdk.core.di.ensureAndroidComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.CioLogLevel
@@ -33,7 +33,7 @@ class CustomerIOBuilder(
     // Initialize AndroidSDKComponent as soon as the builder is created so that
     // it can be used by the modules.
     // Also, it is needed to override test dependencies in the test environment
-    private val androidSDKComponent = SDKComponent.registerAndroidSDKComponent(
+    private val androidSDKComponent = SDKComponent.ensureAndroidComponent(
         context = applicationContext
     )
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
@@ -7,7 +7,7 @@ import com.google.android.gms.cloudmessaging.CloudMessagingReceiver
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.ensureAndroidComponent
+import io.customer.sdk.core.di.setupAndroidComponent
 
 /**
  * Broadcast receiver for listening to push events from GoogleCloudMessaging (GCM).
@@ -27,7 +27,7 @@ class CustomerIOCloudMessagingReceiver : BroadcastReceiver() {
         val extras = intent.extras
         // Ignore event if no data was received in extras
         if (extras == null || extras.isEmpty) return
-        SDKComponent.ensureAndroidComponent(context = context)
+        SDKComponent.setupAndroidComponent(context = context)
         SDKComponent.pushMessageProcessor.processGCMMessageIntent(intent = intent)
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOCloudMessagingReceiver.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.cloudmessaging.CloudMessagingReceiver
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.ensureAndroidComponent
 
 /**
  * Broadcast receiver for listening to push events from GoogleCloudMessaging (GCM).
@@ -26,7 +27,7 @@ class CustomerIOCloudMessagingReceiver : BroadcastReceiver() {
         val extras = intent.extras
         // Ignore event if no data was received in extras
         if (extras == null || extras.isEmpty) return
-        // TODO: Make sure PushMessageProcessor works as expected even if the SDK is not initialized
+        SDKComponent.ensureAndroidComponent(context = context)
         SDKComponent.pushMessageProcessor.processGCMMessageIntent(intent = intent)
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.ensureAndroidComponent
 
 open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
 
@@ -47,6 +48,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         private fun handleNewToken(context: Context, token: String) {
+            SDKComponent.ensureAndroidComponent(context = context)
             eventBus.publish(
                 Event.RegisterDeviceTokenEvent(token)
             )
@@ -57,7 +59,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             remoteMessage: RemoteMessage,
             handleNotificationTrigger: Boolean = true
         ): Boolean {
-            // TODO: Make sure PushNotificationHandler works as expected even if the SDK is not initialized
+            SDKComponent.ensureAndroidComponent(context = context)
             val handler = CustomerIOPushNotificationHandler(
                 pushMessageProcessor = SDKComponent.pushMessageProcessor,
                 remoteMessage = remoteMessage

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -6,7 +6,7 @@ import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.ensureAndroidComponent
+import io.customer.sdk.core.di.setupAndroidComponent
 
 open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
 
@@ -48,7 +48,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         private fun handleNewToken(context: Context, token: String) {
-            SDKComponent.ensureAndroidComponent(context = context)
+            SDKComponent.setupAndroidComponent(context = context)
             eventBus.publish(
                 Event.RegisterDeviceTokenEvent(token)
             )
@@ -59,7 +59,7 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             remoteMessage: RemoteMessage,
             handleNotificationTrigger: Boolean = true
         ): Boolean {
-            SDKComponent.ensureAndroidComponent(context = context)
+            SDKComponent.setupAndroidComponent(context = context)
             val handler = CustomerIOPushNotificationHandler(
                 pushMessageProcessor = SDKComponent.pushMessageProcessor,
                 remoteMessage = remoteMessage

--- a/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.ensureAndroidComponent
 import io.customer.sdk.tracking.TrackableScreen
 
 /**
@@ -24,6 +25,7 @@ class NotificationClickReceiverActivity : Activity(), TrackableScreen {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        SDKComponent.ensureAndroidComponent(context = this)
         handleIntent(data = intent)
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.ensureAndroidComponent
+import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.tracking.TrackableScreen
 
 /**
@@ -25,7 +25,7 @@ class NotificationClickReceiverActivity : Activity(), TrackableScreen {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        SDKComponent.ensureAndroidComponent(context = this)
+        SDKComponent.setupAndroidComponent(context = this)
         handleIntent(data = intent)
     }
 


### PR DESCRIPTION
### Changes

- Renamed `registerAndroidSDKComponent` to `ensureAndroidComponent` for clearer purpose
- Called the renamed method from all entry points (push services, activities) to ensure Android component is always initialized before accessing any of its dependencies
- Removed unused, deprecated methods from `DiGraph`, as they were intended for SDK use only