### PR TITLE
chore: send slack notification on sample app build

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -106,7 +106,7 @@ jobs:
           echo "workspace=${{ matrix.cio-workspace-name }}" >> "$LOCAL_PROPS_FILE"
           echo "branchName=${{ env.BRANCH_NAME }}" >> "$LOCAL_PROPS_FILE"
           echo "commitHash=${{ env.COMMIT_HASH }}" >> "$LOCAL_PROPS_FILE"
-          LAST_TAG="${{ env.LATEST_TAG :- "untagged" }}"
+          LAST_TAG="${LATEST_TAG:-untagged}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "commitsAheadCount=$COMMITS_AHEAD" >> "$LOCAL_PROPS_FILE"
           if [ "${{ inputs.use_latest_sdk_version == true }}" ]; then
@@ -153,7 +153,7 @@ jobs:
         id: determine-sdk-version
         run: |
           sdk_version="${{ env.SDK_VERSION }}"
-          sdk_version="${sdk_version:-${{ env.LATEST_TAG }}}"
+          sdk_version="${sdk_version:-$LATEST_TAG}"
           echo "SDK Version used in app build: $sdk_version"
           echo "APP_SDK_BUILD_VERSION=$sdk_version" >> $GITHUB_ENV
 

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -42,6 +42,7 @@ jobs:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
       - name: Set IS_PRIMARY_APP
+        shell: bash
         run: |
           if [[ "${{ matrix.sample-app }}" == "java_layout" ]]; then
             echo "IS_PRIMARY_APP=true" >> $GITHUB_ENV
@@ -74,13 +75,6 @@ jobs:
           # Export the groups as an environment variable
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
 
-      - name: Get latest SDK version
-        if: ${{ inputs.use_latest_sdk_version == true }}
-        id: latest-sdk-version-step
-        run: |
-          latest_tag=$(git describe --tags --abbrev=0)
-          echo "LATEST_TAG=$latest_tag" >> "$GITHUB_OUTPUT"
-
       - uses: ./.github/actions/setup-android
 
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries.
@@ -94,11 +88,14 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true # cache tools to make builds faster in future
 
-      - name: Set Git Context Variables
+      - name: Capture Git Context
+        shell: bash
+        id: git-context
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
+          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Setup local.properties file for sample app
         run: |
@@ -109,11 +106,11 @@ jobs:
           echo "workspace=${{ matrix.cio-workspace-name }}" >> "$LOCAL_PROPS_FILE"
           echo "branchName=${{ env.BRANCH_NAME }}" >> "$LOCAL_PROPS_FILE"
           echo "commitHash=${{ env.COMMIT_HASH }}" >> "$LOCAL_PROPS_FILE"
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+          LAST_TAG="${{ env.LATEST_TAG :- "untagged" }}"
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "commitsAheadCount=$COMMITS_AHEAD" >> "$LOCAL_PROPS_FILE"
           if [ "${{ inputs.use_latest_sdk_version == true }}" ]; then
-            echo "sdkVersion=${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}" >> "$LOCAL_PROPS_FILE"
+            echo "sdkVersion=${{ env.LATEST_TAG }}" >> "$LOCAL_PROPS_FILE"
           fi
 
       - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase.
@@ -122,7 +119,7 @@ jobs:
       - name: Prepare Fastlane Build Arguments
         run: |
           if [ "${{ inputs.use_latest_sdk_version }}" = "true" ]; then
-            sdk_version="\"sdk_version\":\"${{ steps.latest-sdk-version-step.outputs.LATEST_TAG }}\""
+            sdk_version="\"sdk_version\":\"${{ env.LATEST_TAG }}\""
           else
             sdk_version=""
           fi
@@ -152,11 +149,13 @@ jobs:
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
 
       - name: Determine SDK Version
+        shell: bash
         id: determine-sdk-version
         run: |
