### PR TITLE
chore: Add WorkManager dependency and create safer provider

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -59,6 +59,8 @@ object Dependencies {
     const val okhttpLoggingInterceptor =
         "com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP}"
     const val segment = "com.segment.analytics.kotlin:android:${Versions.SEGMENT}"
+    const val workManager = "androidx.work:work-runtime-ktx:${Versions.WORK_MANAGER}"
+    const val workManagerTesting = "androidx.work:work-testing:${Versions.WORK_MANAGER}"
 
     // Compose dependencies
     const val composeBom = "androidx.compose:compose-bom:${Versions.COMPOSE_BOM}"

--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -2,7 +2,7 @@ package io.customer.android
 
 object Versions {
     // Android SDK versions
-    const val COMPILE_SDK = 34
+    const val COMPILE_SDK = 35
     const val TARGET_SDK = 33
     const val MIN_SDK = 21
 
@@ -44,4 +44,5 @@ object Versions {
     // Compose (using latest stable BOM compatible with Kotlin 2.1.20)
     internal const val COMPOSE_BOM = "2024.12.01"
     internal const val COMPOSE_COMPILER = "2.1.21"
+    internal const val WORK_MANAGER = "2.10.3"
 }

--- a/buildSrc/src/main/kotlin/io.customer/android/apkscale/MeasureAndroidLibrarySizeTask.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/apkscale/MeasureAndroidLibrarySizeTask.kt
@@ -147,7 +147,7 @@ abstract class MeasureAndroidLibrarySizeTask : DefaultTask() {
             }
 
             android {
-                compileSdk 34
+                compileSdk 35
                 namespace "com.apkscale.mock"
                 
                 defaultConfig {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/ApplicationStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/ApplicationStore.kt
@@ -28,7 +28,7 @@ internal class ApplicationStoreImpl(val context: Context) : ApplicationStore {
     override val isPushEnabled: Boolean
         get() = NotificationManagerCompat.from(context).areNotificationsEnabled()
 
-    private fun tryGetValueOrNull(tryGetValue: () -> String): String? {
+    private fun tryGetValueOrNull(tryGetValue: () -> String?): String? {
         return try {
             tryGetValue()
         } catch (e: Exception) {

--- a/messagingpush/build.gradle
+++ b/messagingpush/build.gradle
@@ -37,5 +37,8 @@ dependencies {
     implementation Dependencies.coroutinesCore
     implementation Dependencies.coroutinesAndroid
     implementation Dependencies.googlePlayServicesBase
+    implementation Dependencies.workManager
     api Dependencies.firebaseMessaging
+
+    testImplementation Dependencies.workManagerTesting
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -222,4 +222,20 @@ internal class PushNotificationLogger(private val logger: Logger) {
             appendLine("Data: ${message.data}")
         }
     }
+
+    fun logWorkManagerInitializationAttempt(exception: Exception) {
+        logger.error(
+            tag = TAG,
+            message = "WorkManager not initialized, attempting to initialize",
+            throwable = exception
+        )
+    }
+
+    fun logWorkManagerInitializationFailed(exception: Exception) {
+        logger.error(
+            tag = TAG,
+            message = "Failed to initialize WorkManager",
+            throwable = exception
+        )
+    }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
@@ -7,7 +7,23 @@ import io.customer.messagingpush.logger.PushNotificationLogger
 
 /**
  * Provider for WorkManager instances with safe initialization.
- * Handles cases where WorkManager may not be initialized yet.
+ * Handles various WorkManager initialization scenarios based on hosting app configuration:
+ *
+ * 1. If the hosting app doesn't use WorkManager:
+ *    - WorkManager should be initialized automatically through androidx.work.WorkManagerInitializer
+ *    - The first WorkManager.getInstance() should return a valid instance
+ *
+ * 2. If hosting app does use WorkManager:
+ *    a) If host app depends on auto initialization - same as scenario 1
+ *    b) If host app doesn't depend on auto initialization (removed androidx.work.WorkManagerInitializer):
+ *       - If host app always initializes WorkManager early before push handling - no problems
+ *       - If host app conditionally initializes or doesn't initialize by the time we need it:
+ *         * We attempt to initialize WorkManager ourselves
+ *         * We check if host app implements Configuration.Provider to use their config
+ *         * If host app uses manual WorkManager.initialize(), we can't determine their config
+ *           so we initialize with default configuration
+ *
+ * These scenarios are handled based on documented exceptions from WorkManager's getInstance() and initialize() methods.
  */
 internal class WorkManagerProvider(
     private val context: Context,
@@ -15,7 +31,14 @@ internal class WorkManagerProvider(
 ) {
 
     /**
-     * Gets a WorkManager instance, initializing it if necessary.
+     * Gets a WorkManager instance with fallback initialization strategy.
+     *
+     * First attempts to get an existing WorkManager instance. If that fails (indicating
+     * WorkManager hasn't been initialized yet), attempts to initialize it ourselves:
+     * 1. Checks if the host app implements Configuration.Provider to respect their config
+     * 2. Falls back to default configuration if no custom config is available
+     * 3. Attempts to get the instance again after initialization
+     *
      * This method is synchronized to prevent race conditions during initialization.
      * @return WorkManager instance or null if initialization fails
      */
@@ -27,7 +50,7 @@ internal class WorkManagerProvider(
         } catch (e: Exception) {
             pushLogger.logWorkManagerInitializationAttempt(e)
             try {
-                // Attempt to obtain app WorkManager config if available, otherwise use default config
+                // Check if host app implements Configuration.Provider, otherwise use default config
                 val config = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
                 WorkManager.initialize(context, config)
                 // Now try to get the instance again

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
@@ -1,0 +1,41 @@
+package io.customer.messagingpush.util
+
+import android.content.Context
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import io.customer.messagingpush.logger.PushNotificationLogger
+
+/**
+ * Provider for WorkManager instances with safe initialization.
+ * Handles cases where WorkManager may not be initialized yet.
+ */
+internal class WorkManagerProvider(
+    private val context: Context,
+    private val pushLogger: PushNotificationLogger
+) {
+
+    /**
+     * Gets a WorkManager instance, initializing it if necessary.
+     * This method is synchronized to prevent race conditions during initialization.
+     * @return WorkManager instance or null if initialization fails
+     */
+    @Synchronized
+    fun getWorkManager(): WorkManager? {
+        return try {
+            // Try to get existing instance first
+            WorkManager.getInstance(context)
+        } catch (e: Exception) {
+            pushLogger.logWorkManagerInitializationAttempt(e)
+            try {
+                // Attempt to obtain app WorkManager config if available, otherwise use default config
+                val config = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
+                WorkManager.initialize(context, config)
+                // Now try to get the instance again
+                WorkManager.getInstance(context)
+            } catch (initException: Exception) {
+                pushLogger.logWorkManagerInitializationFailed(initException)
+                null
+            }
+        }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -426,4 +426,34 @@ class PushNotificationLoggerTest : JUnitTest() {
             )
         }
     }
+
+    @Test
+    fun test_logWorkManagerInitializationAttempt_forwardsCorrectCallToLogger() {
+        val exception = RuntimeException("WorkManager not available")
+
+        pushLogger.logWorkManagerInitializationAttempt(exception)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "WorkManager not initialized, attempting to initialize",
+                throwable = exception
+            )
+        }
+    }
+
+    @Test
+    fun test_logWorkManagerInitializationFailed_forwardsCorrectCallToLogger() {
+        val exception = RuntimeException("Initialization failed")
+
+        pushLogger.logWorkManagerInitializationFailed(exception)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Failed to initialize WorkManager",
+                throwable = exception
+            )
+        }
+    }
 }

--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -12,7 +12,7 @@ apply from: "${rootDir}/samples/sample-app.gradle"
 
 android {
     namespace 'io.customer.android.sample.java_layout'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "io.customer.android.sample.java_layout"

--- a/samples/kotlin_compose/build.gradle.kts
+++ b/samples/kotlin_compose/build.gradle.kts
@@ -14,7 +14,7 @@ apply {
 
 android {
     namespace = "io.customer.android.sample.kotlin_compose"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "io.customer.android.sample.kotlin_compose"


### PR DESCRIPTION
Close: [MBL-1350](https://linear.app/customerio/issue/MBL-1350/android-improve-push-metrics-background-deliverability)


Implementation is split across multiple PRs, here's a list to navigate:
- Adding `WorkManager` to push module -> **This PR**
- Move push messages delivery metrics to background -> https://github.com/customerio/customerio-android/pull/605
- Add tests for implementation -> https://github.com/customerio/customerio-android/pull/606

## Problem Statement
Android's power management features (Doze mode and App Standby) severely restrict background processing, preventing immediate delivery metric tracking when push notifications are received. Doze mode suspends network access and background services when devices are stationary and unplugged, while App Standby blocks background network access for unused apps. These restrictions cause delivery metric HTTP requests to fail or be indefinitely deferred, resulting in incomplete analytics data.

- Doze Mode & App Standby: Android suspends network access and background services when device is idle or apps are unused, preventing immediate delivery metric tracking
- Android 15 Enhanced Restrictions: Apps starting network requests outside valid process lifecycle receive exceptions (UnknownHostException or IOException) as documented in Android 15 behavior changes
- Failed Push Metrics: Traditional immediate HTTP requests to track push notification delivery fail when app is backgrounded, causing incomplete analytics data

## Solution
`PushDeliveryMetricsBackgroundScheduler` uses `WorkManager` to defer delivery metric tracking until system constraints are satisfied. The scheduler queues metric tracking tasks with network connectivity requirements, allowing WorkManager to execute them during Doze mode maintenance windows or when the device exits power-saving states.

## Implementation Details
- Constraint-based scheduling: Tasks require `NetworkType.CONNECTED` before execution
- Duplicate prevention: Uses `ExistingWorkPolicy.KEEP` with delivery ID as unique work identifier
- Graceful degradation: Handles `WorkManager` initialization failures without app crashes
- Persistent execution: Tasks survive app process death and device reboots
- Background worker: `PushDeliveryMetricsWorker` executes the actual HTTP request to track delivery metrics

## Technical Benefits
- Ensures delivery metrics are eventually tracked despite Android background restrictions
- Prevents immediate network failures during Doze mode
- Reduces battery consumption by aligning with system power management policies
- Provides reliable metric delivery without blocking the main notification processing flow