### PR TITLE
fix: finish modal message early if sdk is not initialized

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -66,7 +66,7 @@ class GistModalActivity : AppCompatActivity(), ModalInAppMessageViewCallback, Tr
         val message = validateAndParseIntentMessage()
         if (message == null) {
             // Finish the activity immediately to avoid running animations or further processing
-            completeFinish()
+            finishImmediately()
             return
         }
 
@@ -173,13 +173,13 @@ class GistModalActivity : AppCompatActivity(), ModalInAppMessageViewCallback, Tr
             animationSet.start()
             animationSet.doOnEnd {
                 logger.debug("GistModelActivity finish animation completed")
-                completeFinish()
+                finishImmediately()
             }
         }
     }
 
     // Completes finish process by calling super and handling cleanup without further actions
-    private fun completeFinish() {
+    private fun finishImmediately() {
         super.finish()
     }
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/GistModalActivityTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/GistModalActivityTest.kt
@@ -1,0 +1,165 @@
+package io.customer.messaginginapp.gist.presentation
+
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import com.google.gson.Gson
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.assertCalledOnce
+import io.customer.commontest.extensions.attachToSDKComponent
+import io.customer.commontest.extensions.flushCoroutines
+import io.customer.commontest.util.ScopeProviderStub
+import io.customer.messaginginapp.MessagingInAppModuleConfig
+import io.customer.messaginginapp.ModuleMessagingInApp
+import io.customer.messaginginapp.di.inAppMessagingManager
+import io.customer.messaginginapp.gist.GistEnvironment
+import io.customer.messaginginapp.gist.data.listeners.GistQueue
+import io.customer.messaginginapp.gist.data.model.Message
+import io.customer.messaginginapp.gist.data.model.MessagePosition
+import io.customer.messaginginapp.state.InAppMessagingAction
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
+import io.customer.sdk.core.util.ScopeProvider
+import io.customer.sdk.data.model.Region
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GistModalActivityTest : IntegrationTest() {
+    private val mockLogger = mockk<Logger>(relaxed = true)
+    private val scopeProviderStub = ScopeProviderStub.Standard()
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<Logger>(mockLogger)
+                        overrideDependency<ScopeProvider>(scopeProviderStub)
+                        overrideDependency<GistQueue>(mockk(relaxed = true))
+                    }
+                }
+            }
+        )
+    }
+
+    @Test
+    fun onCreate_givenModuleMessagingInAppNotInitialized_expectActivityFinishesEarly() {
+        // Create intent with valid message without initializing ModuleMessagingInApp
+        val testMessage = createTestMessage()
+        val intent = createActivityIntent(testMessage)
+
+        // Launch activity - it should finish immediately due to module not being initialized
+        val scenario = ActivityScenario.launch<GistModalActivity>(intent)
+
+        // Now check that it is destroyed immediately
+        scenario.state shouldBeEqualTo Lifecycle.State.DESTROYED
+        // Verify correct error was logged
+        assertCalledOnce {
+            mockLogger.error(match { it.contains("ModuleMessagingInApp not initialized") })
+        }
+        scenario.close()
+    }
+
+    @Test
+    fun onCreate_givenModuleMessagingInAppInitialized_expectActivityWorksNormally() {
+        // Initialize ModuleMessagingInApp
+        initializeModuleMessagingInApp()
+        // Create intent with valid message with ModuleMessagingInApp initialized
+        val testMessage = createTestMessage()
+        val intent = createActivityIntent(testMessage)
+
+        // Launch activity - it should work normally
+        val scenario = ActivityScenario.launch<GistModalActivity>(intent)
+
+        scenario.onActivity { activity ->
+            // Activity should not be finishing immediately
+            activity.isFinishing.shouldBeFalse()
+            activity.isDestroyed.shouldBeFalse()
+        }
+        // Now check that it is resumed
+        assert(scenario.state == Lifecycle.State.RESUMED)
+        // Verify no error was logged
+        verify(exactly = 0) { mockLogger.error(any()) }
+        scenario.close()
+    }
+
+    @Test
+    fun onCreate_givenNullMessageWithInitializedModule_expectActivityFinishes() {
+        // Initialize ModuleMessagingInApp
+        initializeModuleMessagingInApp()
+        // Create intent without message (null message) with ModuleMessagingInApp initialized
+        val intent = createActivityIntent(message = null)
+
+        // Launch activity - it should finish normally due to null message
+        val scenario = ActivityScenario.launch<GistModalActivity>(intent)
+
+        // Now check that it is destroyed immediately
+        scenario.state shouldBeEqualTo Lifecycle.State.DESTROYED
+        // Verify correct error was logged
+        assertCalledOnce {
+            mockLogger.error(match { it.contains("Message is null") })
+        }
+        scenario.close()
+    }
+
+    @Test
+    fun onCreate_givenInvalidMessageWithInitializedModule_expectActivityFinishes() {
+        // Initialize ModuleMessagingInApp
+        initializeModuleMessagingInApp()
+        // Create intent with invalid message with ModuleMessagingInApp initialized
+        val intent = createActivityIntent(message = "test-message-id")
+
+        // Launch activity - it should finish due to null message
+        val scenario = ActivityScenario.launch<GistModalActivity>(intent)
+
+        // Now check that it is destroyed immediately
+        scenario.state shouldBeEqualTo Lifecycle.State.DESTROYED
+        // Verify correct error was logged
+        assertCalledOnce {
+            mockLogger.error(match { it.contains("Message is null") })
+        }
+        scenario.close()
+    }
+
+    private fun initializeModuleMessagingInApp() {
+        val moduleConfig = MessagingInAppModuleConfig.Builder(
+            siteId = "test-site-id",
+            region = Region.US
+        ).build()
+        ModuleMessagingInApp(config = moduleConfig).attachToSDKComponent()
+
+        val messagingManager = spyk(SDKComponent.inAppMessagingManager).also {
+            SDKComponent.overrideDependency<InAppMessagingManager>(it)
+        }
+        messagingManager.dispatch(
+            InAppMessagingAction.Initialize(
+                siteId = moduleConfig.siteId,
+                dataCenter = moduleConfig.region.code,
+                environment = GistEnvironment.LOCAL
+            )
+        ).flushCoroutines(scopeProviderStub.inAppLifecycleScope)
+    }
+
+    private fun createTestMessage(): Message = Message(
+        messageId = "test-message-id",
+        priority = 1
+    )
+
+    private fun createActivityIntent(message: Any? = null, position: MessagePosition? = null): Intent {
+        return GistModalActivity.newIntent(ApplicationProvider.getApplicationContext()).apply {
+            message?.let { putExtra(GIST_MESSAGE_INTENT, Gson().toJson(it)) }
+            position?.let { putExtra(GIST_MODAL_POSITION_INTENT, it.name) }
+        }
+    }
+}


