### PR TITLE
chore: Use latest version of setup-sd Github action

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -71,11 +71,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-android
 
-    # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
-    # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
-    - name: Install sd CLI to use later in the workflow 
-      uses: kenji-miyake/setup-sd@v2
-    
+
     - name: Install tools from Gemfile (ruby language) used for building our apps with 
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -71,7 +71,11 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-android
 
-
+    # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
+    # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
+    - name: Install sd CLI to use later in the workflow 
+      uses: kenji-miyake/setup-sd@v2
+    
     - name: Install tools from Gemfile (ruby language) used for building our apps with 
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -74,8 +74,7 @@ jobs:
     # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
     # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
     - name: Install sd CLI to use later in the workflow 
-      # uses: kenji-miyake/setup-sd@v1
-      uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it. 
+      uses: kenji-miyake/setup-sd@v2
     
     - name: Install tools from Gemfile (ruby language) used for building our apps with 
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -19,10 +19,6 @@ jobs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
-      - uses: actions/checkout@v4
-      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
-      - name: Install sd CLI to use later in the workflow
-        uses: kenji-miyake/setup-sd@v2
 
       # Setup Android SDK as it's needed to generate the SDK size report.
       - name: Setup Android SDK

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -19,6 +19,10 @@ jobs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
+      - uses: actions/checkout@v4
+      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
+      - name: Install sd CLI to use later in the workflow
+        uses: kenji-miyake/setup-sd@v2
 
       # Setup Android SDK as it's needed to generate the SDK size report.
       - name: Setup Android SDK

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
       - name: Install sd CLI to use later in the workflow
-        # uses: kenji-miyake/setup-sd@v1
-        uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it.
+        uses: kenji-miyake/setup-sd@v2
 
       # Setup Android SDK as it's needed to generate the SDK size report.
       - name: Setup Android SDK

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -103,8 +103,7 @@ jobs:
 
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
       - name: Install sd CLI to use later in the workflow
-        # uses: kenji-miyake/setup-sd@v1
-        uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it.
+        uses: kenji-miyake/setup-sd@v2
 
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -101,10 +101,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
-      - name: Install sd CLI to use later in the workflow
-        uses: kenji-miyake/setup-sd@v2
-
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -101,6 +101,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
+      - name: Install sd CLI to use later in the workflow
+        uses: kenji-miyake/setup-sd@v2
+
       - name: Install tools from Gemfile (ruby language) used for building our apps with
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR update the SD setup Github action to use the [latest version](https://github.com/kenji-miyake/setup-sd/releases/tag/v2.0.0) instead of the fork.