### PR TITLE
chore: clean up WebView on dismiss and improve inline in-app handling

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -447,6 +447,8 @@ public abstract class io/customer/messaginginapp/ui/InlineInAppMessageBaseView :
 	protected final fun getContentWidthInDp ()Ljava/lang/Double;
 	protected final fun getElapsedTimer ()Lio/customer/messaginginapp/gist/utilities/ElapsedTimer;
 	public final fun getElementId ()Ljava/lang/String;
+	protected fun onDetachedFromWindow ()V
+	protected fun onElementIdChanged ()V
 	public fun routeLoaded (Ljava/lang/String;)V
 	protected final fun setContentHeightInDp (Ljava/lang/Double;)V
 	protected final fun setContentWidthInDp (Ljava/lang/Double;)V

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/inline/AndroidXMLInlineExampleFragment.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/inline/AndroidXMLInlineExampleFragment.kt
@@ -8,6 +8,12 @@ class AndroidXMLInlineExampleFragment : BaseFragment<FragmentAndroidXmlInlineExa
         return FragmentAndroidXmlInlineExampleBinding.inflate(layoutInflater)
     }
 
+    override fun setupContent() {
+        // Set element ID for sticky header in-app message using Kotlin property
+        // to validate the functionality of setting element ID from Kotlin code
+        binding.stickyHeaderInAppMessage.elementId = "sticky-header"
+    }
+
     companion object {
         @JvmStatic
         fun newInstance() = AndroidXMLInlineExampleFragment()

--- a/samples/java_layout/src/main/res/layout/fragment_android_xml_inline_example.xml
+++ b/samples/java_layout/src/main/res/layout/fragment_android_xml_inline_example.xml
@@ -13,7 +13,6 @@
         android:id="@+id/sticky_header_in_app_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:elementId="sticky-header"
         tools:background="@android:color/holo_red_dark"
         tools:layout_height="64dp" />
 


### PR DESCRIPTION
part of: [MBL-1088](https://linear.app/customerio/issue/MBL-1088/persist-inline-in-app-message-on-orientation-change)

### Changes

- Updated `releaseResources` in `EngineWebView` to call `stopLoading` and `destroy` on `WebView` for more thorough cleanup
- Updated `InlineInAppMessageBaseView` to:
  - Destroy the view only on `onDetachedFromWindow`, and prevent destruction on temporary detachments like configuration changes
  - Automatically re-show message if the view was destroyed and recreated after a config change or temporary detach
- Improved naming, added code comments, cleaned up code structure, and added extensions to simplify logic
- Updated sample app to cover Kotlin property usage for inline in-app view

### How to Test

#### Background and Foreground Handling

1. Open Inline Examples screen
2. Send and wait for an inline message to appear
3. Put the app in the background
4. Bring it back to the foreground
5. Inline message should remain visible

#### Screen Rotation Handling

1. Open the Inline Examples screen
2. Send and wait for an inline message to appear
3. Rotate the screen (change device orientation)
4. Inline message should be displayed again