### PR TITLE
chore: move in-app json parsing off ui thread

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/extensions/TestExtensions.kt
+++ b/common-test/src/main/java/io/customer/commontest/extensions/TestExtensions.kt
@@ -1,0 +1,59 @@
+package io.customer.commontest.extensions
+
+import android.os.Handler
+import android.os.Looper
+import java.util.Timer
+import java.util.TimerTask
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.schedule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+/**
+ * Executes an action after a delay on the main thread and waits for completion.
+ * Useful for testing async behavior with precise timing control. Default 0ms delay
+ * still ensures the action runs after the current execution cycle completes.
+ */
+inline fun postOnUiThread(
+    delay: Long = 0L,
+    timeout: Long = delay + 1_000L,
+    crossinline action: TimerTask.() -> Unit
+) {
+    val latch = CountDownLatch(1)
+
+    Timer().schedule(delay) {
+        // Ensure the action runs on the main thread
+        Handler(Looper.getMainLooper()).post {
+            action()
+        }
+        latch.countDown()
+    }
+
+    if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+        error("Scheduled block did not complete within timeout of $timeout after delay of $delay")
+    }
+}
+
+/**
+ * Checks if the current thread is the main thread.
+ */
+private val isMainThread: Boolean
+    get() = Looper.myLooper() == Looper.getMainLooper()
+
+/**
+ * Asserts that the current code is executing on the main thread.
+ */
+fun assertOnMainThread() {
+    assertTrue(
+        "Expected to be on main thread but was on ${Thread.currentThread().name}",
+        isMainThread
+    )
+}
+
+/**
+ * Asserts that the current code is executing on a background thread.
+ */
+fun assertNotOnMainThread() {
+    assertFalse("Expected to be on background thread but was on main thread", isMainThread)
+}

--- a/common-test/src/main/java/io/customer/commontest/util/DispatchersProviderStub.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/DispatchersProviderStub.kt
@@ -22,6 +22,14 @@ class DispatchersProviderStub : DispatchersProvider {
         }
     }
 
+    // Resets to using fast test dispatchers instead of real dispatchers.
+    // Should be called after setRealDispatchers() to avoid interfering with other tests.
+    fun resetToTestDispatchers() {
+        overrideBackground = null
+        overrideMain = null
+        overrideDefault = null
+    }
+
     override val background: CoroutineDispatcher
         get() = overrideBackground ?: UnconfinedTestDispatcher()
 

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -159,11 +159,6 @@ public final class io/customer/messaginginapp/gist/presentation/GistModalActivit
 	public final fun newIntent (Landroid/content/Context;)Landroid/content/Intent;
 }
 
