### PR TITLE
chore: Send delivery receipts through WorkManager

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -8,7 +8,7 @@ import io.customer.sdk.util.EventNames
 import org.json.JSONObject
 
 internal interface PushDeliveryTracker {
-    fun trackMetric(token: String, event: String, deliveryId: String, onComplete: ((Result<Unit>) -> Unit?)? = null)
+    suspend fun trackMetric(token: String, event: String, deliveryId: String): Result<Unit>
 }
 
 internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
@@ -20,12 +20,11 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
      * Tracks a metric by performing a single POST request with JSON.
      * Returns a `Result<Unit>`.
      */
-    override fun trackMetric(
+    override suspend fun trackMetric(
         token: String,
         event: String,
-        deliveryId: String,
-        onComplete: ((Result<Unit>) -> Unit?)?
-    ) {
+        deliveryId: String
+    ): Result<Unit> {
         val propertiesJson = JSONObject().apply {
             put("recipient", token)
             put("metric", event.lowercase())
@@ -45,12 +44,7 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
             body = topLevelJson.toString()
         )
 
-        // Perform request
-        httpClient.request(params) { result ->
-            val mappedResult = result.map { /* we only need success/failure */ }
-            if (onComplete != null) {
-                onComplete(mappedResult)
-            }
-        }
+        val result = httpClient.request(params)
+        return result.map { /* we only need success/failure */ }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -12,6 +12,7 @@ import io.customer.messagingpush.PushDeliveryTrackerImpl
 import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.network.HttpClient
 import io.customer.messagingpush.network.HttpClientImpl
+import io.customer.messagingpush.processor.PushDeliveryMetricsBackgroundScheduler
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
 import io.customer.messagingpush.provider.DeviceTokenProvider
@@ -20,6 +21,7 @@ import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
+import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 
@@ -51,12 +53,19 @@ internal val SDKComponent.deepLinkUtil: DeepLinkUtil
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
     get() = newInstance<PushTrackingUtil> { PushTrackingUtilImpl() }
 
+internal val SDKComponent.workManagerProvider: WorkManagerProvider
+    get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, pushLogger) }
+
+internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
+    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider) }
+
 internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {
         PushMessageProcessorImpl(
             pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
-            deepLinkUtil = deepLinkUtil
+            deepLinkUtil = deepLinkUtil,
+            deliveryMetricsScheduler = deliveryMetricsScheduler
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -1,0 +1,65 @@
+package io.customer.messagingpush.processor
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import io.customer.messagingpush.di.pushDeliveryTracker
+import io.customer.messagingpush.util.WorkManagerProvider
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.events.Metric
+
+private const val DELIVERY_ID = "delivery-id"
+private const val DELIVERY_TOKEN = "delivery-token"
+
+internal class PushDeliveryMetricsBackgroundScheduler(
+    private val workManagerProvider: WorkManagerProvider
+) {
+
+    fun scheduleDeliveredPushMetricsReceipt(deliveryId: String, deliveryToken: String) {
+        val input = Data.Builder()
+            .putString(DELIVERY_ID, deliveryId)
+            .putString(DELIVERY_TOKEN, deliveryToken)
+            .build()
+
+        val workRequest = OneTimeWorkRequestBuilder<PushDeliveryMetricsWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+            )
+            .setInputData(input)
+            .build()
+
+        workManagerProvider.getWorkManager()?.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
+    }
+}
+
+internal class PushDeliveryMetricsWorker(
+    appContext: Context,
+    params: androidx.work.WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val deliveryId = inputData.getString(DELIVERY_ID)
+        val deliveryToken = inputData.getString(DELIVERY_TOKEN)
+
+        if (deliveryId.isNullOrEmpty() || deliveryToken.isNullOrEmpty()) {
+            // Missing delivery data, prevent task from being retried
+            return Result.success()
+        }
+
+        val result = SDKComponent.pushDeliveryTracker.trackMetric(
+            event = Metric.Delivered.name,
+            deliveryId = deliveryId,
+            token = deliveryToken
+        )
+
+        return when {
+            result.isSuccess -> Result.success()
+            else -> Result.failure()
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -20,6 +20,11 @@ internal class PushDeliveryMetricsBackgroundScheduler(
     private val workManagerProvider: WorkManagerProvider
 ) {
 
+    companion object {
+        private const val WORK_MANAGER_TAG_CIO = "cio-requests"
+        private const val WORK_MANAGER_TAG_PUSH_DELIVERY = "cio-push-delivery"
+    }
+
     fun scheduleDeliveredPushMetricsReceipt(deliveryId: String, deliveryToken: String) {
         val input = Data.Builder()
             .putString(DELIVERY_ID, deliveryId)
@@ -33,6 +38,8 @@ internal class PushDeliveryMetricsBackgroundScheduler(
                     .build()
             )
             .setInputData(input)
+            .addTag(WORK_MANAGER_TAG_CIO)
+            .addTag(WORK_MANAGER_TAG_PUSH_DELIVERY)
             .build()
 
         workManagerProvider.getWorkManager()?.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -11,6 +11,7 @@ import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.events.Metric
+import java.io.IOException
 
 private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
@@ -48,7 +49,7 @@ internal class PushDeliveryMetricsWorker(
 
         if (deliveryId.isNullOrEmpty() || deliveryToken.isNullOrEmpty()) {
             // Missing delivery data, prevent task from being retried
-            return Result.success()
+            return Result.failure()
         }
 
         val result = SDKComponent.pushDeliveryTracker.trackMetric(
@@ -59,6 +60,7 @@ internal class PushDeliveryMetricsWorker(
 
         return when {
             result.isSuccess -> Result.success()
+            result.exceptionOrNull() is IOException -> Result.retry()
             else -> Result.failure()
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -2,7 +2,6 @@ package io.customer.messagingpush.processor
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.MessagingPushModuleConfig
@@ -47,7 +46,6 @@ internal class PushMessageProcessorImpl(
             PushMessageProcessor.recentMessagesQueue.contains(deliveryId) -> {
                 // Ignore messages that were processed already
                 pushLogger.logReceivedDuplicatePushMessageDeliveryId(deliveryId)
-                Log.i("DelayedPush", "PushMessageProcessorImpl - ignoring message as duplicate $deliveryId")
                 return true
             }
 


### PR DESCRIPTION
Close: [MBL-1350](https://linear.app/customerio/issue/MBL-1350/android-improve-push-metrics-background-deliverability)


Implementation is split across multiple PRs, here's a list to navigate:
- Adding `WorkManager` to push module -> https://github.com/customerio/customerio-android/pull/604
- Move push messages delivery metrics to background -> **This PR**
- Add tests for implementation -> https://github.com/customerio/customerio-android/pull/606

## Problem Statement
Android's power management features (Doze mode and App Standby) severely restrict background processing, preventing immediate delivery metric tracking when push notifications are received. Doze mode suspends network access and background services when devices are stationary and unplugged, while App Standby blocks background network access for unused apps. These restrictions cause delivery metric HTTP requests to fail or be indefinitely deferred, resulting in incomplete analytics data.

- Doze Mode & App Standby: Android suspends network access and background services when device is idle or apps are unused, preventing immediate delivery metric tracking
- Android 15 Enhanced Restrictions: Apps starting network requests outside valid process lifecycle receive exceptions (UnknownHostException or IOException) as documented in Android 15 behavior changes
- Failed Push Metrics: Traditional immediate HTTP requests to track push notification delivery fail when app is backgrounded, causing incomplete analytics data

## Solution
`PushDeliveryMetricsBackgroundScheduler` uses `WorkManager` to defer delivery metric tracking until system constraints are satisfied. The scheduler queues metric tracking tasks with network connectivity requirements, allowing WorkManager to execute them during Doze mode maintenance windows or when the device exits power-saving states.

## Implementation Details
- Constraint-based scheduling: Tasks require `NetworkType.CONNECTED` before execution
- Duplicate prevention: Uses `ExistingWorkPolicy.KEEP` with delivery ID as unique work identifier
- Graceful degradation: Handles `WorkManager` initialization failures without app crashes
- Persistent execution: Tasks survive app process death and device reboots
- Background worker: `PushDeliveryMetricsWorker` executes the actual HTTP request to track delivery metrics

## Technical Benefits
- Ensures delivery metrics are eventually tracked despite Android background restrictions
- Prevents immediate network failures during Doze mode
- Reduces battery consumption by aligning with system power management policies
- Provides reliable metric delivery without blocking the main notification processing flow