### PR TITLE
chore: handle intent extras safely

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -34,7 +34,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                     state.event == Lifecycle.Event.ON_CREATE
                 }.collect { state ->
                     when (state.event) {
-                        Lifecycle.Event.ON_CREATE -> {
+                        Lifecycle.Event.ON_CREATE -> runCatching {
                             val intentArguments = state.activity.get()?.intent?.extras ?: return@collect
 
                             if (moduleConfig.autoTrackPushEvents) {


### PR DESCRIPTION
closes: [MBL-695](https://linear.app/customerio/issue/MBL-695/crash-with-illegalargumentexception)
fixes: #466 

### Changes

- Wrapped `intent.extras` in `ModuleMessagingPushFCM` lifecycle callbacks with try-catch block to prevent potential crashes on older Android versions

### Notes

This change will not trigger a release since issue reports are low but will be included in the next planned release.