### PR DESCRIPTION
part of: [MBL-940](https://linear.app/customerio/issue/MBL-940/android-crash-on-flutter-211-sdks)

### Background

When the app is restored from background by Android OS after being remove from memory while a modal message was displayed, it may crash on restoration if the SDK is not initialized in `Application` class. This occurs more frequently in wrapper SDKs where SDK initialization doesn't happen at app startup.

### Solution

While not a long-term architectural fix, this reliably prevents crashes by:

- Finishing `GistModalActivity` early if the SDK is not initialized
- Lazily accessing SDK dependent properties in `GistModalActivity` to avoid triggering runtime exceptions

Tests have been added to enforce this behavior and prevent future regressions or accidental SDK access before initialization in `GistModalActivity`.

### Code Changes

- Updated `GistModalActivity` to:
  - Finish immediately (without animation) if the SDK is not initialized
  - Lazily access SDK dependent properties to prevent crashes
  - Break down `onCreate` into smaller, readable methods
  - Added a helper method to call `super.finish()` immediately without animations
- Added tests to prevent accidental SDK access before initialization in `GistModalActivity`

### How to Reproduce

1. Make sure SDK is not initialized in `Application` class (or use wrapper sample app)
2. Open Developer Options on Test device
3. Scroll to Background process limit
4. Set the limit to "At most 1 process" (or desired value)
5. Open the Sample app
6. Send a modal in-app message
7. Without dismissing it, put the app to background
8. Open two other apps (or however many needed to hit background process limit) to force Sample app out of memory
9. Reopen the Sample app, it should crash with previous implementation

### Behavior Changes

| Before | After |
| - | - |
| App would crash on restore if the SDK was not initialized in `Application` class (❌ Bug) | `GistModalActivity` finishes early without animations on restore if the SDK is not initialized (✅ Fix) | 
| `GistModalActivity` would finish with animations if the message was `null`/invalid | `GistModalActivity` finishes early without animations if the message is `null`/invalid |

### Tested On

- [x] Native Sample App with SDK initialized in Application
- [x] Native Sample App with SDK not initialized in Application (as shown in the video)
- [x] Flutter Sample App

### Video Comparison

#### Before

https://github.com/user-attachments/assets/fb8761a7-57f2-4621-950c-0f6ea1ff0cd6

#### After (Non-persistent)

https://github.com/user-attachments/assets/c5eebe58-6b1c-4a8c-bb1e-a6cc0a1c2328

#### After (Persistent)

https://github.com/user-attachments/assets/751f3c42-7740-49b1-a579-712cdb40482c

---

### Note

**There are no intentional logic changes other than mentioned above. If any other logic change is observed, please call it out.**