### PR TITLE
chore: update java sample app with screen view configuration

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import io.customer.android.sample.java_layout.BuildConfig;
 import io.customer.android.sample.java_layout.support.Optional;
 import io.customer.android.sample.java_layout.utils.StringUtils;
+import io.customer.datapipelines.config.ScreenView;
 import io.customer.datapipelines.extensions.RegionExtKt;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
@@ -28,6 +29,7 @@ public class CustomerIOSDKConfig {
         static final String TRACK_DEVICE_ATTRIBUTES = "cio_sdk_track_device_attributes";
         static final String LOG_LEVEL = "cio_sdk_log_level";
         static final String REGION = "cio_sdk_region";
+        static final String SCREEN_VIEW_USE = "cio_sdk_screen_view_use";
         static final String TRACK_APPLICATION_LIFECYCLE = "cio_sdk_track_application_lifecycle";
         static final String TEST_MODE_ENABLED = "cio_sdk_test_mode";
         static final String IN_APP_MESSAGING_ENABLED = "cio_sdk_in_app_messaging_enabled";
@@ -42,6 +44,7 @@ public class CustomerIOSDKConfig {
                 true,
                 CioLogLevel.DEBUG,
                 Region.US.INSTANCE,
+                ScreenView.Analytics,
                 true,
                 false,
                 true);
@@ -62,6 +65,7 @@ public class CustomerIOSDKConfig {
         boolean deviceAttributesTrackingEnabled = StringUtils.parseBoolean(bundle.get(Keys.TRACK_DEVICE_ATTRIBUTES), defaultConfig.deviceAttributesTrackingEnabled);
         CioLogLevel logLevel = CioLogLevel.Companion.getLogLevel(bundle.get(Keys.LOG_LEVEL), CioLogLevel.DEBUG);
         Region region = Region.Companion.getRegion(bundle.get(Keys.REGION), Region.US.INSTANCE);
+        ScreenView screenViewUse = ScreenView.Companion.getScreenView(bundle.get(Keys.SCREEN_VIEW_USE));
         boolean applicationLifecycleTrackingEnabled = StringUtils.parseBoolean(bundle.get(Keys.TRACK_APPLICATION_LIFECYCLE), defaultConfig.applicationLifecycleTrackingEnabled);
         boolean testModeEnabled = StringUtils.parseBoolean(bundle.get(Keys.TEST_MODE_ENABLED), defaultConfig.testModeEnabled);
         boolean inAppMessagingEnabled = StringUtils.parseBoolean(bundle.get(Keys.IN_APP_MESSAGING_ENABLED), defaultConfig.inAppMessagingEnabled);
@@ -74,6 +78,7 @@ public class CustomerIOSDKConfig {
                 deviceAttributesTrackingEnabled,
                 logLevel,
                 region,
+                screenViewUse,
                 applicationLifecycleTrackingEnabled,
                 testModeEnabled,
                 inAppMessagingEnabled);
@@ -91,6 +96,7 @@ public class CustomerIOSDKConfig {
         bundle.put(Keys.TRACK_DEVICE_ATTRIBUTES, StringUtils.fromBoolean(config.deviceAttributesTrackingEnabled));
         bundle.put(Keys.LOG_LEVEL, config.logLevel.name());
         bundle.put(Keys.REGION, config.getRegion().getCode());
+        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().name());
         bundle.put(Keys.TRACK_APPLICATION_LIFECYCLE, StringUtils.fromBoolean(config.applicationLifecycleTrackingEnabled));
         bundle.put(Keys.TEST_MODE_ENABLED, StringUtils.fromBoolean(config.testModeEnabled));
         bundle.put(Keys.IN_APP_MESSAGING_ENABLED, StringUtils.fromBoolean(config.inAppMessagingEnabled));
@@ -111,6 +117,7 @@ public class CustomerIOSDKConfig {
     private final CioLogLevel logLevel;
     @NonNull
     private final Region region;
+    private final ScreenView screenViewUse;
     private final boolean applicationLifecycleTrackingEnabled;
     private final boolean testModeEnabled;
     private final boolean inAppMessagingEnabled;
@@ -123,6 +130,7 @@ public class CustomerIOSDKConfig {
                                boolean deviceAttributesTrackingEnabled,
                                @NonNull CioLogLevel logLevel,
                                @NonNull Region region,
+                               @NonNull ScreenView screenViewUse,
                                boolean applicationLifecycleTrackingEnabled,
                                boolean testModeEnabled,
                                boolean inAppMessagingEnabled) {
@@ -134,6 +142,7 @@ public class CustomerIOSDKConfig {
         this.deviceAttributesTrackingEnabled = deviceAttributesTrackingEnabled;
         this.logLevel = logLevel;
         this.region = region;
+        this.screenViewUse = screenViewUse;
         this.applicationLifecycleTrackingEnabled = applicationLifecycleTrackingEnabled;
         this.testModeEnabled = testModeEnabled;
         this.inAppMessagingEnabled = inAppMessagingEnabled;
@@ -187,5 +196,10 @@ public class CustomerIOSDKConfig {
     @NonNull
     public Region getRegion() {
         return region;
+    }
+
+    @NonNull
+    public ScreenView getScreenViewUse() {
+        return screenViewUse;
     }
 }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -77,6 +77,7 @@ public class CustomerIORepository {
         builder.trackApplicationLifecycleEvents(sdkConfig.isApplicationLifecycleTrackingEnabled());
         builder.region(sdkConfig.getRegion());
         builder.logLevel(sdkConfig.getLogLevel());
+        builder.screenViewUse(sdkConfig.getScreenViewUse());
     }
 
     public void identify(@NonNull String email, @NonNull Map<String, String> attributes) {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
@@ -137,6 +137,7 @@ public class InternalSettingsActivity extends BaseActivity<ActivityInternalSetti
                 currentSettings.isDeviceAttributesTrackingEnabled(),
                 currentSettings.getLogLevel(),
                 currentSettings.getRegion(),
+                currentSettings.getScreenViewUse(),
                 currentSettings.isApplicationLifecycleTrackingEnabled(),
                 currentSettings.isTestModeEnabled(),
                 currentSettings.isInAppMessagingEnabled()

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -17,6 +17,7 @@ import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.android.sample.java_layout.ui.dashboard.DashboardActivity;
 import io.customer.android.sample.java_layout.utils.OSUtils;
 import io.customer.android.sample.java_layout.utils.ViewUtils;
+import io.customer.datapipelines.config.ScreenView;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -128,6 +129,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         binding.settingsTrackDeviceAttrsValuesGroup.check(getCheckedAutoTrackDeviceAttributesButtonId(config.isDeviceAttributesTrackingEnabled()));
         binding.settingsTrackScreenViewsValuesGroup.check(getCheckedTrackScreenViewsButtonId(config.isScreenTrackingEnabled()));
         binding.settingsTrackAppLifecycleValuesGroup.check(getCheckedTrackAppLifecycleButtonId(config.isApplicationLifecycleTrackingEnabled()));
+        binding.screenViewUseSettingsValuesGroup.check(getCheckedScreenViewUseButtonId(config.getScreenViewUse()));
         binding.settingsLogLevelValuesGroup.check(getCheckedLogLevelButtonId(config.getLogLevel()));
         binding.settingsTestModeValuesGroup.check(getCheckedTestModeButtonId(config.isTestModeEnabled()));
         binding.settingsInAppMessagingValuesGroup.check(getCheckedInAppMessagingButtonId(config.isInAppMessagingEnabled()));
@@ -173,6 +175,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         boolean featInAppMessagingEnabled = binding.settingsInAppMessagingValuesGroup.getCheckedButtonId() == R.id.settings_in_app_messaging_yes_button;
         CioLogLevel logLevel = getSelectedLogLevel();
         Region region = getSelectedRegion();
+        ScreenView screenViewUse = getSelectedScreenViewUse();
 
         return new CustomerIOSDKConfig(cdpApiKey,
                 siteId,
@@ -182,6 +185,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
                 featTrackDeviceAttributes,
                 logLevel,
                 region,
+                screenViewUse,
                 featTrackApplicationLifecycle,
                 featTestModeEnabled,
                 featInAppMessagingEnabled);
@@ -209,6 +213,18 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
             return Region.US.INSTANCE;
         } else if (checkedButton == R.id.settings_region_eu_button) {
             return Region.EU.INSTANCE;
+        }
+        throw new IllegalStateException();
+    }
+
+
+    @NonNull
+    private ScreenView getSelectedScreenViewUse() {
+        int checkedButton = binding.screenViewUseSettingsValuesGroup.getCheckedButtonId();
+        if (checkedButton == R.id.settings_screen_view_use_analytics_button) {
+            return ScreenView.Analytics;
+        } else if (checkedButton == R.id.settings_screen_view_use_in_app_button) {
+            return ScreenView.InApp;
         }
         throw new IllegalStateException();
     }
@@ -254,6 +270,16 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     private int getCheckedRegionButtonId(@NonNull Region region) {
         return region instanceof Region.US ? R.id.settings_region_us_button
                 : R.id.settings_region_eu_button;
+    }
+
+    private int getCheckedScreenViewUseButtonId(@NonNull ScreenView screenViewUse) {
+        switch (screenViewUse) {
+            case InApp:
+                return R.id.settings_screen_view_use_in_app_button;
+            case Analytics:
+            default:
+                return R.id.settings_screen_view_use_analytics_button;
+        }
     }
 
     private boolean updateErrorState(TextInputLayout textInputLayout,

--- a/samples/java_layout/src/main/res/layout/activity_settings.xml
+++ b/samples/java_layout/src/main/res/layout/activity_settings.xml
@@ -235,6 +235,47 @@
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView
+                    android:id="@+id/screen_view_use_settings_label"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="@string/screen_view_use_settings_label"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/settings_track_app_lifecycle_values_group" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/screen_view_use_settings_values_group"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/screen_view_use_settings_label"
+                    app:selectionRequired="true"
+                    app:singleSelection="true">
+
+                    <Button
+                        android:id="@+id/settings_screen_view_use_analytics_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/screen_view_use_settings_analytics" />
+
+                    <Button
+                        android:id="@+id/settings_screen_view_use_in_app_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/screen_view_use_settings_in_app" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <TextView
                     android:id="@+id/settings_features_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -242,7 +283,7 @@
                     android:text="@string/features"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/settings_track_app_lifecycle_values_group" />
+                    app:layout_constraintTop_toBottomOf="@+id/screen_view_use_settings_values_group" />
 
                 <TextView
                     android:id="@+id/settings_in_app_messaging_label"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -82,5 +82,8 @@
     <!--Internal settings screen-->
     <string name="label_internal_settings_activity">InternalSettingsActivity</string>
     <string name="error_url_input_field">This field must be a valid URL</string>
+    <string name="screen_view_use_settings_label">ScreenView use</string>
+    <string name="screen_view_use_settings_analytics">Analytics</string>
+    <string name="screen_view_use_settings_in_app">InApp</string>
 
 </resources>


### PR DESCRIPTION
part of: [MBL-755](https://linear.app/customerio/issue/MBL-755/add-config-to-android-sdk)

### Changes

- Updated Java sample app to allow `screenViewUse` configuration to be modified from the settings page for testing purposes
- Set `screenViewUse` default behavior to align with SDK settings

### Screenshot

![Screenshot_20241213_204504](https://github.com/user-attachments/assets/bd05b4db-ee55-4cb4-a3d0-169733a2fb74)