-          sdk_version="${{ env.SDK_VERSION || steps.latest-sdk-version-step.outputs.LATEST_TAG }}"
-          echo "Final SDK Version: $sdk_version"
-          echo "SDK_VERSION=$sdk_version" >> $GITHUB_ENV
+          sdk_version="${{ env.SDK_VERSION }}"
+          sdk_version="${sdk_version:-${{ env.LATEST_TAG }}}"
+          echo "SDK Version used in app build: $sdk_version"
+          echo "APP_SDK_BUILD_VERSION=$sdk_version" >> $GITHUB_ENV
 
       - name: Send Slack Notification for Sample App Builds
         if: always() && env.IS_PRIMARY_APP == 'true'
@@ -172,7 +171,7 @@ jobs:
           instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
           platform: "android"
           sdk_name: "Android Native SDK"
-          sdk_version: ${{ env.SDK_VERSION }}
+          sdk_version: ${{ env.APP_SDK_BUILD_VERSION }}
           slack_webhook_url: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
 
       - name: Update sample builds PR comment with build information

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -25,10 +25,12 @@ jobs:
             cio-workspace-name: "Mobile: Native iOS & Android"
             cio-cdpapikey-secret-key: "CUSTOMERIO_JAVA_WORKSPACE_CDP_API_KEY"
             cio-siteid-secret-key: "CUSTOMERIO_JAVA_WORKSPACE_SITE_ID"
+            firebase-app-id-secret-key: "SAMPLE_APPS_JAVA_FIREBASE_APP_ID"
           - sample-app: "kotlin_compose"
             cio-workspace-name: "Mobile: xiOS CocoaPods FCM + Kotlin Android"
             cio-cdpapikey-secret-key: "CUSTOMERIO_KOTLIN_WORKSPACE_CDP_API_KEY"
             cio-siteid-secret-key: "CUSTOMERIO_KOTLIN_WORKSPACE_SITE_ID"
+            firebase-app-id-secret-key: "SAMPLE_APPS_KOTLIN_FIREBASE_APP_ID"
 
     name: Building app...${{ matrix.sample-app }}
     permissions:
@@ -39,6 +41,14 @@ jobs:
         with:
           fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
+      - name: Set IS_PRIMARY_APP
+        run: |
+          if [[ "${{ matrix.sample-app }}" == "java_layout" ]]; then
+            echo "IS_PRIMARY_APP=true" >> $GITHUB_ENV
+          else
+            echo "IS_PRIMARY_APP=false" >> $GITHUB_ENV
+          fi
+
       - name: Set Default Firebase Distribution Groups
         shell: bash
         env:
@@ -48,7 +58,6 @@ jobs:
           NEXT_BUILDS_GROUP: next
           PUBLIC_BUILDS_GROUP: public
           # Input variables
-          IS_PRIMARY_APP: ${{ matrix.sample-app == 'java_layout' }}
           CURRENT_BRANCH: ${{ github.ref }}
           USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
         run: |
@@ -85,18 +94,21 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true # cache tools to make builds faster in future
 
+      - name: Set Git Context Variables
+        run: |
+          echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
+          COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+          echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
+
       - name: Setup local.properties file for sample app
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           LOCAL_PROPS_FILE="samples/local.properties"
           touch "$LOCAL_PROPS_FILE"
           echo "cdpApiKey=${{ secrets[matrix.cio-cdpapikey-secret-key] }}" >> "$LOCAL_PROPS_FILE"
           echo "siteId=${{ secrets[matrix.cio-siteid-secret-key] }}" >> "$LOCAL_PROPS_FILE"
           echo "workspace=${{ matrix.cio-workspace-name }}" >> "$LOCAL_PROPS_FILE"
