### PR TITLE
chore: fix instrumentation test re-runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-v2
 
-      # Create AVD and generate snapshot for caching
+      # Create AVD and generate snapshot for caching, let check itt
       - name: Create AVD and generate snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize] # Don't rerun on `edited` to save time
 
 jobs:
   unit-test:
@@ -30,7 +30,7 @@ jobs:
           report_paths: '**/build/test-results/test*/TEST-*.xml'
           fail_on_failure: true
           require_tests: true
-        if: ${{ always() }}
+        if: ${{ always() }} # if running tests fails, we still want to parse the test results
 
   instrumentation-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,36 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    types: [opened, synchronize] # Don't rerun on `edited` to save time
+    types: [opened, synchronize]
 
 jobs:
-  unit-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        module: [messagingpush, messaginginapp, base, datapipelines, core, tracking-migration]
-    name: Unit tests (${{ matrix.module }})
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-android      
-      - name: Run unit tests (${{ matrix.module }})
-        run: ./gradlew :${{ matrix.module }}:runJacocoTestReport
-      - name: Upload code coverage report
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
-        with:
-          fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
-          verbose: true
-          files: ./${{ matrix.module }}/build/reports/jacoco/test/jacocoTestReport.xml,./${{ matrix.module }}/build/reports/jacoco/runJacocoTestReport/runJacocoTestReport.xml
-      - name: Publish test results (${{ matrix.module }})
-        uses: mikepenz/action-junit-report@v4
-        with:
-          report_paths: '**/build/test-results/test*/TEST-*.xml'
-          fail_on_failure: true
-          require_tests: true
-        if: ${{ always() }} # if running tests fails, we still want to parse the test results
-
   instrumentation-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -40,13 +13,12 @@ jobs:
       matrix:
         sample: [kotlin_compose, java_layout]
         api-level: [31]
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-android
 
-      # Cache Gradle dependencies (big speedup)
+      # Cache Gradle dependencies
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v4
         continue-on-error: true
@@ -55,7 +27,7 @@ jobs:
           cache-overwrite-existing: true
           gradle-home-cache-cleanup: true
 
-      # Enable KVM for hardware virtualization
+      # Enable KVM for hardware virtualization (faster emulators)
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -68,45 +40,33 @@ jobs:
         id: avd-cache
         with:
           path: |
-            ~/.android/avd/*
+            ~/.android/avd
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
-      # Step 1: Create AVD + snapshot if cache doesn't exist
-      - name: Create AVD and snapshot (if needed)
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          arch: x86_64
-          force-avd-creation: false        # We'll still check if we have a local system image
-          enable-snapshot: true            # allow saving a snapshot
-          create-snapshot: true            # create it now
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          script: echo "Generated fresh AVD snapshot for caching."
-
-      # Step 2: Boot emulator from snapshot + run tests
+      # Boot emulator (create or reuse AVD) + run instrumentation tests
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          target: google_apis
+          arch: x86_64
+          # force-avd-creation=false means:
+          #   "If an AVD already exists (from cache), use it as-is."
+          #   If there's no AVD, create a new one automatically.
+          force-avd-creation: false
+          ram-size: 4096M
           cores: 3
-          force-avd-creation: false        # re-use existing AVD files from cache
-          enable-snapshot: true            # use the snapshot
-          create-snapshot: false           # no need to create again
           emulator-options: >-
             -no-window
             -gpu swiftshader_indirect
             -noaudio
             -no-boot-anim
-            # Do NOT use -no-snapshot-save if you want to re-use snapshots
-          ram-size: 4096M
-          target: google_apis
-          arch: x86_64
           script: |
             ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest \
               --no-daemon --stacktrace -PuseKsp=true --debug
 
+      # Publish test results
       - name: Publish test results
         uses: mikepenz/action-junit-report@v4
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-v2
 
-      # Create AVD and generate snapshot for caching, let check it
+      # Create AVD and generate snapshot for caching
       - name: Create AVD and generate snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,31 +37,32 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      # Add more samples here as they are added to the project.
       matrix:
         sample: [kotlin_compose, java_layout]
         api-level: [31]
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup-android
 
-      # Cache Gradle dependencies to speed up the build process
+      # Cache Gradle dependencies (big speedup)
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v4
         continue-on-error: true
         timeout-minutes: 5
         with:
-            cache-overwrite-existing: true
-            gradle-home-cache-cleanup: true
+          cache-overwrite-existing: true
+          gradle-home-cache-cleanup: true
 
-      # Enable KVM (Kernel-based Virtual Machine) for better performance by allowing hardware virtualization
+      # Enable KVM for hardware virtualization
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache the Android Virtual Device (AVD) to avoid recreating it each time
+      # Cache the AVD directory
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
@@ -71,31 +72,41 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
-      # Create AVD and generate snapshot for caching if not already cached
-      - name: create AVD and generate snapshot for caching
+      # Step 1: Create AVD + snapshot if cache doesn't exist
+      - name: Create AVD and snapshot (if needed)
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
+          force-avd-creation: false        # We'll still check if we have a local system image
+          enable-snapshot: true            # allow saving a snapshot
+          create-snapshot: true            # create it now
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: echo "Generated fresh AVD snapshot for caching."
 
-      - name: run tests
+      # Step 2: Boot emulator from snapshot + run tests
+      - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           cores: 3
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
+          force-avd-creation: false        # re-use existing AVD files from cache
+          enable-snapshot: true            # use the snapshot
+          create-snapshot: false           # no need to create again
+          emulator-options: >-
+            -no-window
+            -gpu swiftshader_indirect
+            -noaudio
+            -no-boot-anim
+            # Do NOT use -no-snapshot-save if you want to re-use snapshots
           ram-size: 4096M
           target: google_apis
           arch: x86_64
-          # Run the instrumentation tests on the emulator.
-          script: ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true --debug
+          script: |
+            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest \
+              --no-daemon --stacktrace -PuseKsp=true --debug
+
       - name: Publish test results
         uses: mikepenz/action-junit-report@v4
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-v2
+          key: avd-${{ matrix.api-level }}
 
       # Create AVD and generate snapshot for caching
       - name: Create AVD and generate snapshot

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-v2
 
-      # Create AVD and generate snapshot for caching, let check itt
+      # Create AVD and generate snapshot for caching, let check it
       - name: Create AVD and generate snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,33 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [messagingpush, messaginginapp, base, datapipelines, core, tracking-migration]
+    name: Unit tests (${{ matrix.module }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-android
+      - name: Run unit tests (${{ matrix.module }})
+        run: ./gradlew :${{ matrix.module }}:runJacocoTestReport
+      - name: Upload code coverage report
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          files: ./${{ matrix.module }}/build/reports/jacoco/test/jacocoTestReport.xml,./${{ matrix.module }}/build/reports/jacoco/runJacocoTestReport/runJacocoTestReport.xml
+      - name: Publish test results (${{ matrix.module }})
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: '**/build/test-results/test*/TEST-*.xml'
+          fail_on_failure: true
+          require_tests: true
+        if: ${{ always() }}
+
   instrumentation-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -15,58 +42,49 @@ jobs:
         api-level: [31]
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/setup-android
 
