### PR TITLE
fix: support null handling in nested structures

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/extensions/JsonExtensions.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/extensions/JsonExtensions.kt
@@ -43,3 +43,16 @@ private fun Any?.toSerializableJson(): JsonElement {
         else -> this.toJsonElement()
     }
 }
+
+/**
+ * Recursively replaces all `null` values in nested structure with [JsonNull],
+ * preserving structure and type. Useful for safely converting to `JsonElement`
+ * using `Any.toJsonElement()` extension.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun <T> T?.sanitizeNullsForJson(): T = when (this) {
+    null -> JsonNull as T
+    is Map<*, *> -> this.mapValues { (_, v) -> v.sanitizeNullsForJson() } as T
+    is List<*> -> this.map { it.sanitizeNullsForJson() } as T
+    else -> this
+}

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -187,7 +187,7 @@ class CustomerIO private constructor(
             if (identifier != null) {
                 identify(userId = identifier, traits = value)
             } else {
-                logger.debug("No user profile found, updating traits for anonymous user ${analytics.anonymousId()}")
+                logger.debug("No user profile found, updating sanitized traits for anonymous user ${analytics.anonymousId()}")
                 analytics.identify(traits = value.sanitizeNullsForJson())
             }
         }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -13,6 +13,7 @@ import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.di.analyticsFactory
 import io.customer.datapipelines.extensions.asMap
+import io.customer.datapipelines.extensions.sanitizeNullsForJson
 import io.customer.datapipelines.extensions.type
 import io.customer.datapipelines.extensions.updateAnalyticsConfig
 import io.customer.datapipelines.migration.TrackingMigrationProcessor
@@ -187,7 +188,7 @@ class CustomerIO private constructor(
                 identify(userId = identifier, traits = value)
             } else {
                 logger.debug("No user profile found, updating traits for anonymous user ${analytics.anonymousId()}")
-                analytics.identify(traits = value)
+                analytics.identify(traits = value.sanitizeNullsForJson())
             }
         }
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -67,7 +67,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun identify(userId: String, traits: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        identify(userId = userId, traits = traits.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -89,7 +89,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<Traits>
     ) {
         synchronized {
-            identifyImpl(userId, traits, serializationStrategy)
+            identifyImpl(userId, traits.sanitizeNullsForJson(), serializationStrategy)
         }
     }
 
@@ -131,7 +131,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun track(name: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        track(name = name, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -152,7 +152,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<T>
     ) {
         synchronized {
-            trackImpl(name, properties, serializationStrategy)
+            trackImpl(name, properties.sanitizeNullsForJson(), serializationStrategy)
         }
     }
 
@@ -204,7 +204,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun screen(title: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(title = title, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -220,7 +220,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<T>
     ) {
         synchronized {
-            screenImpl(title, properties, serializationStrategy)
+            screenImpl(title, properties.sanitizeNullsForJson(), serializationStrategy)
         }
     }
 

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -2,6 +2,7 @@ package io.customer.sdk
 
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
+import io.customer.datapipelines.extensions.sanitizeNullsForJson
 import io.customer.sdk.data.model.CustomAttributes
 import io.customer.sdk.events.TrackMetric
 import kotlinx.serialization.SerializationStrategy
@@ -66,7 +67,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun identify(userId: String, traits: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        identify(userId = userId, traits = traits.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -130,7 +131,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun track(name: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        track(name = name, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -203,7 +204,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     fun screen(title: String, properties: CustomAttributes) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        screen(title = title, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -65,9 +65,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits Map of <String, Any> to be added
      */
