### PR TITLE
fix: crash when build attributes are nullable

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/util/DeviceStoreStub.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/DeviceStoreStub.kt
@@ -12,15 +12,15 @@ class DeviceStoreStub {
     fun getDeviceStore(client: Client): DeviceStore {
         return DeviceStoreImpl(
             buildStore = object : BuildStore {
-                override val deviceBrand: String
+                override val deviceBrand: String?
                     get() = "Google"
-                override val deviceModel: String
+                override val deviceModel: String?
                     get() = "Pixel 6"
-                override val deviceManufacturer: String
+                override val deviceManufacturer: String?
                     get() = "Google"
-                override val deviceOSVersion: Int
+                override val deviceOSVersion: Int?
                     get() = 30
-                override val deviceLocale: String
+                override val deviceLocale: String?
                     get() = Locale.US.toLanguageTag()
             },
             applicationStore = object : ApplicationStore {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/BuildStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/BuildStore.kt
@@ -6,31 +6,31 @@ import java.util.*
 interface BuildStore {
 
     // Brand : Google
-    val deviceBrand: String
+    val deviceBrand: String?
 
     // Device model: Pixel
-    val deviceModel: String
+    val deviceModel: String?
 
     // Hardware manufacturer: Samsung
-    val deviceManufacturer: String
+    val deviceManufacturer: String?
 
     // Android SDK Version: 21
-    val deviceOSVersion: Int
+    val deviceOSVersion: Int?
 
     // Device locale: en-US
-    val deviceLocale: String
+    val deviceLocale: String?
 }
 
 internal class BuildStoreImpl : BuildStore {
 
-    override val deviceBrand: String
+    override val deviceBrand: String?
         get() = Build.BRAND
-    override val deviceModel: String
+    override val deviceModel: String?
         get() = Build.MODEL
-    override val deviceManufacturer: String
+    override val deviceManufacturer: String?
         get() = Build.MANUFACTURER
-    override val deviceOSVersion: Int
+    override val deviceOSVersion: Int?
         get() = Build.VERSION.SDK_INT
-    override val deviceLocale: String
+    override val deviceLocale: String?
         get() = Locale.getDefault().toLanguageTag()
 }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/DeviceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/DeviceStore.kt
@@ -18,7 +18,7 @@ interface DeviceStore : BuildStore, ApplicationStore {
      * `Customer.io Android Client/1.0.0-alpha.6`
      */
     fun buildUserAgent(): String
-    fun buildDeviceAttributes(): Map<String, Any>
+    fun buildDeviceAttributes(): Map<String, Any?>
 }
 
 class DeviceStoreImpl(
@@ -28,15 +28,15 @@ class DeviceStoreImpl(
     version: String = client.sdkVersion
 ) : DeviceStore {
 
-    override val deviceBrand: String
+    override val deviceBrand: String?
         get() = buildStore.deviceBrand
-    override val deviceModel: String
+    override val deviceModel: String?
         get() = buildStore.deviceModel
-    override val deviceManufacturer: String
+    override val deviceManufacturer: String?
         get() = buildStore.deviceManufacturer
-    override val deviceOSVersion: Int
+    override val deviceOSVersion: Int?
         get() = buildStore.deviceOSVersion
-    override val deviceLocale: String
+    override val deviceLocale: String?
         get() = buildStore.deviceLocale
     override val customerAppName: String?
         get() = applicationStore.customerAppName
@@ -57,7 +57,7 @@ class DeviceStoreImpl(
         }
     }
 
-    override fun buildDeviceAttributes(): Map<String, Any> {
+    override fun buildDeviceAttributes(): Map<String, Any?> {
         return mapOf(
             "device_os" to deviceOSVersion,
             "device_model" to deviceModel,

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
@@ -430,6 +431,37 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
         // server does not require 'last_used' and 'platform' and may fail if included
         payloadContext.containsKey("last_used") shouldBeEqualTo false
         payloadContext.containsKey("platform") shouldBeEqualTo false
+    }
+
+    @Test
+    fun device_givenTokenRegisteredWithNullableDeviceAttributes_expectDeviceAttributesAreSent() = runTest {
+        val givenToken = String.random
+        val givenAttributes = mapOf(
+            "cio_sdk_version" to "2.0.0-alpha.10",
+            "app_release" to "1.0",
+            "app_build" to "100",
+            "app_namespace" to "io.customer.android",
+            "device_os_version" to "13",
+            "device_os" to "Android",
+            "device_manufacturer" to null,
+            "device_model" to "Pixel 5"
+        )
+
+        every { deviceStore.buildDeviceAttributes() } returns givenAttributes
+        sdkInstance.registerDeviceToken(givenToken)
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+
+        val queuedEvents = getQueuedEvents()
+        // 1. Identify event
+        // 2. Device registration event
+        queuedEvents.count() shouldBeEqualTo 1
+
+        val payload = queuedEvents.last().jsonObject
+        payload.eventType shouldBeEqualTo "track"
+        payload.eventName shouldBeEqualTo EventNames.DEVICE_UPDATE
+
+        val payloadProperties = payload["properties"]?.jsonObject.shouldNotBeNull()
+        payloadProperties["device_manufacturer"] shouldBeEqualTo JsonNull
     }
 
     @Test

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExtensions.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExtensions.kt
@@ -3,7 +3,6 @@ package io.customer.datapipelines.testutils.extensions
 import com.segment.analytics.kotlin.core.emptyJsonObject
 import io.customer.datapipelines.extensions.toJsonObject
 import io.customer.datapipelines.plugins.findAtPath
-import io.customer.sdk.data.model.CustomAttributes
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -17,9 +16,9 @@ import org.amshove.kluent.internal.assertEquals
 import org.json.JSONObject
 
 /**
- * Similar to Kluent's `shouldBeEqualTo` but for comparing JSON objects with custom attributes map.
+ * Similar to Kluent's `shouldBeEqualTo` but for comparing JSON objects with map with nullable values.
  */
-infix fun JsonObject.shouldMatchTo(expected: CustomAttributes): JsonObject {
+infix fun JsonObject.shouldMatchTo(expected: Map<String, Any?>): JsonObject {
     return this.apply { assertEquals(expected.toJsonObject(), this) }
 }
 
@@ -38,16 +37,12 @@ inline fun <K, reified V> Pair<K, V>.encodeToJsonValue(): Pair<K, JsonElement> {
 }
 
 /**
- * Converts a map of custom attributes to a JSON object.
+ * Converts a map with nullable values to a JSON object.
  * If the map is empty, it returns an empty JSON object.
  */
-fun CustomAttributes?.toJsonObject(): JsonObject {
-    val encodedMap = if (this.isNullOrEmpty()) {
-        emptyMap()
-    } else {
-        with(Json) {
-            mapValues { (_, value) -> encode(value) }
-        }
+fun Map<String, Any?>.toJsonObject(): JsonObject {
+    val encodedMap = with(Json) {
+        mapValues { (_, value) -> encode(value) }
     }
     return JsonObject(encodedMap)
 }


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-984/android-sdk-running-into-anr-during-initialization-cont-gh-470

This supports a case, where `nullable` inbuilt device attributes are sent by Device. 

Changes:
This includes updating the `BuildStore` and `DeviceStore` interfaces and their implementations to make fields like `brand, model, and OS version` optional. JSON serialization logic was updated accordingly, and tests were added to verify the changes.

This is a potential fix for the Kotlin reflection crash. 

However, the more robust solution would be to update the `Kotlin serialization` library to `1.9.0`, which includes proper handling for unexpected values (introduced in 1.8.1 – PR #[2911](https://github.com/Kotlin/kotlinx.serialization/pull/2911)). But that upgrade would require bumping the `Kotlin` version to `2.2.0`.
