### PR TITLE
chore: moved analytics initialization to blocking background thread

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -96,6 +96,8 @@ class CustomerIO private constructor(
         }
     }
 
+    // Still synchronously create Analytics instance to ensure it is created before any other module uses it
+    // but we initialize it on background thread to avoid any storage access on main thread by Analytics.
     internal val analytics: Analytics = overrideAnalytics ?: runBlocking(dispatchersProvider.background) {
         Analytics(
             writeKey = moduleConfig.cdpApiKey,


### PR DESCRIPTION
closes: [MBL-1233: Changes in Segment Analytics SDK](https://linear.app/customerio/issue/MBL-1233/changes-in-segment-analytics-sdk)

Since we need to keep it synchronous, kept it blocking but we don't have to perform it on main thread. So moving it to background removes the main thread violations. 