### PR TITLE
chore: Align push initilization logs with definitions

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponent.kt
@@ -5,6 +5,7 @@ import io.customer.sdk.communication.EventBusImpl
 import io.customer.sdk.core.environment.BuildEnvironment
 import io.customer.sdk.core.environment.DefaultBuildEnvironment
 import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.core.util.LoggerImpl
@@ -22,7 +23,7 @@ import io.customer.sdk.lifecycle.CustomerIOActivityLifecycleCallbacks
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 object SDKComponent : DiGraph() {
     // Static map to store all the modules registered with the SDK
-    val modules: MutableMap<String, CustomerIOModule<*>> = mutableMapOf()
+    val modules: MutableMap<String, CustomerIOModule<out CustomerIOModuleConfig>> = mutableMapOf()
 
     // Android component dependencies
     val activityLifecycleCallbacks: CustomerIOActivityLifecycleCallbacks

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -13,12 +13,14 @@ public final class io/customer/datapipelines/config/DataPipelinesModuleConfig : 
 	public final fun getMigrationSiteId ()Ljava/lang/String;
 	public final fun getScreenViewUse ()Lio/customer/datapipelines/config/ScreenView;
 	public final fun getTrackApplicationLifecycleEvents ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class io/customer/datapipelines/config/ScreenView {
 	public static final field Companion Lio/customer/datapipelines/config/ScreenView$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/customer/datapipelines/config/ScreenView$All : io/customer/datapipelines/config/ScreenView {

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/DataPipelinesModuleConfig.kt
@@ -33,4 +33,8 @@ class DataPipelinesModuleConfig(
 ) : CustomerIOModuleConfig {
     val apiHost: String = apiHostOverride ?: region.apiHost()
     val cdnHost: String = cdnHostOverride ?: region.cdnHost()
+
+    override fun toString(): String {
+        return "DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=$flushAt, flushInterval=$flushInterval, flushPolicies=$flushPolicies, autoAddCustomerIODestination=$autoAddCustomerIODestination, trackApplicationLifecycleEvents=$trackApplicationLifecycleEvents, autoTrackDeviceAttributes=$autoTrackDeviceAttributes, autoTrackActivityScreens=$autoTrackActivityScreens, migrationSiteId=[Redacted], screenViewUse=$screenViewUse, apiHost='$apiHost', cdnHost='$cdnHost')"
+    }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/config/ScreenView.kt
@@ -17,6 +17,10 @@ sealed class ScreenView(val name: String) {
 
     object InApp : ScreenView(name = "inapp")
 
+    override fun toString(): String {
+        return "ScreenView('$name')"
+    }
+
     companion object {
         /**
          * Returns the [ScreenView] enum constant for the given name.

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/di/SDKComponentExt.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/di/SDKComponentExt.kt
@@ -2,9 +2,13 @@ package io.customer.datapipelines.di
 
 import com.segment.analytics.kotlin.core.Analytics
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
+import io.customer.sdk.SdkInitializationLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.getOrNull
 
 // Extends the SDKComponent to allow overriding the analytics instance in DataPipelines module
 internal val SDKComponent.analyticsFactory: ((moduleConfig: DataPipelinesModuleConfig) -> Analytics)?
     get() = getOrNull(identifier = SDKComponentKeys.AnalyticsFactory)
+
+internal val SDKComponent.sdkInitLogger: SdkInitializationLogger
+    get() = singleton<SdkInitializationLogger> { SdkInitializationLogger(logger) }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -13,6 +13,7 @@ import com.segment.analytics.kotlin.core.utilities.putInContextUnderKey
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.di.analyticsFactory
+import io.customer.datapipelines.di.sdkInitLogger
 import io.customer.datapipelines.extensions.asMap
 import io.customer.datapipelines.extensions.sanitizeNullsForJson
 import io.customer.datapipelines.extensions.type
@@ -405,15 +406,14 @@ class CustomerIO private constructor(
             androidSDKComponent: AndroidSDKComponent,
             moduleConfig: DataPipelinesModuleConfig
         ): CustomerIO {
-            val logger = SDKComponent.logger
+            val logger = SDKComponent.sdkInitLogger
 
             val existingInstance = instance
             if (existingInstance != null) {
-                logger.error("CustomerIO instance is already initialized, skipping the initialization.")
+                logger.coreSdkAlreadyInitialized()
                 return existingInstance
             }
 
-            logger.debug("creating new instance of CustomerIO SDK.")
             return CustomerIO(
                 androidSDKComponent = androidSDKComponent,
                 moduleConfig = moduleConfig,

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -4,12 +4,12 @@ import android.app.Application
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.config.ScreenView
+import io.customer.datapipelines.di.sdkInitLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.CioLogLevel
-import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.model.Region
 
 /**
@@ -43,7 +43,7 @@ class CustomerIOBuilder(
 
     // Logging configuration
     private var logLevel: CioLogLevel = CioLogLevel.DEFAULT
-    private val logger: Logger = SDKComponent.logger
+    private val logger: SdkInitializationLogger = SDKComponent.sdkInitLogger
 
     // Host Settings
     private var region: Region = Region.US
@@ -192,6 +192,8 @@ class CustomerIOBuilder(
         // Update the log level for the SDK
         SDKComponent.logger.logLevel = logLevel
 
+        logger.coreSdkInitStart()
+
         // Initialize DataPipelinesModule with the provided configuration
         val dataPipelinesConfig = DataPipelinesModuleConfig(
             cdpApiKey = cdpApiKey,
@@ -220,10 +222,12 @@ class CustomerIOBuilder(
         modules.putAll(registeredModules.associateBy { module -> module.moduleName })
 
         modules.forEach { (_, module) ->
-            logger.debug("initializing SDK module ${module.moduleName}...")
+            logger.moduleInitStart(module)
             module.initialize()
+            logger.moduleInitSuccess(module)
         }
 
+        logger.coreSdkInitSuccess()
         return customerIO
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/SdkInitializationLogger.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/SdkInitializationLogger.kt
@@ -1,0 +1,49 @@
+package io.customer.sdk
+
+import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.module.CustomerIOModuleConfig
+import io.customer.sdk.core.util.Logger
+import java.lang.IllegalStateException
+
+internal class SdkInitializationLogger(private val logger: Logger) {
+
+    companion object {
+        const val TAG = "Init"
+    }
+
+    fun coreSdkInitStart() {
+        logger.debug(
+            tag = TAG,
+            message = "Creating new instance of CustomerIO SDK version: ${Version.version}..."
+        )
+    }
+
+    fun coreSdkAlreadyInitialized() {
+        logger.error(
+            tag = TAG,
+            message = "CustomerIO instance is already initialized, skipping the initialization",
+            throwable = IllegalStateException("CustomerIO SDK already initialized")
+        )
+    }
+
+    fun coreSdkInitSuccess() {
+        logger.info(
+            tag = TAG,
+            message = "CustomerIO SDK is initialized and ready to use"
+        )
+    }
+
+    fun moduleInitStart(module: CustomerIOModule<out CustomerIOModuleConfig>) {
+        logger.debug(
+            tag = TAG,
+            message = "Initializing SDK module ${module.moduleName} with config: ${module.moduleConfig}..."
+        )
+    }
+
+    fun moduleInitSuccess(module: CustomerIOModule<out CustomerIOModuleConfig>) {
+        logger.info(
+            tag = TAG,
+            message = "CustomerIO ${module.moduleName} module is initialized and ready to use"
+        )
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/config/DataPipelinesModuleConfigTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/config/DataPipelinesModuleConfigTest.kt
@@ -1,0 +1,31 @@
+package io.customer.datapipelines.config
+
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.sdk.data.model.Region
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+
+class DataPipelinesModuleConfigTest : JUnitTest() {
+
+    @Test
+    fun test_toString_generatesCorrectRepresentation() {
+        val config = DataPipelinesModuleConfig(
+            cdpApiKey = "anyKey",
+            region = Region.EU,
+            apiHostOverride = "test.domain.io/v1",
+            cdnHostOverride = "any.domain.io/v1",
+            flushAt = 20,
+            flushInterval = 30,
+            flushPolicies = emptyList(),
+            autoAddCustomerIODestination = true,
+            trackApplicationLifecycleEvents = true,
+            autoTrackDeviceAttributes = true,
+            autoTrackActivityScreens = true,
+            migrationSiteId = "anyId",
+            screenViewUse = ScreenView.All
+        )
+
+        val actual = config.toString()
+        assertEquals("DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=20, flushInterval=30, flushPolicies=[], autoAddCustomerIODestination=true, trackApplicationLifecycleEvents=true, autoTrackDeviceAttributes=true, autoTrackActivityScreens=true, migrationSiteId=[Redacted], screenViewUse=ScreenView('all'), apiHost='test.domain.io/v1', cdnHost='any.domain.io/v1')", actual)
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/config/ScreenViewTest.kt
@@ -43,4 +43,14 @@ class ScreenViewTest : JUnit5Test() {
 
         parsedValue shouldBeEqualTo ScreenView.All
     }
+
+    @Test
+    fun toString_givenAllType() {
+        ScreenView.All.toString() shouldBeEqualTo "ScreenView('all')"
+    }
+
+    @Test
+    fun toString_givenInAppType() {
+        ScreenView.InApp.toString() shouldBeEqualTo "ScreenView('inapp')"
+    }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -1,5 +1,6 @@
 package io.customer.datapipelines.sdk
 
+import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
 import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
@@ -11,20 +12,38 @@ import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.ScreenFilterPlugin
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.SdkInitializationLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verifyOrder
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class CustomerIOBuilderTest : RobolectricTest() {
+
+    private val mockLogger = mockk<SdkInitializationLogger>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<SdkInitializationLogger>(mockLogger)
+                    }
+                }
+            }
+        )
+    }
 
     override fun teardown() {
         // Clear the instance after each test to reset SDK to initial state
@@ -49,6 +68,25 @@ class CustomerIOBuilderTest : RobolectricTest() {
             .build()
 
         assertCalledOnce { givenModule.initialize() }
+    }
+
+    @Test
+    fun build_givenModule_expectInitializationLogs() {
+        val givenModule: CustomerIOGenericModule = mockGenericModule().apply {
+            every { moduleName } returns String.random
+            every { moduleConfig } returns mockk()
+        }
+
+        createCustomerIOBuilder()
+            .addCustomerIOModule(givenModule)
+            .build()
+
+        verifyOrder {
+            mockLogger.coreSdkInitStart()
+            mockLogger.moduleInitStart(givenModule)
+            mockLogger.moduleInitSuccess(givenModule)
+            mockLogger.coreSdkInitSuccess()
+        }
     }
 
     @Test

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -41,6 +41,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
     fun build_givenModule_expectInitializeModule() {
         val givenModule: CustomerIOGenericModule = mockGenericModule().apply {
             every { moduleName } returns String.random
+            every { moduleConfig } returns mockk()
         }
 
         createCustomerIOBuilder()
@@ -54,9 +55,11 @@ class CustomerIOBuilderTest : RobolectricTest() {
     fun build_givenMultipleModules_expectInitializeAllModules() {
         val givenModule1: CustomerIOGenericModule = mockGenericModule().apply {
             every { moduleName } returns String.random
+            every { moduleConfig } returns mockk()
         }
         val givenModule2: CustomerIOGenericModule = mockGenericModule().apply {
             every { moduleName } returns String.random
+            every { moduleConfig } returns mockk()
         }
 
         createCustomerIOBuilder()
@@ -72,9 +75,11 @@ class CustomerIOBuilderTest : RobolectricTest() {
     fun build_givenMultipleModulesOfSameType_expectOnlyInitializeOneModuleInstance() {
         val givenModule1: CustomerIOGenericModule = mockGenericModule().apply {
             every { moduleName } returns "shared-module-name"
+            every { moduleConfig } returns mockk()
         }
         val givenModule2: CustomerIOGenericModule = mockGenericModule().apply {
             every { moduleName } returns "shared-module-name"
+            every { moduleConfig } returns mockk()
         }
 
         createCustomerIOBuilder()

--- a/datapipelines/src/test/java/io/customer/sdk/SdkInitializationLoggerTest.kt
+++ b/datapipelines/src/test/java/io/customer/sdk/SdkInitializationLoggerTest.kt
@@ -1,0 +1,111 @@
+package io.customer.sdk
+
+import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.module.CustomerIOModuleConfig
+import io.customer.sdk.core.util.Logger
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SdkInitializationLoggerTest : JUnitTest() {
+
+    private val mockLogger = mockk<Logger>()
+    private val initLogger = SdkInitializationLogger(mockLogger)
+
+    @BeforeEach
+    fun setUp() {
+        every { mockLogger.debug(any(), any()) } just runs
+        every { mockLogger.info(any(), any()) } just runs
+        every { mockLogger.error(any(), any(), any()) } just runs
+    }
+
+    @Test
+    fun test_coreSdkInitStart_forwardsCorrectLog() {
+        val version = Version.version
+        initLogger.coreSdkInitStart()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Init",
+                message = "Creating new instance of CustomerIO SDK version: $version..."
+            )
+        }
+    }
+
+    @Test
+    fun test_coreSdkAlreadyInitialized_forwardsCorrectLog() {
+        initLogger.coreSdkAlreadyInitialized()
+
+        val capturedThrowable = slot<Throwable>()
+        assertCalledOnce {
+            mockLogger.error(
+                tag = eq("Init"),
+                message = eq("CustomerIO instance is already initialized, skipping the initialization"),
+                throwable = capture(capturedThrowable)
+            )
+        }
+        assert(capturedThrowable.captured is IllegalStateException)
+        assertEquals("CustomerIO SDK already initialized", capturedThrowable.captured.message)
+    }
+
+    @Test
+    fun test_coreSdkInitSuccess_forwardsCorrectLog() {
+        initLogger.coreSdkInitSuccess()
+
+        assertCalledOnce {
+            mockLogger.info(
+                tag = "Init",
+                message = "CustomerIO SDK is initialized and ready to use"
+            )
+        }
+    }
+
+    @Test
+    fun test_moduleInitStart_forwardsCorrectLog() {
+        initLogger.moduleInitStart(TestModule("TestModuleName", "TestModuleConfigReadableString"))
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Init",
+                message = "Initializing SDK module TestModuleName with config: TestModuleConfigReadableString..."
+            )
+        }
+    }
+
+    @Test
+    fun test_moduleInitSuccess_forwardsCorrectLog() {
+        initLogger.moduleInitSuccess(TestModule("AnotherModule", "Whatever"))
+
+        assertCalledOnce {
+            mockLogger.info(
+                tag = "Init",
+                message = "CustomerIO AnotherModule module is initialized and ready to use"
+            )
+        }
+    }
+
+    private class TestModule(
+        private val name: String,
+        private val configString: String
+    ) : CustomerIOModule<CustomerIOModuleConfig> {
+        override val moduleName: String
+            get() = name
+        override val moduleConfig: CustomerIOModuleConfig
+            get() = object : CustomerIOModuleConfig {
+                override fun toString(): String {
+                    return configString
+                }
+            }
+
+        override fun initialize() {
+            // Do nothing
+        }
+    }
+}

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -26,6 +26,7 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig : io/cust
 	public final fun getAutoTrackPushEvents ()Z
 	public final fun getNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;
 	public final fun getPushClickBehavior ()Lio/customer/messagingpush/config/PushClickBehavior;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder : io/customer/sdk/core/module/CustomerIOModuleConfig$Builder {
@@ -132,7 +133,6 @@ public abstract interface class io/customer/messagingpush/provider/DeviceTokenPr
 public final class io/customer/messagingpush/provider/FCMTokenProviderImpl : io/customer/messagingpush/provider/DeviceTokenProvider {
 	public fun <init> (Landroid/content/Context;)V
 	public fun getCurrentToken (Lkotlin/jvm/functions/Function1;)V
-	public final fun getLogger ()Lio/customer/sdk/core/util/Logger;
 	public fun isValidForThisDevice (Landroid/content/Context;)Z
 }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -65,6 +65,10 @@ class MessagingPushModuleConfig private constructor(
         }
     }
 
+    override fun toString(): String {
+        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior)"
+    }
+
     companion object {
         internal fun default(): MessagingPushModuleConfig = Builder().build()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -7,6 +7,7 @@ import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.PushDeliveryTrackerImpl
+import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.network.HttpClient
 import io.customer.messagingpush.network.HttpClientImpl
 import io.customer.messagingpush.processor.PushMessageProcessor
@@ -55,3 +56,6 @@ internal val SDKComponent.httpClient: HttpClient
 
 internal val SDKComponent.pushDeliveryTracker: PushDeliveryTracker
     get() = singleton<PushDeliveryTracker> { PushDeliveryTrackerImpl() }
+
+internal val SDKComponent.pushLogger: PushNotificationLogger
+    get() = singleton<PushNotificationLogger> { PushNotificationLogger(logger) }

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -1,0 +1,32 @@
+package io.customer.messagingpush.logger
+
+import io.customer.sdk.core.util.Logger
+
+internal class PushNotificationLogger(private val logger: Logger) {
+
+    companion object {
+        const val TAG = "Push"
+    }
+
+    fun logGooglePlayServicesAvailable() {
+        logger.debug(
+            tag = TAG,
+            message = "Google Play Services is available for this device"
+        )
+    }
+
+    fun logGooglePlayServicesUnavailable(result: Int) {
+        logger.debug(
+            tag = TAG,
+            message = "Google Play Services is NOT available for this device with result: $result"
+        )
+    }
+
+    fun logGooglePlayServicesAvailabilityCheckFailed(throwable: Throwable) {
+        logger.error(
+            tag = TAG,
+            message = "Checking Google Play Service availability check failed with error: : ${throwable.message}",
+            throwable = throwable
+        )
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
@@ -1,0 +1,16 @@
+package io.customer.messagingpush
+
+import io.customer.commontest.core.JUnit5Test
+import org.amshove.kluent.internal.assertEquals
+import org.junit.jupiter.api.Test
+
+class MessagingPushModuleConfigTest : JUnit5Test() {
+
+    @Test
+    fun test_toString_generatesCorrectRepresentation() {
+        val config = MessagingPushModuleConfig.default()
+
+        val actual = config.toString()
+        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART)", actual)
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -1,0 +1,62 @@
+package io.customer.messagingpush.logger
+
+import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.messagingpush.testutils.core.JUnitTest
+import io.customer.sdk.core.util.Logger
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PushNotificationLoggerTest : JUnitTest() {
+
+    private val mockLogger = mockk<Logger>()
+    private val pushLogger = PushNotificationLogger(mockLogger)
+
+    @BeforeEach
+    fun setUp() {
+        every { mockLogger.debug(any(), any()) } just runs
+        every { mockLogger.error(any(), any(), any()) } just runs
+    }
+
+    @Test
+    fun test_logGooglePlayServicesAvailable_forwardsCorrectCallToLogger() {
+        pushLogger.logGooglePlayServicesAvailable()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Google Play Services is available for this device"
+            )
+        }
+    }
+
+    @Test
+    fun test_logGooglePlayServicesUnavailable_forwardsCorrectCallToLogger() {
+        pushLogger.logGooglePlayServicesUnavailable(499)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Google Play Services is NOT available for this device with result: 499"
+            )
+        }
+    }
+
+    @Test
+    fun test_logGooglePlayServicesAvailabilityCheckFailed_forwardsCorrectCallToLogger() {
+        val message = "Play service not available"
+        val throwable = IllegalStateException(message)
+        pushLogger.logGooglePlayServicesAvailabilityCheckFailed(throwable)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Checking Google Play Service availability check failed with error: : $message",
+                throwable = throwable
+            )
+        }
+    }
+}


### PR DESCRIPTION
Part of: [MBL-1075](https://linear.app/customerio/issue/MBL-1075/update-push-notifications-logging-for-android)
Closes: [MBL-1117](https://linear.app/customerio/issue/MBL-1117/update-initialization-logs)

### Overview
This PR implements log definitions as defined in the log definitions repo https://github.com/customerio/mobile-log-definitions/pull/6

- Creates an SDK initialization logger and push wrappers for convenience 
- Adds logs for SDK init and SDK modules init and Google play services checks

### Test
- Added unit test for the wrapper logger
- Logs after implementation are as follows
```
[CIO] D  [Init] Creating new instance of CustomerIO SDK version: 4.5.8...

[CIO] D  [Init] Initializing SDK module DataPipelines with config: DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=20, flushInterval=30, flushPolicies=[], autoAddCustomerIODestination=true, trackApplicationLifecycleEvents=true, autoTrackDeviceAttributes=true, autoTrackActivityScreens=true, migrationSiteId=[Redacted], screenViewUse=ScreenView('all'), apiHost='cdp.customer.io/v1', cdnHost='cdp.customer.io/v1')...
[CIO] I  [Init] CustomerIO DataPipelines module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingPushFCM with config: MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART)...
[CIO] D  [Push] Google Play Services is available for this device
[CIO] I  [Init] CustomerIO MessagingPushFCM module is initialized and ready to use

[CIO] I  [Init] CustomerIO SDK is initialized and ready to use
```