### PR TITLE
refactor: base in-app message view

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -72,7 +72,7 @@ class GistModalActivity : AppCompatActivity(), InAppMessageViewEventsListener, T
             logger.debug("GistModelActivity onCreate: $parsedMessage")
             parsedMessage.let { message ->
                 elapsedTimer.start("Displaying modal for message: ${message.messageId}")
-                binding.gistView.listener = this
+                binding.gistView.eventsListener = this
                 binding.gistView.setup(message)
                 val messagePosition = if (modalPositionStr == null) {
                     message.gistProperties.position

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewExtensions.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewExtensions.kt
@@ -1,0 +1,7 @@
+package io.customer.messaginginapp.ui
+
+import android.util.DisplayMetrics
+
+internal fun InAppMessageBaseView.getSizeBasedOnDPI(size: Int): Int {
+    return size * context.resources.displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
@@ -2,6 +2,7 @@ package io.customer.messaginginapp.ui
 
 import android.content.Context
 import android.util.AttributeSet
+import io.customer.messaginginapp.state.InAppMessagingAction
 
 /**
  * Final implementation of the InAppMessageHostView for displaying modal in-app messages.
@@ -11,4 +12,21 @@ internal class ModalInAppMessageView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : InAppMessageBaseView(context, attrs, defStyleAttr)
+) : InAppMessageBaseView(context, attrs, defStyleAttr) {
+    private var isMessageDisplayed: Boolean = true
+
+    init {
+        attachEngineWebView()
+    }
+
+    override fun routeLoaded(route: String) {
+        super.routeLoaded(route)
+        if (!isMessageDisplayed) return
+
+        isMessageDisplayed = false
+        engineWebView?.alpha = 1.0f
+        currentMessage?.let { message ->
+            inAppMessagingManager.dispatch(InAppMessagingAction.DisplayMessage(message))
+        }
+    }
+}


### PR DESCRIPTION
part of: [MBL-1027](https://linear.app/customerio/issue/MBL-1027/refactor-gistview-for-modal-and-inline-in-app-message-reuse)

### Changes

- Renamed `listener` to `eventsListener` in `InAppMessageBaseView` for clarity and to avoid confusion with `listener` in `EngineWebView`
- Cleaned up and reorganized code in `InAppMessageBaseView` to simplify structure and reduce lint warnings
- Moved the following functionality to final child class `ModalInAppMessageView`:
  - Setting up `EngineWebView` during view initialization
  - `routeLoaded` logic for updating alpha
  - Remaining logic will be gradually moved to child classes as needed
- No other intentional logic changes in `InAppMessageBaseView`