### PR TITLE
chore: build primary sample app

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -37,6 +37,29 @@ jobs:
         with:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
+      - name: Set Default Firebase Distribution Groups
+        run: |
+          # Define all the possible distribution groups
+          ALL_BUILDS_GROUP="all-builds"
+          FEATURE_BUILDS_GROUP="feature-branch"
+          STABLE_BUILDS_GROUP="next"
+          
+          # Initialize with the default distribution group
+          distribution_groups=("$ALL_BUILDS_GROUP")
+          
+          # Determine current app type and Git context
+          is_primary_app=$([[ "${{ matrix.sample-app }}" == "java_layout" ]] && echo "true" || echo "false")
+          current_branch="${GITHUB_REF}"
+          
+          # Append distribution groups based on branch and context if the app is primary
+          if [[ "$is_primary_app" == "true" ]]; then
+            [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+            [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+          fi
+          
+          # Export the groups as an environment variable
+          echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
+
       - name: Get latest SDK version
         if: ${{ inputs.use_latest_sdk_version == true }}
         id: latest-sdk-version-step
@@ -74,13 +97,32 @@ jobs:
       - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase.
         run: cat $GITHUB_EVENT_PATH
 
+      - name: Prepare Fastlane Build Arguments
+        run: |
+          if [ "${{ inputs.use_latest_sdk_version }}" = "true" ]; then
+            sdk_version="\"sdk_version\":\"${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}\""
+          else
+            sdk_version=""
+          fi
+          
+          distribution_groups="\"distribution_groups\":\"${{ env.firebase_distribution_groups }}\""
+          
+          # Construct the fastlane-build-args JSON
+          if [ -n "$sdk_version" ]; then
+            fastlane_build_args="{${sdk_version},${distribution_groups}}"
+          else
+            fastlane_build_args="{${distribution_groups}}"
+          fi
+          
+          echo "fastlane_build_args=$fastlane_build_args" >> $GITHUB_ENV
+
       - name: Deploy build via Fastlane
         if: ${{ ! (inputs.use_latest_sdk_version == true && matrix.sample-app == 'kotlin_compose') }}
         uses: maierj/fastlane-action@v3.1.0
         with:
           lane: ${{ inputs.use_latest_sdk_version == true && 'android build_sample_app_for_sdk_release' || 'android build' }}
           subdirectory: "samples/${{ matrix.sample-app }}"
-          options: ${{ inputs.use_latest_sdk_version == true && format('{{"sdk_version":"{0}"}}', steps.latest-sdk-version-step.outputs.LATEST_TAG) || '' }}
+          options: ${{ env.fastlane_build_args }}
         env:
           ANDROID_SIGNING_ALIAS: ${{ secrets.ANDROID_SIGNING_ALIAS }}
           ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -43,6 +43,7 @@ jobs:
           ALL_BUILDS_GROUP="all-builds"
           FEATURE_BUILDS_GROUP="feature-branch"
           STABLE_BUILDS_GROUP="next"
+          PUBLIC_BUILDS_GROUP="public"
           
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
@@ -50,11 +51,15 @@ jobs:
           # Determine current app type and Git context
           is_primary_app=$([[ "${{ matrix.sample-app }}" == "java_layout" ]] && echo "true" || echo "false")
           current_branch="${GITHUB_REF}"
+          use_latest_sdk_version="${{ inputs.use_latest_sdk_version }}"
           
           # Append distribution groups based on branch and context if the app is primary
           if [[ "$is_primary_app" == "true" ]]; then
             [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
             [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+            if [[ "$use_latest_sdk_version" == "true" ]]; then
+              distribution_groups+=("$PUBLIC_BUILDS_GROUP")
+            fi
           fi
           
           # Export the groups as an environment variable

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -43,8 +43,8 @@ jobs:
           # Distribution group constants
           ALL_BUILDS_GROUP: all-builds
           FEATURE_BUILDS_GROUP: feature-branch
-          RELEASE_BUILDS_GROUP: public
-          STABLE_BUILDS_GROUP: next
+          NEXT_BUILDS_GROUP: next
+          PUBLIC_BUILDS_GROUP: public
           # Input variables
           IS_PRIMARY_APP: ${{ matrix.sample-app == 'java_layout' }}
           CURRENT_BRANCH: ${{ github.ref }}
@@ -56,8 +56,8 @@ jobs:
           # Append distribution groups based on branch and context if the app is primary
           if [[ "$IS_PRIMARY_APP" == "true" ]]; then
             [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-            [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
-            [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("$RELEASE_BUILDS_GROUP")
+            [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("NEXT_BUILDS_GROUP")
+            [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("PUBLIC_BUILDS_GROUP")
           fi
           
           # Export the groups as an environment variable

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -38,26 +38,26 @@ jobs:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
       - name: Set Default Firebase Distribution Groups
+        shell: bash
+        env:
+          # Distribution group constants
+          ALL_BUILDS_GROUP: all-builds
+          FEATURE_BUILDS_GROUP: feature-branch
+          RELEASE_BUILDS_GROUP: public
+          STABLE_BUILDS_GROUP: next
+          # Input variables
+          IS_PRIMARY_APP: ${{ matrix.sample-app == 'java_layout' }}
+          CURRENT_BRANCH: ${{ github.ref }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
         run: |
-          # Define all the possible distribution groups
-          ALL_BUILDS_GROUP="all-builds"
-          FEATURE_BUILDS_GROUP="feature-branch"
-          STABLE_BUILDS_GROUP="next"
-          PUBLIC_BUILDS_GROUP="public"
-          
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
           
-          # Determine current app type and Git context
-          is_primary_app=$([[ "${{ matrix.sample-app }}" == "java_layout" ]] && echo "true" || echo "false")
-          current_branch="${GITHUB_REF}"
-          use_latest_sdk_version="${{ inputs.use_latest_sdk_version }}"
-          
           # Append distribution groups based on branch and context if the app is primary
-          if [[ "$is_primary_app" == "true" ]]; then
-            [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-            [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
-            [[ "$use_latest_sdk_version" == "true" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
+          if [[ "$IS_PRIMARY_APP" == "true" ]]; then
+            [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+            [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+            [[ "$USE_LATEST_SDK_VERSION" == "true" ]] && distribution_groups+=("$RELEASE_BUILDS_GROUP")
           fi
           
           # Export the groups as an environment variable

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -57,9 +57,7 @@ jobs:
           if [[ "$is_primary_app" == "true" ]]; then
             [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
             [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
-            if [[ "$use_latest_sdk_version" == "true" ]]; then
-              distribution_groups+=("$PUBLIC_BUILDS_GROUP")
-            fi
+            [[ "$use_latest_sdk_version" == "true" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
           fi
           
           # Export the groups as an environment variable

--- a/samples/fastlane/Fastfile
+++ b/samples/fastlane/Fastfile
@@ -1,7 +1,7 @@
 # There are some re-usable functions in other Fastfile files in the org we can re-use. 
 import_from_git(
   url: "https://github.com/customerio/customerio-ios.git", 
-  branch: "rehan/mbl-710-ci-updates",
+  branch: "main",
   path: "Apps/fastlane/Fastfile"
 )
 

--- a/samples/fastlane/Fastfile
+++ b/samples/fastlane/Fastfile
@@ -1,7 +1,7 @@
 # There are some re-usable functions in other Fastfile files in the org we can re-use. 
 import_from_git(
   url: "https://github.com/customerio/customerio-ios.git", 
-  branch: "main", 
+  branch: "rehan/mbl-710-ci-updates",
   path: "Apps/fastlane/Fastfile"
 )
 
@@ -65,7 +65,7 @@ platform :android do
     name_of_sample_app_module = File.basename(path_to_root_directory_sample_app) # just get the name of the directory I am in now. `samples/N`
 
     new_app_version = get_new_app_version().gsub("/", ".")
-    test_groups = get_build_test_groups()
+    test_groups = get_build_test_groups(distribution_groups: values[:distribution_groups])
     app_package_name = CredentialsManager::AppfileConfig.try_fetch_value(:package_name) # get package_name from Appfile
 
     build_sample_app(


### PR DESCRIPTION
part of: [MBL-710](https://linear.app/customerio/issue/MBL-710/single-app-per-platform-distributed-to-firebase)
blocked by: https://github.com/customerio/customerio-ios/pull/847

### Changes

- Updated `Build Sample Apps` action to push only primary app to relevant channels
- Updated `get_build_test_groups` call to pass arguments to match with implementation from iOS repository

Please refer to linked ticket for detailed expectations regarding channel distribution.