### PR TITLE
chore: move to v2 for user queue request and user agent in headers

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/NetworkUtilities.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/NetworkUtilities.kt
@@ -5,5 +5,7 @@ class NetworkUtilities {
         internal const val CIO_SITE_ID_HEADER = "X-CIO-Site-Id"
         internal const val USER_TOKEN_HEADER = "X-Gist-Encoded-User-Token"
         internal const val CIO_DATACENTER_HEADER = "X-CIO-Datacenter"
+        internal const val CIO_CLIENT_PLATFORM = "X-CIO-Client-Platform"
+        internal const val CIO_CLIENT_VERSION = "X-CIO-Client-Version"
     }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/listeners/Queue.kt
@@ -26,7 +26,7 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface GistQueueService {
-    @POST("/api/v1/users")
+    @POST("/api/v2/users")
     suspend fun fetchMessagesForUser(@Body body: Any = Object()): Response<List<Message>>
 
     @POST("/api/v1/logs/message/{messageId}")
@@ -69,6 +69,8 @@ class Queue : GistQueue {
                 val networkRequest = originalRequest.newBuilder()
                     .addHeader(NetworkUtilities.CIO_SITE_ID_HEADER, state.siteId)
                     .addHeader(NetworkUtilities.CIO_DATACENTER_HEADER, state.dataCenter)
+                    .addHeader(NetworkUtilities.CIO_CLIENT_PLATFORM, SDKComponent.android().client.source.lowercase())
+                    .addHeader(NetworkUtilities.CIO_CLIENT_VERSION, SDKComponent.android().client.sdkVersion)
                     .apply {
                         state.userId?.let { userToken ->
                             addHeader(


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-495/move-to-v2-apis-of-gist-and-add-sdk-reporting

changes:
- Upgrade user queue endpoint path to v2
- Added SDK version and platform in request headers