### PR TITLE
chore: Trigger sample apps public builds after deployment is successful

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -1,6 +1,8 @@
 name: Build sample app for SDK release
 on:
   workflow_dispatch:
+  workflow_call:
+
 jobs:
   build-sample-apps:
     uses: ./.github/workflows/reusable_build_sample_apps.yml

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -237,3 +237,9 @@ jobs:
           # Help on how to get the webhook URL: https://github.com/marketplace/actions/slack-send#setup-2
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  publish-sample-apps-public-builds:
+    needs: deploy-sonatype
+    uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    secrets: inherit
+    


### PR DESCRIPTION
Closes: [MBL-1053](https://linear.app/customerio/issue/MBL-1053/auto-create-testbed-releases-for-every-sdk-release)

This PR triggers a sample apps public release build after the SDK has been deployed successfully so that internal stakeholders always have up to date versions to test with.

### Note
I am not entirely sure if the package will be immediately available after publishing before it can be used to build the sample app or we need a delay. Starting out with immediate trigger and we can revise later if the build fails.