-    fun identify(userId: String, traits: CustomAttributes) {
+    fun identify(userId: String, traits: Map<String, Any?>) {
         // Method needed for Java interop as inline doesn't work with Java
-        identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        identify(userId = userId, traits = traits.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -89,7 +89,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<Traits>
     ) {
         synchronized {
-            identifyImpl(userId, traits.sanitizeNullsForJson(), serializationStrategy)
+            identifyImpl(userId, traits, serializationStrategy)
         }
     }
 
@@ -129,9 +129,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Map of <String, Any> to be added
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
-    fun track(name: String, properties: CustomAttributes) {
+    fun track(name: String, properties: Map<String, Any?>) {
         // Method needed for Java interop as inline doesn't work with Java
-        track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        track(name = name, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -152,7 +152,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<T>
     ) {
         synchronized {
-            trackImpl(name, properties.sanitizeNullsForJson(), serializationStrategy)
+            trackImpl(name, properties, serializationStrategy)
         }
     }
 
@@ -202,9 +202,9 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen in Map <String, Any> format.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    fun screen(title: String, properties: CustomAttributes) {
+    fun screen(title: String, properties: Map<String, Any?>) {
         // Method needed for Java interop as inline doesn't work with Java
-        screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
+        screen(title = title, properties = properties.sanitizeNullsForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
     /**
@@ -220,7 +220,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
         serializationStrategy: SerializationStrategy<T>
     ) {
         synchronized {
-            screenImpl(title, properties.sanitizeNullsForJson(), serializationStrategy)
+            screenImpl(title, properties, serializationStrategy)
         }
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
@@ -6,11 +6,14 @@ import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.data.model.CustomAttributes
 import io.mockk.every
 import io.mockk.mockkConstructor
 import okio.IOException
 import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
 /**
@@ -61,5 +64,70 @@ class CustomerIODestinationTest : JUnitTest() {
         val integrations = configuration.defaultSettings?.integrations
         integrations shouldNotBe null
         (integrations?.contains(CUSTOMER_IO_DATA_PIPELINES) ?: false) shouldBe true
+    }
+
+    @Test
+    fun givenComplexEventWithNestedNulls_expectSuccessfulEventProcessingThroughDestination() {
+        // Create an event with complex nested structure containing nulls
+        val eventName = "complex_event"
+        val properties: CustomAttributes = mapOf(
+            "customer" to mapOf(
+                "id" to 123,
+                "name" to "Test Customer",
+                "account" to mapOf(
+                    "type" to "premium",
+                    "paymentMethod" to null, // Null at deeper level
+                    "details" to mapOf(
+                        "active" to true,
+                        "lastPaymentDate" to null // Another null at even deeper level
+                    )
+                ),
+                "preferences" to null // Null at second level
+            ),
+            "products" to listOf(
+                mapOf("id" to 1, "name" to "Product A", "variants" to null), // Null in list item
+                mapOf(
+                    "id" to 2,
+                    "name" to "Product B",
+                    "variants" to listOf(
+                        mapOf("color" to "red", "size" to null), // Null in nested list item
+                        null // Null list item in nested list
+                    )
+                ),
+                null // Null list item
+            )
+        )
+
+        // Track event with complex properties containing nulls
+        sdkInstance.track(eventName, properties)
+
+        // Verify the event was processed successfully
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
+        val event = outputReaderPlugin.trackEvents.first()
+        event.shouldNotBeNull()
+        event.event shouldBeEqualTo eventName
+
+        // Verify the nested structures were preserved
+        val customer = event.properties["customer"] as? Map<*, *>
+        customer.shouldNotBeNull()
+
+        val account = customer["account"] as? Map<*, *>
+        account.shouldNotBeNull()
+
+        val details = account["details"] as? Map<*, *>
+        details.shouldNotBeNull()
+
+        // Verify the list was properly processed
+        val products = event.properties["products"] as? List<*>
+        products.shouldNotBeNull()
+        products.size shouldBeEqualTo 3
+
+        // Verify an item with a nested list was processed correctly
+        val productB = products[1] as? Map<*, *>
+        productB.shouldNotBeNull()
+
+        val variants = productB["variants"] as? List<*>
+        variants.shouldNotBeNull()
+        variants.size shouldBeEqualTo 2
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/util/SanitizeNullsForJsonTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/util/SanitizeNullsForJsonTest.kt
@@ -1,0 +1,68 @@
+package io.customer.datapipelines.util
+
+import io.customer.datapipelines.extensions.sanitizeNullsForJson
+import io.customer.datapipelines.testutils.core.JUnitTest
+import kotlinx.serialization.json.JsonNull
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class SanitizeNullsForJsonTest : JUnitTest() {
+    @Test
+    fun sanitize_givenNull_expectJsonNull() {
+        val input: String? = null
+        val expected = JsonNull
+        input.sanitizeNullsForJson() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun sanitize_givenFlatMapWithNull_expectJsonNullReplacement() {
+        val input = mapOf("a" to 1, "b" to null)
+        val expected = mapOf("a" to 1, "b" to JsonNull)
+        input.sanitizeNullsForJson() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun sanitize_givenNestedMapWithNull_expectJsonNullReplacement() {
+        val input = mapOf("meta" to mapOf("os" to "android", "root" to false, "vendor" to null, "version" to 13))
+        val expected = mapOf("meta" to mapOf("os" to "android", "root" to false, "vendor" to JsonNull, "version" to 13))
+        input.sanitizeNullsForJson() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun sanitize_givenListWithNull_expectJsonNullReplacement() {
+        val input = listOf("a", null, "b")
+        val expected = listOf("a", JsonNull, "b")
+        input.sanitizeNullsForJson() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun sanitize_givenNestedStructureWithNull_expectJsonNullReplacement() {
+        val input = mapOf(
+            "maps" to listOf(
+                mapOf("key" to null),
+                mapOf("key" to "value")
+            ),
+            "colors" to listOf("red", null, "blue")
+        )
+        val expected = mapOf(
+            "maps" to listOf(
+                mapOf("key" to JsonNull),
+                mapOf("key" to "value")
+            ),
+            "colors" to listOf("red", JsonNull, "blue")
+        )
+        input.sanitizeNullsForJson() shouldBeEqualTo expected
+    }
+
+    @Test
+    fun sanitize_givenMapWithoutNull_expectReturnSameStructure() {
+        val input = mapOf("x" to 42, "y" to "hello")
+        input.sanitizeNullsForJson() shouldBeEqualTo input
+    }
+
+    @Test
+    fun sanitize_givenListWithoutNull_expectReturnSameStructure() {
+        val input = listOf("apple", "banana", "cherry")
+        input.sanitizeNullsForJson() shouldBeEqualTo input
+    }
+}


### PR DESCRIPTION
closes: [MBL-955](https://linear.app/customerio/issue/MBL-955/[bug]-passing-nested-null-attribute-crashes-android-in-react-native)

### Changes

- Added `sanitizeNullsForJson()` extension to recursively replace all `null` values with `JsonNull` in `CustomAttributes` for `Map` and `List` before forwarding to `analytics`
- Added unit tests to validate the behavior of new extension
- Added tests on `CustomerIO.instance` to validate end-to-end behavior
- Updated Datapipeline method to cater `Map<String,Any?>` so they can cater cases of both, `CustomeAttribute` and `mapof type <string, any?>` 
 
#### Sample Code

Crash on `main` before this fix:

```kotlin
CustomerIO.instance().track(
    "Add to Cart",
    mapOf(
        "item" to mapOf(
            "id" to "100",
            "name" to "Mobile",
            "discount" to null,
        ),
    )
)
```