### PR TITLE
chore: clean up EngineWebView and related improvements

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -116,15 +116,14 @@ public final class io/customer/messaginginapp/gist/data/model/GistProperties {
 
 public final class io/customer/messaginginapp/gist/data/model/Message {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lio/customer/messaginginapp/gist/data/model/Message;
-	public static synthetic fun copy$default (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/messaginginapp/gist/data/model/Message;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;)Lio/customer/messaginginapp/gist/data/model/Message;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/messaginginapp/gist/data/model/Message;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEmbeddedElementId ()Ljava/lang/String;
 	public final fun getGistProperties ()Lio/customer/messaginginapp/gist/data/model/GistProperties;
@@ -448,6 +447,7 @@ public abstract class io/customer/messaginginapp/ui/InlineInAppMessageBaseView :
 	protected final fun getContentWidthInDp ()Ljava/lang/Double;
 	protected final fun getElapsedTimer ()Lio/customer/messaginginapp/gist/utilities/ElapsedTimer;
 	public final fun getElementId ()Ljava/lang/String;
+	public fun routeLoaded (Ljava/lang/String;)V
 	protected final fun setContentHeightInDp (Ljava/lang/Double;)V
 	protected final fun setContentWidthInDp (Ljava/lang/Double;)V
 	public final fun setElementId (Ljava/lang/String;)V

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -25,6 +25,8 @@ data class Message(
     val queueId: String? = null,
     val properties: Map<String, Any?>? = null
 ) {
+    // Should be property and not constructor parameter so it isn't used in equals
+    // As messages are identified uniquely by their queueId and not instanceId
     val instanceId: String = UUID.randomUUID().toString()
     val gistProperties: GistProperties
         get() = convertToGistProperties()

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/Message.kt
@@ -21,11 +21,11 @@ data class GistProperties(
 
 data class Message(
     val messageId: String = "",
-    val instanceId: String = UUID.randomUUID().toString(),
     val priority: Int? = null,
     val queueId: String? = null,
     val properties: Map<String, Any?>? = null
 ) {
+    val instanceId: String = UUID.randomUUID().toString()
     val gistProperties: GistProperties
         get() = convertToGistProperties()
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -66,6 +66,23 @@ internal class EngineWebView @JvmOverloads constructor(
         webView?.let { engineWebViewInterface.detach(webView = it) }
     }
 
+    fun releaseResources() {
+        val view = webView ?: return
+        if (view.parent != null) {
+            logger.debug("EngineWebView is still attached to parent, skipping cleanup")
+            return
+        }
+
+        logger.debug("Cleaning up EngineWebView")
+        webView = null
+        runCatching {
+            engineWebViewInterface.detach(view)
+            view.destroy()
+        }.onFailure { ex ->
+            logger.error("Error while destroying EngineWebView: ${ex.message}")
+        }
+    }
+
     fun stopLoading() {
         webView?.stopLoading()
         // stop the timer and clean up

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -63,47 +63,33 @@ internal sealed class InlineMessageState {
     abstract val message: Message
 
     data class ReadyToEmbed(override val message: Message, val elementId: String) : InlineMessageState() {
-        override fun toString(): String {
-            return "ReadyToEmbed(message=${message.queueId}, elementId=$elementId)"
-        }
+        override fun toString() = "ReadyToEmbed(message=${message.queueId}, elementId=$elementId)"
     }
 
     data class Embedded(override val message: Message, val elementId: String) : InlineMessageState() {
-        override fun toString(): String {
-            return "Embedded(message=${message.queueId}, elementId=$elementId)"
-        }
+        override fun toString() = "Embedded(message=${message.queueId}, elementId=$elementId)"
     }
 
     data class Dismissed(override val message: Message) : InlineMessageState() {
-        override fun toString(): String {
-            return "Dismissed(message=${message.queueId})"
-        }
+        override fun toString() = "Dismissed(message=${message.queueId})"
     }
 }
 
 internal sealed class ModalMessageState {
     object Initial : ModalMessageState() {
-        override fun toString(): String {
-            return "Initial"
-        }
+        override fun toString() = "Initial"
     }
 
     data class Loading(val message: Message) : ModalMessageState() {
-        override fun toString(): String {
-            return "Loading(message=${message.queueId})"
-        }
+        override fun toString() = "Loading(message=${message.queueId})"
     }
 
     data class Displayed(val message: Message) : ModalMessageState() {
-        override fun toString(): String {
-            return "Displayed(message=${message.queueId})"
-        }
+        override fun toString() = "Displayed(message=${message.queueId})"
     }
 
     data class Dismissed(val message: Message) : ModalMessageState() {
-        override fun toString(): String {
-            return "Dismissed(message=${message.queueId})"
-        }
+        override fun toString() = "Dismissed(message=${message.queueId})"
     }
 }
 
@@ -136,6 +122,6 @@ internal data class QueuedInlineMessagesState(
 
     fun allMessages(): List<InlineMessageState> = messagesByElementId.values.toList()
 
-    override fun toString(): String =
+    override fun toString() =
         "EmbeddedMessagesState(messages=${messagesByElementId.size}, ids=${messagesByElementId.keys}, states=${messagesByElementId.values.joinToString { it.toString() }})"
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -62,29 +62,48 @@ internal fun InAppMessagingState.withUpdatedEmbeddedMessage(
 internal sealed class InlineMessageState {
     abstract val message: Message
 
-    data class ReadyToEmbed(override val message: Message, val elementId: String) : InlineMessageState()
-    data class Embedded(override val message: Message, val elementId: String) : InlineMessageState()
-    data class Dismissed(override val message: Message) : InlineMessageState()
+    data class ReadyToEmbed(override val message: Message, val elementId: String) : InlineMessageState() {
+        override fun toString(): String {
+            return "ReadyToEmbed(message=${message.queueId}, elementId=$elementId)"
+        }
+    }
 
-    override fun toString(): String = when (this) {
-        is ReadyToEmbed -> "ReadyToEmbed(message=${message.queueId}, elementId=$elementId)"
-        is Embedded -> "Embedded(message=${message.queueId}, elementId=$elementId)"
-        is Dismissed -> "Dismissed(message=${message.queueId})"
+    data class Embedded(override val message: Message, val elementId: String) : InlineMessageState() {
+        override fun toString(): String {
+            return "Embedded(message=${message.queueId}, elementId=$elementId)"
+        }
+    }
+
+    data class Dismissed(override val message: Message) : InlineMessageState() {
+        override fun toString(): String {
+            return "Dismissed(message=${message.queueId})"
+        }
     }
 }
 
 internal sealed class ModalMessageState {
-    object Initial : ModalMessageState()
-    data class Loading(val message: Message) : ModalMessageState()
-    data class Displayed(val message: Message) : ModalMessageState()
-    data class Dismissed(val message: Message) : ModalMessageState()
+    object Initial : ModalMessageState() {
+        override fun toString(): String {
+            return "Initial"
+        }
+    }
 
-    // More concise toString with 'when' expression
-    override fun toString(): String = when (this) {
-        is Initial -> "Initial"
-        is Loading -> "Loading(message=${message.queueId})"
-        is Displayed -> "Displayed(message=${message.queueId})"
-        is Dismissed -> "Dismissed(message=${message.queueId})"
+    data class Loading(val message: Message) : ModalMessageState() {
+        override fun toString(): String {
+            return "Loading(message=${message.queueId})"
+        }
+    }
+
+    data class Displayed(val message: Message) : ModalMessageState() {
+        override fun toString(): String {
+            return "Displayed(message=${message.queueId})"
+        }
+    }
+
+    data class Dismissed(val message: Message) : ModalMessageState() {
+        override fun toString(): String {
+            return "Dismissed(message=${message.queueId})"
+        }
     }
 }
 
@@ -118,5 +137,5 @@ internal data class QueuedInlineMessagesState(
     fun allMessages(): List<InlineMessageState> = messagesByElementId.values.toList()
 
     override fun toString(): String =
-        "EmbeddedMessagesState(messages=${messagesByElementId.size}, ids=${messagesByElementId.keys})"
+        "EmbeddedMessagesState(messages=${messagesByElementId.size}, ids=${messagesByElementId.keys}, states=${messagesByElementId.values.joinToString { it.toString() }})"
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -122,6 +122,11 @@ internal data class QueuedInlineMessagesState(
 
     fun allMessages(): List<InlineMessageState> = messagesByElementId.values.toList()
 
-    override fun toString() =
-        "EmbeddedMessagesState(messages=${messagesByElementId.size}, ids=${messagesByElementId.keys}, states=${messagesByElementId.values.joinToString { it.toString() }})"
+    override fun toString() = buildString {
+        append("EmbeddedMessagesState(")
+        append("messages=${messagesByElementId.size}, ")
+        append("ids=${messagesByElementId.keys}, ")
+        append("states=${messagesByElementId.values}")
+        append(")")
+    }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageBaseView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageBaseView.kt
@@ -8,6 +8,7 @@ import androidx.annotation.UiThread
 import androidx.core.view.updateLayoutParams
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.utilities.ElapsedTimer
+import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.state.InlineMessageState
 
@@ -42,6 +43,14 @@ abstract class InlineInAppMessageBaseView @JvmOverloads constructor(
             }
         ) { state ->
             post { refreshViewState(state = state) }
+        }
+    }
+
+    override fun routeLoaded(route: String) {
+        super.routeLoaded(route)
+
+        currentMessage?.let { message ->
+            inAppMessagingManager.dispatch(InAppMessagingAction.DisplayMessage(message))
         }
     }
 
@@ -154,7 +163,9 @@ abstract class InlineInAppMessageBaseView @JvmOverloads constructor(
             engineWebView?.alpha = 0F
             contentWidthInDp = null
             contentHeightInDp = null
+            engineWebView?.stopLoading()
             detachEngineWebView()
+            engineWebView?.releaseResources()
             viewListener?.onNoMessageToDisplay()
             onComplete?.invoke()
         }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/extension/GistExtensions.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/testutils/extension/GistExtensions.kt
@@ -1,7 +1,5 @@
 package io.customer.messaginginapp.testutils.extension
 
-import android.util.Base64
-import com.google.gson.JsonParser
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.type.InAppMessage
@@ -15,17 +13,6 @@ fun mapToInAppMessage(message: Message): InAppMessage = InAppMessage.getFromGist
 fun pageRuleContains(route: String): String = "^(.*$route.*)\$"
 
 fun pageRuleEquals(route: String): String = "^($route)\$"
-
-fun decodeOptionsString(options: String): Message {
-    val decodedOptions = String(Base64.decode(options, Base64.DEFAULT), Charsets.UTF_8)
-    val decodedMessage = JsonParser().parse(decodedOptions).asJsonObject
-    return Message(
-        messageId = decodedMessage["messageId"].asString,
-        instanceId = decodedMessage["instanceId"].asString,
-        priority = decodedMessage["priority"]?.asInt,
-        queueId = decodedMessage["queueId"]?.asString
-    )
-}
 
 fun createInAppMessage(
     messageId: String = UUID.randomUUID().toString(),


### PR DESCRIPTION
part of: [MBL-989](https://linear.app/customerio/issue/MBL-989/showhide-the-xml-based-view)

### Changes

- Moved `instanceId` in `Message` class from constructor to a property to avoid it affecting equality checks and triggering unnecessary store events
- Added `releaseResources` method to `EngineWebView` to properly clean up `WebView` after use
- Updated `InAppMessageState` to print as expected by overriding `toString` directly as data classes were previously overriding it implicitly
- Updated `InlineInAppMessageBaseView` to dispatch `DisplayMessage` and clean up `EngineWebView` when it is no longer needed