### PR TITLE
chore: added state for embedded

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -126,6 +126,7 @@ public final class io/customer/messaginginapp/gist/data/model/Message {
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lio/customer/messaginginapp/gist/data/model/Message;
 	public static synthetic fun copy$default (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/messaginginapp/gist/data/model/Message;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElementId ()Ljava/lang/String;
 	public final fun getGistProperties ()Lio/customer/messaginginapp/gist/data/model/GistProperties;
 	public final fun getInstanceId ()Ljava/lang/String;
 	public final fun getMessageId ()Ljava/lang/String;
@@ -133,6 +134,7 @@ public final class io/customer/messaginginapp/gist/data/model/Message {
 	public final fun getProperties ()Ljava/util/Map;
 	public final fun getQueueId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun isEmbedded ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -234,6 +236,21 @@ public final class io/customer/messaginginapp/gist/utilities/ElapsedTimer {
 	public final fun start (Ljava/lang/String;)V
 }
 
+public final class io/customer/messaginginapp/state/EmbeddedMessagesState {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addMessage (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)Lio/customer/messaginginapp/state/EmbeddedMessagesState;
+	public final fun allMessages ()Ljava/util/List;
+	public final fun copy (Ljava/util/Map;)Lio/customer/messaginginapp/state/EmbeddedMessagesState;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/EmbeddedMessagesState;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/messaginginapp/state/EmbeddedMessagesState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage (Ljava/lang/String;)Lio/customer/messaginginapp/state/InlineMessageState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun updateMessageState (Ljava/lang/String;Lio/customer/messaginginapp/state/InlineMessageState;)Lio/customer/messaginginapp/state/EmbeddedMessagesState;
+}
+
 public final class io/customer/messaginginapp/state/InAppMessageReducerKt {
 	public static final fun getInAppMessagingReducer ()Lkotlin/jvm/functions/Function2;
 }
@@ -272,15 +289,13 @@ public final class io/customer/messaginginapp/state/InAppMessagingAction$Display
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/customer/messaginginapp/state/InAppMessagingAction$EmbedMessage : io/customer/messaginginapp/state/InAppMessagingAction {
-	public fun <init> (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
-	public final fun component1 ()Lio/customer/messaginginapp/gist/data/model/Message;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessage;
-	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessage;Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessage;
+public final class io/customer/messaginginapp/state/InAppMessagingAction$EmbedMessages : io/customer/messaginginapp/state/InAppMessagingAction {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessages;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessages;Ljava/util/List;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InAppMessagingAction$EmbedMessages;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getElementId ()Ljava/lang/String;
-	public final fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public final fun getMessages ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -430,35 +445,79 @@ public final class io/customer/messaginginapp/state/InAppMessagingManager {
 
 public final class io/customer/messaginginapp/state/InAppMessagingState {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Ljava/util/Set;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Lio/customer/messaginginapp/state/EmbeddedMessagesState;Ljava/util/Set;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Lio/customer/messaginginapp/state/EmbeddedMessagesState;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/customer/messaginginapp/gist/GistEnvironment;
 	public final fun component4 ()J
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lio/customer/messaginginapp/state/MessageState;
-	public final fun component8 ()Ljava/util/Set;
+	public final fun component8 ()Lio/customer/messaginginapp/state/EmbeddedMessagesState;
 	public final fun component9 ()Ljava/util/Set;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Ljava/util/Set;Ljava/util/Set;)Lio/customer/messaginginapp/state/InAppMessagingState;
-	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InAppMessagingState;Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InAppMessagingState;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Lio/customer/messaginginapp/state/EmbeddedMessagesState;Ljava/util/Set;Ljava/util/Set;)Lio/customer/messaginginapp/state/InAppMessagingState;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InAppMessagingState;Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;JLjava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/state/MessageState;Lio/customer/messaginginapp/state/EmbeddedMessagesState;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InAppMessagingState;
+	public final fun diff (Lio/customer/messaginginapp/state/InAppMessagingState;)Ljava/util/Map;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCurrentMessageState ()Lio/customer/messaginginapp/state/MessageState;
 	public final fun getCurrentRoute ()Ljava/lang/String;
 	public final fun getDataCenter ()Ljava/lang/String;
+	public final fun getEmbeddedMessagesState ()Lio/customer/messaginginapp/state/EmbeddedMessagesState;
 	public final fun getEnvironment ()Lio/customer/messaginginapp/gist/GistEnvironment;
 	public final fun getMessagesInQueue ()Ljava/util/Set;
+	public final fun getModalMessageState ()Lio/customer/messaginginapp/state/MessageState;
 	public final fun getPollInterval ()J
 	public final fun getShownMessageQueueIds ()Ljava/util/Set;
 	public final fun getSiteId ()Ljava/lang/String;
 	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun reset ()Lio/customer/messaginginapp/state/InAppMessagingState;
+	public fun toString ()Ljava/lang/String;
+	public final fun updateEmbeddedMessage (Ljava/lang/String;Lio/customer/messaginginapp/state/InlineMessageState;Ljava/util/Set;Ljava/util/Set;)Lio/customer/messaginginapp/state/InAppMessagingState;
+	public static synthetic fun updateEmbeddedMessage$default (Lio/customer/messaginginapp/state/InAppMessagingState;Ljava/lang/String;Lio/customer/messaginginapp/state/InlineMessageState;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InAppMessagingState;
+}
+
+public abstract class io/customer/messaginginapp/state/InlineMessageState {
+	public abstract fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/customer/messaginginapp/state/InAppMessagingStateKt {
-	public static final fun diff (Lio/customer/messaginginapp/state/InAppMessagingState;Lio/customer/messaginginapp/state/InAppMessagingState;)Ljava/util/Map;
+public final class io/customer/messaginginapp/state/InlineMessageState$Dismissed : io/customer/messaginginapp/state/InlineMessageState {
+	public fun <init> (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	public final fun component1 ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;)Lio/customer/messaginginapp/state/InlineMessageState$Dismissed;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InlineMessageState$Dismissed;Lio/customer/messaginginapp/gist/data/model/Message;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InlineMessageState$Dismissed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messaginginapp/state/InlineMessageState$Embedded : io/customer/messaginginapp/state/InlineMessageState {
+	public fun <init> (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
+	public final fun component1 ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)Lio/customer/messaginginapp/state/InlineMessageState$Embedded;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InlineMessageState$Embedded;Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InlineMessageState$Embedded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElementId ()Ljava/lang/String;
+	public fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messaginginapp/state/InlineMessageState$ReadyToEmbed : io/customer/messaginginapp/state/InlineMessageState {
+	public fun <init> (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
+	public final fun component1 ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)Lio/customer/messaginginapp/state/InlineMessageState$ReadyToEmbed;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/InlineMessageState$ReadyToEmbed;Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/state/InlineMessageState$ReadyToEmbed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElementId ()Ljava/lang/String;
+	public fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class io/customer/messaginginapp/state/MessageState {
@@ -482,19 +541,6 @@ public final class io/customer/messaginginapp/state/MessageState$Displayed : io/
 	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;)Lio/customer/messaginginapp/state/MessageState$Displayed;
 	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/MessageState$Displayed;Lio/customer/messaginginapp/gist/data/model/Message;ILjava/lang/Object;)Lio/customer/messaginginapp/state/MessageState$Displayed;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/customer/messaginginapp/state/MessageState$Embedded : io/customer/messaginginapp/state/MessageState {
-	public fun <init> (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
-	public final fun component1 ()Lio/customer/messaginginapp/gist/data/model/Message;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)Lio/customer/messaginginapp/state/MessageState$Embedded;
-	public static synthetic fun copy$default (Lio/customer/messaginginapp/state/MessageState$Embedded;Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/state/MessageState$Embedded;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getElementId ()Ljava/lang/String;
 	public final fun getMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -28,6 +28,12 @@ data class Message(
     val gistProperties: GistProperties
         get() = convertToGistProperties()
 
+    val elementId: String?
+        get() = gistProperties.elementId
+
+    val isEmbedded: Boolean
+        get() = elementId != null
+
     private fun convertToGistProperties(): GistProperties {
         var routeRule: String? = null
         var elementId: String? = null

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -43,7 +43,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
     private var messagePosition: MessagePosition = MessagePosition.CENTER
 
     private val currentMessageState: MessageState.Displayed?
-        get() = state.currentMessageState as? MessageState.Displayed
+        get() = state.modalMessageState as? MessageState.Displayed
 
     override fun getScreenName(): String? {
         // Return null to prevent this screen from being tracked
@@ -98,7 +98,7 @@ class GistModalActivity : AppCompatActivity(), GistViewListener, TrackableScreen
     private fun subscribeToAttributes() {
         attributesListenerJob.add(
             inAppMessagingManager.subscribeToAttribute(
-                selector = { it.currentMessageState },
+                selector = { it.modalMessageState },
                 areEquivalent = { old, new ->
                     when {
                         old is MessageState.Initial && new is MessageState.Initial -> true

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -116,7 +116,7 @@ class GistSdk(
 
     override fun dismissMessage() {
         // only dismiss the message if it is currently displayed
-        val currentMessageState = state.currentMessageState as? MessageState.Displayed ?: return
+        val currentMessageState = state.modalMessageState as? MessageState.Displayed ?: return
         inAppMessagingManager.dispatch(InAppMessagingAction.DismissMessage(message = currentMessageState.message))
     }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -10,21 +10,77 @@ data class InAppMessagingState(
     val pollInterval: Long = 600_000L,
     val userId: String? = null,
     val currentRoute: String? = null,
-    val currentMessageState: MessageState = MessageState.Initial,
-    val messagesInQueue: Set<Message> = setOf(),
-    val shownMessageQueueIds: Set<String> = setOf()
+    val modalMessageState: MessageState = MessageState.Initial,
+    val embeddedMessagesState: EmbeddedMessagesState = EmbeddedMessagesState(),
+    val messagesInQueue: Set<Message> = emptySet(),
+    val shownMessageQueueIds: Set<String> = emptySet()
 ) {
-    override fun toString(): String {
-        return "InAppMessagingState(" +
-            "siteId='$siteId',\n" +
-            "dataCenter='$dataCenter',\n" +
-            "environment=$environment,\n" +
-            "pollInterval=$pollInterval,\n" +
-            "userId=$userId,\n" +
-            "currentRoute=$currentRoute,\n" +
-            "currentMessageState=$currentMessageState,\n" +
-            "messagesInQueue=${messagesInQueue.map(Message::queueId)},\n" +
-            "shownMessageQueueIds=$shownMessageQueueIds)"
+    override fun toString(): String = buildString {
+        append("InAppMessagingState(")
+        append("siteId='$siteId',\n")
+        append("dataCenter='$dataCenter',\n")
+        append("environment=$environment,\n")
+        append("pollInterval=$pollInterval,\n")
+        append("userId=$userId,\n")
+        append("currentRoute=$currentRoute,\n")
+        append("modalMessageState=$modalMessageState,\n")
+        append("embeddedMessagesState=$embeddedMessagesState,\n")
+        append("messagesInQueue=${messagesInQueue.map(Message::queueId)},\n")
+        append("shownMessageQueueIds=$shownMessageQueueIds)")
+    }
+
+    // Helper function to create new state with cleared messages but preserve site settings
+    fun reset(): InAppMessagingState = copy(
+        userId = null,
+        currentRoute = null,
+        modalMessageState = MessageState.Initial,
+        embeddedMessagesState = EmbeddedMessagesState(),
+        messagesInQueue = emptySet(),
+        shownMessageQueueIds = emptySet()
+    )
+
+    // Compute differences between states - moved from extension function to method
+    fun diff(other: InAppMessagingState): Map<String, Pair<Any?, Any?>> {
+        return buildMap {
+            if (siteId != other.siteId) put("siteId", siteId to other.siteId)
+            if (dataCenter != other.dataCenter) put("dataCenter", dataCenter to other.dataCenter)
+            if (environment != other.environment) put("environment", environment to other.environment)
+            if (pollInterval != other.pollInterval) put("pollInterval", pollInterval to other.pollInterval)
+            if (userId != other.userId) put("userId", userId to other.userId)
+            if (currentRoute != other.currentRoute) put("currentRoute", currentRoute to other.currentRoute)
+            if (modalMessageState != other.modalMessageState) put("modalMessageState", modalMessageState to other.modalMessageState)
+            if (embeddedMessagesState != other.embeddedMessagesState) put("embeddedMessagesState", embeddedMessagesState to other.embeddedMessagesState)
+            if (messagesInQueue != other.messagesInQueue) put("messagesInQueue", messagesInQueue to other.messagesInQueue)
+            if (shownMessageQueueIds != other.shownMessageQueueIds) put("shownMessageQueueIds", shownMessageQueueIds to other.shownMessageQueueIds)
+        }
+    }
+
+    fun updateEmbeddedMessage(
+        queueId: String,
+        newState: InlineMessageState,
+        shownMessageQueueIds: Set<String> = this.shownMessageQueueIds,
+        messagesInQueue: Set<Message> = this.messagesInQueue
+    ): InAppMessagingState {
+        val updatedEmbeddedMessagesState = embeddedMessagesState.updateMessageState(queueId, newState)
+        return copy(
+            embeddedMessagesState = updatedEmbeddedMessagesState,
+            shownMessageQueueIds = shownMessageQueueIds,
+            messagesInQueue = messagesInQueue
+        )
+    }
+}
+
+sealed class InlineMessageState {
+    abstract val message: Message
+
+    data class ReadyToEmbed(override val message: Message, val elementId: String) : InlineMessageState()
+    data class Embedded(override val message: Message, val elementId: String) : InlineMessageState()
+    data class Dismissed(override val message: Message) : InlineMessageState()
+
+    override fun toString(): String = when (this) {
+        is ReadyToEmbed -> "ReadyToEmbed(message=${message.queueId}, elementId=$elementId)"
+        is Embedded -> "Embedded(message=${message.queueId}, elementId=$elementId)"
+        is Dismissed -> "Dismissed(message=${message.queueId})"
     }
 }
 
@@ -32,31 +88,46 @@ sealed class MessageState {
     object Initial : MessageState()
     data class Loading(val message: Message) : MessageState()
     data class Displayed(val message: Message) : MessageState()
-    data class Embedded(val message: Message, val elementId: String) : MessageState()
     data class Dismissed(val message: Message) : MessageState()
 
-    override fun toString(): String {
-        return when (this) {
-            is Initial -> "Initial"
-            is Loading -> "Loading(message=${message.queueId})"
-            is Displayed -> "Displayed(message=${message.queueId})"
-            is Embedded -> "Embedded(message=${message.queueId}, elementId=$elementId)"
-            is Dismissed -> "Dismissed(message=${message.queueId})"
-        }
+    // More concise toString with 'when' expression
+    override fun toString(): String = when (this) {
+        is Initial -> "Initial"
+        is Loading -> "Loading(message=${message.queueId})"
+        is Displayed -> "Displayed(message=${message.queueId})"
+        is Dismissed -> "Dismissed(message=${message.queueId})"
     }
 }
 
-fun InAppMessagingState.diff(other: InAppMessagingState): Map<String, Pair<Any?, Any?>> {
-    return listOf(
-        "siteId" to (siteId to other.siteId),
-        "dataCenter" to (dataCenter to other.dataCenter),
-        "environment" to (environment to other.environment),
-        "pollInterval" to (pollInterval to other.pollInterval),
-        "userId" to (userId to other.userId),
-        "currentRoute" to (currentRoute to other.currentRoute),
-        "currentMessageState" to (currentMessageState to other.currentMessageState),
-        "messagesInQueue" to (messagesInQueue to other.messagesInQueue),
-        "shownMessageQueueIds" to (shownMessageQueueIds to other.shownMessageQueueIds)
-    ).filter { (_, pair) -> pair.first != pair.second }
-        .toMap()
+data class EmbeddedMessagesState(
+    internal val messagesByElementId: Map<String, InlineMessageState> = emptyMap()
+) {
+    fun addMessage(message: Message, elementId: String): EmbeddedMessagesState {
+        val state = InlineMessageState.ReadyToEmbed(message, elementId)
+        val updatedMap = buildMap(messagesByElementId.size + 1) {
+            putAll(messagesByElementId)
+            put(elementId, state)
+        }
+        return copy(messagesByElementId = updatedMap)
+    }
+
+    fun updateMessageState(queueId: String, newState: InlineMessageState): EmbeddedMessagesState {
+        val entry = messagesByElementId.entries.find { (_, state) ->
+            state.message.queueId == queueId
+        } ?: return this
+
+        return copy(
+            messagesByElementId = buildMap(messagesByElementId.size) {
+                putAll(messagesByElementId)
+                put(entry.key, newState)
+            }
+        )
+    }
+
+    fun getMessage(elementId: String): InlineMessageState? = messagesByElementId[elementId]
+
+    fun allMessages(): List<InlineMessageState> = messagesByElementId.values.toList()
+
+    override fun toString(): String =
+        "EmbeddedMessagesState(messages=${messagesByElementId.size}, ids=${messagesByElementId.keys})"
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/GistSDKTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/GistSDKTest.kt
@@ -86,7 +86,7 @@ class GistSDKTest : JUnitTest() {
     @Test
     fun dismissMessage_whenMessageAvailable_expectDismissMessageActionDispatched() = runTest {
         val testMessage = Message(queueId = String.random)
-        testState = testState.copy(currentMessageState = MessageState.Displayed(testMessage))
+        testState = testState.copy(modalMessageState = MessageState.Displayed(testMessage))
         every { mockInAppMessagingManager.getCurrentState() } returns testState
 
         gistSdk.dismissMessage()
@@ -96,7 +96,7 @@ class GistSDKTest : JUnitTest() {
 
     @Test
     fun dismissMessage_whenNoMessageAvailable_expectNoDismissMessageActionDispatched() = runTest {
-        testState = testState.copy(currentMessageState = MessageState.Initial)
+        testState = testState.copy(modalMessageState = MessageState.Initial)
         every { mockInAppMessagingManager.getCurrentState() } returns testState
 
         // clear any previous calls to dispatch to avoid false positives like `initialize`


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-1022/create-update-data-models-to-cater-inlineembedded-types
closes: https://linear.app/customerio/issue/MBL-1023/createupdate-states-to-differentiate-between-modal-and-inline-views

changes:
- Updated `state` to cater for embedded messages
- Refactored state class and its usage