### PR TITLE
chore: Update logs for push deep link handling

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/activity/NotificationClickReceiverActivity.kt
@@ -3,6 +3,7 @@ package io.customer.messagingpush.activity
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
@@ -16,7 +17,7 @@ import io.customer.sdk.tracking.TrackableScreen
  */
 class NotificationClickReceiverActivity : Activity(), TrackableScreen {
     private val diGraph = SDKComponent
-    val logger = SDKComponent.logger
+    private val logger = SDKComponent.pushLogger
 
     override fun getScreenName(): String? {
         // Return null to prevent this screen from being tracked
@@ -37,7 +38,7 @@ class NotificationClickReceiverActivity : Activity(), TrackableScreen {
     private fun handleIntent(data: Intent?) {
         if (data == null || data.extras == null) {
             // This should never happen ideally
-            logger.error("Intent is null, cannot process notification click")
+            logger.logNotificationActivityStartedWithInvalidIntent()
         } else {
             diGraph.pushMessageProcessor.processNotificationClick(
                 activityContext = this,

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -54,7 +54,6 @@ val SDKComponent.pushTrackingUtil: PushTrackingUtil
 internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {
         PushMessageProcessorImpl(
-            logger = logger,
             pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
             deepLinkUtil = deepLinkUtil

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush.logger
 
 import com.google.firebase.messaging.RemoteMessage
+import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.sdk.core.util.Logger
 
@@ -136,6 +137,55 @@ internal class PushNotificationLogger(private val logger: Logger) {
             tag = TAG,
             message = "Failed to handle push click: ${throwable.message}",
             throwable = throwable
+        )
+    }
+
+    fun logHandlingNotificationDeepLink(payload: CustomerIOParsedPushPayload, behavior: PushClickBehavior) {
+        logger.debug(
+            tag = TAG,
+            message = "Handling push notification deep link with payload: $payload - pushClickBehavior: $behavior"
+        )
+    }
+
+    fun logDeepLinkHandledByCallback() {
+        logger.debug(
+            tag = TAG,
+            message = "Deep link handled by host app callback implementation"
+        )
+    }
+
+    fun logDeepLinkHandledByHostApp() {
+        logger.debug(
+            tag = TAG,
+            message = "Deep link handled by internal host app navigation"
+        )
+    }
+
+    fun logDeepLinkHandledExternally() {
+        logger.debug(
+            tag = TAG,
+            message = "Deep link handled by external app"
+        )
+    }
+
+    fun logDeepLinkHandledDefaultHostAppLauncher() {
+        logger.debug(
+            tag = TAG,
+            message = "Deep link handled by opening default host app"
+        )
+    }
+
+    fun logDeepLinkWasNotHandled() {
+        logger.debug(
+            tag = TAG,
+            message = "Deep link was not handled"
+        )
+    }
+
+    fun logNotificationActivityStartedWithInvalidIntent() {
+        logger.error(
+            tag = TAG,
+            message = "Intent is null, cannot process notification click"
         )
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -3,6 +3,7 @@ package io.customer.messagingpush.logger
 import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.core.util.Logger
@@ -291,6 +292,93 @@ class PushNotificationLoggerTest : JUnitTest() {
                 tag = "Push",
                 message = "Failed to handle push click: error message",
                 throwable = throwable
+            )
+        }
+    }
+
+    @Test
+    fun test_logHandlingNotificationDeepLink_forwardsCorrectCallToLogger() {
+        val payload = mockk<CustomerIOParsedPushPayload>(relaxed = true)
+        val behavior = PushClickBehavior.ACTIVITY_NO_FLAGS
+
+        pushLogger.logHandlingNotificationDeepLink(payload, behavior)
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Handling push notification deep link with payload: $payload - pushClickBehavior: $behavior"
+            )
+        }
+    }
+
+    @Test
+    fun test_logDeepLinkHandledByCallback_forwardsCorrectCallToLogger() {
+        pushLogger.logDeepLinkHandledByCallback()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Deep link handled by host app callback implementation"
+            )
+        }
+    }
+
+    @Test
+    fun test_logDeepLinkHandledByHostApp_forwardsCorrectCallToLogger() {
+        pushLogger.logDeepLinkHandledByHostApp()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Deep link handled by internal host app navigation"
+            )
+        }
+    }
+
+    @Test
+    fun test_logDeepLinkHandledExternally_forwardsCorrectCallToLogger() {
+        pushLogger.logDeepLinkHandledExternally()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Deep link handled by external app"
+            )
+        }
+    }
+
+    @Test
+    fun test_logDeepLinkHandledDefaultHostAppLauncher_forwardsCorrectCallToLogger() {
+        pushLogger.logDeepLinkHandledDefaultHostAppLauncher()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Deep link handled by opening default host app"
+            )
+        }
+    }
+
+    @Test
+    fun test_logDeepLinkWasNotHandled_forwardsCorrectCallToLogger() {
+        pushLogger.logDeepLinkWasNotHandled()
+
+        assertCalledOnce {
+            mockLogger.debug(
+                tag = "Push",
+                message = "Deep link was not handled"
+            )
+        }
+    }
+
+    @Test
+    fun test_logNotificationActivityStartedWithInvalidIntent_forwardsCorrectCallToLogger() {
+        pushLogger.logNotificationActivityStartedWithInvalidIntent()
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Intent is null, cannot process notification click"
             )
         }
     }


