### PR TITLE
fix: delete old device token on token refresh

### DIFF
--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesStandardDispatcherTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesStandardDispatcherTest.kt
@@ -1,0 +1,175 @@
+package io.customer.datapipelines
+
+import com.segment.analytics.kotlin.core.EventType
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.extensions.deviceToken
+import io.customer.datapipelines.testutils.extensions.shouldMatchTo
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.identifyEvents
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.DeviceStore
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.customer.sdk.util.EventNames
+import io.mockk.every
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests DataPipelines behavior using StandardTestDispatcher to simulate realistic coroutine
+ * scheduling and timing.
+ */
+class DataPipelinesStandardDispatcherTest : JUnitTest(dispatcher = StandardTestDispatcher()) {
+    //region Setup test environment
+
+    private val testScope get() = delegate.testScope
+
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var deviceStore: DeviceStore
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfiguration {
+                sdkConfig {
+                    // Enable adding destination so events are processed and stored in the storage
+                    autoAddCustomerIODestination(true)
+                }
+            }
+        )
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+        deviceStore = androidSDKComponent.deviceStore
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+
+        // Run all pending coroutines to ensure analytics is initialized and ready to process events
+        @Suppress("OPT_IN_USAGE")
+        testScope.runCurrent()
+    }
+
+    //endregion
+    //region Device token
+
+    @Test
+    fun device_givenTokenRefreshed_expectDeleteAndRegisterDeviceToken() = runTest {
+        val givenIdentifier = String.random
+        val givenPreviousDeviceToken = "old-token"
+        val givenToken = "new-token"
+
+        sdkInstance.identify(givenIdentifier).flushCoroutines()
+        sdkInstance.registerDeviceToken(givenPreviousDeviceToken).flushCoroutines()
+        sdkInstance.registerDeviceToken(givenToken).flushCoroutines()
+
+        // 1. Device register (old token)
+        // 2. Device delete (old token)
+        // 3. Device register (new token)
+        val trackedEvents = outputReaderPlugin.trackEvents shouldHaveSize 3
+
+        val deviceDeleteEvent = trackedEvents[trackedEvents.lastIndex - 1]
+        deviceDeleteEvent.userId shouldBeEqualTo givenIdentifier
+        deviceDeleteEvent.type shouldBeEqualTo EventType.Track
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
+
+        val deviceDeleteEventContext = deviceDeleteEvent.context
+        deviceDeleteEventContext.deviceToken shouldBeEqualTo givenPreviousDeviceToken
+        deviceDeleteEvent.properties.shouldBeEmpty()
+
+        val deviceRegisterEvent = trackedEvents.last()
+        deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
+        deviceRegisterEvent.type shouldBeEqualTo EventType.Track
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
+
+        val deviceRegisterEventContext = deviceRegisterEvent.context
+        deviceRegisterEventContext.deviceToken shouldBeEqualTo givenToken
+        deviceRegisterEvent.properties shouldMatchTo deviceStore.buildDeviceAttributes()
+    }
+
+    @Test
+    fun device_givenProfileChanged_expectDeleteDeviceTokenForOldProfile() = runTest {
+        val givenIdentifier = "new-profile"
+        val givenPreviouslyIdentifiedProfile = "old-profile"
+        val givenToken = String.random
+
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+
+        sdkInstance.identify(givenPreviouslyIdentifiedProfile).flushCoroutines()
+        sdkInstance.identify(givenIdentifier).flushCoroutines()
+
+        // 1. Identify event for the old profile
+        // 2. Identify event for the new profile
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 2
+        // 1. Device update event for the old profile
+        // 2. Device delete event for the old profile
+        // 3. Device update event for the new profile
+        val trackedEvents = outputReaderPlugin.trackEvents shouldHaveSize 3
+
+        val deviceDeleteEvent = trackedEvents[trackedEvents.lastIndex - 1]
+        deviceDeleteEvent.userId shouldBeEqualTo givenPreviouslyIdentifiedProfile
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
+        deviceDeleteEvent.context.deviceToken shouldBeEqualTo givenToken
+
+        val deviceRegisterEvent = trackedEvents.last()
+        deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
+        deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
+    }
+
+    @Test
+    fun device_givenClearIdentify_expectDeviceUnregisteredFromProfile() = runTest {
+        val givenIdentifier = String.random
+        val givenToken = String.random
+
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+
+        sdkInstance.identify(givenIdentifier).flushCoroutines()
+        sdkInstance.clearIdentify().flushCoroutines()
+
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        // 1. Device update event
+        // 2. Device delete event
+        val trackedEvents = outputReaderPlugin.trackEvents shouldHaveSize 2
+
+        val deviceRegisterEvent = trackedEvents[trackedEvents.lastIndex - 1]
+        deviceRegisterEvent.userId shouldBeEqualTo givenIdentifier
+        deviceRegisterEvent.event shouldBeEqualTo EventNames.DEVICE_UPDATE
+        deviceRegisterEvent.context.deviceToken shouldBeEqualTo givenToken
+
+        val deviceDeleteEvent = trackedEvents.last()
+        deviceDeleteEvent.userId shouldBeEqualTo givenIdentifier
+        deviceDeleteEvent.event shouldBeEqualTo EventNames.DEVICE_DELETE
+        deviceDeleteEvent.context.deviceToken shouldBeEqualTo givenToken
+    }
+
+    //endregion
+    //region Extension functions
+
+    /**
+     * Extension function to run a block of code and flush all pending coroutines
+     * to ensure all events are processed
+     */
+    private fun runAndFlushCoroutines(block: () -> Unit) {
+        block().flushCoroutines()
+    }
+
+    /**
+     * Flushes all pending coroutines in the test scope to ensure all events are processed
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun <T : Any> T.flushCoroutines(): T {
+        testScope.runCurrent()
+        return this
+    }
+    //endregion
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/JUnitTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/JUnitTest.kt
@@ -4,15 +4,20 @@ import com.segment.analytics.kotlin.core.Analytics
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.JUnit5Test
 import io.customer.sdk.CustomerIO
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
  * Extension of [JUnit5Test] that utilizes [UnitTestDelegate] to setup test environment
  * for running unit tests.
  * This class should be used for running unit tests using JUnit.
  */
