### PR TITLE
chore: fix branch name fallback

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -90,15 +90,18 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
           COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
-          touch "samples/local.properties"
-          echo "cdpApiKey=${{ secrets[matrix.cio-cdpapikey-secret-key] }}" >> "samples/local.properties"
-          echo "siteId=${{ secrets[matrix.cio-siteid-secret-key] }}" >> "samples/local.properties"
-          echo "workspace=${{ matrix.cio-workspace-name }}" >> "samples/local.properties"
-          echo "branchName=$BRANCH_NAME" >> "samples/local.properties"
-          echo "commitHash=${COMMIT_HASH:0:7}" >> "samples/local.properties"
-          echo "commitsAheadCount=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)" >> samples/local.properties
+          LOCAL_PROPS_FILE="samples/local.properties"
+          touch "$LOCAL_PROPS_FILE"
+          echo "cdpApiKey=${{ secrets[matrix.cio-cdpapikey-secret-key] }}" >> "$LOCAL_PROPS_FILE"
+          echo "siteId=${{ secrets[matrix.cio-siteid-secret-key] }}" >> "$LOCAL_PROPS_FILE"
+          echo "workspace=${{ matrix.cio-workspace-name }}" >> "$LOCAL_PROPS_FILE"
+          echo "branchName=$BRANCH_NAME" >> "$LOCAL_PROPS_FILE"
+          echo "commitHash=${COMMIT_HASH:0:7}" >> "$LOCAL_PROPS_FILE"
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
+          echo "commitsAheadCount=$COMMITS_AHEAD" >> "$LOCAL_PROPS_FILE"
           if [ "${{ inputs.use_latest_sdk_version == true }}" ]; then
-            echo "sdkVersion=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "samples/local.properties"
+            echo "sdkVersion=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "$LOCAL_PROPS_FILE"
           fi
 
       - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase.

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/buildinfo/BuildInfoMetadata.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/buildinfo/BuildInfoMetadata.java
@@ -34,7 +34,7 @@ public class BuildInfoMetadata {
         this.appVersion = String.valueOf(BuildConfig.VERSION_CODE);
         this.buildDate = BuildInfoMetadataUtils.formatBuildDateWithRelativeTime(BuildConfig.BUILD_TIMESTAMP);
         this.gitMetadata = String.format(Locale.ENGLISH, "%s-%s",
-                BuildInfoMetadataUtils.resolveValidOrElse(BuildConfig.BRANCH_NAME, () -> "working branch"),
+                BuildInfoMetadataUtils.resolveValidOrElse(BuildConfig.BRANCH_NAME, () -> "development build"),
                 BuildInfoMetadataUtils.resolveValidOrElse(BuildConfig.COMMIT_HASH, () -> "untracked"));
         this.defaultWorkspace = BuildInfoMetadataUtils.resolveValidOrElse(BuildConfig.DEFAULT_WORKSPACE);
         this.language = BuildInfoMetadataUtils.resolveValidOrElse(BuildConfig.LANGUAGE);


### PR DESCRIPTION
### Changes

- Fixed fallback value for `branchName` in primary sample app to match with other sample apps
- Updated workflow to add fallback for cases where tags are not fetched properly

### Screenshots

| Before |  After |
|-|-|
| ![img_before](https://github.com/user-attachments/assets/aa3d8cdb-ba43-4079-a25d-a5bffbf51c3d) | ![img_after](https://github.com/user-attachments/assets/3d06b9d7-44a0-459c-a535-d737c5df95f2) |