### PR TITLE
chore: Turn deviceAttributes into setDeviceAttributes

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -137,6 +137,7 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public static final field Companion Lio/customer/sdk/CustomerIO$Companion;
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/datapipelines/config/DataPipelinesModuleConfig;Lcom/segment/analytics/kotlin/core/Analytics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAnonymousId ()Ljava/lang/String;
+	public fun getDeviceAttributes ()Ljava/util/Map;
 	public fun getModuleConfig ()Lio/customer/datapipelines/config/DataPipelinesModuleConfig;
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
@@ -146,6 +147,7 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public fun initialize ()V
 	public static final fun instance ()Lio/customer/sdk/CustomerIO;
 	public fun setDeviceAttributes (Ljava/util/Map;)V
+	public fun setDeviceAttributesDeprecated (Ljava/util/Map;)V
 	public fun setProfileAttributes (Ljava/util/Map;)V
 }
 
@@ -179,6 +181,7 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public final fun deleteDeviceToken ()V
 	protected abstract fun deleteDeviceTokenImpl ()V
 	public abstract fun getAnonymousId ()Ljava/lang/String;
+	public abstract fun getDeviceAttributes ()Ljava/util/Map;
 	public abstract fun getProfileAttributes ()Ljava/util/Map;
 	public abstract fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public abstract fun getUserId ()Ljava/lang/String;

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -137,7 +137,6 @@ public final class io/customer/sdk/CustomerIO : io/customer/sdk/DataPipelineInst
 	public static final field Companion Lio/customer/sdk/CustomerIO$Companion;
 	public synthetic fun <init> (Lio/customer/sdk/core/di/AndroidSDKComponent;Lio/customer/datapipelines/config/DataPipelinesModuleConfig;Lcom/segment/analytics/kotlin/core/Analytics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getAnonymousId ()Ljava/lang/String;
-	public fun getDeviceAttributes ()Ljava/util/Map;
 	public fun getModuleConfig ()Lio/customer/datapipelines/config/DataPipelinesModuleConfig;
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
@@ -180,7 +179,6 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public final fun deleteDeviceToken ()V
 	protected abstract fun deleteDeviceTokenImpl ()V
 	public abstract fun getAnonymousId ()Ljava/lang/String;
-	public abstract fun getDeviceAttributes ()Ljava/util/Map;
 	public abstract fun getProfileAttributes ()Ljava/util/Map;
 	public abstract fun getRegisteredDeviceToken ()Ljava/lang/String;
 	public abstract fun getUserId ()Ljava/lang/String;

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -302,6 +302,14 @@ class CustomerIO private constructor(
     override val userId: String?
         get() = analytics.userId()
 
+    @Deprecated("Use setDeviceAttributes() function instead")
+    @set:JvmName("setDeviceAttributesDeprecated")
+    override var deviceAttributes: CustomAttributes
+        get() = emptyMap()
+        set(value) {
+            setDeviceAttributes(value)
+        }
+
     override fun setDeviceAttributes(attributes: CustomAttributes) {
         trackDeviceAttributes(registeredDeviceToken, attributes)
     }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -302,11 +302,9 @@ class CustomerIO private constructor(
     override val userId: String?
         get() = analytics.userId()
 
-    override var deviceAttributes: CustomAttributes
-        get() = emptyMap()
-        set(value) {
-            trackDeviceAttributes(registeredDeviceToken, value)
-        }
+    override fun setDeviceAttributes(attributes: CustomAttributes) {
+        trackDeviceAttributes(registeredDeviceToken, attributes)
+    }
 
     override fun registerDeviceTokenImpl(deviceToken: String) {
         if (deviceToken.isBlank()) {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -301,6 +301,13 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * Use to provide additional and custom device attributes
      * apart from the ones the SDK is programmed to send to customer workspace.
      */
+    @Deprecated("Use setDeviceAttributes() function instead")
+    abstract val deviceAttributes: CustomAttributes
+
+    /**
+     * Use to provide additional and custom device attributes
+     * apart from the ones the SDK is programmed to send to customer workspace.
+     */
     abstract fun setDeviceAttributes(attributes: CustomAttributes)
 
     /**

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -301,7 +301,7 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * Use to provide additional and custom device attributes
      * apart from the ones the SDK is programmed to send to customer workspace.
      */
-    abstract var deviceAttributes: CustomAttributes
+    abstract fun setDeviceAttributes(attributes: CustomAttributes)
 
     /**
      * Registers a new device token with Customer.io, associated with the current

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesCompatibilityTests.kt
@@ -475,7 +475,7 @@ class DataPipelinesCompatibilityTests : JUnitTest() {
         sdkInstance.identify(String.random)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
-        sdkInstance.deviceAttributes = customAttributes
+        sdkInstance.setDeviceAttributes(customAttributes)
 
         val queuedEvents = getQueuedEvents()
         // 1. Identify

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -458,7 +458,7 @@ class DataPipelinesInteractionTests : JUnitTest() {
         sdkInstance.identify(givenIdentifier)
         sdkInstance.registerDeviceToken(givenToken)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
-        sdkInstance.deviceAttributes = givenAttributes
+        sdkInstance.setDeviceAttributes(givenAttributes)
 
         outputReaderPlugin.identifyEvents.size shouldBeEqualTo 1
         outputReaderPlugin.trackEvents.count() shouldBeEqualTo 2

--- a/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DeviceAttributesTests.kt
@@ -149,7 +149,7 @@ class DeviceAttributesTests : IntegrationTest() {
         sdkInstance.identify(givenIdentifier)
         every { globalPreferenceStore.getDeviceToken() } returns givenToken
         sdkInstance.registerDeviceToken(givenToken)
-        sdkInstance.deviceAttributes = givenAttributes
+        sdkInstance.setDeviceAttributes(givenAttributes)
 
         // 1. Device Created
         // 2. Device Updated

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/customTrack/CustomAttribute.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/customTrack/CustomAttribute.kt
@@ -102,7 +102,7 @@ fun CustomAttributeRoute(
                 }
             } else {
                 Pair(stringResource(R.string.send_device_attribute)) {
-                    CustomerIO.instance().deviceAttributes = mapOf(attributeName to attributeValue)
+                    CustomerIO.instance().setDeviceAttributes(mapOf(attributeName to attributeValue))
                 }
             }
             val testTag = if (attributeType == TYPE_PROFILE) {


### PR DESCRIPTION
Closes: [MBL-1299](https://linear.app/customerio/issue/MBL-1299/device-and-user-enrichment-api-alignment)

Tweaks public API `deviceAttributes` to be `setDeviceAttributes` for clarify and consistency with other SDKs