### PR TITLE
chore: move setting storage to background

### DIFF
--- a/common-test/src/main/java/io/customer/commontest/util/ScopeProviderStub.kt
+++ b/common-test/src/main/java/io/customer/commontest/util/ScopeProviderStub.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 class ScopeProviderStub private constructor(
     override val eventBusScope: TestScope,
     override val lifecycleListenerScope: TestScope,
-    override val inAppLifecycleScope: TestScope
+    override val inAppLifecycleScope: TestScope,
+    override val globalPreferenceStoreScope: TestScope
 ) : ScopeProvider {
 
     @Suppress("FunctionName")
@@ -18,13 +19,15 @@ class ScopeProviderStub private constructor(
         fun Unconfined(): ScopeProviderStub = ScopeProviderStub(
             eventBusScope = TestScope(UnconfinedTestDispatcher()),
             lifecycleListenerScope = TestScope(UnconfinedTestDispatcher()),
-            inAppLifecycleScope = TestScope(UnconfinedTestDispatcher())
+            inAppLifecycleScope = TestScope(UnconfinedTestDispatcher()),
+            globalPreferenceStoreScope = TestScope(UnconfinedTestDispatcher())
         )
 
         fun Standard(): ScopeProviderStub = ScopeProviderStub(
             eventBusScope = TestScope(StandardTestDispatcher()),
             lifecycleListenerScope = TestScope(StandardTestDispatcher()),
-            inAppLifecycleScope = TestScope(StandardTestDispatcher())
+            inAppLifecycleScope = TestScope(StandardTestDispatcher()),
+            globalPreferenceStoreScope = TestScope(StandardTestDispatcher())
         )
     }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -221,6 +221,7 @@ public final class io/customer/sdk/core/util/Logger$DefaultImpls {
 
 public abstract interface class io/customer/sdk/core/util/ScopeProvider {
 	public abstract fun getEventBusScope ()Lkotlinx/coroutines/CoroutineScope;
+	public abstract fun getGlobalPreferenceStoreScope ()Lkotlinx/coroutines/CoroutineScope;
 	public abstract fun getInAppLifecycleScope ()Lkotlinx/coroutines/CoroutineScope;
 	public abstract fun getLifecycleListenerScope ()Lkotlinx/coroutines/CoroutineScope;
 }
@@ -235,6 +236,7 @@ public final class io/customer/sdk/core/util/SdkDispatchers : io/customer/sdk/co
 public final class io/customer/sdk/core/util/SdkScopeProvider : io/customer/sdk/core/util/ScopeProvider {
 	public fun <init> (Lio/customer/sdk/core/util/DispatchersProvider;)V
 	public fun getEventBusScope ()Lkotlinx/coroutines/CoroutineScope;
+	public fun getGlobalPreferenceStoreScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getInAppLifecycleScope ()Lkotlinx/coroutines/CoroutineScope;
 	public fun getLifecycleListenerScope ()Lkotlinx/coroutines/CoroutineScope;
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
@@ -7,6 +7,7 @@ interface ScopeProvider {
     val eventBusScope: CoroutineScope
     val lifecycleListenerScope: CoroutineScope
     val inAppLifecycleScope: CoroutineScope
+    val globalPreferenceStoreScope: CoroutineScope
 }
 
 class SdkScopeProvider(private val dispatchers: DispatchersProvider) : ScopeProvider {
@@ -16,4 +17,6 @@ class SdkScopeProvider(private val dispatchers: DispatchersProvider) : ScopeProv
         get() = CoroutineScope(dispatchers.default + SupervisorJob())
     override val inAppLifecycleScope: CoroutineScope
         get() = CoroutineScope(dispatchers.default + SupervisorJob())
+    override val globalPreferenceStoreScope: CoroutineScope
+        get() = CoroutineScope(dispatchers.background + SupervisorJob())
 }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
@@ -26,7 +26,7 @@ internal class GlobalPreferenceStoreImpl(
     context: Context
 ) : PreferenceStore(context), GlobalPreferenceStore {
 
-    val scope: CoroutineScope = SDKComponent.scopeProvider.globalPreferenceStoreScope
+    private val scope: CoroutineScope = SDKComponent.scopeProvider.globalPreferenceStoreScope
 
     override val prefsName: String by lazy {
         "io.customer.sdk.${context.packageName}"

--- a/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
@@ -2,7 +2,10 @@ package io.customer.sdk.data.store
 
 import android.content.Context
 import androidx.core.content.edit
+import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.Settings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 /**
@@ -23,6 +26,8 @@ internal class GlobalPreferenceStoreImpl(
     context: Context
 ) : PreferenceStore(context), GlobalPreferenceStore {
 
+    val scope: CoroutineScope = SDKComponent.scopeProvider.globalPreferenceStoreScope
+
     override val prefsName: String by lazy {
         "io.customer.sdk.${context.packageName}"
     }
@@ -31,8 +36,12 @@ internal class GlobalPreferenceStoreImpl(
         putString(KEY_DEVICE_TOKEN, token)
     }
 
-    override fun saveSettings(value: Settings) = prefs.edit {
-        putString(KEY_CONFIG_SETTINGS, Json.encodeToString(Settings.serializer(), value))
+    override fun saveSettings(value: Settings) {
+        scope.launch {
+            prefs.edit {
+                putString(KEY_CONFIG_SETTINGS, Json.encodeToString(Settings.serializer(), value))
+            }
+        }
     }
 
     override fun getDeviceToken(): String? = prefs.read {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 
 import java.util.Map;
 
+import io.customer.android.sample.java_layout.BuildConfig;
 import io.customer.android.sample.java_layout.SampleApplication;
 import io.customer.android.sample.java_layout.data.PreferencesDataStore;
 import io.customer.android.sample.java_layout.data.model.CustomerIOSDKConfig;
@@ -27,8 +28,11 @@ public class CustomerIORepository {
         // Get desired SDK config, only required by sample app
         final CustomerIOSDKConfig sdkConfig = getSdkConfig(appGraph.getPreferencesDataStore());
 
-        // Enable strict mode after config
-        enableStrictMode();
+        // Enable strict mode after config to focus on SDK issues
+        // Only enable in debug builds to avoid performance impact in release builds
+        if (BuildConfig.DEBUG) {
+            enableStrictMode();
+        }
 
         // Initialize Customer.io SDK builder
         CustomerIOBuilder builder = new CustomerIOBuilder(application, sdkConfig.getCdpApiKey());

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -1,5 +1,6 @@
 package io.customer.android.sample.java_layout.sdk;
 
+import android.os.StrictMode;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -25,6 +26,9 @@ public class CustomerIORepository {
         ApplicationGraph appGraph = application.getApplicationGraph();
         // Get desired SDK config, only required by sample app
         final CustomerIOSDKConfig sdkConfig = getSdkConfig(appGraph.getPreferencesDataStore());
+
+        // Enable strict mode after config
+        enableStrictMode();
 
         // Initialize Customer.io SDK builder
         CustomerIOBuilder builder = new CustomerIOBuilder(application, sdkConfig.getCdpApiKey());
@@ -121,5 +125,25 @@ public class CustomerIORepository {
 
         // Return default configurations if no configurations were saved in data store
         return CustomerIOSDKConfig.getDefaultConfigurations();
+    }
+
+    private void enableStrictMode() {
+        // Thread policy - detects network calls, disk reads, custom slow calls on main thread
+        StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                .detectNetwork()   // Detect network calls on main thread
+                .detectDiskReads() // Detect disk reads on main thread
+                .detectDiskWrites() // Detect disk writes on main thread
+                .detectCustomSlowCalls() // Detect custom slow calls marked with StrictMode.noteSlowCall()
+                .penaltyLog()      // Log violations to LogCat
+                //.penaltyDialog()   // Show dialog for violations (useful for debugging)
+                .build());
+
+        // VM policy - detects leaks and other VM-level violations
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects() // Detect leaked SQLite objects
+                .detectLeakedClosableObjects() // Detect leaked closeable objects
+                .detectActivityLeaks()         // Detect leaked activities
+                .penaltyLog()
+                .build());
     }
 }


### PR DESCRIPTION
changes:

- Moved strict mode enabling before SDK startup rather App to avoid false positives of app
- We were storing `settings` on main thread, while this method doesn't need to be blocking nor it needs to be done in main thread. 

testing:
- Verified manually by running app and ensuring setting are being saved and running app without internet to ensure we are able to fetch loaded settings.