### PR TITLE
ci: use app credentials for semantic release

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -39,6 +39,12 @@ jobs:
 #           # Use local version to make sure the report is generated for the current changes
 #           IS_DEVELOPMENT: 'true'
 
+      - name: 'Generate token'
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.CIO_APP_ID }}
+          private_key: ${{ secrets.CIO_APP_SECRET }}
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.
       #    For example, if the last deployment you made was version 1.3.5 and you are releasing a new feature
@@ -59,7 +65,7 @@ jobs:
             @semantic-release/exec
         env:
           # Needs to push git commits to repo. Needs write access.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Notify team of git tag being created
         uses: slackapi/slack-github-action@71c4f79cb8ada5ed920ec668b73f8530444a133b # v2.0.0-rc.3


### PR DESCRIPTION
This pr updates the semantic release action so that it uses app credentials instead of GITHUB_TOKEN.
By using an app, we can setup the regular branch protection and ruleset while allowing the semantic release action to bypass them.

## Test plan
I tested the approach on the RN repo [#431](https://github.com/customerio/customerio-reactnative/pull/431)