### PR DESCRIPTION
Part of: [MBL-1075](https://linear.app/customerio/issue/MBL-1075/update-push-notifications-logging-for-android)
Closes: [MBL-1123](https://linear.app/customerio/issue/MBL-1123/update-push-notification-deep-linking-handling-logs)

### Overview
This PR implements log definitions as defined in the log definitions repo https://github.com/customerio/mobile-log-definitions/pull/10

- Adds logs for push notification deep link handling

### Test
- Added unit test for the wrapper logger and call sites
- You can test by sending a push notification with the following link: `https://www.java-sample.com/settings`
- Logs after implementation are as follows
```
[CIO] D  [Init] Creating new instance of CustomerIO SDK version: 4.5.8...

[CIO] D  [Init] Initializing SDK module DataPipelines with config: DataPipelinesModuleConfig(cdpApiKey='[Redacted]', flushAt=20, flushInterval=30, flushPolicies=[], autoAddCustomerIODestination=true, trackApplicationLifecycleEvents=true, autoTrackDeviceAttributes=true, autoTrackActivityScreens=true, migrationSiteId=[Redacted], screenViewUse=ScreenView('all'), apiHost='cdp.customer.io/v1', cdnHost='cdp.customer.io/v1')...
[CIO] I  [Init] CustomerIO DataPipelines module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingPushFCM with config: MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART)...

[CIO] D  [Push] Getting current device token from Firebase messaging on app launch
[CIO] D  [Push] Google Play Services is available for this device
[CIO] I  [Init] CustomerIO MessagingPushFCM module is initialized and ready to use

[CIO] D  [Init] Initializing SDK module MessagingInApp with config: io.customer.messaginginapp.MessagingInAppModuleConfig@1c6fb9f...
[CIO] I  [Init] CustomerIO MessagingInApp module is initialized and ready to use

[CIO] I  [Init] CustomerIO SDK is initialized and ready to use

[CIO] D  [Push] Got current device token: {actualToken}
[CIO] D  [Push] Storing device token: {actualToken} for user profile: null
[CIO] D  [Push] Registering device token: {actualToken} for user profile: null
[CIO] D  [Push] Automatically registering device token: {{token}} to newly identified profile: mo@push.io
[CIO] D  [Push] Received new message with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] Tracking push message delivered with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] handleNotificationTrigger: true - Received notification for message: {CIO-Delivery-Token={token}, body=Test push message!, link=http://www.java-sample.com/settings, image=https://userimg-assets.customeriomail.com/images/client-env-122175/1730071976590_cat-hd-wallpaper-1_01JB856PZPSRSGV3GP9C44TBGV.jpg, title=Test Push, CIO-Delivery-ID=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==}
[CIO] D  [Push] Received CIO push message
[CIO] D  [Push] Received duplicate message with deliveryId: dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==
[CIO] D  [Push] Showing notification for message: {CIO-Delivery-Token={token}, body=Test push message!, link=http://www.java-sample.com/settings, image=https://userimg-assets.customeriomail.com/images/client-env-122175/1730071976590_cat-hd-wallpaper-1_01JB856PZPSRSGV3GP9C44TBGV.jpg, title=Test Push, CIO-Delivery-ID=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==}
[CIO] D  [Push] Tracking push message opened with payload: CustomerIOParsedPushPayload(extras=Bundle[mParcelledData.dataSize=992], deepLink=http://www.java-sample.com/settings, cioDeliveryId=dgS_ugcABQAAAZbOJjDxdVE5iOvKe1WPCw==, cioDeliveryToken={token}, title=Test Push, body=Test push message!)

[CIO] D  [Push] Handling push notification deep link with payload: CustomerIOParsedPushPayload(extras=Bundle[mParcelledData.dataSize=712], deepLink=https://www.java-sample.com/settings, cioDeliveryId=dgS_ugcABQAAAZbXy-WBmpeffUKuMUtyPQ==, cioDeliveryToken={token}, title=Push test, body=Push test message...) - pushClickBehavior: ACTIVITY_PREVENT_RESTART
[CIO] D  [Push] Deep link handled by internal host app navigation
```