### PR TITLE
chore: handle the case of empty identifier

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -194,7 +194,7 @@ class CustomerIO private constructor(
         }
 
         // this is the current userId that is identified in the SDK
-        val currentlyIdentifiedProfile = this.userId
+        val currentlyIdentifiedProfile = this.userId.takeUnless { it.isNullOrBlank() }
         val isChangingIdentifiedProfile = currentlyIdentifiedProfile != null && currentlyIdentifiedProfile != userId
         val isFirstTimeIdentifying = currentlyIdentifiedProfile == null
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -73,6 +73,29 @@ class DataPipelinesInteractionTests : JUnitTest() {
     }
 
     @Test
+    fun identify_givenProfileAttributesAndNoIdentifier_expectSetNewProfileWithoutAttributes() {
+        val givenIdentifier = String.random
+
+        analytics.userId().shouldBeNull()
+        every { globalPreferenceStore.getDeviceToken() } returns String.random
+
+        sdkInstance.profileAttributes = mapOf("first_name" to "Dana", "ageInYears" to 30)
+        analytics.userId() shouldBe ""
+        sdkInstance.identify(givenIdentifier)
+
+        analytics.userId().shouldBeEqualTo(givenIdentifier)
+        analytics.traits().shouldBeEqualTo(emptyJsonObject)
+
+        outputReaderPlugin.identifyEvents.size shouldBeEqualTo 2
+        val identifyEvent = outputReaderPlugin.identifyEvents.lastOrNull()
+        identifyEvent.shouldNotBeNull()
+        identifyEvent.userId.shouldBeEqualTo(givenIdentifier)
+        identifyEvent.traits.shouldBeEqualTo(emptyJsonObject)
+
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
+    }
+
+    @Test
     fun identify_givenIdentifierWithMap_expectSetNewProfileWithAttributes() {
         val givenIdentifier = String.random
         val givenTraits: CustomAttributes = mapOf("first_name" to "Dana", "ageInYears" to 30)


### PR DESCRIPTION
closes: [MBL-738: Android - Handle device registration when switching from profile with empty string/null identifier.](https://linear.app/customerio/issue/MBL-738/android-handle-device-registration-when-switching-from-profile-with)

handles the case, where if profile attributes are added before the identifying the profile, `userId` was set to empty string. 