### PR TITLE
fix: Decrease CustomerIOFirebaseMessagingService priority handling

### DIFF
--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <service
             android:name=".CustomerIOFirebaseMessagingService"
             android:exported="false">
-            <intent-filter android:priority="-1">
+            <intent-filter android:priority="-10">
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>


### PR DESCRIPTION
### Problem
CustomerIO's Firebase messaging service was intercepting notifications intended for [Expo notification library](https://github.com/expo/expo/blob/9b687cc495a2a36cb47c3f5d50fedc9cc0ede0a9/packages/expo-notifications/android/src/main/AndroidManifest.xml#L6-L12) due to higher priority.

### Solution
Changed CustomerIOFirebaseMessagingService intent filter priority from `-1` to `-10`, this allows Expo notifications to handle messages if it exists.
