### PR TITLE
chore: Update push setup logs

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/di/SDKComponentExt.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/di/SDKComponentExt.kt
@@ -2,7 +2,7 @@ package io.customer.datapipelines.di
 
 import com.segment.analytics.kotlin.core.Analytics
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
-import io.customer.sdk.SdkInitializationLogger
+import io.customer.sdk.DataPipelinesLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.getOrNull
 
@@ -10,5 +10,5 @@ import io.customer.sdk.core.extensions.getOrNull
 internal val SDKComponent.analyticsFactory: ((moduleConfig: DataPipelinesModuleConfig) -> Analytics)?
     get() = getOrNull(identifier = SDKComponentKeys.AnalyticsFactory)
 
-internal val SDKComponent.sdkInitLogger: SdkInitializationLogger
-    get() = singleton<SdkInitializationLogger> { SdkInitializationLogger(logger) }
+internal val SDKComponent.dataPipelinesLogger: DataPipelinesLogger
+    get() = singleton<DataPipelinesLogger> { DataPipelinesLogger(logger) }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIOBuilder.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import io.customer.datapipelines.config.DataPipelinesModuleConfig
 import io.customer.datapipelines.config.ScreenView
-import io.customer.datapipelines.di.sdkInitLogger
+import io.customer.datapipelines.di.dataPipelinesLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.module.CustomerIOModule
@@ -43,7 +43,7 @@ class CustomerIOBuilder(
 
     // Logging configuration
     private var logLevel: CioLogLevel = CioLogLevel.DEFAULT
-    private val logger: SdkInitializationLogger = SDKComponent.sdkInitLogger
+    private val logger: DataPipelinesLogger = SDKComponent.dataPipelinesLogger
 
     // Host Settings
     private var region: Region = Region.US

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelinesLogger.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelinesLogger.kt
@@ -5,22 +5,23 @@ import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.core.util.Logger
 import java.lang.IllegalStateException
 
-internal class SdkInitializationLogger(private val logger: Logger) {
+internal class DataPipelinesLogger(private val logger: Logger) {
 
     companion object {
-        const val TAG = "Init"
+        const val INIT_TAG = "Init"
+        const val PUSH_TAG = "Push"
     }
 
     fun coreSdkInitStart() {
         logger.debug(
-            tag = TAG,
+            tag = INIT_TAG,
             message = "Creating new instance of CustomerIO SDK version: ${Version.version}..."
         )
     }
 
     fun coreSdkAlreadyInitialized() {
         logger.error(
-            tag = TAG,
+            tag = INIT_TAG,
             message = "CustomerIO instance is already initialized, skipping the initialization",
             throwable = IllegalStateException("CustomerIO SDK already initialized")
         )
@@ -28,22 +29,52 @@ internal class SdkInitializationLogger(private val logger: Logger) {
 
     fun coreSdkInitSuccess() {
         logger.info(
-            tag = TAG,
+            tag = INIT_TAG,
             message = "CustomerIO SDK is initialized and ready to use"
         )
     }
 
     fun moduleInitStart(module: CustomerIOModule<out CustomerIOModuleConfig>) {
         logger.debug(
-            tag = TAG,
+            tag = INIT_TAG,
             message = "Initializing SDK module ${module.moduleName} with config: ${module.moduleConfig}..."
         )
     }
 
     fun moduleInitSuccess(module: CustomerIOModule<out CustomerIOModuleConfig>) {
         logger.info(
-            tag = TAG,
+            tag = INIT_TAG,
             message = "CustomerIO ${module.moduleName} module is initialized and ready to use"
         )
     }
+
+    //region Push
+    fun logStoringDevicePushToken(token: String, userId: String?) {
+        logger.debug(
+            tag = PUSH_TAG,
+            message = "Storing device token: $token for user profile: $userId"
+        )
+    }
+
+    fun logStoringBlankPushToken() {
+        logger.debug(
+            tag = PUSH_TAG,
+            message = "Attempting to register blank token, ignoring request"
+        )
+    }
+
+    fun logRegisteringPushToken(token: String, userId: String?) {
+        logger.debug(
+            tag = PUSH_TAG,
+            message = "Registering device token: $token for user profile: $userId"
+        )
+    }
+
+    fun logPushTokenRefreshed() {
+        logger.debug(
+            tag = PUSH_TAG,
+            message = "Token refreshed, deleting old token to avoid registering same device multiple times"
+        )
+    }
+    //endregion Push
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/sdk/CustomerIOBuilderTest.kt
@@ -12,7 +12,7 @@ import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.ScreenFilterPlugin
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
-import io.customer.sdk.SdkInitializationLogger
+import io.customer.sdk.DataPipelinesLogger
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.data.model.Region
@@ -30,7 +30,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CustomerIOBuilderTest : RobolectricTest() {
 
-    private val mockLogger = mockk<SdkInitializationLogger>(relaxed = true)
+    private val mockLogger = mockk<DataPipelinesLogger>(relaxed = true)
 
     @Before
     fun setUp() {
@@ -38,7 +38,7 @@ class CustomerIOBuilderTest : RobolectricTest() {
             testConfigurationDefault {
                 diGraph {
                     sdk {
-                        overrideDependency<SdkInitializationLogger>(mockLogger)
+                        overrideDependency<DataPipelinesLogger>(mockLogger)
                     }
                 }
             }

--- a/datapipelines/src/test/java/io/customer/sdk/DataPipelinesLoggerTest.kt
+++ b/datapipelines/src/test/java/io/customer/sdk/DataPipelinesLoggerTest.kt
@@ -14,10 +14,10 @@ import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class SdkInitializationLoggerTest : JUnitTest() {
+class DataPipelinesLoggerTest : JUnitTest() {
 
     private val mockLogger = mockk<Logger>()
-    private val initLogger = SdkInitializationLogger(mockLogger)
+    private val initLogger = DataPipelinesLogger(mockLogger)
 
     @BeforeEach
     fun setUp() {
@@ -87,6 +87,58 @@ class SdkInitializationLoggerTest : JUnitTest() {
             mockLogger.info(
                 tag = "Init",
                 message = "CustomerIO AnotherModule module is initialized and ready to use"
+            )
+        }
+    }
+
+    @Test
+    fun test_logStoringDevicePushToken_forwardsCorrectLog() {
+        val token = "fcm-token"
+        val userId = "user-id"
+        initLogger.logStoringDevicePushToken(token, userId)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Storing device token: $token for user profile: $userId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logStoringBlankPushToken_forwardsCorrectLog() {
+        initLogger.logStoringBlankPushToken()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Attempting to register blank token, ignoring request"
+            )
+        }
+    }
+
+    @Test
+    fun test_logRegisteringPushToken_forwardsCorrectLog() {
+        val token = "fcm-token"
+        val userId = "user-id"
+        initLogger.logRegisteringPushToken(token, userId)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Registering device token: $token for user profile: $userId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logPushTokenRefreshed_forwardsCorrectLog() {
+        initLogger.logPushTokenRefreshed()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Token refreshed, deleting old token to avoid registering same device multiple times"
             )
         }
     }

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -127,13 +127,6 @@ public final class io/customer/messagingpush/processor/PushMessageProcessor$Comp
 
 public abstract interface class io/customer/messagingpush/provider/DeviceTokenProvider {
 	public abstract fun getCurrentToken (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun isValidForThisDevice (Landroid/content/Context;)Z
-}
-
-public final class io/customer/messagingpush/provider/FCMTokenProviderImpl : io/customer/messagingpush/provider/DeviceTokenProvider {
-	public fun <init> (Landroid/content/Context;)V
-	public fun getCurrentToken (Lkotlin/jvm/functions/Function1;)V
-	public fun isValidForThisDevice (Landroid/content/Context;)Z
 }
 
 public abstract interface class io/customer/messagingpush/util/DeepLinkUtil {

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -2,6 +2,8 @@
 
 package io.customer.messagingpush.di
 
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
@@ -28,7 +30,14 @@ The use of extensions was chosen over creating a separate graph class for each m
  */
 
 internal val AndroidSDKComponent.fcmTokenProvider: DeviceTokenProvider
-    get() = newInstance<DeviceTokenProvider> { FCMTokenProviderImpl(context = applicationContext) }
+    get() = newInstance<DeviceTokenProvider> {
+        FCMTokenProviderImpl(
+            context = applicationContext,
+            googleApiAvailabilityProvider = { GoogleApiAvailability.getInstance() },
+            firebaseMessagingProvider = { FirebaseMessaging.getInstance() },
+            pushLogger = SDKComponent.pushLogger
+        )
+    }
 
 val SDKComponent.pushModuleConfig: MessagingPushModuleConfig
     get() = newInstance {

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -29,4 +29,26 @@ internal class PushNotificationLogger(private val logger: Logger) {
             throwable = throwable
         )
     }
+
+    fun obtainingTokenStarted() {
+        logger.debug(
+            tag = TAG,
+            message = "Getting current device token from Firebase messaging on app launch"
+        )
+    }
+
+    fun obtainingTokenSuccess(token: String) {
+        logger.debug(
+            tag = TAG,
+            message = "Got current device token: $token"
+        )
+    }
+
+    fun obtainingTokenFailed(throwable: Throwable?) {
+        logger.error(
+            tag = TAG,
+            message = "Failed to get device token with error: ${throwable?.message}",
+            throwable = throwable
+        )
+    }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
@@ -4,14 +4,13 @@ import android.content.Context
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
-import io.customer.messagingpush.di.pushLogger
-import io.customer.sdk.core.di.SDKComponent
+import io.customer.messagingpush.logger.PushNotificationLogger
+import javax.inject.Provider
 
 /**
  *  Responsible for token generation and validity
  */
 interface DeviceTokenProvider {
-    fun isValidForThisDevice(context: Context): Boolean
     fun getCurrentToken(onComplete: (String?) -> Unit)
 }
 
@@ -19,16 +18,16 @@ interface DeviceTokenProvider {
  * Wrapper around FCM SDK to make the code base more testable. There is no concept of checked-exceptions in Kotlin
  * so we need to handle the exception manually.
  */
-class FCMTokenProviderImpl(
-    private val context: Context
+internal class FCMTokenProviderImpl(
+    private val context: Context,
+    private val googleApiAvailabilityProvider: Provider<GoogleApiAvailability>,
+    private val firebaseMessagingProvider: Provider<FirebaseMessaging>,
+    private val pushLogger: PushNotificationLogger
 ) : DeviceTokenProvider {
 
-    private val logger = SDKComponent.logger
-    private val pushLogger = SDKComponent.pushLogger
-
-    override fun isValidForThisDevice(context: Context): Boolean {
+    private fun isValidForThisDevice(): Boolean {
         return try {
-            val result = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+            val result = googleApiAvailabilityProvider.get().isGooglePlayServicesAvailable(context)
 
             if (result == ConnectionResult.SUCCESS) {
                 pushLogger.logGooglePlayServicesAvailable()
@@ -44,27 +43,26 @@ class FCMTokenProviderImpl(
     }
 
     override fun getCurrentToken(onComplete: (String?) -> Unit) {
-        logger.debug("getting current FCM device token...")
+        pushLogger.obtainingTokenStarted()
         try {
-            if (!isValidForThisDevice(context)) {
+            if (!isValidForThisDevice()) {
                 onComplete(null)
                 return
             }
 
-            FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            firebaseMessagingProvider.get().token.addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     val existingDeviceToken = task.result
-                    logger.debug("got current FCM token: $existingDeviceToken")
+                    pushLogger.obtainingTokenSuccess(existingDeviceToken)
 
                     onComplete(existingDeviceToken)
                 } else {
-                    logger.debug("got current FCM token: null")
-                    logger.error(task.exception?.message ?: "error while getting FCM token")
+                    pushLogger.obtainingTokenFailed(task.exception)
                     onComplete(null)
                 }
             }
         } catch (exception: Throwable) {
-            logger.error(exception.message ?: "error while getting FCM token")
+            pushLogger.obtainingTokenFailed(exception)
             onComplete(null)
         }
     }

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -59,4 +59,44 @@ class PushNotificationLoggerTest : JUnitTest() {
             )
         }
     }
+
+    @Test
+    fun test_obtainingTokenStarted_forwardsCorrectCallToLogger() {
+        pushLogger.obtainingTokenStarted()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Getting current device token from Firebase messaging on app launch"
+            )
+        }
+    }
+
+    @Test
+    fun test_obtainingTokenSuccess_forwardsCorrectCallToLogger() {
+        val token = "fcm-token"
+        pushLogger.obtainingTokenSuccess(token)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Got current device token: $token"
+            )
+        }
+    }
+
+    @Test
+    fun test_obtainingTokenFailed_forwardsCorrectCallToLogger() {
+        val errorMessage = "Error message!"
+        val throwable = IllegalStateException(errorMessage)
+        pushLogger.obtainingTokenFailed(throwable)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Failed to get device token with error: $errorMessage",
+                throwable = throwable
+            )
+        }
+    }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
@@ -1,0 +1,119 @@
+package io.customer.messagingpush.provider
+
+import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.messaging.FirebaseMessaging
+import io.customer.commontest.core.JUnit5Test
+import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.messagingpush.logger.PushNotificationLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class FCMTokenProviderTest : JUnit5Test() {
+
+    private val mockContext = mockk<Context>()
+    private val mockGoogleApiAvailability = mockk<GoogleApiAvailability>()
+    private val mockFirebaseMessaging = mockk<FirebaseMessaging>()
+    private val mockPushLogger = mockk<PushNotificationLogger>(relaxed = true)
+
+    private val tokenProvider: DeviceTokenProvider = FCMTokenProviderImpl(
+        mockContext, { mockGoogleApiAvailability }, { mockFirebaseMessaging }, mockPushLogger
+    )
+
+    @Test
+    fun test_getCurrentToken_givenPlayServicesAvailable_logSuccess() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+
+        tokenProvider.getCurrentToken { }
+
+        assertCalledOnce {
+            mockPushLogger.logGooglePlayServicesAvailable()
+        }
+    }
+
+    @Test
+    fun test_getCurrentToken_givenPlayServicesUnavailable_logUnavailable() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.API_UNAVAILABLE
+
+        tokenProvider.getCurrentToken { }
+
+        assertCalledOnce {
+            mockPushLogger.logGooglePlayServicesUnavailable(ConnectionResult.API_UNAVAILABLE)
+        }
+    }
+
+    @Test
+    fun test_getCurrentToken_givenPlayServicesCheckThrows_logUnavailable() {
+        val illegalArgumentException = IllegalArgumentException()
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } throws illegalArgumentException
+
+        tokenProvider.getCurrentToken { }
+
+        assertCalledOnce {
+            mockPushLogger.logGooglePlayServicesAvailabilityCheckFailed(illegalArgumentException)
+        }
+    }
+
+    @Test
+    fun test_getCurrentToken_givenObtainingTokenSuccessful() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+
+        val token = "fcm-token"
+        val task = mockk<Task<String>>(relaxed = true)
+        val taskSlot = slot<OnCompleteListener<String>>()
+        every { task.isSuccessful } returns true
+        every { task.result } returns token
+        every { mockFirebaseMessaging.getToken() } returns task
+        every { task.addOnCompleteListener(capture(taskSlot)) } returns task
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        taskSlot.captured.onComplete(task)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenStarted() }
+        assertCalledOnce { mockPushLogger.obtainingTokenSuccess(token) }
+        result shouldBeEqualTo token
+    }
+
+    @Test
+    fun test_getCurrentToken_givenObtainingTokenNotSuccessful() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+
+        val task = mockk<Task<String>>(relaxed = true)
+        val exception = IllegalStateException()
+        val taskSlot = slot<OnCompleteListener<String>>()
+        every { task.isSuccessful } returns false
+        every { task.exception } returns exception
+        every { mockFirebaseMessaging.getToken() } returns task
+        every { task.addOnCompleteListener(capture(taskSlot)) } returns task
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        taskSlot.captured.onComplete(task)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenStarted() }
+        assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun test_getCurrentToken_givenObtainingTokenThrows() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+
+        val exception = IllegalStateException()
+        every { mockFirebaseMessaging.getToken() } throws exception
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+
+        assertCalledOnce { mockPushLogger.obtainingTokenStarted() }
+        assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
+        result shouldBeEqualTo null
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
@@ -23,7 +23,10 @@ class FCMTokenProviderTest : JUnit5Test() {
     private val mockPushLogger = mockk<PushNotificationLogger>(relaxed = true)
 
     private val tokenProvider: DeviceTokenProvider = FCMTokenProviderImpl(
-        mockContext, { mockGoogleApiAvailability }, { mockFirebaseMessaging }, mockPushLogger
+        mockContext,
+        { mockGoogleApiAvailability },
+        { mockFirebaseMessaging },
+        mockPushLogger
     )
 
     @Test


### PR DESCRIPTION
Part of: [MBL-1075](https://linear.app/customerio/issue/MBL-1075/update-push-notifications-logging-for-android)
Closes: [MBL-1118](https://linear.app/customerio/issue/MBL-1118/update-initialization-logs)

### Overview
This PR implements log definitions as defined in the log definitions repo https://github.com/customerio/mobile-log-definitions/pull/7

- Transforms the initialization logger into a DataPipelines logger
- Adds logs for pulling, storing and registering push token

### Test
- Added unit test for the wrapper logger
- Logs after implementation are as follows
```
[CIO] D  [Init] Creating new instance of CustomerIO SDK version: 4.5.8...

[CIO] D  [Init] Initializing SDK module DataPipelines with config: DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=20, flushInterval=30, flushPolicies=[], autoAddCustomerIODestination=true, trackApplicationLifecycleEvents=true, autoTrackDeviceAttributes=true, autoTrackActivityScreens=true, migrationSiteId=[Redacted], screenViewUse=ScreenView('all'), apiHost='cdp.customer.io/v1', cdnHost='cdp.customer.io/v1')...
[CIO] I  [Init] CustomerIO DataPipelines module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingPushFCM with config: MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART)...

[CIO] D  [Push] Getting current device token from Firebase messaging on app launch
[CIO] D  [Push] Google Play Services is available for this device
[CIO] I  [Init] CustomerIO MessagingPushFCM module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingInApp with config: io.customer.messaginginapp.MessagingInAppModuleConfig@1c6fb9f...
[CIO] I  [Init] CustomerIO MessagingInApp module is initialized and ready to use

[CIO] I  [Init] CustomerIO SDK is initialized and ready to use

[CIO] D  [Push] Got current device token: {actualToken}
[CIO] D  [Push] Storing device token: {actualToken} for user profile: null
[CIO] D  [Push] Registering device token: {actualToken} for user profile: null
```