### PR TITLE
chore: Improve sample apps build info

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -58,10 +58,15 @@ jobs:
           bundler-cache: true # cache tools to make builds faster in future
 
       - name: Setup local.properties file for sample app
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           touch "samples/local.properties"
           echo "cdpApiKey=${{ secrets[matrix.cio-cdpapikey-secret-key] }}" >> "samples/local.properties"
           echo "siteId=${{ secrets[matrix.cio-siteid-secret-key] }}" >> "samples/local.properties"
+          echo "branch=$BRANCH_NAME" >> "samples/local.properties"
+          echo "commit=${COMMIT_HASH:0:7}" >> "samples/local.properties"
           if [ "${{ inputs.use_latest_sdk_version == true }}" ]; then
             echo "sdkVersion=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "samples/local.properties"
           fi

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/utils/ViewUtils.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/utils/ViewUtils.java
@@ -15,12 +15,12 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.Locale;
 
 import io.customer.android.sample.java_layout.BuildConfig;
 import io.customer.android.sample.java_layout.R;
-import io.customer.sdk.core.di.AndroidSDKComponent;
-import io.customer.sdk.core.di.SDKComponent;
 
 public class ViewUtils {
     public static void prepareForAutomatedTests(@NonNull View view, @StringRes int contentDescResId) {
@@ -55,14 +55,38 @@ public class ViewUtils {
     }
 
     public static void setBuildInfo(@NonNull TextView textView) {
-        AndroidSDKComponent androidSDKComponent = SDKComponent.INSTANCE.android();
-        String sdkVersion = androidSDKComponent.getClient().getSdkVersion();
-        String buildInfo = String.format(Locale.ENGLISH,
-                "Customer.io Android SDK %s Java Layout %s (%s)",
-                sdkVersion,
-                BuildConfig.VERSION_NAME,
-                BuildConfig.VERSION_CODE);
+        String buildInfo = String.format(
+                Locale.ENGLISH,
+                "SDK version: %s\n" +
+                        "Build date: %s\n" +
+                        "Branch: %s\n" +
+                        "Default workspace: Native iOS & Android\n" +
+                        "App version: %s",
+                getSdkVersion(),
+                getBuildTime(),
+                getBranchName(),
+                BuildConfig.VERSION_CODE
+        );
         textView.setText(buildInfo);
+    }
+
+    private static String getBuildTime() {
+        return DateFormat.getDateTimeInstance().format(new Date(BuildConfig.BUILD_TIMESTAMP));
+    }
+
+    private static String getSdkVersion() {
+        if (isEmptyOrUnset(BuildConfig.SDK_VERSION)) return "as source code";
+        return BuildConfig.SDK_VERSION;
+    }
+
+    private static String getBranchName() {
+        if (isEmptyOrUnset(BuildConfig.BRANCH)) return "local development";
+        return BuildConfig.BRANCH + "." + BuildConfig.COMMIT;
+    }
+
+    private static boolean isEmptyOrUnset(String text) {
+        // When local properties are not set, they have a string value of "null"
+        return TextUtils.isEmpty(text) || "null".equalsIgnoreCase(text);
     }
 
     @NonNull

--- a/samples/java_layout/src/main/res/layout/activity_dashboard.xml
+++ b/samples/java_layout/src/main/res/layout/activity_dashboard.xml
@@ -177,7 +177,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_default"
-                android:gravity="center"
                 android:textAppearance="@style/TextAppearance.Material3.BodySmall"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/samples/java_layout/src/main/res/layout/activity_login.xml
+++ b/samples/java_layout/src/main/res/layout/activity_login.xml
@@ -127,7 +127,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_default"
-            android:gravity="center"
             android:textAppearance="@style/TextAppearance.Material3.BodySmall"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -20,10 +20,17 @@ android {
         // cdpApiKey=KEY can be used as a fallback for all sample apps
         String cdpApiKey = getConfigWithPrefix("cdpApiKey")
         String siteId = getConfigWithPrefix("siteId")
+        String sdkVersion = localProperties["sdkVersion"]
+        String branch = localProperties["branch"]
+        String commit = localProperties["commit"]
 
         // Set build config fields for API keys
         buildConfigField "String", "CDP_API_KEY", "\"${cdpApiKey}\""
         buildConfigField "String", "SITE_ID", "\"${siteId}\""
+        buildConfigField "String", "SDK_VERSION", "\"${sdkVersion}\""
+        buildConfigField "String", "BRANCH", "\"${branch}\""
+        buildConfigField "String", "COMMIT", "\"${commit}\""
+        buildConfigField "long", "BUILD_TIMESTAMP", System.currentTimeMillis() + "L"
     }
     // Avoid redefining signing configs in sample apps to avoid breaking release
     // builds (specially on CI servers)


### PR DESCRIPTION
### Motivation
This PR updates the build info we show on sample apps. The changes aims to make those build info useful to the development team and other stakeholders determining how the sample app they are using was built. It also helps the development team reproduce the same build when they get issues or reports.

### The new build info
#### SDK version
This is the version of the SDK that the sample app is using, it can have the following values:
- A version "x.y.z" when a released SDK version was used
- "as source code (branch name)" when the SDK was built as source code from a certain branch
- "as source code (local development)" when it was built locally on a developer's machine
#### Build date
The date and time when the sample app was built, displayed in local time zone of the user
#### Branch
The branch from which the sample app was built
#### Default workspace
The default workspace that the app connects to by default or when resetting defaults in the settings screen
#### App version
This is unique version code of the sample app to identify the specific app version

## Screenshots
Here's a screenshot of different cases and how the info is displayed.

| Local with local SDK | Local with SDK version | CI with local SDK | CI with SDK version |
| ------------- | ------------- | ------------- | ------------- |
| <img width="320" src="https://github.com/user-attachments/assets/7b258dfa-aa8a-4b99-a353-273608881dfa"> | <img width="318"  src="https://github.com/user-attachments/assets/09751fa3-9ce4-4a27-846a-c13daf6bf18f"> | <img width="318" src="https://github.com/user-attachments/assets/0923a46c-d2ca-4466-9db1-fbe1971bc12e"> | <img width="318" src="https://github.com/user-attachments/assets/71f1cc64-6c5d-4e62-a5fc-d886cbc488bd"> |


