### PR TITLE
Subscription Topics

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -22,42 +22,8 @@ class ModuleMessagingInApp(
         get() = SDKComponent.gistProvider
     private val logger = SDKComponent.logger
 
-    @Volatile
-    private var inAppEnabled: Boolean = true
-
-    /**
-     * Disable displaying and polling of in-app messages.
-     * Calling this method will immediately dismiss any message currently being
-     * shown and stop further polling for new messages until [enable] is called.
-     */
-    fun disable() {
-        if (!inAppEnabled) return
-        logger.info("In-app messaging disabled by user call")
-        inAppEnabled = false
-        // Reset provider which clears timers, queues and dismisses currently shown message
-        gistProvider.reset()
-    }
-
-    /**
-     * Re-enable in-app messaging after it has been disabled via [disable].
-     * When re-enabled, polling for messages will resume immediately using the
-     * last known polling interval.
-     */
-    fun enable() {
-        if (inAppEnabled) return
-        logger.info("In-app messaging enabled by user call")
-        inAppEnabled = true
-        // Start polling again to fetch fresh messages
-        gistProvider.fetchInAppMessages()
-    }
-
-    /** Internal convenience to quickly check if in-app is enabled */
-    private inline fun ifEnabled(block: () -> Unit) {
-        if (inAppEnabled) block()
-    }
-
     fun dismissMessage() {
-        ifEnabled { gistProvider.dismissMessage() }
+        gistProvider.dismissMessage()
     }
 
     override fun initialize() {
@@ -66,18 +32,16 @@ class ModuleMessagingInApp(
 
     private fun setupHooks() {
         eventBus.subscribe<Event.ScreenViewedEvent> {
-            ifEnabled { gistProvider.setCurrentRoute(it.name) }
+            gistProvider.setCurrentRoute(it.name)
         }
 
         eventBus.subscribe<Event.ProfileIdentifiedEvent> {
-            ifEnabled { gistProvider.setUserId(it.identifier) }
+            gistProvider.setUserId(it.identifier)
         }
 
         eventBus.subscribe<Event.ResetEvent> {
-            ifEnabled {
-                logger.debug("Resetting user token")
-                gistProvider.reset()
-            }
+            logger.debug("Resetting user token")
+            gistProvider.reset()
         }
     }
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -28,7 +28,6 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import io.mockk.clearMocks
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -237,43 +236,5 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         verify(exactly = 0) {
             eventBus.publish(any<Event.TrackInAppMetricEvent>())
         }
-    }
-
-    @Test
-    fun disable_whenCalled_shouldResetAndBlockFurtherActions() {
-        module.initialize()
-
-        // Disable in-app messaging
-        module.disable()
-
-        // Reset should be invoked once
-        assertCalledOnce { inAppMessagesProviderMock.reset() }
-
-        // Any subsequent interactions should be blocked
-        eventBus.publish(Event.ScreenViewedEvent(name = "test_route"))
-        assertCalledNever { inAppMessagesProviderMock.setCurrentRoute(any()) }
-
-        // Even direct API calls are ignored
-        module.dismissMessage()
-        assertCalledNever { inAppMessagesProviderMock.dismissMessage() }
-    }
-
-    @Test
-    fun enable_afterDisable_shouldFetchMessagesAndResumeProcessing() {
-        module.initialize()
-        module.disable()
-
-        // Clear previous interactions so we only capture calls after enabling
-        clearMocks(inAppMessagesProviderMock, answers = false)
-
-        module.enable()
-
-        // Should trigger an immediate fetch
-        assertCalledOnce { inAppMessagesProviderMock.fetchInAppMessages() }
-
-        // Verify that normal processing resumes
-        val givenRoute = "home_screen"
-        eventBus.publish(Event.ScreenViewedEvent(name = givenRoute))
-        assertCalledOnce { inAppMessagesProviderMock.setCurrentRoute(givenRoute) }
     }
 }


### PR DESCRIPTION
We would like to implement the ability for users to subscribe and unsubscribe to topics directly from the app. Before we begin the full pull request process, could you please let us know if there are any existing reasons why this functionality has not been implemented in this way previously?

Our current alternative is to build an API wrapper on our own API. However, we believe that providing users with the ability to manage their communication preferences directly from the SDK is a critical core function.

Please advise if a full pull request for both iOS and Android would be a viable solution.