-          echo "branchName=$BRANCH_NAME" >> "$LOCAL_PROPS_FILE"
-          echo "commitHash=${COMMIT_HASH:0:7}" >> "$LOCAL_PROPS_FILE"
+          echo "branchName=${{ env.BRANCH_NAME }}" >> "$LOCAL_PROPS_FILE"
+          echo "commitHash=${{ env.COMMIT_HASH }}" >> "$LOCAL_PROPS_FILE"
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "commitsAheadCount=$COMMITS_AHEAD" >> "$LOCAL_PROPS_FILE"
@@ -138,6 +150,31 @@ jobs:
           ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
           ANDROID_SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
           FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
+
+      - name: Determine SDK Version
+        id: determine-sdk-version
+        run: |
+          sdk_version="${{ env.SDK_VERSION || steps.latest-sdk-version-step.outputs.LATEST_TAG }}"
+          echo "Final SDK Version: $sdk_version"
+          echo "SDK_VERSION=$sdk_version" >> $GITHUB_ENV
+
+      - name: Send Slack Notification for Sample App Builds
+        if: env.IS_PRIMARY_APP == 'true'
+        uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1
+        with:
+          build_status: ${{ job.status }}
+          app_icon_emoji: ":android:"
+          app_name: "Android Native"
+          firebase_app_id: ${{ secrets[matrix.firebase-app-id-secret-key] }}
+          firebase_distribution_groups: ${{ env.firebase_distribution_groups }}
+          git_context: "${{ env.BRANCH_NAME }} (${{ env.COMMIT_HASH }})"
+          icon_url: "https://media.pocketgamer.com/artwork/na-qulrguj/android.jpg"
+          instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
+          platform: "android"
+          repository_name: "Android"
+          sdk_name: "Android Native SDK"
+          sdk_version: ${{ env.SDK_VERSION }}
+          slack_webhook_url: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
 
       - name: Update sample builds PR comment with build information
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -159,7 +159,7 @@ jobs:
           echo "SDK_VERSION=$sdk_version" >> $GITHUB_ENV
 
       - name: Send Slack Notification for Sample App Builds
-        if: env.IS_PRIMARY_APP == 'true'
+        if: always() && env.IS_PRIMARY_APP == 'true'
         uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1
         with:
           build_status: ${{ job.status }}
@@ -171,7 +171,6 @@ jobs:
           icon_url: "https://media.pocketgamer.com/artwork/na-qulrguj/android.jpg"
           instructions_guide_link: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
           platform: "android"
-          repository_name: "Android"
           sdk_name: "Android Native SDK"
           sdk_version: ${{ env.SDK_VERSION }}
           slack_webhook_url: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -158,7 +158,7 @@ jobs:
           echo "APP_SDK_BUILD_VERSION=$sdk_version" >> $GITHUB_ENV
 
       - name: Send Slack Notification for Sample App Builds
-        if: always() && env.IS_PRIMARY_APP == 'true'
+        if: ${{ always() && env.IS_PRIMARY_APP == 'true' }}
         uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1
         with:
           build_status: ${{ job.status }}

--- a/samples/fastlane/Fastfile
+++ b/samples/fastlane/Fastfile
@@ -32,7 +32,9 @@ private_lane :build_sample_app do |options|
 
     if !options.key?(:sdk_version)
         UI.important("Updating the SDK's source code version to non-production version. This allows the sample apps to show the SDK version at runtime for app user to better understand the version of the SDK they are running.")
-        sh("../../../scripts/update-version.sh \"#{new_app_version}.#{new_build_number}\"")
+        new_sdk_version = "#{new_app_version}.#{new_build_number}"
+        sh("../../../scripts/update-version.sh \"#{new_sdk_version}\"")
+        sh("echo 'SDK_VERSION=#{new_sdk_version}' >> $GITHUB_ENV")
     end
 
     build_android_app(


### PR DESCRIPTION
part of: [MBL-750](https://linear.app/customerio/issue/MBL-750/slack-notifications-on-new-builds)

### Changes

- Integrated common GitHub Action to send slack notifications when a sample app build completes
- Updated relevant GitHub Action and lane to extract necessary values for triggering the notification

**_Example messages can be seen in slack channels used for notifications_**