### PR TITLE
chore: simplify in-app base view implementation

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -156,7 +156,7 @@ public abstract interface class io/customer/messaginginapp/gist/presentation/Gis
 	public abstract fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
 }
 
-public final class io/customer/messaginginapp/gist/presentation/GistModalActivity : androidx/appcompat/app/AppCompatActivity, io/customer/messaginginapp/ui/InAppMessageViewEventsListener, io/customer/sdk/tracking/TrackableScreen {
+public final class io/customer/messaginginapp/gist/presentation/GistModalActivity : androidx/appcompat/app/AppCompatActivity, io/customer/messaginginapp/ui/ModalInAppMessageViewListener, io/customer/sdk/tracking/TrackableScreen {
 	public static final field Companion Lio/customer/messaginginapp/gist/presentation/GistModalActivity$Companion;
 	public fun <init> ()V
 	public fun finish ()V
@@ -412,5 +412,29 @@ public final class io/customer/messaginginapp/type/InAppMessage$Companion {
 
 public final class io/customer/messaginginapp/type/InAppMessageKt {
 	public static final fun getMessage (Lio/customer/messaginginapp/type/InAppMessage;)Lio/customer/messaginginapp/gist/data/model/Message;
+}
+
+public abstract class io/customer/messaginginapp/ui/InAppMessageBaseView : android/widget/FrameLayout, io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun attachEngineWebView ()V
+	public fun bootstrapped ()V
+	protected final fun detachEngineWebView ()V
+	public fun error ()V
+	protected final fun getCurrentMessage ()Lio/customer/messaginginapp/gist/data/model/Message;
+	protected final fun getCurrentRoute ()Ljava/lang/String;
+	protected final fun getLogger ()Lio/customer/sdk/core/util/Logger;
+	protected final fun logViewEvent (Ljava/lang/String;)V
+	public fun routeChanged (Ljava/lang/String;)V
+	public fun routeError (Ljava/lang/String;)V
+	public fun routeLoaded (Ljava/lang/String;)V
+	protected final fun setCurrentMessage (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	protected final fun setCurrentRoute (Ljava/lang/String;)V
+	public final fun setup (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	public final fun stopLoading ()V
+	public fun tap (Ljava/lang/String;Ljava/lang/String;Z)V
 }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -20,7 +20,7 @@ import io.customer.messaginginapp.gist.utilities.ModalAnimationUtil
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.state.ModalMessageState
-import io.customer.messaginginapp.ui.InAppMessageViewEventsListener
+import io.customer.messaginginapp.ui.ModalInAppMessageViewListener
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.tracking.TrackableScreen
 import kotlinx.coroutines.Job
@@ -28,7 +28,7 @@ import kotlinx.coroutines.Job
 const val GIST_MESSAGE_INTENT: String = "GIST_MESSAGE"
 const val GIST_MODAL_POSITION_INTENT: String = "GIST_MODAL_POSITION"
 
-class GistModalActivity : AppCompatActivity(), InAppMessageViewEventsListener, TrackableScreen {
+class GistModalActivity : AppCompatActivity(), ModalInAppMessageViewListener, TrackableScreen {
     private lateinit var binding: ActivityGistBinding
     private var elapsedTimer: ElapsedTimer = ElapsedTimer()
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
@@ -72,7 +72,7 @@ class GistModalActivity : AppCompatActivity(), InAppMessageViewEventsListener, T
             logger.debug("GistModelActivity onCreate: $parsedMessage")
             parsedMessage.let { message ->
                 elapsedTimer.start("Displaying modal for message: ${message.messageId}")
-                binding.gistView.eventsListener = this
+                binding.gistView.viewListener = this
                 binding.gistView.setup(message)
                 val messagePosition = if (modalPositionStr == null) {
                     message.gistProperties.position

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewEventsListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewEventsListener.kt
@@ -1,8 +1,0 @@
-package io.customer.messaginginapp.ui
-
-/**
- * Listener interface to send events from the InAppMessageHostView to the host activity or fragment.
- */
-internal interface InAppMessageViewEventsListener {
-    fun onViewSizeChanged(width: Int, height: Int) {}
-}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewExtensions.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewExtensions.kt
@@ -2,6 +2,9 @@ package io.customer.messaginginapp.ui
 
 import android.util.DisplayMetrics
 
-internal fun InAppMessageBaseView.getSizeBasedOnDPI(size: Int): Int {
-    return size * context.resources.displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT
+/**
+ * Converts the given size from dp to pixels based on the device's screen density.
+ */
+internal fun InAppMessageBaseView.dpToPixels(size: Double): Int {
+    return size.toInt() * context.resources.displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InAppMessageViewListener.kt
@@ -1,0 +1,13 @@
+package io.customer.messaginginapp.ui
+
+/**
+ * Base listener interface to send events from in-app messages view to the host component.
+ */
+internal interface InAppMessageViewListener {
+    fun onViewSizeChanged(width: Int, height: Int) {}
+}
+
+/**
+ * Listener interface to send events from modal in-app messages view to the host component.
+ */
+internal interface ModalInAppMessageViewListener : InAppMessageViewListener

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/ModalInAppMessageView.kt
@@ -2,17 +2,26 @@ package io.customer.messaginginapp.ui
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
 import io.customer.messaginginapp.state.InAppMessagingAction
 
 /**
- * Final implementation of the InAppMessageHostView for displaying modal in-app messages.
+ * Final implementation of the [InlineInAppMessageBaseView] for displaying modal in-app messages.
  * The view should be directly added to activity layout for displaying modal in-app messages.
  */
 internal class ModalInAppMessageView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : InAppMessageBaseView(context, attrs, defStyleAttr) {
+    @AttrRes defStyleAttr: Int = 0,
+    @StyleRes defStyleRes: Int = 0
+) : InAppMessageBaseView(
+    context,
+    attrs,
+    defStyleAttr,
+    defStyleRes
+) {
+    internal var viewListener: ModalInAppMessageViewListener? = null
     private var isMessageDisplayed: Boolean = true
 
     init {
@@ -28,5 +37,26 @@ internal class ModalInAppMessageView @JvmOverloads constructor(
         currentMessage?.let { message ->
             inAppMessagingManager.dispatch(InAppMessagingAction.DisplayMessage(message))
         }
+    }
+
+    override fun bootstrapped() {
+        super.bootstrapped()
+        // Cleaning after engine web is bootstrapped and all assets downloaded.
+        clearResourcesIfMessageIdEmpty()
+    }
+
+    private fun clearResourcesIfMessageIdEmpty() {
+        val message = currentMessage ?: return
+        if (message.messageId.isNotBlank()) return
+
+        logViewEvent("Clearing resources for empty messageId")
+        detachEngineWebView()
+        currentMessage = null
+        viewListener = null
+    }
+
+    override fun sizeChanged(width: Double, height: Double) {
+        logViewEvent("Modal in-app message size changed: $width x $height")
+        viewListener?.onViewSizeChanged(dpToPixels(width), dpToPixels(height))
     }
 }


### PR DESCRIPTION
part of: [MBL-1028](https://linear.app/customerio/issue/MBL-1028/create-base-inline-message-view-using-refactored-gistview)

### Changes

- Reverted `InAppMessageBaseView` to `public` to avoid the need for an extra wrapper view, which could introduce challenges with updating size and view attributes like `alpha`, etc. Keeping it `public` simplifies the implementation.
- Moved several methods to child `ModalInAppMessageView` that are not needed for inline in-app messages
- Renamed a few internal methods for clarity and added `@UiThread` annotations to signal that these should not be called from JS, helping minimize thread related exceptions.