### PR TITLE
feat: add option to disable screen view usage

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -15,18 +15,24 @@ public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : 
 	public final fun getTrackApplicationLifecycleEvents ()Z
 }
 
-public final class io/customer/datapipelines/config/ScreenView : java/lang/Enum {
-	public static final field Analytics Lio/customer/datapipelines/config/ScreenView;
+public abstract class io/customer/datapipelines/config/ScreenView {
 	public static final field Companion Lio/customer/datapipelines/config/ScreenView$Companion;
-	public static final field InApp Lio/customer/datapipelines/config/ScreenView;
-	public static fun valueOf (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
-	public static fun values ()[Lio/customer/datapipelines/config/ScreenView;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class io/customer/datapipelines/config/ScreenView$All : io/customer/datapipelines/config/ScreenView {
+	public static final field INSTANCE Lio/customer/datapipelines/config/ScreenView$All;
 }
 
 public final class io/customer/datapipelines/config/ScreenView$Companion {
 	public final fun getScreenView (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
 	public final fun getScreenView (Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;)Lio/customer/datapipelines/config/ScreenView;
 	public static synthetic fun getScreenView$default (Lio/customer/datapipelines/config/ScreenView$Companion;Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;ILjava/lang/Object;)Lio/customer/datapipelines/config/ScreenView;
+}
+
+public final class io/customer/datapipelines/config/ScreenView$InApp : io/customer/datapipelines/config/ScreenView {
+	public static final field INSTANCE Lio/customer/datapipelines/config/ScreenView$InApp;
 }
 
 public final class io/customer/datapipelines/extensions/JsonExtensionsKt {

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -1,6 +1,6 @@
 public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;Lio/customer/datapipelines/config/ScreenView;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Ljava/lang/String;Ljava/lang/String;IILjava/util/List;ZZZZLjava/lang/String;Lio/customer/datapipelines/config/ScreenView;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getApiHost ()Ljava/lang/String;
 	public final fun getAutoAddCustomerIODestination ()Z
 	public final fun getAutoTrackActivityScreens ()Z
@@ -11,7 +11,22 @@ public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : 
 	public final fun getFlushInterval ()I
 	public final fun getFlushPolicies ()Ljava/util/List;
 	public final fun getMigrationSiteId ()Ljava/lang/String;
+	public final fun getScreenViewUse ()Lio/customer/datapipelines/config/ScreenView;
 	public final fun getTrackApplicationLifecycleEvents ()Z
+}
+
+public final class io/customer/datapipelines/config/ScreenView : java/lang/Enum {
+	public static final field Analytics Lio/customer/datapipelines/config/ScreenView;
+	public static final field Companion Lio/customer/datapipelines/config/ScreenView$Companion;
+	public static final field InApp Lio/customer/datapipelines/config/ScreenView;
+	public static fun valueOf (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
+	public static fun values ()[Lio/customer/datapipelines/config/ScreenView;
+}
+
+public final class io/customer/datapipelines/config/ScreenView$Companion {
+	public final fun getScreenView (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
+	public final fun getScreenView (Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;)Lio/customer/datapipelines/config/ScreenView;
+	public static synthetic fun getScreenView$default (Lio/customer/datapipelines/config/ScreenView$Companion;Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;ILjava/lang/Object;)Lio/customer/datapipelines/config/ScreenView;
 }
 
 public final class io/customer/datapipelines/extensions/JsonExtensionsKt {
@@ -136,6 +151,24 @@ public final class io/customer/datapipelines/plugins/PluginExtensionsKt {
 	public static final fun findInContextAtPath (Lcom/segment/analytics/kotlin/core/BaseEvent;Ljava/lang/String;)Ljava/util/List;
 }
 
+public final class io/customer/datapipelines/plugins/ScreenFilterPlugin : com/segment/analytics/kotlin/core/platform/EventPlugin {
+	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun <init> (Lio/customer/datapipelines/config/ScreenView;)V
+	public fun alias (Lcom/segment/analytics/kotlin/core/AliasEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun flush ()V
+	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
+	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
+	public fun group (Lcom/segment/analytics/kotlin/core/GroupEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun identify (Lcom/segment/analytics/kotlin/core/IdentifyEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun reset ()V
+	public fun screen (Lcom/segment/analytics/kotlin/core/ScreenEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun track (Lcom/segment/analytics/kotlin/core/TrackEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
+	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
+}
+
 public final class io/customer/datapipelines/plugins/StringExtensionsKt {
 	public static final fun getScreenNameFromActivity (Ljava/lang/String;)Ljava/lang/String;
 }
@@ -183,6 +216,7 @@ public final class io/customer/sdk/CustomerIOBuilder {
 	public final fun logLevel (Lio/customer/sdk/core/util/CioLogLevel;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun migrationSiteId (Ljava/lang/String;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun region (Lio/customer/sdk/data/model/Region;)Lio/customer/sdk/CustomerIOBuilder;
+	public final fun screenViewUse (Lio/customer/datapipelines/config/ScreenView;)Lio/customer/sdk/CustomerIOBuilder;
 	public final fun trackApplicationLifecycleEvents (Z)Lio/customer/sdk/CustomerIOBuilder;
 }
 

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -151,24 +151,6 @@ public final class io/customer/datapipelines/plugins/PluginExtensionsKt {
 	public static final fun findInContextAtPath (Lcom/segment/analytics/kotlin/core/BaseEvent;Ljava/lang/String;)Ljava/util/List;
 }
 
-public final class io/customer/datapipelines/plugins/ScreenFilterPlugin : com/segment/analytics/kotlin/core/platform/EventPlugin {
-	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
-	public fun <init> (Lio/customer/datapipelines/config/ScreenView;)V
-	public fun alias (Lcom/segment/analytics/kotlin/core/AliasEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun flush ()V
-	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
-	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
-	public fun group (Lcom/segment/analytics/kotlin/core/GroupEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun identify (Lcom/segment/analytics/kotlin/core/IdentifyEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun reset ()V
-	public fun screen (Lcom/segment/analytics/kotlin/core/ScreenEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
-	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
-	public fun track (Lcom/segment/analytics/kotlin/core/TrackEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
-}
-
 public final class io/customer/datapipelines/plugins/StringExtensionsKt {
 	public static final fun getScreenNameFromActivity (Ljava/lang/String;)Ljava/lang/String;
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
@@ -27,7 +27,9 @@ class DataPipelinesModuleConfig(
     // Track screen views for Activities
     val autoTrackActivityScreens: Boolean,
     // Configuration options required for migration from earlier versions
-    val migrationSiteId: String? = null
+    val migrationSiteId: String? = null,
+    // Determines how SDK should handle screen view events
+    val screenViewUse: ScreenView
 ) : CustomerIOModuleConfig {
     val apiHost: String = apiHostOverride ?: region.apiHost()
     val cdnHost: String = cdnHostOverride ?: region.cdnHost()

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -5,7 +5,7 @@ package io.customer.datapipelines.config
  */
 enum class ScreenView {
     /**
-     * Screen view events are sent to our back end servers for analytics purposes.
+     * Screen view events are sent to destinations for analytics purposes.
      */
     Analytics,
 

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -3,26 +3,36 @@ package io.customer.datapipelines.config
 /**
  * Enum class to define how CustomerIO SDK should handle screen view events.
  */
-enum class ScreenView {
+sealed class ScreenView(val name: String) {
     /**
      * Screen view events are sent to destinations for analytics purposes.
+     * They are also used to display in-app messages based on page rules.
      */
-    Analytics,
+    object All : ScreenView(name = "all")
 
     /**
-     * Screen view events are kept on device only. They are used to display in-app messages based on page rules. Events are not sent to our back end servers.
+     * Screen view events are kept on device only. They are used to display in-app messages based on
+     * page rules. Events are not sent to our back end servers.
      */
-    InApp;
+
+    object InApp : ScreenView(name = "inapp")
 
     companion object {
         /**
          * Returns the [ScreenView] enum constant for the given name.
          * Returns fallback if the specified enum type has no constant with the given name.
-         * Defaults to [Analytics].
+         * Defaults to [All].
          */
         @JvmOverloads
-        fun getScreenView(screenView: String?, fallback: ScreenView = Analytics): ScreenView {
-            return values().firstOrNull { it.name.equals(screenView, ignoreCase = true) } ?: fallback
+        fun getScreenView(screenView: String?, fallback: ScreenView = All): ScreenView {
+            if (screenView.isNullOrBlank()) {
+                return fallback
+            }
+
+            return listOf(
+                All,
+                InApp
+            ).find { value -> value.name.equals(screenView, ignoreCase = true) } ?: fallback
         }
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -1,0 +1,28 @@
+package io.customer.datapipelines.config
+
+/**
+ * Enum class to define how CustomerIO SDK should handle screen view events.
+ */
+enum class ScreenView {
+    /**
+     * Screen view events are sent to our back end servers for analytics purposes.
+     */
+    Analytics,
+
+    /**
+     * Screen view events are kept on device only. They are used to display in-app messages based on page rules. Events are not sent to our back end servers.
+     */
+    InApp;
+
+    companion object {
+        /**
+         * Returns the [ScreenView] enum constant for the given name.
+         * Returns fallback if the specified enum type has no constant with the given name.
+         * Defaults to [Analytics].
+         */
+        @JvmOverloads
+        fun getScreenView(screenView: String?, fallback: ScreenView = Analytics): ScreenView {
+            return values().firstOrNull { it.name.equals(screenView, ignoreCase = true) } ?: fallback
+        }
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
@@ -19,7 +19,7 @@ internal class ScreenFilterPlugin(private val screenViewUse: ScreenView) : Event
         // Filter out screen events based on the configuration provided by customer app
         // Using when expression so it enforce right check for all possible values of ScreenView in future
         return when (screenViewUse) {
-            ScreenView.Analytics -> payload
+            ScreenView.All -> payload
             // Do not send screen events to server if ScreenView is not Analytics
             ScreenView.InApp -> null
         }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
@@ -1,0 +1,27 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.ScreenEvent
+import com.segment.analytics.kotlin.core.platform.EventPlugin
+import com.segment.analytics.kotlin.core.platform.Plugin
+import io.customer.datapipelines.config.ScreenView
+
+/**
+ * Plugin to filter screen events based on the configuration provided by customer app.
+ * This plugin is used to filter out screen events that should not be processed further.
+ */
+class ScreenFilterPlugin(private val screenViewUse: ScreenView) : EventPlugin {
+    override lateinit var analytics: Analytics
+    override val type: Plugin.Type = Plugin.Type.Enrichment
+
+    override fun screen(payload: ScreenEvent): BaseEvent? {
+        // Filter out screen events based on the configuration provided by customer app
+        // Using when expression so it enforce right check for all possible values of ScreenView in future
+        return when (screenViewUse) {
+            ScreenView.Analytics -> payload
+            // Do not send screen events to server if ScreenView is not Analytics
+            ScreenView.InApp -> null
+        }
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
@@ -11,7 +11,7 @@ import io.customer.datapipelines.config.ScreenView
  * Plugin to filter screen events based on the configuration provided by customer app.
  * This plugin is used to filter out screen events that should not be processed further.
  */
-class ScreenFilterPlugin(private val screenViewUse: ScreenView) : EventPlugin {
+internal class ScreenFilterPlugin(private val screenViewUse: ScreenView) : EventPlugin {
     override lateinit var analytics: Analytics
     override val type: Plugin.Type = Plugin.Type.Enrichment
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -21,6 +21,7 @@ import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.ContextPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.DataPipelinePublishedEvents
+import io.customer.datapipelines.plugins.ScreenFilterPlugin
 import io.customer.datapipelines.util.EventNames
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
@@ -120,6 +121,9 @@ class CustomerIO private constructor(
         }
         // Add plugin to publish events to EventBus for other modules to consume
         analytics.add(DataPipelinePublishedEvents())
+
+        // Add plugin to filter events based on SDK configuration
+        analytics.add(ScreenFilterPlugin(moduleConfig.screenViewUse))
 
         // subscribe to journey events emitted from push/in-app module to send them via data pipelines
         subscribeToJourneyEvents()

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -71,7 +71,7 @@ class CustomerIOBuilder(
     private var migrationSiteId: String? = null
 
     // Determines how SDK should handle screen view events
-    private var screenViewUse: ScreenView = ScreenView.Analytics
+    private var screenViewUse: ScreenView = ScreenView.All
 
     /**
      * Specifies the log level for the SDK.

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -3,6 +3,7 @@ package io.customer.sdk
 import android.app.Application
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
+import io.customer.datapipelines.config.ScreenView
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.module.CustomerIOModule
@@ -68,6 +69,9 @@ class CustomerIOBuilder(
 
     // Configuration options required for migration from earlier versions
     private var migrationSiteId: String? = null
+
+    // Determines how SDK should handle screen view events
+    private var screenViewUse: ScreenView = ScreenView.Analytics
 
     /**
      * Specifies the log level for the SDK.
@@ -167,6 +171,16 @@ class CustomerIOBuilder(
         return this
     }
 
+    /**
+     * Set the screen view configuration for the SDK.
+     *
+     * @see ScreenView for more details.
+     */
+    fun screenViewUse(screenView: ScreenView): CustomerIOBuilder {
+        this.screenViewUse = screenView
+        return this
+    }
+
     fun <Config : CustomerIOModuleConfig> addCustomerIOModule(module: CustomerIOModule<Config>): CustomerIOBuilder {
         registeredModules.add(module)
         return this
@@ -191,7 +205,8 @@ class CustomerIOBuilder(
             trackApplicationLifecycleEvents = trackApplicationLifecycleEvents,
             autoTrackDeviceAttributes = autoTrackDeviceAttributes,
             autoTrackActivityScreens = autoTrackActivityScreens,
-            migrationSiteId = migrationSiteId
+            migrationSiteId = migrationSiteId,
+            screenViewUse = screenViewUse
         )
 
         // Initialize CustomerIO instance before initializing the modules

--- a/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
@@ -1,0 +1,46 @@
+package io.customer.datapipelines.config
+
+import io.customer.commontest.core.JUnit5Test
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class ScreenViewTest : JUnit5Test() {
+    @Test
+    fun getScreenView_givenNamesWithMatchingCase_expectCorrectScreenView() {
+        val screenViewAnalytics = ScreenView.getScreenView("All")
+        val screenViewInApp = ScreenView.getScreenView("InApp")
+
+        screenViewAnalytics shouldBeEqualTo ScreenView.All
+        screenViewInApp shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenNamesWithDifferentCase_expectCorrectScreenView() {
+        val screenViewAnalytics = ScreenView.getScreenView("all")
+        val screenViewInApp = ScreenView.getScreenView("inapp")
+
+        screenViewAnalytics shouldBeEqualTo ScreenView.All
+        screenViewInApp shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenInvalidValue_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView("none")
+
+        parsedValue shouldBeEqualTo ScreenView.All
+    }
+
+    @Test
+    fun getScreenView_givenEmptyValue_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView(screenView = "", fallback = ScreenView.InApp)
+
+        parsedValue shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenNull_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView(null)
+
+        parsedValue shouldBeEqualTo ScreenView.All
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
@@ -36,7 +36,7 @@ class ScreenFilterPluginTest : JUnitTest() {
 
     @Test
     fun process_givenScreenViewUseAnalytics_expectScreenEventWithoutPropertiesProcessed() {
-        setupWithConfig(screenViewUse = ScreenView.Analytics)
+        setupWithConfig(screenViewUse = ScreenView.All)
 
         val givenScreenTitle = String.random
         sdkInstance.screen(givenScreenTitle)
@@ -48,7 +48,7 @@ class ScreenFilterPluginTest : JUnitTest() {
 
     @Test
     fun process_givenScreenViewUseAnalytics_expectScreenEventWithPropertiesProcessed() {
-        setupWithConfig(screenViewUse = ScreenView.Analytics)
+        setupWithConfig(screenViewUse = ScreenView.All)
 
         val givenScreenTitle = String.random
         val givenProperties: CustomAttributes = mapOf("source" to "push", "discount" to 10)

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
@@ -1,0 +1,72 @@
+package io.customer.datapipelines.plugins
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.config.ScreenView
+import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.extensions.shouldMatchTo
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.screenEvents
+import io.customer.sdk.data.model.CustomAttributes
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSingleItem
+import org.junit.jupiter.api.Test
+
+class ScreenFilterPluginTest : JUnitTest() {
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        // Keep setup empty to avoid calling super.setup() as it will initialize the SDK
+        // and we want to test the SDK with different configurations in each test
+    }
+
+    private fun setupWithConfig(screenViewUse: ScreenView, testConfig: DataPipelinesTestConfig = testConfiguration {}) {
+        super.setup(
+            testConfiguration {
+                analytics { add(ScreenFilterPlugin(screenViewUse = screenViewUse)) }
+            } + testConfig
+        )
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun process_givenScreenViewUseAnalytics_expectScreenEventWithoutPropertiesProcessed() {
+        setupWithConfig(screenViewUse = ScreenView.Analytics)
+
+        val givenScreenTitle = String.random
+        sdkInstance.screen(givenScreenTitle)
+
+        val result = outputReaderPlugin.screenEvents.shouldHaveSingleItem()
+        result.name shouldBeEqualTo givenScreenTitle
+        result.properties.shouldBeEmpty()
+    }
+
+    @Test
+    fun process_givenScreenViewUseAnalytics_expectScreenEventWithPropertiesProcessed() {
+        setupWithConfig(screenViewUse = ScreenView.Analytics)
+
+        val givenScreenTitle = String.random
+        val givenProperties: CustomAttributes = mapOf("source" to "push", "discount" to 10)
+        sdkInstance.screen(givenScreenTitle, givenProperties)
+
+        val screenEvent = outputReaderPlugin.screenEvents.shouldHaveSingleItem()
+        screenEvent.name shouldBeEqualTo givenScreenTitle
+        screenEvent.properties shouldMatchTo givenProperties
+    }
+
+    @Test
+    fun process_givenScreenViewUseInApp_expectAllScreenEventsIgnored() {
+        setupWithConfig(screenViewUse = ScreenView.InApp)
+
+        for (i in 1..5) {
+            sdkInstance.screen(String.random)
+        }
+
+        outputReaderPlugin.allEvents.shouldBeEmpty()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -5,9 +5,11 @@ import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
 import io.customer.commontest.module.CustomerIOGenericModule
+import io.customer.datapipelines.config.ScreenView
 import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.DataPipelinePublishedEvents
+import io.customer.datapipelines.plugins.ScreenFilterPlugin
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.di.SDKComponent
@@ -105,6 +107,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
         dataPipelinesModuleConfig.apiHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.cdnHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.autoAddCustomerIODestination shouldBe true
+        dataPipelinesModuleConfig.screenViewUse shouldBe ScreenView.Analytics
     }
 
     @Test
@@ -112,6 +115,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
         val givenCdpApiKey = String.random
         val givenMigrationSiteId = String.random
         val givenRegion = Region.EU
+        val givenScreenViewUse = ScreenView.InApp
 
         createCustomerIOBuilder(givenCdpApiKey)
             .logLevel(CioLogLevel.DEBUG)
@@ -123,6 +127,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
             .flushAt(100)
             .flushInterval(2)
             .flushPolicies(emptyList())
+            .screenViewUse(givenScreenViewUse)
             .build()
 
         // verify the customerIOBuilder config with DataPipelinesModuleConfig
@@ -137,6 +142,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
         dataPipelinesModuleConfig.flushInterval shouldBe 2
         dataPipelinesModuleConfig.apiHost shouldBe "cdp-eu.customer.io/v1"
         dataPipelinesModuleConfig.cdnHost shouldBe "cdp-eu.customer.io/v1"
+        dataPipelinesModuleConfig.screenViewUse shouldBe givenScreenViewUse
 
         // verify the shared logger has updated log level
         SDKComponent.logger.logLevel shouldBe CioLogLevel.DEBUG
@@ -163,6 +169,13 @@ class CustomerIOBuilderTest : RobolectricTest() {
             .build()
 
         CustomerIO.instance().analytics.find(AutomaticActivityScreenTrackingPlugin::class) shouldBe null
+    }
+
+    @Test
+    fun build_givenModuleInitialized_expectScreenFilterPluginPluginAdded() {
+        createCustomerIOBuilder().build()
+
+        CustomerIO.instance().analytics.find(ScreenFilterPlugin::class) shouldNotBe null
     }
 
     @Test

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -107,7 +107,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
         dataPipelinesModuleConfig.apiHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.cdnHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.autoAddCustomerIODestination shouldBe true
-        dataPipelinesModuleConfig.screenViewUse shouldBe ScreenView.Analytics
+        dataPipelinesModuleConfig.screenViewUse shouldBe ScreenView.All
     }
 
     @Test

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -44,7 +44,7 @@ public class CustomerIOSDKConfig {
                 true,
                 CioLogLevel.DEBUG,
                 Region.US.INSTANCE,
-                ScreenView.Analytics,
+                ScreenView.All.INSTANCE,
                 true,
                 false,
                 true);
@@ -96,7 +96,7 @@ public class CustomerIOSDKConfig {
         bundle.put(Keys.TRACK_DEVICE_ATTRIBUTES, StringUtils.fromBoolean(config.deviceAttributesTrackingEnabled));
         bundle.put(Keys.LOG_LEVEL, config.logLevel.name());
         bundle.put(Keys.REGION, config.getRegion().getCode());
-        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().name());
+        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().getName());
         bundle.put(Keys.TRACK_APPLICATION_LIFECYCLE, StringUtils.fromBoolean(config.applicationLifecycleTrackingEnabled));
         bundle.put(Keys.TEST_MODE_ENABLED, StringUtils.fromBoolean(config.testModeEnabled));
         bundle.put(Keys.IN_APP_MESSAGING_ENABLED, StringUtils.fromBoolean(config.inAppMessagingEnabled));

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import io.customer.android.sample.java_layout.BuildConfig;
 import io.customer.android.sample.java_layout.support.Optional;
 import io.customer.android.sample.java_layout.utils.StringUtils;
+import io.customer.datapipelines.config.ScreenView;
 import io.customer.datapipelines.extensions.RegionExtKt;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
@@ -28,6 +29,7 @@ public class CustomerIOSDKConfig {
         static final String TRACK_DEVICE_ATTRIBUTES = "cio_sdk_track_device_attributes";
         static final String LOG_LEVEL = "cio_sdk_log_level";
         static final String REGION = "cio_sdk_region";
+        static final String SCREEN_VIEW_USE = "cio_sdk_screen_view_use";
         static final String TRACK_APPLICATION_LIFECYCLE = "cio_sdk_track_application_lifecycle";
         static final String TEST_MODE_ENABLED = "cio_sdk_test_mode";
         static final String IN_APP_MESSAGING_ENABLED = "cio_sdk_in_app_messaging_enabled";
@@ -42,6 +44,7 @@ public class CustomerIOSDKConfig {
                 true,
                 CioLogLevel.DEBUG,
                 Region.US.INSTANCE,
+                ScreenView.Analytics,
                 true,
                 false,
                 true);
@@ -62,6 +65,7 @@ public class CustomerIOSDKConfig {
         boolean deviceAttributesTrackingEnabled = StringUtils.parseBoolean(bundle.get(Keys.TRACK_DEVICE_ATTRIBUTES), defaultConfig.deviceAttributesTrackingEnabled);
         CioLogLevel logLevel = CioLogLevel.Companion.getLogLevel(bundle.get(Keys.LOG_LEVEL), CioLogLevel.DEBUG);
         Region region = Region.Companion.getRegion(bundle.get(Keys.REGION), Region.US.INSTANCE);
+        ScreenView screenViewUse = ScreenView.Companion.getScreenView(bundle.get(Keys.SCREEN_VIEW_USE));
         boolean applicationLifecycleTrackingEnabled = StringUtils.parseBoolean(bundle.get(Keys.TRACK_APPLICATION_LIFECYCLE), defaultConfig.applicationLifecycleTrackingEnabled);
         boolean testModeEnabled = StringUtils.parseBoolean(bundle.get(Keys.TEST_MODE_ENABLED), defaultConfig.testModeEnabled);
         boolean inAppMessagingEnabled = StringUtils.parseBoolean(bundle.get(Keys.IN_APP_MESSAGING_ENABLED), defaultConfig.inAppMessagingEnabled);
@@ -74,6 +78,7 @@ public class CustomerIOSDKConfig {
                 deviceAttributesTrackingEnabled,
                 logLevel,
                 region,
+                screenViewUse,
                 applicationLifecycleTrackingEnabled,
                 testModeEnabled,
                 inAppMessagingEnabled);
@@ -91,6 +96,7 @@ public class CustomerIOSDKConfig {
         bundle.put(Keys.TRACK_DEVICE_ATTRIBUTES, StringUtils.fromBoolean(config.deviceAttributesTrackingEnabled));
         bundle.put(Keys.LOG_LEVEL, config.logLevel.name());
         bundle.put(Keys.REGION, config.getRegion().getCode());
+        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().name());
         bundle.put(Keys.TRACK_APPLICATION_LIFECYCLE, StringUtils.fromBoolean(config.applicationLifecycleTrackingEnabled));
         bundle.put(Keys.TEST_MODE_ENABLED, StringUtils.fromBoolean(config.testModeEnabled));
         bundle.put(Keys.IN_APP_MESSAGING_ENABLED, StringUtils.fromBoolean(config.inAppMessagingEnabled));
@@ -111,6 +117,7 @@ public class CustomerIOSDKConfig {
     private final CioLogLevel logLevel;
     @NonNull
     private final Region region;
+    private final ScreenView screenViewUse;
     private final boolean applicationLifecycleTrackingEnabled;
     private final boolean testModeEnabled;
     private final boolean inAppMessagingEnabled;
@@ -123,6 +130,7 @@ public class CustomerIOSDKConfig {
                                boolean deviceAttributesTrackingEnabled,
                                @NonNull CioLogLevel logLevel,
                                @NonNull Region region,
+                               @NonNull ScreenView screenViewUse,
                                boolean applicationLifecycleTrackingEnabled,
                                boolean testModeEnabled,
                                boolean inAppMessagingEnabled) {
@@ -134,6 +142,7 @@ public class CustomerIOSDKConfig {
         this.deviceAttributesTrackingEnabled = deviceAttributesTrackingEnabled;
         this.logLevel = logLevel;
         this.region = region;
+        this.screenViewUse = screenViewUse;
         this.applicationLifecycleTrackingEnabled = applicationLifecycleTrackingEnabled;
         this.testModeEnabled = testModeEnabled;
         this.inAppMessagingEnabled = inAppMessagingEnabled;
@@ -187,5 +196,10 @@ public class CustomerIOSDKConfig {
     @NonNull
     public Region getRegion() {
         return region;
+    }
+
+    @NonNull
+    public ScreenView getScreenViewUse() {
+        return screenViewUse;
     }
 }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -77,6 +77,7 @@ public class CustomerIORepository {
         builder.trackApplicationLifecycleEvents(sdkConfig.isApplicationLifecycleTrackingEnabled());
         builder.region(sdkConfig.getRegion());
         builder.logLevel(sdkConfig.getLogLevel());
+        builder.screenViewUse(sdkConfig.getScreenViewUse());
     }
 
     public void identify(@NonNull String email, @NonNull Map<String, String> attributes) {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
@@ -137,6 +137,7 @@ public class InternalSettingsActivity extends BaseActivity<ActivityInternalSetti
                 currentSettings.isDeviceAttributesTrackingEnabled(),
                 currentSettings.getLogLevel(),
                 currentSettings.getRegion(),
+                currentSettings.getScreenViewUse(),
                 currentSettings.isApplicationLifecycleTrackingEnabled(),
                 currentSettings.isTestModeEnabled(),
                 currentSettings.isInAppMessagingEnabled()

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -54,6 +54,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
 
     @Override
     protected void setupContent() {
+        prepareViews();
         prepareViewsForAutomatedTests();
         setupViews();
         setupObservers();
@@ -83,6 +84,11 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
             }
         }
         isLinkParamsPopulated = true;
+    }
+
+    private void prepareViews() {
+        binding.settingsScreenViewUseAllButton.setText(ScreenView.All.INSTANCE.getName());
+        binding.settingsScreenViewUseInAppButton.setText(ScreenView.InApp.INSTANCE.getName());
     }
 
     private void prepareViewsForAutomatedTests() {
@@ -221,10 +227,10 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     @NonNull
     private ScreenView getSelectedScreenViewUse() {
         int checkedButton = binding.screenViewUseSettingsValuesGroup.getCheckedButtonId();
-        if (checkedButton == R.id.settings_screen_view_use_analytics_button) {
-            return ScreenView.Analytics;
+        if (checkedButton == R.id.settings_screen_view_use_all_button) {
+            return ScreenView.All.INSTANCE;
         } else if (checkedButton == R.id.settings_screen_view_use_in_app_button) {
-            return ScreenView.InApp;
+            return ScreenView.InApp.INSTANCE;
         }
         throw new IllegalStateException();
     }
@@ -273,13 +279,10 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     }
 
     private int getCheckedScreenViewUseButtonId(@NonNull ScreenView screenViewUse) {
-        switch (screenViewUse) {
-            case InApp:
-                return R.id.settings_screen_view_use_in_app_button;
-            case Analytics:
-            default:
-                return R.id.settings_screen_view_use_analytics_button;
+        if (screenViewUse instanceof ScreenView.InApp) {
+            return R.id.settings_screen_view_use_in_app_button;
         }
+        return R.id.settings_screen_view_use_all_button;
     }
 
     private boolean updateErrorState(TextInputLayout textInputLayout,

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -17,6 +17,7 @@ import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.android.sample.java_layout.ui.dashboard.DashboardActivity;
 import io.customer.android.sample.java_layout.utils.OSUtils;
 import io.customer.android.sample.java_layout.utils.ViewUtils;
+import io.customer.datapipelines.config.ScreenView;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -128,6 +129,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         binding.settingsTrackDeviceAttrsValuesGroup.check(getCheckedAutoTrackDeviceAttributesButtonId(config.isDeviceAttributesTrackingEnabled()));
         binding.settingsTrackScreenViewsValuesGroup.check(getCheckedTrackScreenViewsButtonId(config.isScreenTrackingEnabled()));
         binding.settingsTrackAppLifecycleValuesGroup.check(getCheckedTrackAppLifecycleButtonId(config.isApplicationLifecycleTrackingEnabled()));
+        binding.screenViewUseSettingsValuesGroup.check(getCheckedScreenViewUseButtonId(config.getScreenViewUse()));
         binding.settingsLogLevelValuesGroup.check(getCheckedLogLevelButtonId(config.getLogLevel()));
         binding.settingsTestModeValuesGroup.check(getCheckedTestModeButtonId(config.isTestModeEnabled()));
         binding.settingsInAppMessagingValuesGroup.check(getCheckedInAppMessagingButtonId(config.isInAppMessagingEnabled()));
@@ -173,6 +175,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         boolean featInAppMessagingEnabled = binding.settingsInAppMessagingValuesGroup.getCheckedButtonId() == R.id.settings_in_app_messaging_yes_button;
         CioLogLevel logLevel = getSelectedLogLevel();
         Region region = getSelectedRegion();
+        ScreenView screenViewUse = getSelectedScreenViewUse();
 
         return new CustomerIOSDKConfig(cdpApiKey,
                 siteId,
@@ -182,6 +185,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
                 featTrackDeviceAttributes,
                 logLevel,
                 region,
+                screenViewUse,
                 featTrackApplicationLifecycle,
                 featTestModeEnabled,
                 featInAppMessagingEnabled);
@@ -209,6 +213,18 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
             return Region.US.INSTANCE;
         } else if (checkedButton == R.id.settings_region_eu_button) {
             return Region.EU.INSTANCE;
+        }
+        throw new IllegalStateException();
+    }
+
+
+    @NonNull
+    private ScreenView getSelectedScreenViewUse() {
+        int checkedButton = binding.screenViewUseSettingsValuesGroup.getCheckedButtonId();
+        if (checkedButton == R.id.settings_screen_view_use_analytics_button) {
+            return ScreenView.Analytics;
+        } else if (checkedButton == R.id.settings_screen_view_use_in_app_button) {
+            return ScreenView.InApp;
         }
         throw new IllegalStateException();
     }
@@ -254,6 +270,16 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     private int getCheckedRegionButtonId(@NonNull Region region) {
         return region instanceof Region.US ? R.id.settings_region_us_button
                 : R.id.settings_region_eu_button;
+    }
+
+    private int getCheckedScreenViewUseButtonId(@NonNull ScreenView screenViewUse) {
+        switch (screenViewUse) {
+            case InApp:
+                return R.id.settings_screen_view_use_in_app_button;
+            case Analytics:
+            default:
+                return R.id.settings_screen_view_use_analytics_button;
+        }
     }
 
     private boolean updateErrorState(TextInputLayout textInputLayout,

--- a/samples/java_layout/src/main/res/layout/activity_settings.xml
+++ b/samples/java_layout/src/main/res/layout/activity_settings.xml
@@ -235,6 +235,47 @@
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView
+                    android:id="@+id/screen_view_use_settings_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="@string/screen_view_use_settings_label"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/settings_track_app_lifecycle_values_group" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/screen_view_use_settings_values_group"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/screen_view_use_settings_label"
+                    app:selectionRequired="true"
+                    app:singleSelection="true">
+
+                    <Button
+                        android:id="@+id/settings_screen_view_use_analytics_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/screen_view_use_settings_analytics" />
+
+                    <Button
+                        android:id="@+id/settings_screen_view_use_in_app_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/screen_view_use_settings_in_app" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <TextView
                     android:id="@+id/settings_features_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -242,7 +283,7 @@
                     android:text="@string/features"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/settings_track_app_lifecycle_values_group" />
+                    app:layout_constraintTop_toBottomOf="@+id/screen_view_use_settings_values_group" />
 
                 <TextView
                     android:id="@+id/settings_in_app_messaging_label"

--- a/samples/java_layout/src/main/res/layout/activity_settings.xml
+++ b/samples/java_layout/src/main/res/layout/activity_settings.xml
@@ -259,12 +259,12 @@
                     app:singleSelection="true">
 
                     <Button
-                        android:id="@+id/settings_screen_view_use_analytics_button"
+                        android:id="@+id/settings_screen_view_use_all_button"
                         style="?attr/materialButtonOutlinedStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@string/screen_view_use_settings_analytics" />
+                        tools:text="All" />
 
                     <Button
                         android:id="@+id/settings_screen_view_use_in_app_button"
@@ -272,7 +272,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@string/screen_view_use_settings_in_app" />
+                        tools:text="InApp" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -82,5 +82,8 @@
     <!--Internal settings screen-->
     <string name="label_internal_settings_activity">InternalSettingsActivity</string>
     <string name="error_url_input_field">This field must be a valid URL</string>
+    <string name="screen_view_use_settings_label">ScreenView use</string>
+    <string name="screen_view_use_settings_analytics">Analytics</string>
+    <string name="screen_view_use_settings_in_app">InApp</string>
 
 </resources>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -83,7 +83,5 @@
     <string name="label_internal_settings_activity">InternalSettingsActivity</string>
     <string name="error_url_input_field">This field must be a valid URL</string>
     <string name="screen_view_use_settings_label">ScreenView use</string>
-    <string name="screen_view_use_settings_analytics">Analytics</string>
-    <string name="screen_view_use_settings_in_app">InApp</string>
 
 </resources>


### PR DESCRIPTION
part of: [MBL-755](https://linear.app/customerio/issue/MBL-755/add-config-to-android-sdk)

### Changes

- Added `screenViewUse` enum option to allow disable sending screen view events to server and use them locally only
- Added `ScreenFilterPlugin` to filter events based on the `screenViewUse` configuration
- Added tests to ensure functionality

### `ScreenView` Options

- `Analytics` -> Sends all screen events to the server (same as before) - Default behavior
- `InApp` -> Retains screen events locally for in-app use only

### Sample Usage

```kotlin
CustomerIOBuilder(...)
    .screenViewUse(ScreenView.InApp)
    .build()
```