-abstract class JUnitTest : JUnit5Test() {
-    private val delegate: UnitTestDelegate = UnitTestDelegate(applicationInstance = "Test")
+abstract class JUnitTest(
+    @OptIn(ExperimentalCoroutinesApi::class)
+    dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : JUnit5Test() {
+    protected val delegate: UnitTestDelegate = UnitTestDelegate("Test", dispatcher)
     private val defaultTestConfiguration: DataPipelinesTestConfig = testConfiguration {}
 
     val testDispatcher: TestDispatcher get() = delegate.testDispatcher

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
@@ -5,6 +5,7 @@ import com.segment.analytics.kotlin.core.Analytics
 import io.customer.commontest.config.configureAndroidSDKComponent
 import io.customer.commontest.util.DeviceStoreStub
 import io.customer.datapipelines.testutils.extensions.registerAnalyticsFactory
+import io.customer.datapipelines.testutils.stubs.TestCoroutineConfiguration
 import io.customer.datapipelines.testutils.utils.clearPersistentStorage
 import io.customer.datapipelines.testutils.utils.createTestAnalyticsInstance
 import io.customer.datapipelines.testutils.utils.mockHTTPClient
@@ -25,8 +26,12 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  * The class makes it easy to setup both JUnit and Robolectric tests by delegating setup to this class.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class UnitTestDelegate(private val applicationInstance: Any) {
+class UnitTestDelegate(
+    val applicationInstance: Any,
     val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) {
+    val testCoroutineConfiguration = TestCoroutineConfiguration(testDispatcher)
+    val testScope get() = testCoroutineConfiguration.testScope
 
     private lateinit var testConfig: DataPipelinesTestConfig
     lateinit var sdkInstance: CustomerIO
@@ -56,7 +61,8 @@ class UnitTestDelegate(private val applicationInstance: Any) {
             val testAnalyticsInstance = createTestAnalyticsInstance(
                 moduleConfig = moduleConfig,
                 application = applicationInstance,
-                testDispatcher = testDispatcher
+                testDispatcher = testDispatcher,
+                testCoroutineConfiguration = testCoroutineConfiguration
             )
             // Configure plugins for the test analytics instance to allow adding
             // desired plugins before CustomerIO initialization


### PR DESCRIPTION
fixes: [MBL-1061](https://linear.app/customerio/issue/MBL-1061/android-sdk-455-device-refresh-removals)

### Changes

- Included old token in Device Delete event to prevent it from being overwritten by new token, avoiding accidental deletion of new device
- Updated token deletion logic during profile change to ensure the device is removed only from previous profile
- Added tests to verify the updated behavior