### PR TITLE
chore: update screenview to sealed class

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -15,18 +15,24 @@ public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : 
 	public final fun getTrackApplicationLifecycleEvents ()Z
 }
 
-public final class io/customer/datapipelines/config/ScreenView : java/lang/Enum {
-	public static final field Analytics Lio/customer/datapipelines/config/ScreenView;
+public abstract class io/customer/datapipelines/config/ScreenView {
 	public static final field Companion Lio/customer/datapipelines/config/ScreenView$Companion;
-	public static final field InApp Lio/customer/datapipelines/config/ScreenView;
-	public static fun valueOf (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
-	public static fun values ()[Lio/customer/datapipelines/config/ScreenView;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class io/customer/datapipelines/config/ScreenView$All : io/customer/datapipelines/config/ScreenView {
+	public static final field INSTANCE Lio/customer/datapipelines/config/ScreenView$All;
 }
 
 public final class io/customer/datapipelines/config/ScreenView$Companion {
 	public final fun getScreenView (Ljava/lang/String;)Lio/customer/datapipelines/config/ScreenView;
 	public final fun getScreenView (Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;)Lio/customer/datapipelines/config/ScreenView;
 	public static synthetic fun getScreenView$default (Lio/customer/datapipelines/config/ScreenView$Companion;Ljava/lang/String;Lio/customer/datapipelines/config/ScreenView;ILjava/lang/Object;)Lio/customer/datapipelines/config/ScreenView;
+}
+
+public final class io/customer/datapipelines/config/ScreenView$InApp : io/customer/datapipelines/config/ScreenView {
+	public static final field INSTANCE Lio/customer/datapipelines/config/ScreenView$InApp;
 }
 
 public final class io/customer/datapipelines/extensions/JsonExtensionsKt {

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -6,11 +6,13 @@ package io.customer.datapipelines.config
 sealed class ScreenView(val name: String) {
     /**
      * Screen view events are sent to destinations for analytics purposes.
+     * They are also used to display in-app messages based on page rules.
      */
     object All : ScreenView(name = "all")
 
     /**
-     * Screen view events are kept on device only. They are used to display in-app messages based on page rules. Events are not sent to our back end servers.
+     * Screen view events are kept on device only. They are used to display in-app messages based on
+     * page rules. Events are not sent to our back end servers.
      */
 
     object InApp : ScreenView(name = "inapp")

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -3,26 +3,34 @@ package io.customer.datapipelines.config
 /**
  * Enum class to define how CustomerIO SDK should handle screen view events.
  */
-enum class ScreenView {
+sealed class ScreenView(val name: String) {
     /**
      * Screen view events are sent to destinations for analytics purposes.
      */
-    Analytics,
+    object All : ScreenView(name = "all")
 
     /**
      * Screen view events are kept on device only. They are used to display in-app messages based on page rules. Events are not sent to our back end servers.
      */
-    InApp;
+
+    object InApp : ScreenView(name = "inapp")
 
     companion object {
         /**
          * Returns the [ScreenView] enum constant for the given name.
          * Returns fallback if the specified enum type has no constant with the given name.
-         * Defaults to [Analytics].
+         * Defaults to [All].
          */
         @JvmOverloads
-        fun getScreenView(screenView: String?, fallback: ScreenView = Analytics): ScreenView {
-            return values().firstOrNull { it.name.equals(screenView, ignoreCase = true) } ?: fallback
+        fun getScreenView(screenView: String?, fallback: ScreenView = All): ScreenView {
+            if (screenView.isNullOrBlank()) {
+                return fallback
+            }
+
+            return listOf(
+                All,
+                InApp
+            ).find { value -> value.name.equals(screenView, ignoreCase = true) } ?: fallback
         }
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ScreenFilterPlugin.kt
@@ -19,7 +19,7 @@ internal class ScreenFilterPlugin(private val screenViewUse: ScreenView) : Event
         // Filter out screen events based on the configuration provided by customer app
         // Using when expression so it enforce right check for all possible values of ScreenView in future
         return when (screenViewUse) {
-            ScreenView.Analytics -> payload
+            ScreenView.All -> payload
             // Do not send screen events to server if ScreenView is not Analytics
             ScreenView.InApp -> null
         }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -71,7 +71,7 @@ class CustomerIOBuilder(
     private var migrationSiteId: String? = null
 
     // Determines how SDK should handle screen view events
-    private var screenViewUse: ScreenView = ScreenView.Analytics
+    private var screenViewUse: ScreenView = ScreenView.All
 
     /**
      * Specifies the log level for the SDK.

--- a/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
@@ -1,0 +1,46 @@
+package io.customer.datapipelines.config
+
+import io.customer.commontest.core.JUnit5Test
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class ScreenViewTest : JUnit5Test() {
+    @Test
+    fun getScreenView_givenNamesWithMatchingCase_expectCorrectScreenView() {
+        val screenViewAnalytics = ScreenView.getScreenView("All")
+        val screenViewInApp = ScreenView.getScreenView("InApp")
+
+        screenViewAnalytics shouldBeEqualTo ScreenView.All
+        screenViewInApp shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenNamesWithDifferentCase_expectCorrectScreenView() {
+        val screenViewAnalytics = ScreenView.getScreenView("all")
+        val screenViewInApp = ScreenView.getScreenView("inapp")
+
+        screenViewAnalytics shouldBeEqualTo ScreenView.All
+        screenViewInApp shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenInvalidValue_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView("none")
+
+        parsedValue shouldBeEqualTo ScreenView.All
+    }
+
+    @Test
+    fun getScreenView_givenEmptyValue_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView(screenView = "", fallback = ScreenView.InApp)
+
+        parsedValue shouldBeEqualTo ScreenView.InApp
+    }
+
+    @Test
+    fun getScreenView_givenNull_expectFallbackScreenView() {
+        val parsedValue = ScreenView.getScreenView(null)
+
+        parsedValue shouldBeEqualTo ScreenView.All
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ScreenFilterPluginTest.kt
@@ -36,7 +36,7 @@ class ScreenFilterPluginTest : JUnitTest() {
 
     @Test
     fun process_givenScreenViewUseAnalytics_expectScreenEventWithoutPropertiesProcessed() {
-        setupWithConfig(screenViewUse = ScreenView.Analytics)
+        setupWithConfig(screenViewUse = ScreenView.All)
 
         val givenScreenTitle = String.random
         sdkInstance.screen(givenScreenTitle)
@@ -48,7 +48,7 @@ class ScreenFilterPluginTest : JUnitTest() {
 
     @Test
     fun process_givenScreenViewUseAnalytics_expectScreenEventWithPropertiesProcessed() {
-        setupWithConfig(screenViewUse = ScreenView.Analytics)
+        setupWithConfig(screenViewUse = ScreenView.All)
 
         val givenScreenTitle = String.random
         val givenProperties: CustomAttributes = mapOf("source" to "push", "discount" to 10)

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -107,7 +107,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
         dataPipelinesModuleConfig.apiHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.cdnHost shouldBe "cdp.customer.io/v1"
         dataPipelinesModuleConfig.autoAddCustomerIODestination shouldBe true
-        dataPipelinesModuleConfig.screenViewUse shouldBe ScreenView.Analytics
+        dataPipelinesModuleConfig.screenViewUse shouldBe ScreenView.All
     }
 
     @Test

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -44,7 +44,7 @@ public class CustomerIOSDKConfig {
                 true,
                 CioLogLevel.DEBUG,
                 Region.US.INSTANCE,
-                ScreenView.Analytics,
+                ScreenView.All.INSTANCE,
                 true,
                 false,
                 true);
@@ -96,7 +96,7 @@ public class CustomerIOSDKConfig {
         bundle.put(Keys.TRACK_DEVICE_ATTRIBUTES, StringUtils.fromBoolean(config.deviceAttributesTrackingEnabled));
         bundle.put(Keys.LOG_LEVEL, config.logLevel.name());
         bundle.put(Keys.REGION, config.getRegion().getCode());
-        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().name());
+        bundle.put(Keys.SCREEN_VIEW_USE, config.getScreenViewUse().getName());
         bundle.put(Keys.TRACK_APPLICATION_LIFECYCLE, StringUtils.fromBoolean(config.applicationLifecycleTrackingEnabled));
         bundle.put(Keys.TEST_MODE_ENABLED, StringUtils.fromBoolean(config.testModeEnabled));
         bundle.put(Keys.IN_APP_MESSAGING_ENABLED, StringUtils.fromBoolean(config.inAppMessagingEnabled));

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -54,6 +54,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
 
     @Override
     protected void setupContent() {
+        prepareViews();
         prepareViewsForAutomatedTests();
         setupViews();
         setupObservers();
@@ -83,6 +84,11 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
             }
         }
         isLinkParamsPopulated = true;
+    }
+
+    private void prepareViews() {
+        binding.settingsScreenViewUseAllButton.setText(ScreenView.All.INSTANCE.getName());
+        binding.settingsScreenViewUseInAppButton.setText(ScreenView.InApp.INSTANCE.getName());
     }
 
     private void prepareViewsForAutomatedTests() {
@@ -221,10 +227,10 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     @NonNull
     private ScreenView getSelectedScreenViewUse() {
         int checkedButton = binding.screenViewUseSettingsValuesGroup.getCheckedButtonId();
-        if (checkedButton == R.id.settings_screen_view_use_analytics_button) {
-            return ScreenView.Analytics;
+        if (checkedButton == R.id.settings_screen_view_use_all_button) {
+            return ScreenView.All.INSTANCE;
         } else if (checkedButton == R.id.settings_screen_view_use_in_app_button) {
-            return ScreenView.InApp;
+            return ScreenView.InApp.INSTANCE;
         }
         throw new IllegalStateException();
     }
@@ -273,13 +279,10 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
     }
 
     private int getCheckedScreenViewUseButtonId(@NonNull ScreenView screenViewUse) {
-        switch (screenViewUse) {
-            case InApp:
-                return R.id.settings_screen_view_use_in_app_button;
-            case Analytics:
-            default:
-                return R.id.settings_screen_view_use_analytics_button;
+        if (screenViewUse instanceof ScreenView.InApp) {
+            return R.id.settings_screen_view_use_in_app_button;
         }
+        return R.id.settings_screen_view_use_all_button;
     }
 
     private boolean updateErrorState(TextInputLayout textInputLayout,

--- a/samples/java_layout/src/main/res/layout/activity_settings.xml
+++ b/samples/java_layout/src/main/res/layout/activity_settings.xml
@@ -259,12 +259,12 @@
                     app:singleSelection="true">
 
                     <Button
-                        android:id="@+id/settings_screen_view_use_analytics_button"
+                        android:id="@+id/settings_screen_view_use_all_button"
                         style="?attr/materialButtonOutlinedStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@string/screen_view_use_settings_analytics" />
+                        tools:text="All" />
 
                     <Button
                         android:id="@+id/settings_screen_view_use_in_app_button"
@@ -272,7 +272,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:text="@string/screen_view_use_settings_in_app" />
+                        tools:text="InApp" />
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -83,7 +83,5 @@
     <string name="label_internal_settings_activity">InternalSettingsActivity</string>
     <string name="error_url_input_field">This field must be a valid URL</string>
     <string name="screen_view_use_settings_label">ScreenView use</string>
-    <string name="screen_view_use_settings_analytics">Analytics</string>
-    <string name="screen_view_use_settings_in_app">InApp</string>
 
 </resources>


### PR DESCRIPTION
part of: [MBL-755](https://linear.app/customerio/issue/MBL-755/add-config-to-android-sdk)

### Changes

- Refactored `ScreenView` from enum to sealed class for greater flexibility in future updates
- Added tests to ensure proper parsing of `ScreenView` from strings
- Updated sample app and relevant tests to align with these changes

### `ScreenView` Options

- `All` -> Sends all screen events to the server (same as before) - Default behavior
- `InApp` -> Retains screen events locally for in-app use only

### Sample Usage

**Kotlin**

```kotlin
CustomerIOBuilder(...)
    .screenViewUse(ScreenView.InApp)
    .build()
```

**Java**

```java
CustomerIOBuilder(...)
    .screenViewUse(ScreenView.InApp.INSTANCE)
    .build()
```