### PR TITLE
chore: Create a plugin that tracks application lifecycle foreground event

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -9,6 +9,7 @@ object Dependencies {
     const val coroutinesAndroid =
         "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.COROUTINES}"
     const val androidxCoreKtx = "androidx.core:core-ktx:${Versions.ANDROIDX_KTX}"
+    const val androidxProcessLifecycle = "androidx.lifecycle:lifecycle-process:${Versions.ANDROIDX_LIFECYCLE_PROCESS}"
     const val androidxAnnotations =
         "androidx.annotation:annotation:${Versions.ANDROIDX_ANNOTATIONS}"
     const val apkScale = "com.twilio:apkscale:${Versions.APK_SCALE}"

--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -9,6 +9,7 @@ object Versions {
     internal const val ANDROIDX_TEST_RULES = "1.4.0"
     internal const val ANDROIDX_APPCOMPAT = "1.3.1"
     internal const val ANDROIDX_KTX = "1.6.0"
+    internal const val ANDROIDX_LIFECYCLE_PROCESS = "2.6.1"
     internal const val ANDROIDX_ANNOTATIONS = "1.2.0"
     internal const val APK_SCALE = "0.1.7"
     internal const val COROUTINES = "1.6.4"

--- a/datapipelines/build.gradle
+++ b/datapipelines/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(":tracking-migration")
 
     implementation(Dependencies.segment)
+    implementation Dependencies.androidxProcessLifecycle
     // Use this as API so customers can provide objects serializations without
     // needing to add it as a dependency to their app
     api(Dependencies.kotlinxSerializationJson)

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPlugin.kt
@@ -1,0 +1,33 @@
+package io.customer.datapipelines.plugins
+
+import android.app.Activity
+import com.segment.analytics.kotlin.android.plugins.AndroidLifecycle
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.platform.Plugin
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Plugin that automatically tracks application lifecycle.
+ *
+ * At the moment, this plugin only tracks 'Application Foregrounded' event because it's the only one missing from Segment SDK
+ */
+internal class AutomaticApplicationLifecycleTrackingPlugin : Plugin, AndroidLifecycle {
+
+    override val type: Plugin.Type = Plugin.Type.Utility
+    override lateinit var analytics: Analytics
+
+    private val startedActivitiesCounter = AtomicInteger(0)
+    private val isChangingConfigurations = AtomicBoolean(false)
+
+    override fun onActivityStarted(activity: Activity?) {
+        if (startedActivitiesCounter.incrementAndGet() == 1 && !isChangingConfigurations.get()) {
+            analytics.track("Application Foregrounded")
+        }
+    }
+
+    override fun onActivityStopped(activity: Activity?) {
+        isChangingConfigurations.set(activity?.isChangingConfigurations == true)
+        startedActivitiesCounter.decrementAndGet() // Return is ignored
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/UiThreadRunner.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/UiThreadRunner.kt
@@ -1,0 +1,13 @@
+package io.customer.datapipelines.util
+
+import android.os.Handler
+import android.os.Looper
+
+internal class UiThreadRunner {
+
+    private val mainThreadHandler = Handler(Looper.getMainLooper())
+
+    fun run(block: () -> Unit) {
+        mainThreadHandler.post(block)
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -18,6 +18,7 @@ import io.customer.datapipelines.extensions.updateAnalyticsConfig
 import io.customer.datapipelines.migration.TrackingMigrationProcessor
 import io.customer.datapipelines.plugins.AutoTrackDeviceAttributesPlugin
 import io.customer.datapipelines.plugins.AutomaticActivityScreenTrackingPlugin
+import io.customer.datapipelines.plugins.AutomaticApplicationLifecycleTrackingPlugin
 import io.customer.datapipelines.plugins.ContextPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.DataPipelinePublishedEvents
@@ -115,6 +116,11 @@ class CustomerIO private constructor(
         if (moduleConfig.autoTrackActivityScreens) {
             analytics.add(AutomaticActivityScreenTrackingPlugin())
         }
+
+        if (moduleConfig.trackApplicationLifecycleEvents) {
+            analytics.add(AutomaticApplicationLifecycleTrackingPlugin())
+        }
+
         // Add auto track device attributes plugin only if enabled in config
         if (moduleConfig.autoTrackDeviceAttributes) {
             analytics.add(AutoTrackDeviceAttributesPlugin())

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
@@ -1,0 +1,92 @@
+package io.customer.datapipelines.plugins
+
+import android.app.Activity
+import com.segment.analytics.kotlin.core.Analytics
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
+
+    private val mockAnalytics = mockk<Analytics>()
+
+    private val subject = AutomaticApplicationLifecycleTrackingPlugin()
+
+    @BeforeEach
+    fun beforeEach() {
+        every { mockAnalytics.track(any()) } just runs
+        subject.setup(mockAnalytics)
+    }
+
+    @Test
+    fun `GIVEN app is closed WHEN app is opened THEN ApplicationForegrounded is tracked`() {
+        simulateAppOpened()
+
+        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    @Test
+    fun `GIVEN app is open WHEN app is put to background THEN ApplicationForegrounded is tracked only once`() {
+        simulateAppOpened()
+        simulateActivityClosing(false)
+
+        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    @Test
+    fun `GIVEN app is open WHEN app is put to background AND reopened THEN ApplicationForegrounded is tracked twice`() {
+        simulateAppOpened()
+        simulateActivityClosing(false)
+        simulateAppOpened()
+
+        verify(exactly = 2) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    @Test
+    fun `GIVEN app is open WHEN configuration changes THEN ApplicationForegrounded is tracked only once`() {
+        simulateAppOpened()
+        simulateConfigurationChange()
+
+        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    @Test
+    fun `GIVEN app is open WHEN configuration changes AND app is put to background THEN ApplicationForegrounded is tracked only once`() {
+        simulateAppOpened()
+        simulateConfigurationChange()
+        simulateActivityClosing(false)
+
+        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    @Test
+    fun `GIVEN app is open WHEN app is reopened after config changes THEN ApplicationForegrounded is tracked twice`() {
+        simulateAppOpened()
+        simulateConfigurationChange()
+        simulateActivityClosing(false)
+        simulateAppOpened()
+
+        verify(exactly = 2) { mockAnalytics.track("Application Foregrounded") }
+    }
+
+    private fun simulateAppOpened() {
+        subject.onActivityStarted(null)
+    }
+
+    private fun simulateActivityClosing(isConfigChanging: Boolean) {
+        val activity = mockk<Activity> {
+            every { isChangingConfigurations } returns isConfigChanging
+        }
+        subject.onActivityStopped(activity)
+    }
+
+    private fun simulateConfigurationChange() {
+        simulateActivityClosing(true)
+        simulateAppOpened()
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
@@ -1,92 +1,95 @@
 package io.customer.datapipelines.plugins
 
-import android.app.Activity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.segment.analytics.kotlin.core.Analytics
+import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.util.UiThreadRunner
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.verify
+import io.mockk.slot
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
 
 class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
 
+    private val mockProcessLifecycleOwner = mockk<LifecycleOwner>()
+    private val mockUiThreadRunner = mockk<UiThreadRunner>()
     private val mockAnalytics = mockk<Analytics>()
+    private val lifecycleObserverCaptor = slot<DefaultLifecycleObserver>()
 
-    private val subject = AutomaticApplicationLifecycleTrackingPlugin()
+    private val subject = AutomaticApplicationLifecycleTrackingPlugin(mockProcessLifecycleOwner, mockUiThreadRunner)
 
     @BeforeEach
     fun beforeEach() {
+        val uiThreadRunnerCaptor = slot<() -> Unit>()
+        every { mockUiThreadRunner.run(capture(uiThreadRunnerCaptor)) } answers { uiThreadRunnerCaptor.captured.invoke() }
+
+        val mockLifecycle = mockk<Lifecycle>()
+        every { mockProcessLifecycleOwner.lifecycle } returns mockLifecycle
+        every { mockLifecycle.addObserver(capture(lifecycleObserverCaptor)) } just runs
+
         every { mockAnalytics.track(any()) } just runs
         subject.setup(mockAnalytics)
     }
 
     @Test
-    fun `GIVEN app is closed WHEN app is opened THEN ApplicationForegrounded is tracked`() {
-        simulateAppOpened()
+    fun `WHEN application lifecycle moves to CREATED THEN Application Foregrounded is NOT tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onCreate(mockk())
 
-        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledNever { mockAnalytics.track("Application Foregrounded") }
     }
 
     @Test
-    fun `GIVEN app is open WHEN app is put to background THEN ApplicationForegrounded is tracked only once`() {
-        simulateAppOpened()
-        simulateActivityClosing(false)
+    fun `WHEN application lifecycle moves to STARTED THEN Application Foregrounded is tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onStart(mockk())
 
-        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledOnce { mockAnalytics.track("Application Foregrounded") }
     }
 
     @Test
-    fun `GIVEN app is open WHEN app is put to background AND reopened THEN ApplicationForegrounded is tracked twice`() {
-        simulateAppOpened()
-        simulateActivityClosing(false)
-        simulateAppOpened()
+    fun `WHEN application lifecycle moves to RESUMED THEN Application Foregrounded is NOT tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onResume(mockk())
 
-        verify(exactly = 2) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledNever { mockAnalytics.track("Application Foregrounded") }
     }
 
     @Test
-    fun `GIVEN app is open WHEN configuration changes THEN ApplicationForegrounded is tracked only once`() {
-        simulateAppOpened()
-        simulateConfigurationChange()
+    fun `WHEN application lifecycle moves to PAUSED THEN Application Foregrounded is NOT tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onPause(mockk())
 
-        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledNever { mockAnalytics.track("Application Foregrounded") }
     }
 
     @Test
-    fun `GIVEN app is open WHEN configuration changes AND app is put to background THEN ApplicationForegrounded is tracked only once`() {
-        simulateAppOpened()
-        simulateConfigurationChange()
-        simulateActivityClosing(false)
+    fun `WHEN application lifecycle moves to STOPPED THEN Application Foregrounded is NOT tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onStop(mockk())
 
-        verify(exactly = 1) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledNever { mockAnalytics.track("Application Foregrounded") }
     }
 
     @Test
-    fun `GIVEN app is open WHEN app is reopened after config changes THEN ApplicationForegrounded is tracked twice`() {
-        simulateAppOpened()
-        simulateConfigurationChange()
-        simulateActivityClosing(false)
-        simulateAppOpened()
+    fun `WHEN application lifecycle moves to DESTROYED THEN Application Foregrounded is NOT tracked`() {
+        ensureLifecycleObserverAdded()
+        lifecycleObserverCaptor.captured.onDestroy(mockk())
 
-        verify(exactly = 2) { mockAnalytics.track("Application Foregrounded") }
+        assertCalledNever { mockAnalytics.track("Application Foregrounded") }
     }
 
-    private fun simulateAppOpened() {
-        subject.onActivityStarted(null)
-    }
-
-    private fun simulateActivityClosing(isConfigChanging: Boolean) {
-        val activity = mockk<Activity> {
-            every { isChangingConfigurations } returns isConfigChanging
+    private fun ensureLifecycleObserverAdded() {
+        if (!lifecycleObserverCaptor.isCaptured) {
+            fail("Lifecycle observer was not added!")
         }
-        subject.onActivityStopped(activity)
-    }
-
-    private fun simulateConfigurationChange() {
-        simulateActivityClosing(true)
-        simulateAppOpened()
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticApplicationLifecycleTrackingPluginTest.kt
@@ -40,7 +40,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to CREATED THEN Application Foregrounded is NOT tracked`() {
+    fun onCreate_expectApplicationForegroundedEventToNotBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onCreate(mockk())
 
@@ -48,7 +48,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to STARTED THEN Application Foregrounded is tracked`() {
+    fun onStart_expectApplicationForegroundedEventToBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onStart(mockk())
 
@@ -56,7 +56,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to RESUMED THEN Application Foregrounded is NOT tracked`() {
+    fun onResume_expectApplicationForegroundedEventToNotBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onResume(mockk())
 
@@ -64,7 +64,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to PAUSED THEN Application Foregrounded is NOT tracked`() {
+    fun onPause_expectApplicationForegroundedEventToNotBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onPause(mockk())
 
@@ -72,7 +72,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to STOPPED THEN Application Foregrounded is NOT tracked`() {
+    fun onStop_expectApplicationForegroundedEventToNotBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onStop(mockk())
 
@@ -80,7 +80,7 @@ class AutomaticApplicationLifecycleTrackingPluginTest : JUnitTest() {
     }
 
     @Test
-    fun `WHEN application lifecycle moves to DESTROYED THEN Application Foregrounded is NOT tracked`() {
+    fun onDestroy_expectApplicationForegroundedEventToNotBeTracked() {
         ensureLifecycleObserverAdded()
         lifecycleObserverCaptor.captured.onDestroy(mockk())
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -76,8 +76,9 @@ class AndroidLifecyclePluginTests : IntegrationTest() {
         val tracks = mutableListOf<TrackEvent>()
         verify { mockPlugin.track(capture(tracks)) }
         // 1. Application Installed
-        // 2. Application Opened
-        assertEquals(2, tracks.size)
+        // 2. Application Foregrounded
+        // 3. Application Opened
+        assertEquals(3, tracks.size)
         with(tracks.last()) {
             assertEquals("Application Opened", event)
             assertEquals(

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/AndroidLifecyclePluginTests.kt
@@ -76,9 +76,8 @@ class AndroidLifecyclePluginTests : IntegrationTest() {
         val tracks = mutableListOf<TrackEvent>()
         verify { mockPlugin.track(capture(tracks)) }
         // 1. Application Installed
-        // 2. Application Foregrounded
-        // 3. Application Opened
-        assertEquals(3, tracks.size)
+        // 2. Application Opened
+        assertEquals(2, tracks.size)
         with(tracks.last()) {
             assertEquals("Application Opened", event)
             assertEquals(


### PR DESCRIPTION
Completes [MBL-526
](https://linear.app/customerio/issue/MBL-526/add-application-foregrounded-lifecycle-event-in-android-sdk)

This PR adds the missing application lifecycle event `Application Foregrounded`.

### Why are we not using `Application.ActivityLifecycleCallbacks`?
Our wrapper SDKs are initialized later in the app lifecycle, so they miss the initial `onCreate()` -> `onStart()` -> `onResume()` for the first activity in the application. That makes `Acitvity` lifecycle callbacks not usable for us.

### Some notes about the implementation
- Our SDKs already pull `AndroidX` lifecycle dependency `2.6.1`, so that's why I choose to include it with that specific version
- In ReactNative the `Plugin#setup()` method is not called on the main thread which causes the `lifecycle#addObserver()` call to not work, that's why I'm explicitly running it on UI thread

### Testing
##### Flutter

https://github.com/user-attachments/assets/ce2cdfd1-1ef3-412c-8fa4-597f14dbaa82

##### RN

https://github.com/user-attachments/assets/10f801cd-abf5-415c-8fa5-1b9181d720f5


Here are some of the events of Fly for the what's going on in the video
<img width="1246" alt="Screenshot 2024-12-26 at 2 54 07 PM" src="https://github.com/user-attachments/assets/8b2a21e5-7fdc-4c3c-9dc8-d965c00dad6a" />
