### PR TITLE
chore: fix display event handling and error recovery for in-app messages

### DIFF
--- a/messaginginapp-compose/src/main/java/io/customer/messaginginapp/compose/InlineInAppMessageView.kt
+++ b/messaginginapp-compose/src/main/java/io/customer/messaginginapp/compose/InlineInAppMessageView.kt
@@ -46,9 +46,6 @@ fun InlineInAppMessage(
                 ViewGroup.LayoutParams.WRAP_CONTENT
             )
 
-            // Set a minimum height to ensure visibility
-            minimumHeight = (context.resources.displayMetrics.density * 48).toInt()
-
             // Set custom progress tint if provided
             progressTint?.let { color ->
                 setProgressTint(color.toArgb())

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -46,7 +46,6 @@ class ModuleMessagingInApp(
     }
 
     override fun embedMessage(message: Message, elementId: String) {
-        moduleConfig.eventListener?.messageShown(InAppMessage.getFromGistMessage(message))
     }
 
     override fun onMessageShown(message: Message) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -45,20 +45,6 @@ internal data class InAppMessagingState(
     }
 }
 
-internal fun InAppMessagingState.withUpdatedEmbeddedMessage(
-    queueId: String,
-    newState: InlineMessageState,
-    shownMessageQueueIds: Set<String> = this.shownMessageQueueIds,
-    messagesInQueue: Set<Message> = this.messagesInQueue
-): InAppMessagingState {
-    val updatedEmbeddedMessagesState = queuedInlineMessagesState.updateMessageState(queueId, newState)
-    return copy(
-        queuedInlineMessagesState = updatedEmbeddedMessagesState,
-        shownMessageQueueIds = shownMessageQueueIds,
-        messagesInQueue = messagesInQueue
-    )
-}
-
 internal sealed class InlineMessageState {
     abstract val message: Message
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingStateExtensions.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingStateExtensions.kt
@@ -1,0 +1,76 @@
+package io.customer.messaginginapp.state
+
+import io.customer.messaginginapp.gist.data.model.Message
+
+/**
+ * Updates [InAppMessagingState] to reflect the new state of an embedded messages.
+ *
+ * @param queueId The queueId of the embedded message to update.
+ * @param newState The new state of the embedded message.
+ * @param shownMessageQueueIds The set of queueIds that have been shown.
+ * @param messagesInQueue The set of messages in the queue.
+ * @return Updated [InAppMessagingState] with new state of the embedded message.
+ */
+internal fun InAppMessagingState.withUpdatedEmbeddedMessage(
+    queueId: String,
+    newState: InlineMessageState,
+    shownMessageQueueIds: Set<String> = this.shownMessageQueueIds,
+    messagesInQueue: Set<Message> = this.messagesInQueue
+): InAppMessagingState {
+    val updatedEmbeddedMessagesState = queuedInlineMessagesState.updateMessageState(queueId, newState)
+    return copy(
+        queuedInlineMessagesState = updatedEmbeddedMessagesState,
+        shownMessageQueueIds = shownMessageQueueIds,
+        messagesInQueue = messagesInQueue
+    )
+}
+
+/**
+ * Updates [InAppMessagingState] to reflect the dismissal of current in-app message.
+ * If the message is embedded, it updates the state of the embedded message.
+ * If the message is modal, it updates the modal message state.
+ *
+ * @param message The message from current action.
+ * @param shouldMarkAsShown Indicates whether the message should be marked as shown when dismissed.
+ * @return Updated [InAppMessagingState] with the dismissed message.
+ */
+internal fun InAppMessagingState.withMessageDismissed(
+    message: Message,
+    shouldMarkAsShown: Boolean
+): InAppMessagingState {
+    var shownMessageQueueIds = this.shownMessageQueueIds
+    // If the message should be tracked shown when it is dismissed, add the queueId to shownMessageQueueIds.
+    if (shouldMarkAsShown && message.queueId != null) {
+        shownMessageQueueIds = shownMessageQueueIds + message.queueId
+    }
+
+    when {
+        message.isEmbedded -> {
+            // For embedded messages
+            return when {
+                message.queueId != null -> {
+                    // Update embedded message state if it has a queueId
+                    this.withUpdatedEmbeddedMessage(
+                        queueId = message.queueId,
+                        newState = InlineMessageState.Dismissed(message),
+                        shownMessageQueueIds = shownMessageQueueIds
+                    )
+                }
+
+                else -> {
+                    // For embedded messages without queueId
+                    // Just return the state unchanged
+                    this
+                }
+            }
+        }
+
+        else -> {
+            // Handle modal message
+            return this.copy(
+                modalMessageState = ModalMessageState.Dismissed(message),
+                shownMessageQueueIds = shownMessageQueueIds
+            )
+        }
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageView.kt
@@ -39,9 +39,10 @@ class InlineInAppMessageView @JvmOverloads constructor(
     @StyleRes defStyleRes: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr, defStyleRes),
     InlineInAppMessageViewCallback {
+    private val platformDelegate = AndroidInAppPlatformDelegate(view = this)
     private val controller = InlineInAppMessageViewController(
         viewDelegate = InAppHostViewDelegateImpl(view = this),
-        platformDelegate = AndroidInAppPlatformDelegate(view = this)
+        platformDelegate = platformDelegate
     )
     private val progressIndicator: ProgressBar = ProgressBar(context)
 
@@ -118,8 +119,17 @@ class InlineInAppMessageView @JvmOverloads constructor(
     }
 
     override fun onLoadingStarted() {
-        progressIndicator.visibility = VISIBLE
-        progressIndicator.bringToFront()
+        // Set a minimum height to ensure visibility
+        // Keep the animation duration shorter so it can be completed before we
+        // start receiving size update callbacks from WebView to avoid flickering
+        platformDelegate.animateViewSize(
+            heightInPx = platformDelegate.convertDpToPixels(48.0),
+            duration = 100,
+            onStart = {
+                progressIndicator.visibility = VISIBLE
+                progressIndicator.bringToFront()
+            }
+        )
     }
 
     override fun onLoadingFinished() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InlineInAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InlineInAppMessageViewController.kt
@@ -74,14 +74,6 @@ internal constructor(
         viewDelegate.post { refreshViewState(state = state) }
     }
 
-    override fun routeLoaded(route: String) {
-        super.routeLoaded(route)
-
-        currentMessage?.let { message ->
-            inAppMessagingManager.dispatch(InAppMessagingAction.DisplayMessage(message))
-        }
-    }
-
     internal fun onDetachedFromWindow() {
         val message = currentMessage ?: return
 
@@ -151,6 +143,7 @@ internal constructor(
                     viewDelegate.isVisible = false
                     contentWidthInDp = null
                     contentHeightInDp = null
+                    shouldDispatchDisplayEvent = true
                     detachAndCleanupEngineWebView()
                     viewCallback?.onNoMessageToDisplay()
                     onComplete()
@@ -162,8 +155,8 @@ internal constructor(
     @UiThread
     private fun displayMessage(message: Message) {
         elapsedTimer.start("Displaying inline message: ${message.messageId}")
-        attachEngineWebView()
         viewCallback?.onLoadingStarted()
+        attachEngineWebView()
         viewDelegate.isVisible = true
         loadMessage(message)
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
@@ -1,6 +1,6 @@
 package io.customer.messaginginapp.ui.controller
 
-import io.customer.messaginginapp.state.InAppMessagingAction
+import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppPlatformDelegate
 import io.customer.messaginginapp.ui.bridge.ModalInAppMessageViewCallback
@@ -13,8 +13,6 @@ internal class ModalInAppMessageViewController(
     viewDelegate = viewDelegate,
     platformDelegate = platformDelegate
 ) {
-    private var shouldDispatchDisplayEvent: Boolean = true
-
     init {
         attachEngineWebView()
     }
@@ -27,15 +25,9 @@ internal class ModalInAppMessageViewController(
         return result
     }
 
-    override fun routeLoaded(route: String) {
-        super.routeLoaded(route)
-        if (!shouldDispatchDisplayEvent) return
-
-        shouldDispatchDisplayEvent = false
+    override fun onRouteLoaded(message: Message, route: String) {
         engineWebViewDelegate?.setAlpha(1.0F)
-        currentMessage?.let { message ->
-            inAppMessagingManager.dispatch(InAppMessagingAction.DisplayMessage(message))
-        }
+        super.onRouteLoaded(message, route)
     }
 
     override fun bootstrapped() {

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
@@ -2,6 +2,7 @@ package io.customer.messaginginapp
 
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.TestConstants
+import io.customer.commontest.extensions.assertNoInteractions
 import io.customer.commontest.extensions.attachToSDKComponent
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.di.inAppMessagingManager
@@ -354,7 +355,7 @@ class InAppMessagingStoreTest : IntegrationTest() {
     }
 
     @Test
-    fun givenMessage_whenEmbedded_thenEmbedMessageCallbackIsCalled() = runTest {
+    fun givenMessage_whenEmbedded_thenNoCallbackIsCalled() = runTest {
         initializeAndSetUser()
         // Create a message with custom properties to include an elementId for embedding
         // We need to manually construct the Message here since our helper doesn't support elementId
@@ -366,7 +367,7 @@ class InAppMessagingStoreTest : IntegrationTest() {
 
         manager.dispatch(InAppMessagingAction.EmbedMessages(listOf(message)))
 
-        verify { inAppEventListener.messageShown(InAppMessage.getFromGistMessage(message)) }
+        assertNoInteractions(inAppEventListener)
     }
 
     @Test

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
@@ -230,6 +230,27 @@ class InAppMessageReducerTest : JUnitTest() {
     }
 
     @Test
+    fun messageDismissed_whenInlineMessageWithoutQueueId_expectStateUnchanged() {
+        // Given a persistent message that is displayed but not yet marked as shown
+        val elementId = String.random
+        val testMessage = createTestMessage(persistent = false, queueId = null, elementId = elementId)
+
+        // The message is displayed but not in shownMessageQueueIds
+        val startingState = initialState.copy(
+            queuedInlineMessagesState = QueuedInlineMessagesState()
+                .addMessage(message = testMessage, elementId = elementId),
+            shownMessageQueueIds = emptySet()
+        )
+
+        // When the message is dismissed via close action but logging is disabled
+        val dismissAction = InAppMessagingAction.DismissMessage(message = testMessage)
+        val resultState = inAppMessagingReducer(startingState, dismissAction)
+
+        // Starting state should be unchanged
+        assertEquals(startingState, resultState)
+    }
+
+    @Test
     fun messageLoadingFailed_whenModalMessage_expectModalMessageToBeDismissed() {
         // Given a persistent message that is displayed but not yet marked as shown
         val testMessage = createTestMessage(persistent = false)
@@ -240,7 +261,7 @@ class InAppMessageReducerTest : JUnitTest() {
             shownMessageQueueIds = emptySet()
         )
 
-        // When the message is dismissed via close action but logging is disabled
+        // When the message fails to load
         val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
         val resultState = inAppMessagingReducer(startingState, dismissAction)
 
@@ -265,7 +286,7 @@ class InAppMessageReducerTest : JUnitTest() {
             shownMessageQueueIds = emptySet()
         )
 
-        // When the message is dismissed via close action but logging is disabled
+        // When the message fails to load
         val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
         val resultState = inAppMessagingReducer(startingState, dismissAction)
 
@@ -302,9 +323,12 @@ class InAppMessageReducerTest : JUnitTest() {
     /**
      * Helper method to create a test message with customizable persistence
      */
-    private fun createTestMessage(persistent: Boolean, elementId: String? = null): Message {
+    private fun createTestMessage(
+        persistent: Boolean,
+        queueId: String? = String.random,
+        elementId: String? = null
+    ): Message {
         val messageId = String.random
-        val queueId = String.random
 
         return mockk<Message>(relaxed = true) {
             every { this@mockk.messageId } returns messageId

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
@@ -230,6 +230,56 @@ class InAppMessageReducerTest : JUnitTest() {
     }
 
     @Test
+    fun messageLoadingFailed_whenModalMessage_expectModalMessageToBeDismissed() {
+        // Given a persistent message that is displayed but not yet marked as shown
+        val testMessage = createTestMessage(persistent = false)
+
+        // The message is displayed but not in shownMessageQueueIds
+        val startingState = initialState.copy(
+            modalMessageState = ModalMessageState.Displayed(testMessage),
+            shownMessageQueueIds = emptySet()
+        )
+
+        // When the message is dismissed via close action but logging is disabled
+        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
+        val resultState = inAppMessagingReducer(startingState, dismissAction)
+
+        // Then the message should NOT be added to shownMessageQueueIds
+        assertTrue(resultState.shownMessageQueueIds.isEmpty())
+
+        // And the message state should be Dismissed
+        val modalState = resultState.modalMessageState as ModalMessageState.Dismissed
+        assertEquals(testMessage, modalState.message)
+    }
+
+    @Test
+    fun messageLoadingFailed_whenInlineMessage_expectInlineMessageToBeDismissed() {
+        // Given a persistent message that is displayed but not yet marked as shown
+        val elementId = String.random
+        val testMessage = createTestMessage(persistent = false, elementId = elementId)
+
+        // The message is displayed but not in shownMessageQueueIds
+        val startingState = initialState.copy(
+            queuedInlineMessagesState = QueuedInlineMessagesState()
+                .addMessage(message = testMessage, elementId = elementId),
+            shownMessageQueueIds = emptySet()
+        )
+
+        // When the message is dismissed via close action but logging is disabled
+        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
+        val resultState = inAppMessagingReducer(startingState, dismissAction)
+
+        // Then the message should NOT be added to shownMessageQueueIds
+        assertTrue(resultState.shownMessageQueueIds.isEmpty())
+
+        // And the message state should be Dismissed
+        val inlineMessageStateMap = resultState.queuedInlineMessagesState.messagesByElementId
+        assertEquals(1, inlineMessageStateMap.count())
+        val inlineMessageState = inlineMessageStateMap[elementId] as InlineMessageState.Dismissed
+        assertEquals(testMessage, inlineMessageState.message)
+    }
+
+    @Test
     fun reset_shouldClearAllStates() {
         // Given a state with some messages
         val testMessage = createTestMessage(persistent = true)
@@ -252,7 +302,7 @@ class InAppMessageReducerTest : JUnitTest() {
     /**
      * Helper method to create a test message with customizable persistence
      */
-    private fun createTestMessage(persistent: Boolean): Message {
+    private fun createTestMessage(persistent: Boolean, elementId: String? = null): Message {
         val messageId = String.random
         val queueId = String.random
 
@@ -261,13 +311,13 @@ class InAppMessageReducerTest : JUnitTest() {
             every { this@mockk.queueId } returns queueId
             every { this@mockk.gistProperties } returns GistProperties(
                 routeRule = null,
-                elementId = null,
+                elementId = elementId,
                 campaignId = null,
                 position = MessagePosition.CENTER,
                 persistent = persistent,
                 overlayColor = null
             )
-            every { this@mockk.isEmbedded } returns false
+            every { this@mockk.isEmbedded } returns (elementId != null)
         }
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
@@ -231,7 +231,7 @@ class InAppMessageReducerTest : JUnitTest() {
 
     @Test
     fun messageDismissed_whenInlineMessageWithoutQueueId_expectStateUnchanged() {
-        // Given a persistent message that is displayed but not yet marked as shown
+        // Given a non-persistent message that is displayed but not yet marked as shown
         val elementId = String.random
         val testMessage = createTestMessage(persistent = false, queueId = null, elementId = elementId)
 
@@ -242,7 +242,7 @@ class InAppMessageReducerTest : JUnitTest() {
             shownMessageQueueIds = emptySet()
         )
 
-        // When the message is dismissed via close action but logging is disabled
+        // When the message is dismissed
         val dismissAction = InAppMessagingAction.DismissMessage(message = testMessage)
         val resultState = inAppMessagingReducer(startingState, dismissAction)
 
@@ -252,7 +252,7 @@ class InAppMessageReducerTest : JUnitTest() {
 
     @Test
     fun messageLoadingFailed_whenModalMessage_expectModalMessageToBeDismissed() {
-        // Given a persistent message that is displayed but not yet marked as shown
+        // Given a non-persistent message that is displayed but not yet marked as shown
         val testMessage = createTestMessage(persistent = false)
 
         // The message is displayed but not in shownMessageQueueIds
@@ -275,7 +275,7 @@ class InAppMessageReducerTest : JUnitTest() {
 
     @Test
     fun messageLoadingFailed_whenInlineMessage_expectInlineMessageToBeDismissed() {
-        // Given a persistent message that is displayed but not yet marked as shown
+        // Given a non-persistent message that is displayed but not yet marked as shown
         val elementId = String.random
         val testMessage = createTestMessage(persistent = false, elementId = elementId)
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
@@ -24,6 +24,7 @@ import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppMessageViewCallback
 import io.customer.messaginginapp.ui.bridge.InAppPlatformDelegate
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -313,12 +314,33 @@ class InAppMessageViewControllerTest : JUnitTest() {
     //region Route tests
 
     @Test
-    fun routeListener_givenRouteLoaded_expectCurrentRouteIsUpdated() {
+    fun routeLoaded_givenPendingEvent_expectRouteUpdatedAndEventDispatched() {
+        val givenMessage = createInAppMessage()
         val givenRoute = String.random
+        controller.currentMessage = givenMessage
 
         controller.routeLoaded(givenRoute)
 
         controller.currentRoute shouldBeEqualTo givenRoute
+        verifyOrder {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.DisplayMessage(givenMessage)
+            )
+        }
+    }
+
+    @Test
+    fun routeLoaded_givenEventAlreadyDispatched_expectRouteUpdatedAndNoDispatch() {
+        val givenMessage = createInAppMessage()
+        val givenRoute = String.random
+        controller.currentMessage = givenMessage
+        controller.routeLoaded(givenRoute)
+        clearMocks(inAppMessagingManager)
+
+        controller.routeLoaded(givenRoute)
+
+        controller.currentRoute shouldBeEqualTo givenRoute
+        assertNoInteractions(inAppMessagingManager)
     }
 
     @Test


### PR DESCRIPTION
closes: [MBL-1155](https://linear.app/customerio/issue/MBL-1155/fix-inline-message-view-not-dismissed-on-error)

### Changes

- Updated `InAppMessageViewController` to dispatch the display event only once per message using flag
- In `InlineInAppMessageViewController`:
  - Reset display event flag on dismiss to allow proper handling for the next message
  - Called `onLoadingStarted` at start to improve loading UI experience
- In `ModalInAppMessageViewController`, ensured `EngineWebView` is updated only on first `routeLoaded`
- Updated `InAppMessageReducer` to dismiss inline messages on loading failure
- Moved inline message dismissal logic to an extension and extracted `InAppMessagingState` extensions to a dedicated file
- Moved min height setting from Compose view to base view for a consistent experience across Compose and XML
- Added and updated tests to validate these changes

### How to Reproduce

**Issue 1: Display Event Dispatched Multiple Times**

- Open Inline Examples
- Observe logs and display message event should never be dispatched multiple times even if `routeLoaded` is called multiple times for same message

**Issue 2: Inline View Not Dismissed on Message Loading Failure**

- Open Inline Examples
- Simulate message load failure
- Notice that the view remains partially visible and state isn't properly cleared before the fix

**Issue 3: Extra Space in Compose Inline View**

- Open Inline Compose Examples
- Before this fix, the first message loads, an empty space is shown and is fixed after the first message appears

**Issue 4: Progress Bar Not Visible in Inline XML View**

- Open Inline XML Examples
- Set `InlineInAppMessageView` height to `0dp` instead of `wrap_content`
- Before this fix, the progress bar might not show up properly due to missing `minHeight`