### PR TITLE
refactor: rename GistView to base in-app view

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -35,7 +35,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp$Companion {
 }
 
 public final class io/customer/messaginginapp/databinding/ActivityGistBinding : androidx/viewbinding/ViewBinding {
-	public final field gistView Lio/customer/messaginginapp/gist/presentation/GistView;
+	public final field gistView Lio/customer/messaginginapp/ui/ModalInAppMessageView;
 	public final field modalGistViewLayout Landroid/widget/RelativeLayout;
 	public static fun bind (Landroid/view/View;)Lio/customer/messaginginapp/databinding/ActivityGistBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
@@ -154,12 +154,12 @@ public abstract interface class io/customer/messaginginapp/gist/presentation/Gis
 	public abstract fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
 }
 
-public final class io/customer/messaginginapp/gist/presentation/GistModalActivity : androidx/appcompat/app/AppCompatActivity, io/customer/messaginginapp/gist/presentation/GistViewListener, io/customer/sdk/tracking/TrackableScreen {
+public final class io/customer/messaginginapp/gist/presentation/GistModalActivity : androidx/appcompat/app/AppCompatActivity, io/customer/messaginginapp/ui/InAppMessageViewEventsListener, io/customer/sdk/tracking/TrackableScreen {
 	public static final field Companion Lio/customer/messaginginapp/gist/presentation/GistModalActivity$Companion;
 	public fun <init> ()V
 	public fun finish ()V
 	public fun getScreenName ()Ljava/lang/String;
-	public fun onGistViewSizeChanged (II)V
+	public fun onViewSizeChanged (II)V
 }
 
 public final class io/customer/messaginginapp/gist/presentation/GistModalActivity$Companion {
@@ -185,32 +185,6 @@ public final class io/customer/messaginginapp/gist/presentation/GistSdk : io/cus
 	public fun reset ()V
 	public fun setCurrentRoute (Ljava/lang/String;)V
 	public fun setUserId (Ljava/lang/String;)V
-}
-
-public final class io/customer/messaginginapp/gist/presentation/GistView : android/widget/FrameLayout, io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener {
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun bootstrapped ()V
-	public fun error ()V
-	public final fun getListener ()Lio/customer/messaginginapp/gist/presentation/GistViewListener;
-	public final fun getLogger ()Lio/customer/sdk/core/util/Logger;
-	public fun routeChanged (Ljava/lang/String;)V
-	public fun routeError (Ljava/lang/String;)V
-	public fun routeLoaded (Ljava/lang/String;)V
-	public final fun setListener (Lio/customer/messaginginapp/gist/presentation/GistViewListener;)V
-	public final fun setup (Lio/customer/messaginginapp/gist/data/model/Message;)V
-	public fun sizeChanged (DD)V
-	public final fun stopLoading ()V
-	public fun tap (Ljava/lang/String;Ljava/lang/String;Z)V
-}
-
-public abstract interface class io/customer/messaginginapp/gist/presentation/GistViewListener {
-	public abstract fun onGistViewSizeChanged (II)V
-}
-
-public final class io/customer/messaginginapp/gist/presentation/GistViewListener$DefaultImpls {
-	public static fun onGistViewSizeChanged (Lio/customer/messaginginapp/gist/presentation/GistViewListener;II)V
 }
 
 public final class io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -20,6 +20,7 @@ import io.customer.messaginginapp.gist.utilities.ModalAnimationUtil
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.state.MessageState
+import io.customer.messaginginapp.ui.InAppMessageViewEventsListener
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.tracking.TrackableScreen
 import kotlinx.coroutines.Job
@@ -27,7 +28,7 @@ import kotlinx.coroutines.Job
 const val GIST_MESSAGE_INTENT: String = "GIST_MESSAGE"
 const val GIST_MODAL_POSITION_INTENT: String = "GIST_MODAL_POSITION"
 
-class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen {
+class GistModalActivity : AppCompatActivity(), InAppMessageViewEventsListener, TrackableScreen {
     private lateinit var binding: ActivityGistBinding
     private var elapsedTimer: ElapsedTimer = ElapsedTimer()
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
@@ -193,7 +194,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
         finish()
     }
 
-    override fun onGistViewSizeChanged(width: Int, height: Int) {
+    override fun onViewSizeChanged(width: Int, height: Int) {
         logger.debug("GistModelActivity Size changed: $width x $height")
         val params = binding.gistView.layoutParams
         params.height = height

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageBaseView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageBaseView.kt
@@ -1,4 +1,4 @@
-package io.customer.messaginginapp.gist.presentation
+package io.customer.messaginginapp.ui
 
 import android.content.ActivityNotFoundException
 import android.content.Context
@@ -22,16 +22,23 @@ import io.customer.sdk.core.di.SDKComponent
 import java.net.URI
 import java.nio.charset.StandardCharsets
 
-class GistView @JvmOverloads constructor(
+/**
+ * Base view class for displaying in-app messages. This class is responsible for managing common
+ * in-app message functionality, such as setting up the EngineWebView, handling tap events, etc.
+ * This class will be extended by specific in-app message views (e.g., ModalInAppMessageView)
+ * to handle specific message types.
+ */
+internal abstract class InAppMessageBaseView @JvmOverloads constructor(
     context: Context,
-    attrs: AttributeSet? = null
-) : FrameLayout(context, attrs), EngineWebViewListener {
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr), EngineWebViewListener {
 
     private var engineWebView: EngineWebView? = EngineWebView(context)
     private var currentMessage: Message? = null
     private var currentRoute: String? = null
     private var firstLoad: Boolean = true
-    var listener: GistViewListener? = null
+    var listener: InAppMessageViewEventsListener? = null
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
     val logger = SDKComponent.logger
     private val store: InAppMessagingState
@@ -184,14 +191,10 @@ class GistView @JvmOverloads constructor(
 
     override fun sizeChanged(width: Double, height: Double) {
         logger.debug("GistView Size changed: $width x $height")
-        listener?.onGistViewSizeChanged(getSizeBasedOnDPI(width.toInt()), getSizeBasedOnDPI(height.toInt()))
+        listener?.onViewSizeChanged(getSizeBasedOnDPI(width.toInt()), getSizeBasedOnDPI(height.toInt()))
     }
 
     private fun getSizeBasedOnDPI(size: Int): Int {
         return size * context.resources.displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT
     }
-}
-
-interface GistViewListener {
-    fun onGistViewSizeChanged(width: Int, height: Int) {}
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewEventsListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewEventsListener.kt
@@ -1,0 +1,8 @@
+package io.customer.messaginginapp.ui
+
+/**
+ * Listener interface to send events from the InAppMessageHostView to the host activity or fragment.
+ */
+internal interface InAppMessageViewEventsListener {
+    fun onViewSizeChanged(width: Int, height: Int) {}
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
@@ -1,0 +1,14 @@
+package io.customer.messaginginapp.ui
+
+import android.content.Context
+import android.util.AttributeSet
+
+/**
+ * Final implementation of the InAppMessageHostView for displaying modal in-app messages.
+ * The view should be directly added to activity layout for displaying modal in-app messages.
+ */
+internal class ModalInAppMessageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : InAppMessageBaseView(context, attrs, defStyleAttr)

--- a/messaginginapp/src/main/res/layout/activity_gist.xml
+++ b/messaginginapp/src/main/res/layout/activity_gist.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:visibility="gone"
     android:alpha="0">
-    <io.customer.messaginginapp.gist.presentation.GistView
+    <io.customer.messaginginapp.ui.ModalInAppMessageView
         android:id="@+id/gistView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION
part of: [MBL-1027](https://linear.app/customerio/issue/MBL-1027/refactor-gistview-for-modal-and-inline-in-app-message-reuse)

### Changes

- Removed `Gist` naming convention from base views and listeners related to in-app message display:
  - Renamed `GistView` to `InAppMessageBaseView` - an abstract base class for both modal and inline in-app messages
  - Renamed `GistViewListener` to `InAppMessageViewEventsListener` for clarity
- Added `ModalInAppMessageView` as final view class for displaying and managing modal in-app message logic
- Replaced `GistView` with `ModalInAppMessageView` and used it for displaying modal in-app messages (no functional changes)