### PR TITLE
chore: fix unnecessary UI recreation in Java sample app

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/core/BaseFragmentContainerActivity.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/core/BaseFragmentContainerActivity.kt
@@ -20,6 +20,7 @@ abstract class BaseFragmentContainerActivity<VB : ViewBinding> : BaseActivity<VB
     protected open fun getFragmentTitle(): String? = null
 
     protected lateinit var fragmentName: String
+    protected var hasDisplayedContent = false
 
     override fun onBackPressed() {
         finish()
@@ -50,7 +51,13 @@ abstract class BaseFragmentContainerActivity<VB : ViewBinding> : BaseActivity<VB
     protected fun setupWithAuthViewModel(authViewModel: AuthViewModel) {
         authViewModel.userLoggedInStateObservable.observe(this) { isLoggedIn: Boolean ->
             if (isLoggedIn) {
-                replaceFragmentInView()
+                // LiveData can emit the same value again when Activity returns from background.
+                // To avoid replacing the fragment multiple times, we track whether the fragment has already
+                // been added using a boolean flag.
+                if (!hasDisplayedContent) {
+                    replaceFragmentInView()
+                    hasDisplayedContent = true
+                }
             } else {
                 if (isTaskRoot) {
                     startActivity(Intent(this, LoginActivity::class.java))


### PR DESCRIPTION
part of: [MBL-1088](https://linear.app/customerio/issue/MBL-1088/persist-inline-in-app-message-on-orientation-change)

### Background

In Java sample app, `BaseFragmentContainerActivity` was readding fragment in `LiveData` observer every time the app returned from background. This led to full UI recreation and loss of state including inline messages being destroyed, making testing unreliable.

### Changes

- Added a boolean flag to prevent same fragment from being re-added when returning from background

### How to Test

No SDK changes, only the sample app is updated.

#### Using Inline

1. Open Inline Examples screen
2. Send and wait for an inline message to appear
3. Put the app in background
4. Bring it back to foreground
5. Inline message should remain visible

#### Using Tracking Screen

1. Open any Tracking screen (e.g. Custom Event)
2. Enter some input text
3. Put the app in background
4. Bring it back to foreground
5. Input should still be preserved

### Note

I'll improve this later by migrating from `LiveData` to Flows for better lifecycle aware state handling.