### PR TITLE
chore: Change sample app config default value for Test Mode to "NO"

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -43,7 +43,7 @@ public class CustomerIOSDKConfig {
                 CioLogLevel.DEBUG,
                 Region.US.INSTANCE,
                 true,
-                true,
+                false,
                 true);
     }
 


### PR DESCRIPTION
This PR changes the sample app config value of "Test Mode" to "No"

The motivation is that this by default aligns more closely to the settings our customers would be using when integrating the SDK into their apps.