-      # Cache Gradle dependencies
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v4
         continue-on-error: true
         timeout-minutes: 5
         with:
-          cache-overwrite-existing: true
-          gradle-home-cache-cleanup: true
+            cache-overwrite-existing: true
+            gradle-home-cache-cleanup: true
 
-      # Enable KVM for hardware virtualization (faster emulators)
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Cache the AVD directory
+      # Modified AVD cache strategy
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
         with:
           path: |
-            ~/.android/avd
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+            ~/.android/avd/*/*.ini
+            ~/.android/avd/*/*.img
+          key: avd-${{ matrix.api-level }}-v1  # Added version suffix to invalidate old caches
 
-      # Boot emulator (create or reuse AVD) + run instrumentation tests
+      # Always create a fresh AVD instance
+      - name: Create AVD
+        run: |
+          echo "no" | avdmanager create avd -n test -k "system-images;android-${{ matrix.api-level }};google_apis;x86_64" --force
+
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          cores: 3
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
+          disable-animations: true
+          ram-size: 4096M
           target: google_apis
           arch: x86_64
-          # force-avd-creation=false means:
-          #   "If an AVD already exists (from cache), use it as-is."
-          #   If there's no AVD, create a new one automatically.
-          force-avd-creation: false
-          ram-size: 4096M
-          cores: 3
-          emulator-options: >-
-            -no-window
-            -gpu swiftshader_indirect
-            -noaudio
-            -no-boot-anim
-          script: |
-            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest \
-              --no-daemon --stacktrace -PuseKsp=true --debug
+          script: ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
-      # Publish test results
       - name: Publish test results
         uses: mikepenz/action-junit-report@v4
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          # Run the instrumentation tests on the emulator.
           script: ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
       - name: Publish test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,31 +58,41 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # Modified AVD cache strategy
+      # Create and cache the AVD
       - name: AVD cache
         uses: actions/cache@v4
         id: avd-cache
         with:
           path: |
-            ~/.android/avd/*/*.ini
-            ~/.android/avd/*/*.img
-          key: avd-${{ matrix.api-level }}-v1  # Added version suffix to invalidate old caches
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}-v2
 
-      # Always create a fresh AVD instance
-      - name: Create AVD
-        run: |
-          echo "no" | avdmanager create avd -n test -k "system-images;android-${{ matrix.api-level }};google_apis;x86_64" --force
+      # Create AVD and generate snapshot for caching
+      - name: Create AVD and generate snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          target: google_apis
+          ram-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
 
+      # Run the actual tests
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          cores: 3
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
-          disable-animations: true
-          ram-size: 4096M
-          target: google_apis
           arch: x86_64
+          target: google_apis
+          ram-size: 4096M
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
       - name: Publish test results


### PR DESCRIPTION
Currently when the PR is created the instrumentation tests would run perfectly, but on any changes to PR causing re-run of action would result in the emulator not booting and resulting in instrumentation tests not being run. 

This PR fixes that issue. 