### PR TITLE
fix: Fixes issue with legacy renderer bridge

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -99,6 +99,7 @@ internal class EngineWebView @JvmOverloads constructor(
                     // post message to webview with the configuration data so that the message can be rendered
                     val script = """
                     window.postMessage($jsonString, '*');
+                    window.parent.postMessage = function(message) {window.${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.postMessage(JSON.stringify(message))}
                 """.trim()
                     view.evaluateJavascript(script) { result ->
                         logger.debug("JavaScript execution result: $result")

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -96,22 +96,18 @@ internal class EngineWebView @JvmOverloads constructor(
 
             it.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String?) {
-                    // post message to webview with the configuration data so that the message can be rendered
                     val script = """
-                    window.postMessage($jsonString, '*');
-                    val script = """
-    // Post the JSON message to the current frame's listeners
-    // Ensures internal JavaScript communication via window.addEventListener('message') remains functional
-    window.postMessage($jsonString, '*');
-    
-    // Override window.parent.postMessage to route messages to the native Android interface
-    // This is necessary only for legacy message because WebView can only attach one native interface 
-    // and we have already added it as ${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.
-    window.parent.postMessage = function(message) {
-        window.${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.postMessage($jsonString);
-    }
-""".trim()
-                """.trim()
+                        // Post the JSON message to the current frame's listeners
+                        // Ensures internal JavaScript communication via window.addEventListener('message') remains functional
+                        window.postMessage($jsonString, '*');
+                        
+                        // Override window.parent.postMessage to route messages to the native Android interface
+                        // This is necessary only for legacy message because WebView can only attach one native interface 
+                        // and we have already added it as ${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.
+                        window.parent.postMessage = function(message) {
+                            window.${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.postMessage(JSON.stringify(message));
+                        }
+                    """.trim()
                     view.evaluateJavascript(script) { result ->
                         logger.debug("JavaScript execution result: $result")
                     }


### PR DESCRIPTION
Reintroduces bridge function to pass messages between SDK and Renderer

Fixes issue: https://linear.app/customerio/issue/MBL-721/mobile-in-app-crashes-after-updating-from-version-3x-to-44-of-android