### PR TITLE
chore: Deprecate unnecessary non-Map overloads in DataPipelineInstance API

### DIFF
--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -188,7 +188,7 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public final fun identify (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun identify (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun identify (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	protected abstract fun identifyImpl (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun registerDeviceToken (Ljava/lang/String;)V
 	protected abstract fun registerDeviceTokenImpl (Ljava/lang/String;)V
@@ -196,7 +196,7 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public final fun screen (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun screen (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun screen (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public static synthetic fun screen$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	protected abstract fun screenImpl (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public abstract fun setDeviceAttributes (Ljava/util/Map;)V
 	public abstract fun setProfileAttributes (Ljava/util/Map;)V
@@ -204,7 +204,7 @@ public abstract class io/customer/sdk/DataPipelineInstance : io/customer/sdk/Cus
 	public final fun track (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public static synthetic fun track$default (Lio/customer/sdk/DataPipelineInstance;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	protected abstract fun trackImpl (Ljava/lang/String;Ljava/lang/Object;Lkotlinx/serialization/SerializationStrategy;)V
 	public final fun trackMetric (Lio/customer/sdk/events/TrackMetric;)V
 	protected abstract fun trackMetricImpl (Lio/customer/sdk/events/TrackMetric;)V

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -34,6 +34,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits [Traits] about the user. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      */
+    @Deprecated(
+        message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("identify(userId, traits as Map<String, Any?>)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun <reified Traits> identify(userId: String, traits: Traits) {
         identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
@@ -49,8 +54,12 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits JsonObject about the user.
      */
-    @JvmOverloads
-    fun identify(userId: String, traits: JsonObject = emptyJsonObject) {
+    @Deprecated(
+        message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("identify(userId, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
+    fun identify(userId: String, traits: JsonObject) {
         identify(userId = userId, traits = traits, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
@@ -65,7 +74,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * [Learn more](https://customer.io/docs/api/#operation/identify)
      * @param traits Map of <String, Any> to be added
      */
-    fun identify(userId: String, traits: Map<String, Any?>) {
+    @JvmOverloads
+    fun identify(userId: String, traits: Map<String, Any?> = emptyMap()) {
         // Method needed for Java interop as inline doesn't work with Java
         identify(userId = userId, traits = traits.sanitizeForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
@@ -83,6 +93,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param traits [Traits] about the user. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      * @param serializationStrategy strategy to serialize [traits]
      */
+    @Deprecated(
+        message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("identify(userId, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
     fun <Traits> identify(
         userId: String,
         traits: Traits,
@@ -113,8 +128,12 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties custom values providing extra information about the event.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
-    @JvmOverloads
-    fun track(name: String, properties: JsonObject = emptyJsonObject) {
+    @Deprecated(
+        message = "Use track(name: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("track(name, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
+    fun track(name: String, properties: JsonObject) {
         track(name = name, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
@@ -129,7 +148,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Map of <String, Any> to be added
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
-    fun track(name: String, properties: Map<String, Any?>) {
+    @JvmOverloads
+    fun track(name: String, properties: Map<String, Any?> = emptyMap()) {
         // Method needed for Java interop as inline doesn't work with Java
         track(name = name, properties = properties.sanitizeForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
@@ -146,6 +166,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param serializationStrategy strategy to serialize [properties]
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
+    @Deprecated(
+        message = "Use track(name: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("track(name, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
     fun <T> track(
         name: String,
         properties: T,
@@ -176,6 +201,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties to describe the action. Needs to be [serializable](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/track-spec/)
      */
+    @Deprecated(
+        message = "Use track(name: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("track(name, properties as Map<String, Any?>)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun <reified T> track(
         name: String,
         properties: T
@@ -190,8 +220,12 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    @JvmOverloads
-    fun screen(title: String, properties: JsonObject = emptyJsonObject) {
+    @Deprecated(
+        message = "Use screen(title: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("screen(title, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
+    fun screen(title: String, properties: JsonObject) {
         screen(title = title, properties = properties, serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
 
@@ -202,7 +236,8 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen in Map <String, Any> format.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
-    fun screen(title: String, properties: Map<String, Any?>) {
+    @JvmOverloads
+    fun screen(title: String, properties: Map<String, Any?> = emptyMap()) {
         // Method needed for Java interop as inline doesn't work with Java
         screen(title = title, properties = properties.sanitizeForJson(), serializationStrategy = JsonAnySerializer.serializersModule.serializer())
     }
@@ -214,6 +249,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
+    @Deprecated(
+        message = "Use screen(title: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("screen(title, emptyMap())"),
+        level = DeprecationLevel.WARNING
+    )
     fun <T> screen(
         title: String,
         properties: T,
@@ -240,6 +280,11 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      * @param properties Additional details about the screen.
      * @see [Learn more](https://customer.io/docs/cdp/sources/source-spec/screen-spec/)
      */
+    @Deprecated(
+        message = "Use screen(title: String, properties: Map<String, Any?>) instead",
+        replaceWith = ReplaceWith("screen(title, properties as Map<String, Any?>)"),
+        level = DeprecationLevel.WARNING
+    )
     inline fun <reified T> screen(
         title: String,
         properties: T

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -1,6 +1,5 @@
 package io.customer.sdk
 
-import com.segment.analytics.kotlin.core.emptyJsonObject
 import com.segment.analytics.kotlin.core.utilities.JsonAnySerializer
 import io.customer.datapipelines.extensions.sanitizeForJson
 import io.customer.sdk.data.model.CustomAttributes

--- a/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/DataPipelineInstance.kt
@@ -35,7 +35,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("identify(userId, traits as Map<String, Any?>)"),
         level = DeprecationLevel.WARNING
     )
     inline fun <reified Traits> identify(userId: String, traits: Traits) {
@@ -55,7 +54,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("identify(userId, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun identify(userId: String, traits: JsonObject) {
@@ -94,7 +92,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use identify(userId: String, traits: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("identify(userId, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun <Traits> identify(
@@ -129,7 +126,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use track(name: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("track(name, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun track(name: String, properties: JsonObject) {
@@ -167,7 +163,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use track(name: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("track(name, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun <T> track(
@@ -202,7 +197,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use track(name: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("track(name, properties as Map<String, Any?>)"),
         level = DeprecationLevel.WARNING
     )
     inline fun <reified T> track(
@@ -221,7 +215,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use screen(title: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("screen(title, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun screen(title: String, properties: JsonObject) {
@@ -250,7 +243,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use screen(title: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("screen(title, emptyMap())"),
         level = DeprecationLevel.WARNING
     )
     fun <T> screen(
@@ -281,7 +273,6 @@ abstract class DataPipelineInstance : CustomerIOInstance {
      */
     @Deprecated(
         message = "Use screen(title: String, properties: Map<String, Any?>) instead",
-        replaceWith = ReplaceWith("screen(title, properties as Map<String, Any?>)"),
         level = DeprecationLevel.WARNING
     )
     inline fun <reified T> screen(


### PR DESCRIPTION
Closes: [MBL-1298](https://linear.app/customerio/issue/MBL-1298/tracking-api-alignment)

## Summary
Deprecates overloaded methods in DataPipelineInstance that accept generic types or JsonObject parameters in favor of the Map<String, Any?> variants for better API consistency.

## Changes
- Deprecated methods:
  - `identify(userId: String, traits: Traits) (reified generic)`
  - `identify(userId: String, traits: JsonObject)`
  - `identify(userId: String, traits: Traits, serializationStrategy: SerializationStrategy<Traits>)`
  - `track(name: String, properties: JsonObject)`
  - `track(name: String, properties: T) (reified generic)`
  - `track(name: String, properties: T, serializationStrategy: SerializationStrategy<T>)`
  - `screen(title: String, properties: JsonObject)`
  - `screen(title: String, properties: T) (reified generic)`
  - `screen(title: String, properties: T, serializationStrategy: SerializationStrategy<T>)`
  
- Enhanced Map-based methods with default empty parameters:
  - `identify(userId: String, traits: Map<String, Any?> = emptyMap())`
  - `track(name: String, properties: Map<String, Any?> = emptyMap())`
  - `screen(title: String, properties: Map<String, Any?> = emptyMap())`

## Migration
- All deprecated methods include @Deprecated annotations with ReplaceWith suggestions for automatic IDE migration. Existing code continues to work but will show deprecation warnings.

## Rationale
Simplifies the API surface by consolidating on a single, consistent parameter type (Map<String, Any?>) while maintaining backward compatibility.