-public final class io/customer/messaginginapp/gist/presentation/GistModalActivityKt {
-	public static final field GIST_MESSAGE_INTENT Ljava/lang/String;
-	public static final field GIST_MODAL_POSITION_INTENT Ljava/lang/String;
-}
-
 public final class io/customer/messaginginapp/gist/presentation/GistSdk : io/customer/messaginginapp/gist/presentation/GistProvider {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/customer/messaginginapp/gist/GistEnvironment;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -1,11 +1,15 @@
 package io.customer.messaginginapp.di
 
+import com.google.gson.Gson
 import io.customer.messaginginapp.MessagingInAppModuleConfig
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.gist.data.listeners.GistQueue
 import io.customer.messaginginapp.gist.data.listeners.Queue
 import io.customer.messaginginapp.gist.presentation.GistProvider
 import io.customer.messaginginapp.gist.presentation.GistSdk
+import io.customer.messaginginapp.gist.utilities.ModalMessageGsonParser
+import io.customer.messaginginapp.gist.utilities.ModalMessageParser
+import io.customer.messaginginapp.gist.utilities.ModalMessageParserDefault
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.store.InAppPreferenceStore
 import io.customer.messaginginapp.store.InAppPreferenceStoreImpl
@@ -35,6 +39,15 @@ internal val SDKComponent.inAppMessagingManager: InAppMessagingManager
 internal val SDKComponent.gistSdk: GistSdk
     get() = singleton<GistSdk> {
         GistSdk(siteId = inAppModuleConfig.siteId, dataCenter = inAppModuleConfig.region.code)
+    }
+
+internal val SDKComponent.modalMessageParser: ModalMessageParser
+    get() = singleton<ModalMessageParser> {
+        ModalMessageParserDefault(
+            logger = logger,
+            dispatchersProvider = dispatchersProvider,
+            parser = ModalMessageGsonParser(gson = Gson())
+        )
     }
 
 /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/utilities/ModalMessageParser.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/utilities/ModalMessageParser.kt
@@ -1,0 +1,98 @@
+package io.customer.messaginginapp.gist.utilities
+
+import com.google.gson.Gson
+import io.customer.messaginginapp.gist.data.model.Message
+import io.customer.messaginginapp.gist.data.model.MessagePosition
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.core.util.Logger
+import kotlinx.coroutines.withContext
+
+/**
+ * Parsed modal message data ready for display, including message content and position.
+ */
+internal data class ModalMessageExtras(
+    val message: Message,
+    val messagePosition: MessagePosition
+)
+
+/**
+ * Interface for parsing modal messages from extras like Intent or Bundle.
+ * It provides methods to extract message data and position from extras.
+ */
+internal interface ModalMessageParser {
+    suspend fun parseExtras(provider: ExtrasProvider): ModalMessageExtras?
+
+    /**
+     * Abstraction for accessing string values by key from extras like Intent or Bundle.
+     */
+    interface ExtrasProvider {
+        fun getString(key: String): String?
+    }
+
+    /**
+     * Abstraction for parsing JSON strings into Message objects.
+     */
+    interface JsonParser {
+        @Throws(Exception::class)
+        fun parseMessageFromJson(json: String): Message?
+    }
+
+    companion object {
+        const val EXTRA_IN_APP_MESSAGE: String = "GIST_MESSAGE"
+        const val EXTRA_IN_APP_MODAL_POSITION: String = "GIST_MODAL_POSITION"
+    }
+}
+
+/**
+ * Default JSON parser implementation using Gson for modal message deserialization.
+ */
+internal class ModalMessageGsonParser(
+    private val gson: Gson
+) : ModalMessageParser.JsonParser {
+    @Throws(Exception::class)
+    override fun parseMessageFromJson(json: String): Message? {
+        return gson.fromJson(json, Message::class.java)
+    }
+}
+
+/**
+ * Default implementation of ModalMessageParser to be used in production environments.
+ */
+internal class ModalMessageParserDefault(
+    private val logger: Logger,
+    private val dispatchersProvider: DispatchersProvider,
+    private val parser: ModalMessageParser.JsonParser
+) : ModalMessageParser {
+    override suspend fun parseExtras(provider: ModalMessageParser.ExtrasProvider): ModalMessageExtras? {
+        val rawMessage = provider.getString(ModalMessageParser.EXTRA_IN_APP_MESSAGE)
+        if (rawMessage.isNullOrEmpty()) {
+            logger.error("ModalMessageParser: Message is null or empty")
+            return null
+        }
+
+        return withContext(dispatchersProvider.background) {
+            try {
+                val message = parser.parseMessageFromJson(rawMessage)
+                if (message == null) {
+                    logger.error("ModalMessageParser: Message parsing failed for: $rawMessage")
+                    return@withContext null
+                }
+
+                val rawPosition = provider.getString(ModalMessageParser.EXTRA_IN_APP_MODAL_POSITION)
+                val position = if (rawPosition == null) {
+                    message.gistProperties.position
+                } else {
+                    MessagePosition.valueOf(rawPosition.uppercase())
+                }
+
+                return@withContext ModalMessageExtras(
+                    message = message,
+                    messagePosition = position
+                )
+            } catch (ex: Exception) {
+                logger.error("ModalMessageParser: Failed to parse modal message with error: ${ex.message}")
+                return@withContext null
+            }
+        }
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -6,10 +6,9 @@ import io.customer.messaginginapp.di.gistQueue
 import io.customer.messaginginapp.di.gistSdk
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.matchesRoute
-import io.customer.messaginginapp.gist.presentation.GIST_MESSAGE_INTENT
-import io.customer.messaginginapp.gist.presentation.GIST_MODAL_POSITION_INTENT
 import io.customer.messaginginapp.gist.presentation.GistListener
 import io.customer.messaginginapp.gist.presentation.GistModalActivity
+import io.customer.messaginginapp.gist.utilities.ModalMessageParser
 import io.customer.sdk.core.di.SDKComponent
 import org.reduxkotlin.Store
 import org.reduxkotlin.middleware
@@ -86,8 +85,8 @@ private fun handleModalMessageDisplay(store: Store<InAppMessagingState>, action:
         SDKComponent.logger.debug("Showing message: ${action.message} with position: ${action.position} and context: $context")
         val intent = GistModalActivity.newIntent(context).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            putExtra(GIST_MESSAGE_INTENT, Gson().toJson(action.message))
-            putExtra(GIST_MODAL_POSITION_INTENT, action.position?.toString())
+            putExtra(ModalMessageParser.EXTRA_IN_APP_MESSAGE, Gson().toJson(action.message))
+            putExtra(ModalMessageParser.EXTRA_IN_APP_MODAL_POSITION, action.position?.toString())
         }
         context.startActivity(intent)
         next(action)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/utilities/ModalMessageParserTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/utilities/ModalMessageParserTest.kt
@@ -1,0 +1,236 @@
+package io.customer.messaginginapp.gist.utilities
+
+import com.google.gson.Gson
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.assertNotOnMainThread
+import io.customer.commontest.util.DispatchersProviderStub
+import io.customer.messaginginapp.gist.data.model.Message
+import io.customer.messaginginapp.gist.data.model.MessagePosition
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.customer.messaginginapp.testutils.extension.createInAppMessage
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.core.util.Logger
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ModalMessageParserTest : IntegrationTest() {
+    private val mockLogger = mockk<Logger>(relaxed = true)
+    private val dispatchersProviderStub = spyk(DispatchersProviderStub())
+    private val gson = Gson()
+
+    private val parser = ModalMessageParserDefault(
+        logger = mockLogger,
+        dispatchersProvider = dispatchersProviderStub,
+        parser = ModalMessageGsonParser(gson = gson)
+    )
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<Logger>(mockLogger)
+                        overrideDependency<DispatchersProvider>(dispatchersProviderStub)
+                    }
+                }
+            }
+        )
+    }
+
+    @Test
+    fun parseExtras_givenValidMessageAndPosition_expectCorrectParsing() = runTest {
+        val givenMessage = createInAppMessage(
+            messageId = "test-123",
+            priority = 1,
+            position = MessagePosition.CENTER.name
+        )
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = MessagePosition.TOP.name
+        )
+
+        val result = parser.parseExtras(provider).shouldNotBeNull()
+        result.message shouldBeEqualTo givenMessage
+        result.messagePosition shouldBeEqualTo MessagePosition.TOP
+    }
+
+    @Test
+    fun parseExtras_givenValidMessageWithoutPosition_expectDefaultPosition() = runTest {
+        val givenMessage = createInAppMessage(
+            messageId = "test-456",
+            priority = 2,
+            position = MessagePosition.BOTTOM.name
+        )
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = null
+        )
+
+        val result = parser.parseExtras(provider).shouldNotBeNull()
+        result.message shouldBeEqualTo givenMessage
+        result.messagePosition shouldBeEqualTo MessagePosition.BOTTOM // From message gist properties
+    }
+
+    @Test
+    fun parseExtras_givenNullMessage_expectNullResultAndError() = runTest {
+        val provider = createExtrasProvider(
+            message = null,
+            position = MessagePosition.CENTER.name
+        )
+
+        val result = parser.parseExtras(provider)
+
+        result.shouldBeNull()
+        verify { mockLogger.error("ModalMessageParser: Message is null or empty") }
+    }
+
+    @Test
+    fun parseExtras_givenEmptyMessage_expectNullResultAndError() = runTest {
+        val provider = createExtrasProvider(
+            message = "",
+            position = MessagePosition.CENTER.name
+        )
+
+        val result = parser.parseExtras(provider)
+
+        result.shouldBeNull()
+        verify { mockLogger.error("ModalMessageParser: Message is null or empty") }
+    }
+
+    @Test
+    fun parseExtras_givenInvalidJson_expectNullResultAndError() = runTest {
+        val provider = createExtrasProvider(
+            message = "invalid-json-{",
+            position = MessagePosition.CENTER.name
+        )
+
+        val result = parser.parseExtras(provider)
+
+        result.shouldBeNull()
+        verify { mockLogger.error(match { it.contains("Failed to parse modal message with error") }) }
+    }
+
+    @Test
+    fun parseExtras_givenInvalidPosition_expectExceptionHandling() = runTest {
+        val givenMessage = Message(messageId = "test-789", priority = 2)
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = "INVALID_POSITION"
+        )
+
+        val result = parser.parseExtras(provider)
+
+        result.shouldBeNull()
+        verify { mockLogger.error(match { it.contains("Failed to parse modal message with error") }) }
+    }
+
+    @Test
+    fun parseExtras_givenCaseInsensitivePosition_expectCorrectParsing() = runTest {
+        val givenMessage = createInAppMessage(
+            messageId = "test-case",
+            priority = 1,
+            position = MessagePosition.CENTER.name
+        )
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = "bottom" // lowercase should work
+        )
+
+        val result = parser.parseExtras(provider)
+
+        result?.messagePosition shouldBeEqualTo MessagePosition.BOTTOM
+    }
+
+    @Test
+    fun parseExtras_givenPositionPriorityOrder_expectExtrasOverrideMessagePosition() = runTest {
+        val givenMessage = createInAppMessage(
+            messageId = "priority-test",
+            position = MessagePosition.CENTER.name // Message default
+        )
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = MessagePosition.BOTTOM.name // Extras override
+        )
+
+        val result = parser.parseExtras(provider).shouldNotBeNull()
+        // Extras position should override message position
+        result.messagePosition shouldBeEqualTo MessagePosition.BOTTOM
+        // But message still contains its original gist properties
+        result.message.gistProperties.position shouldBeEqualTo MessagePosition.CENTER
+    }
+
+    @Test
+    fun parseExtras_givenNullProvider_expectGracefulHandling() = runTest {
+        val provider = object : ModalMessageParser.ExtrasProvider {
+            override fun getString(key: String): String? = null
+        }
+
+        val result = parser.parseExtras(provider)
+
+        result.shouldBeNull()
+        verify { mockLogger.error("ModalMessageParser: Message is null or empty") }
+    }
+
+    @Test
+    fun parseExtras_givenSpiedDispatcher_expectBackgroundDispatcherUsed() = runTest {
+        dispatchersProviderStub.setRealDispatchers()
+        val jsonParser = object : ModalMessageParser.JsonParser {
+            override fun parseMessageFromJson(json: String): Message? {
+                assertNotOnMainThread()
+                return gson.fromJson(json, Message::class.java)
+            }
+        }
+        val messageParser = ModalMessageParserDefault(
+            logger = mockLogger,
+            dispatchersProvider = dispatchersProviderStub,
+            parser = jsonParser
+        )
+        val givenMessage = createInAppMessage(
+            messageId = "threading-test",
+            priority = 1
+        )
+
+        val provider = createExtrasProvider(
+            message = gson.toJson(givenMessage),
+            position = MessagePosition.CENTER.name
+        )
+
+        val result = messageParser.parseExtras(provider).shouldNotBeNull()
+        // Compare specific fields instead of entire object - Gson deserializes nested Maps as LinkedTreeMap
+        // while createInAppMessage uses different Map types, causing equals() to fail despite same data
+        result.message.messageId shouldBeEqualTo givenMessage.messageId
+        result.message.priority shouldBeEqualTo givenMessage.priority
+        result.messagePosition shouldBeEqualTo MessagePosition.CENTER
+        dispatchersProviderStub.resetToTestDispatchers()
+    }
+
+    private fun createExtrasProvider(
+        message: String?,
+        position: String?
+    ): ModalMessageParser.ExtrasProvider {
+        return object : ModalMessageParser.ExtrasProvider {
+            override fun getString(key: String): String? {
+                return when (key) {
+                    ModalMessageParser.EXTRA_IN_APP_MESSAGE -> message
+                    ModalMessageParser.EXTRA_IN_APP_MODAL_POSITION -> position
+                    else -> null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
closes: [MBL-1235](https://linear.app/customerio/issue/MBL-1235/move-json-parsing-off-ui-thread-in-gistmodalactivity)

### Changes

- Moved JSON parsing of modal in-app message from UI thread to background thread
- Added `ModalMessageParser` interface and implementation for safe message parsing
- Introduced `ModalMessageExtras` data class for parsed message content and position
- Modified `GistModalActivity` to use async parsing with coroutines instead of synchronous parsing
- Updated `SDKComponent` to provide `ModalMessageParser` instance
- Removed public constants from `GistModalActivity` for simplification

### Behavior Updates

- JSON parsing now occurs on background thread preventing UI blocking during message parsing
-  No impact on customer experience for modal in-app message display - messages continue to show normally with improved performance
