### PR TITLE
chore: Update logs for handling push and tracking delivery and open events

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -55,7 +55,6 @@ internal class CustomerIOPushNotificationHandler(
     }
 
     private val diGraph = SDKComponent
-    private val logger = SDKComponent.logger
     private val pushLogger = SDKComponent.pushLogger
 
     private val moduleConfig: MessagingPushModuleConfig
@@ -73,10 +72,10 @@ internal class CustomerIOPushNotificationHandler(
         context: Context,
         handleNotificationTrigger: Boolean = true
     ): Boolean {
-        logger.debug("Handling push message. Bundle: $bundle")
+        pushLogger.logReceivedPushMessage(remoteMessage, handleNotificationTrigger)
         // Check if message contains a data payload.
         if (bundle.isEmpty) {
-            logger.debug("Push message received is empty")
+            pushLogger.logReceivedEmptyPushMessage()
             return false
         }
 
@@ -87,12 +86,15 @@ internal class CustomerIOPushNotificationHandler(
         val deliveryToken = bundle.getString(DELIVERY_TOKEN_KEY)
 
         if (deliveryId != null && deliveryToken != null) {
+            // CIO push notification
+            pushLogger.logReceivedCioPushMessage()
             // Use processor to track metrics properly and avoid duplication
             pushMessageProcessor.processRemoteMessageDeliveredMetrics(
                 deliveryId = deliveryId,
                 deliveryToken = deliveryToken
             )
         } else {
+            pushLogger.logReceivedNonCioPushMessage()
             // not a CIO push notification
             return false
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -55,6 +55,7 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {
         PushMessageProcessorImpl(
             logger = logger,
+            pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
             deepLinkUtil = deepLinkUtil
         )

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush.logger
 
 import com.google.firebase.messaging.RemoteMessage
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.sdk.core.util.Logger
 
 internal class PushNotificationLogger(private val logger: Logger) {
@@ -57,6 +58,84 @@ internal class PushNotificationLogger(private val logger: Logger) {
         logger.debug(
             tag = TAG,
             message = "Showing notification for message: ${toString(message)}"
+        )
+    }
+
+    fun logReceivedPushMessage(message: RemoteMessage, handleNotificationTrigger: Boolean) {
+        logger.debug(
+            tag = TAG,
+            message = "handleNotificationTrigger: $handleNotificationTrigger - Received notification for message: ${toString(message)}"
+        )
+    }
+
+    fun logReceivedEmptyPushMessage() {
+        logger.debug(
+            tag = TAG,
+            message = "Push message received is empty"
+        )
+    }
+
+    fun logReceivedCioPushMessage() {
+        logger.debug(
+            tag = TAG,
+            message = "Received CIO push message"
+        )
+    }
+
+    fun logReceivedNonCioPushMessage() {
+        logger.debug(
+            tag = TAG,
+            message = "Received non CIO push message, ignoring message"
+        )
+    }
+
+    fun logReceivedPushMessageWithEmptyDeliveryId() {
+        logger.debug(
+            tag = TAG,
+            message = "Received message with empty deliveryId"
+        )
+    }
+
+    fun logReceivedDuplicatePushMessageDeliveryId(deliveryId: String) {
+        logger.debug(
+            tag = TAG,
+            message = "Received duplicate message with deliveryId: $deliveryId"
+        )
+    }
+
+    fun logReceivedNewMessageWithDeliveryId(deliveryId: String) {
+        logger.debug(
+            tag = TAG,
+            message = "Received new message with deliveryId: $deliveryId"
+        )
+    }
+
+    fun logPushMetricsAutoTrackingDisabled() {
+        logger.debug(
+            tag = TAG,
+            message = "Received message but auto tracking is disabled"
+        )
+    }
+
+    fun logTrackingPushMessageDelivered(deliveryId: String) {
+        logger.debug(
+            tag = TAG,
+            message = "Tracking push message delivered with deliveryId: $deliveryId"
+        )
+    }
+
+    fun logTrackingPushMessageOpened(payload: CustomerIOParsedPushPayload) {
+        logger.debug(
+            tag = TAG,
+            message = "Tracking push message opened with payload: $payload"
+        )
+    }
+
+    fun logFailedToHandlePushClick(throwable: Throwable) {
+        logger.error(
+            tag = TAG,
+            message = "Failed to handle push click: ${throwable.message}",
+            throwable = throwable
         )
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/CustomerIOPushNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/CustomerIOPushNotificationHandlerTest.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
@@ -68,9 +69,55 @@ internal class CustomerIOPushNotificationHandlerTest : IntegrationTest() {
     }
 
     @Test
-    fun handleMessage_shouldLogShowingPushNotification() {
+    fun handleMessage_givenNonCioBundle_shouldLogPushMessageEmpty() {
+        val bundle = Bundle()
+        bundle.putString("anyKey", "anyValue")
+        val remoteMessage = RemoteMessage(bundle)
+        val handler = CustomerIOPushNotificationHandler(mockk(relaxed = true), remoteMessage)
+
+        handler.handleMessage(contextMock, false)
+
+        assertCalledOnce { mockPushLogger.logReceivedPushMessage(remoteMessage, false) }
+        assertCalledOnce { mockPushLogger.logReceivedNonCioPushMessage() }
+    }
+
+    @Test
+    fun handleMessage_givenEmptyBundle_shouldLogPushMessageEmpty() {
+        val bundle = Bundle()
+        val remoteMessage = RemoteMessage(bundle)
+        val handler = CustomerIOPushNotificationHandler(mockk(relaxed = true), remoteMessage)
+
+        handler.handleMessage(contextMock, true)
+
+        assertCalledOnce { mockPushLogger.logReceivedPushMessage(remoteMessage, true) }
+        assertCalledOnce { mockPushLogger.logReceivedEmptyPushMessage() }
+    }
+
+    @Test
+    fun handleMessage_givenValidCioBundle_shouldLogPushMessageEmpty() {
+        val bundle = Bundle()
+        bundle.putString("CIO-Delivery-ID", "anyId")
+        bundle.putString("CIO-Delivery-Token", "anyToken")
+        val remoteMessage = RemoteMessage(bundle)
+        val handler = CustomerIOPushNotificationHandler(mockk(relaxed = true), remoteMessage)
+
+        handler.handleMessage(contextMock, false)
+
+        assertCalledOnce { mockPushLogger.logReceivedPushMessage(remoteMessage, false) }
+        assertCalledOnce { mockPushLogger.logReceivedCioPushMessage() }
+    }
+
+    @Test
+    fun handleMessage_givenHandleNotificationTriggerTrue_shouldLogShowingPushNotification() {
         pushNotificationHandler.handleMessage(contextMock, true)
 
         assertCalledOnce { mockPushLogger.logShowingPushNotification(any()) }
+    }
+
+    @Test
+    fun handleMessage_givenHandleNotificationTriggerFalse_shouldNotLogShowingPushNotification() {
+        pushNotificationHandler.handleMessage(contextMock, false)
+
+        assertCalledNever { mockPushLogger.logShowingPushNotification(any()) }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -1,7 +1,9 @@
 package io.customer.messagingpush.logger
 
+import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.every
@@ -126,6 +128,169 @@ class PushNotificationLoggerTest : JUnitTest() {
                     "  color = testColor\n" +
                     "  imageUrl = null\n" +
                     "Data: {testKey=testValue}\n"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedPushMessage_forwardsCorrectCallToLogger() {
+        val notification = mockk<RemoteMessage.Notification>()
+        every { notification.title } returns "testTitle"
+        every { notification.body } returns "test body"
+        every { notification.icon } returns "testIcon"
+        every { notification.color } returns "testColor"
+        every { notification.imageUrl } returns null
+        val data = mapOf("testKey" to "testValue")
+        val message = mockk<RemoteMessage>()
+        every { message.notification } returns notification
+        every { message.data } returns data
+
+        pushLogger.logReceivedPushMessage(message, true)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "handleNotificationTrigger: true - Received notification for message: Notification:\n" +
+                    "  title = testTitle\n" +
+                    "  body = test body\n" +
+                    "  icon = testIcon\n" +
+                    "  color = testColor\n" +
+                    "  imageUrl = null\n" +
+                    "Data: {testKey=testValue}\n"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedEmptyPushMessage_forwardsCorrectCallToLogger() {
+        pushLogger.logReceivedEmptyPushMessage()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Push message received is empty"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedCioPushMessage_forwardsCorrectCallToLogger() {
+        pushLogger.logReceivedCioPushMessage()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received CIO push message"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedNonCioPushMessage_forwardsCorrectCallToLogger() {
+        pushLogger.logReceivedNonCioPushMessage()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received non CIO push message, ignoring message"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedPushMessageWithEmptyDeliveryId_forwardsCorrectCallToLogger() {
+        pushLogger.logReceivedPushMessageWithEmptyDeliveryId()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received message with empty deliveryId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedDuplicatePushMessageDeliveryId_forwardsCorrectCallToLogger() {
+        val deliveryId = "delivery-id"
+        pushLogger.logReceivedDuplicatePushMessageDeliveryId(deliveryId)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received duplicate message with deliveryId: $deliveryId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logReceivedNewMessageWithDeliveryId_forwardsCorrectCallToLogger() {
+        val deliveryId = "delivery-id"
+        pushLogger.logReceivedNewMessageWithDeliveryId(deliveryId)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received new message with deliveryId: $deliveryId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logPushMetricsAutoTrackingDisabled_forwardsCorrectCallToLogger() {
+        pushLogger.logPushMetricsAutoTrackingDisabled()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Received message but auto tracking is disabled"
+            )
+        }
+    }
+
+    @Test
+    fun test_logTrackingPushMessageDelivered_forwardsCorrectCallToLogger() {
+        val deliveryId = "delivery-id"
+        pushLogger.logTrackingPushMessageDelivered(deliveryId)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Tracking push message delivered with deliveryId: $deliveryId"
+            )
+        }
+    }
+
+    @Test
+    fun test_logTrackingPushMessageOpened_forwardsCorrectCallToLogger() {
+        val bundle = mockk<Bundle>()
+        val payload = CustomerIOParsedPushPayload(
+            extras = bundle,
+            deepLink = "deepLink",
+            cioDeliveryId = "deliveryId",
+            cioDeliveryToken = "token",
+            title = "title",
+            body = "body"
+        )
+        pushLogger.logTrackingPushMessageOpened(payload)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Tracking push message opened with payload: $payload"
+            )
+        }
+    }
+
+    @Test
+    fun test_logFailedToHandlePushClick_forwardsCorrectCallToLogger() {
+        val throwable = IllegalArgumentException("error message")
+        pushLogger.logFailedToHandlePushClick(throwable)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Failed to handle push click: error message",
+                throwable = throwable
             )
         }
     }


### PR DESCRIPTION
Part of: [MBL-1075](https://linear.app/customerio/issue/MBL-1075/update-push-notifications-logging-for-android)
Closes: [MBL-1121](https://linear.app/customerio/issue/MBL-1121/update-push-notification-click-handling-logs)

### Overview
This PR implements log definitions as defined in the log definitions repo https://github.com/customerio/mobile-log-definitions/pull/9

- Adds logs for push received handling, tracking delivery and opening

### Test
- Added unit test for the wrapper logger and call sites
- Logs after implementation are as follows
```
[CIO] D  [Init] Creating new instance of CustomerIO SDK version: 4.5.8...

[CIO] D  [Init] Initializing SDK module DataPipelines with config: DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=20, flushInterval=30, flushPolicies=[], autoAddCustomerIODestination=true, trackApplicationLifecycleEvents=true, autoTrackDeviceAttributes=true, autoTrackActivityScreens=true, migrationSiteId=[Redacted], screenViewUse=ScreenView('all'), apiHost='cdp.customer.io/v1', cdnHost='cdp.customer.io/v1')...
[CIO] I  [Init] CustomerIO DataPipelines module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingPushFCM with config: MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART)...

[CIO] D  [Push] Getting current device token from Firebase messaging on app launch
[CIO] D  [Push] Google Play Services is available for this device
[CIO] I  [Init] CustomerIO MessagingPushFCM module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingInApp with config: io.customer.messaginginapp.MessagingInAppModuleConfig@1c6fb9f...
[CIO] I  [Init] CustomerIO MessagingInApp module is initialized and ready to use

[CIO] I  [Init] CustomerIO SDK is initialized and ready to use

[CIO] D  [Push] Got current device token: {actualToken}
[CIO] D  [Push] Storing device token: {actualToken} for user profile: null
[CIO] D  [Push] Registering device token: {actualToken} for user profile: null
[CIO] D  [Push] Automatically registering device token: {{token}} to newly identified profile: mo@push.io
[CIO] D  [Push] Received new message with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] Tracking push message delivered with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] handleNotificationTrigger: true - Received notification for message: {CIO-Delivery-Token={token}, body=Test push message!, link=http://www.java-sample.com/settings, image=https://userimg-assets.customeriomail.com/images/client-env-122175/1730071976590_cat-hd-wallpaper-1_01JB856PZPSRSGV3GP9C44TBGV.jpg, title=Test Push, CIO-Delivery-ID=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==}
[CIO] D  [Push] Received CIO push message
[CIO] D  [Push] Received duplicate message with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] Showing notification for message: {CIO-Delivery-Token={token}, body=Test push message!, link=http://www.java-sample.com/settings, image=https://userimg-assets.customeriomail.com/images/client-env-122175/1730071976590_cat-hd-wallpaper-1_01JB856PZPSRSGV3GP9C44TBGV.jpg, title=Test Push, CIO-Delivery-ID=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==}
[CIO] D  [Push] Tracking push message opened with payload: CustomerIOParsedPushPayload(extras=Bundle[mParcelledData.dataSize=992], deepLink=http://www.java-sample.com/settings, cioDeliveryId=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==, cioDeliveryToken={token}, title=Test Push, body=Test push message!)
```