### PR TITLE
chore: make device token thread safe

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -76,17 +76,6 @@ public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrac
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 
-public final class io/customer/datapipelines/plugins/ContextPlugin : com/segment/analytics/kotlin/core/platform/Plugin {
-	public field analytics Lcom/segment/analytics/kotlin/core/Analytics;
-	public fun <init> (Lio/customer/sdk/data/store/DeviceStore;)V
-	public fun execute (Lcom/segment/analytics/kotlin/core/BaseEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;
-	public fun getAnalytics ()Lcom/segment/analytics/kotlin/core/Analytics;
-	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
-	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
-	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
-	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
-}
-
 public final class io/customer/datapipelines/plugins/CustomerIODestination : com/segment/analytics/kotlin/core/platform/DestinationPlugin, com/segment/analytics/kotlin/core/platform/VersionedPlugin, sovran/kotlin/Subscriber {
 	public fun <init> ()V
 	public fun alias (Lcom/segment/analytics/kotlin/core/AliasEvent;)Lcom/segment/analytics/kotlin/core/BaseEvent;

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -12,13 +12,35 @@ import io.customer.sdk.data.store.DeviceStore
  * Plugin class responsible for updating the context properties in events
  * tracked by Customer.io SDK.
  */
-class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
+internal class ContextPlugin(
+    private val deviceStore: DeviceStore,
+    private val eventProcessor: ContextPluginEventProcessor = DefaultContextPluginEventProcessor()
+) : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var analytics: Analytics
 
+    @Volatile
     internal var deviceToken: String? = null
 
     override fun execute(event: BaseEvent): BaseEvent {
+        return eventProcessor.execute(event, deviceStore) { deviceToken }
+    }
+}
+
+/**
+ * Interface to handle the processing of events inside [ContextPlugin].
+ * Allows custom logic to be injected for testing or extension.
+ */
+internal interface ContextPluginEventProcessor {
+    fun execute(event: BaseEvent, deviceStore: DeviceStore, deviceTokenProvider: () -> String?): BaseEvent
+}
+
+/**
+ * Default implementation of [ContextPluginEventProcessor] that sets the user agent
+ * in the context and ensures the device token is added if not already present.
+ */
+internal class DefaultContextPluginEventProcessor : ContextPluginEventProcessor {
+    override fun execute(event: BaseEvent, deviceStore: DeviceStore, deviceTokenProvider: () -> String?): BaseEvent {
         // Set user agent in context as it is required by Customer.io Data Pipelines
         event.putInContext("userAgent", deviceStore.buildUserAgent())
         // Remove analytics library information from context as Customer.io
@@ -28,7 +50,7 @@ class ContextPlugin(private val deviceStore: DeviceStore) : Plugin {
         // In case of migration from older versions, the token might already be present in context
         // We need to ensure that the token is not overridden to avoid corruption of data
         // So we add current token to context only if context does not have any token already
-        event.findInContextAtPath("device.token").firstOrNull()?.content ?: deviceToken?.let { token ->
+        event.findInContextAtPath("device.token").firstOrNull()?.content ?: deviceTokenProvider()?.let { token ->
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)
         }

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginBehaviorTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginBehaviorTest.kt
@@ -1,0 +1,185 @@
+package io.customer.datapipelines.plugins
+
+import com.segment.analytics.kotlin.core.BaseEvent
+import com.segment.analytics.kotlin.core.utilities.putInContextUnderKey
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.flushCoroutines
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.extensions.deviceToken
+import io.customer.datapipelines.testutils.extensions.getStringAtPath
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.DataPipelinesLogger
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.DeviceStore
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests [ContextPlugin] behavior using [StandardTestDispatcher] to simulate realistic coroutine
+ * scheduling and timing.
+ */
+class ContextPluginBehaviorTest : JUnitTest(dispatcher = StandardTestDispatcher()) {
+    private val testScope get() = delegate.testScope
+
+    private lateinit var deviceStore: DeviceStore
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfiguration {
+                diGraph {
+                    sdk {
+                        overrideDependency<DataPipelinesLogger>(mockk(relaxed = true))
+                        overrideDependency<DeviceStore>(mockk(relaxed = true))
+                        overrideDependency<GlobalPreferenceStore>(mockk(relaxed = true))
+                    }
+                }
+            }
+        )
+
+        val androidSDKComponent = SDKComponent.android()
+        deviceStore = androidSDKComponent.deviceStore
+        every { deviceStore.buildUserAgent() } returns "test-user-agent"
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+
+        // Run all pending coroutines to ensure analytics is initialized and ready to process events
+        @Suppress("OPT_IN_USAGE")
+        testScope.runCurrent()
+    }
+
+    /**
+     * Verifies that the plugin correctly adds the expected device token to the event context
+     * when the token is accessed from a different thread, including within coroutine dispatchers.
+     * This test should fail intermittently if token value is not correctly synchronized across threads.
+     */
+    @Test
+    fun execute_whenDeviceTokenIsSetFromAnotherThread_thenAddsCorrectTokenToEvent() = runTest {
+        // Define test parameters for easier configuration
+        val readerExecutionTimeMillis = 5000
+        val writerCutoffTimeMillis = readerExecutionTimeMillis - 200 // ensure writer ends before reader execution
+        val minThreadWaitTime = 50
+        val maxThreadWaitTime = 100
+        val tokenPrefix = "test-token-"
+        val currentNanoTime = { System.nanoTime() }
+        // Setup context plugin with a custom processor to track execution time
+        val contextPluginProcessor = object : ContextPluginEventProcessor {
+            val defaultProcessor = DefaultContextPluginEventProcessor()
+            override fun execute(event: BaseEvent, deviceStore: DeviceStore, deviceTokenProvider: () -> String?): BaseEvent {
+                // Add execution time to context for verification later
+                event.putInContextUnderKey("test", "executionStartTime", currentNanoTime())
+                val result = defaultProcessor.execute(event, deviceStore, deviceTokenProvider)
+                event.putInContextUnderKey("test", "executionEndTime", currentNanoTime())
+                return result
+            }
+        }
+        val contextPlugin = ContextPlugin(deviceStore, contextPluginProcessor)
+        analytics.add(contextPlugin)
+        // Set initial value for test
+        val writerLog = mutableMapOf<Long, String>() // (timestamp, read)
+        // Set initial device token to skip unnecessary null checks and ensure value is fetched for initial events
+        writerLog[currentNanoTime()] = ""
+        // Prepare for concurrent execution
+        val executor = Executors.newFixedThreadPool(2)
+        val testStartTimeMs = currentNanoTime().nanosToMillis()
+
+        // Writer thread: writes tokens at random intervals
+        val writerThread = executor.submit {
+            var counter = 1
+            while (true) {
+                val nowMs = currentNanoTime().nanosToMillis()
+                if (nowMs - testStartTimeMs >= writerCutoffTimeMillis) break
+
+                val newToken = "${tokenPrefix}${counter++}"
+                waitUntil(nowMs + Random.nextInt(minThreadWaitTime, maxThreadWaitTime))
+
+                sdkInstance.registerDeviceToken(newToken).flushCoroutines(testScope)
+                writerLog[currentNanoTime()] = newToken
+            }
+        }
+
+        // Reader thread: executes events with the current device token at random intervals
+        val readerThread = executor.submit {
+            var counter = 1
+            // Ensure writer has started
+            Thread.sleep(maxThreadWaitTime.toLong())
+            while (true) {
+                val nowMs = currentNanoTime().nanosToMillis()
+                if (nowMs - testStartTimeMs >= readerExecutionTimeMillis) break
+
+                waitUntil(nowMs + Random.nextInt(minThreadWaitTime, maxThreadWaitTime))
+                // Track an event with so that the context is updated with the current device token
+                sdkInstance.track(name = "test-event-${counter++}").flushCoroutines(testScope)
+                // Yield to allow other thread to run
+                Thread.yield()
+            }
+        }
+
+        // Wait for both threads to finish
+        writerThread.get(readerExecutionTimeMillis + 500L, TimeUnit.MILLISECONDS)
+        readerThread.get(readerExecutionTimeMillis + 500L, TimeUnit.MILLISECONDS)
+        executor.shutdown()
+
+        // For each event executed by SDK, verify writer token that was active during the event's execution
+        val mismatches = outputReaderPlugin.trackEvents.mapNotNull { event ->
+            val executionStartTime = event.context.getStringAtPath("test.executionStartTime")?.toLong().shouldNotBeNull()
+            val executionEndTime = event.context.getStringAtPath("test.executionEndTime")?.toLong().shouldNotBeNull()
+            val actualToken = event.context.deviceToken
+
+            // Find the latest write before the event execution end time
+            val latestWriteBeforeEvent = writerLog
+                .filterKeys { it <= executionEndTime }
+                .maxByOrNull { it.key }
+            // Find the newest write after the latest write
+            // This is because the writer might have written a new token after the event was executed
+            // So having a newer token is valid
+            val nextWriteAfterLatest = writerLog
+                .filterKeys { it > (latestWriteBeforeEvent?.key ?: Long.MAX_VALUE) }
+                .minByOrNull { it.key }
+            // Valid tokens are the latest write before the event and the next write after the latest
+            val validTokens = setOfNotNull(latestWriteBeforeEvent?.value, nextWriteAfterLatest?.value)
+
+            // If the actual token is not in valid tokens, it's a mismatch
+            if (actualToken !in validTokens) {
+                return@mapNotNull Triple("$executionStartTime..$executionEndTime", actualToken, validTokens.joinToString(" or "))
+            }
+            return@mapNotNull null
+        }
+
+        assertEquals(
+            expected = 0,
+            actual = mismatches.size,
+            message = buildString {
+                append("Event processed with incorrect device token:\n")
+                append(
+                    mismatches.joinToString("\n") { (time, actual, expected) ->
+                        "- At $time NS: saw `$actual`, expected `$expected`"
+                    }
+                )
+            }
+        )
+    }
+
+    private fun waitUntil(timeMs: Long) {
+        val sleepTime = timeMs - System.nanoTime().nanosToMillis()
+        assert(sleepTime > 0) { "Cannot wait for past time: $timeMs" }
+        Thread.sleep(sleepTime)
+    }
+
+    private fun Long.nanosToMillis(): Long {
+        return this / 1_000_000
+    }
+}


### PR DESCRIPTION
closes: [MBL-1198](https://linear.app/customerio/issue/MBL-1198/android-non-volatile-shared-property-in-contextplugin)

### Changes

- Improved thread safety and testability for `ContextPlugin`:
  - Marked `deviceToken` as `@Volatile` to ensure proper visibility across threads
  - Extracted `ContextPluginEventProcessor` to isolate event processing logic and support test time behavior (e.g. timing assertions)
  - Added tests to validate correct propagation and visibility of `deviceToken`, following the same path as in production

### Note

The PR is created as `chore` because the SDK currently works fine without this change, but this improves reliability and helps surface potential bugs earlier.