### PR TITLE
chore: optimize EventBus performance under high-frequency publishing

### DIFF
--- a/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
+++ b/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
@@ -15,7 +15,6 @@ import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
-import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeLessThan
 import org.amshove.kluent.shouldHaveSingleItem
 import org.junit.jupiter.api.Test
@@ -215,7 +214,7 @@ class EventBusTest : JUnit5Test() {
 
         // Publish 100 events concurrently to test ordering behavior
         val publishJobs = (1..100).map { index ->
-            async { 
+            async {
                 eventBus.publish(Event.TrackPushMetricEvent("deliveryId$index", Metric.Delivered, "deviceToken$index"))
             }
         }
@@ -225,7 +224,7 @@ class EventBusTest : JUnit5Test() {
 
         // Should receive all 100 events
         events.size shouldBeEqualTo 100
-        
+
         // Events should be TrackPushMetricEvent instances
         events.forEach { event ->
             event.shouldBeInstanceOf<Event.TrackPushMetricEvent>()
@@ -258,10 +257,10 @@ class EventBusTest : JUnit5Test() {
 
         // Should receive all 1000 events
         events.size shouldBeEqualTo 1000
-        
+
         // Should complete reasonably quickly (less than 1 second total)
         duration shouldBeLessThan 1000
-        
+
         // Verify events are correct type and have expected content
         events.forEachIndexed { index, event ->
             event.shouldBeInstanceOf<Event.ScreenViewedEvent>()
@@ -289,12 +288,12 @@ class EventBusTest : JUnit5Test() {
 
         // Should only receive the last 100 events due to replay buffer limit
         events.size shouldBeEqualTo 100
-        
+
         // First received event should be from index 50 (events 0-49 should be dropped)
         val firstEvent = events.first() as Event.TrackInAppMetricEvent
         firstEvent.deliveryID shouldBeEqualTo "deliveryId50"
         firstEvent.params["index"] shouldBeEqualTo "50"
-        
+
         // Last received event should be from index 149
         val lastEvent = events.last() as Event.TrackInAppMetricEvent
         lastEvent.deliveryID shouldBeEqualTo "deliveryId149"

--- a/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
+++ b/core/src/test/java/io/customer/sdk/communication/EventBusTest.kt
@@ -7,12 +7,16 @@ import io.customer.commontest.util.ScopeProviderStub
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.ScopeProvider
 import io.customer.sdk.events.Metric
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeLessThan
 import org.amshove.kluent.shouldHaveSingleItem
 import org.junit.jupiter.api.Test
 
@@ -198,6 +202,103 @@ class EventBusTest : JUnit5Test() {
             (events[i] as Event.TrackInAppMetricEvent).deliveryID shouldBeEqualTo "deliveryId$i"
             (events[i] as Event.TrackInAppMetricEvent).params shouldBeEqualTo mapOf("message" to "Message $i")
         }
+
+        job.cancel()
+    }
+
+    @Test
+    fun givenConcurrentPublishingExpectCorrectOrdering() = runBlocking {
+        val events = mutableListOf<Event>()
+        val job = eventBus.subscribe<Event.TrackPushMetricEvent> { event ->
+            events.add(event)
+        }
+
+        // Publish 100 events concurrently to test ordering behavior
+        val publishJobs = (1..100).map { index ->
+            async { 
+                eventBus.publish(Event.TrackPushMetricEvent("deliveryId$index", Metric.Delivered, "deviceToken$index"))
+            }
+        }
+        publishJobs.awaitAll()
+
+        delay(200) // Give time for all events to be processed
+
+        // Should receive all 100 events
+        events.size shouldBeEqualTo 100
+        
+        // Events should be TrackPushMetricEvent instances
+        events.forEach { event ->
+            event.shouldBeInstanceOf<Event.TrackPushMetricEvent>()
+        }
+
+        // Verify all unique events were received (no duplicates/losses)
+        val deliveryIds = events.map { (it as Event.TrackPushMetricEvent).deliveryId }.toSet()
+        deliveryIds.size shouldBeEqualTo 100
+
+        job.cancel()
+    }
+
+    @Test
+    fun givenHighFrequencyPublishingExpectAllEventsReceived() = runBlocking {
+        val events = mutableListOf<Event>()
+        val job = eventBus.subscribe<Event.ScreenViewedEvent> { event ->
+            events.add(event)
+        }
+
+        val startTime = System.currentTimeMillis()
+
+        // Rapid publishing (simulates ViewPager or rapid navigation)
+        repeat(1000) { index ->
+            eventBus.publish(Event.ScreenViewedEvent("screen$index"))
+        }
+
+        delay(500) // Allow processing time
+
+        val duration = System.currentTimeMillis() - startTime
+
+        // Should receive all 1000 events
+        events.size shouldBeEqualTo 1000
+        
+        // Should complete reasonably quickly (less than 1 second total)
+        duration shouldBeLessThan 1000
+        
+        // Verify events are correct type and have expected content
+        events.forEachIndexed { index, event ->
+            event.shouldBeInstanceOf<Event.ScreenViewedEvent>()
+            (event as Event.ScreenViewedEvent).name shouldBeEqualTo "screen$index"
+        }
+
+        job.cancel()
+    }
+
+    @Test
+    fun givenMoreThan100EventsExpectReplayBufferLimited() = runBlocking {
+        // Publish 150 events without any subscribers to test replay buffer limit
+        repeat(150) { index ->
+            eventBus.publish(Event.TrackInAppMetricEvent("deliveryId$index", Metric.Delivered, params = mapOf("index" to index.toString())))
+        }
+
+        delay(100) // Allow events to be buffered
+
+        val events = mutableListOf<Event>()
+        val job = eventBus.subscribe<Event.TrackInAppMetricEvent> { event ->
+            events.add(event)
+        }
+
+        delay(100) // Give time for replay events to be delivered
+
+        // Should only receive the last 100 events due to replay buffer limit
+        events.size shouldBeEqualTo 100
+        
+        // First received event should be from index 50 (events 0-49 should be dropped)
+        val firstEvent = events.first() as Event.TrackInAppMetricEvent
+        firstEvent.deliveryID shouldBeEqualTo "deliveryId50"
+        firstEvent.params["index"] shouldBeEqualTo "50"
+        
+        // Last received event should be from index 149
+        val lastEvent = events.last() as Event.TrackInAppMetricEvent
+        lastEvent.deliveryID shouldBeEqualTo "deliveryId149"
+        lastEvent.params["index"] shouldBeEqualTo "149"
 
         job.cancel()
     }


### PR DESCRIPTION
 Changes 

  • Replace coroutine-per-event with hybrid channel-based approach to eliminate thread pool exhaustion risk
  • Maintain 100-event replay buffer and all existing functionality while improving performance under load
  • Add comprehensive test coverage for concurrent publishing, high-frequency scenarios, and replay buffer boundaries

Test plan

  - All existing EventBus tests pass
  - New concurrent publishing test validates no event loss/duplication under load
  - High-frequency publishing test ensures 1000+ events process efficiently
  - Replay buffer boundary test confirms 100-event limit works correctly
  - No functional regressions in event ordering, subscription, or cleanup behavior
