### PR TITLE
chore: Add tests for push delivery background scheduling

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -53,7 +53,7 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 }
 
 internal class AsyncPushDeliveryTracker(
-    private val deliveryTracker: PushDeliveryTrackerImpl
+    private val deliveryTracker: PushDeliveryTracker
 ) {
     private val dispatcher: DispatchersProvider
         get() = SDKComponent.dispatchersProvider

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -5,6 +5,7 @@ package io.customer.messagingpush.di
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.PushDeliveryTracker
@@ -56,8 +57,11 @@ val SDKComponent.pushTrackingUtil: PushTrackingUtil
 internal val SDKComponent.workManagerProvider: WorkManagerProvider
     get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, pushLogger) }
 
+internal val SDKComponent.asyncPushDeliveryTracker: AsyncPushDeliveryTracker
+    get() = singleton<AsyncPushDeliveryTracker> { AsyncPushDeliveryTracker(pushDeliveryTracker) }
+
 internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
-    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider) }
+    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider, asyncPushDeliveryTracker) }
 
 internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -2,6 +2,7 @@ package io.customer.messagingpush.processor
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.MessagingPushModuleConfig
@@ -46,6 +47,7 @@ internal class PushMessageProcessorImpl(
             PushMessageProcessor.recentMessagesQueue.contains(deliveryId) -> {
                 // Ignore messages that were processed already
                 pushLogger.logReceivedDuplicatePushMessageDeliveryId(deliveryId)
+                Log.i("DelayedPush", "PushMessageProcessorImpl - ignoring message as duplicate $deliveryId")
                 return true
             }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -2,7 +2,6 @@ package io.customer.messagingpush.processor
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.MessagingPushModuleConfig
@@ -47,7 +46,6 @@ internal class PushMessageProcessorImpl(
             PushMessageProcessor.recentMessagesQueue.contains(deliveryId) -> {
                 // Ignore messages that were processed already
                 pushLogger.logReceivedDuplicatePushMessageDeliveryId(deliveryId)
-                Log.i("DelayedPush", "PushMessageProcessorImpl - ignoring message as duplicate $deliveryId")
                 return true
             }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -1,0 +1,66 @@
+package io.customer.messagingpush.processor
+
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.testutils.core.JUnitTest
+import io.customer.messagingpush.util.WorkManagerProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBe
+import org.junit.jupiter.api.Test
+
+class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
+
+    private val mockWorkManagerProvider = mockk<WorkManagerProvider>(relaxed = true)
+    private val mockWorkManager = mockk<WorkManager>(relaxed = true)
+    private val scheduler = PushDeliveryMetricsBackgroundScheduler(mockWorkManagerProvider)
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenValidInputs_expectWorkRequestEnqueued() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val workRequestSlot = slot<OneTimeWorkRequest>()
+
+        every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
+
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        verify(exactly = 1) {
+            mockWorkManager.enqueueUniqueWork(
+                eq(deliveryId),
+                eq(ExistingWorkPolicy.KEEP),
+                capture(workRequestSlot)
+            )
+        }
+
+        val inputData = workRequestSlot.captured.workSpec.input
+        inputData.getString("delivery-id") shouldBeEqualTo deliveryId
+        inputData.getString("delivery-token") shouldBeEqualTo deliveryToken
+
+        val constraints = workRequestSlot.captured.workSpec.constraints
+        constraints shouldNotBe null
+        constraints.requiredNetworkType shouldBe NetworkType.CONNECTED
+    }
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectNoException() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+
+        every { mockWorkManagerProvider.getWorkManager() } returns null
+
+        // Should not throw exception
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        verify(exactly = 0) {
+            mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+        }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -39,8 +39,8 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val deliveryId = String.random
         val deliveryToken = String.random
         val inputData = createInputData(deliveryId, deliveryToken)
-        
-        coEvery { 
+
+        coEvery {
             mockPushDeliveryTracker.trackMetric(
                 event = Metric.Delivered.name,
                 deliveryId = deliveryId,
@@ -52,7 +52,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 1) {
             mockPushDeliveryTracker.trackMetric(
                 event = Metric.Delivered.name,
@@ -67,8 +67,8 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val deliveryId = String.random
         val deliveryToken = String.random
         val inputData = createInputData(deliveryId, deliveryToken)
-        
-        coEvery { 
+
+        coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         } returns Result.failure(Exception("Network error"))
 
@@ -76,7 +76,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
-        
+
         coVerify(exactly = 1) {
             mockPushDeliveryTracker.trackMetric(
                 event = Metric.Delivered.name,
@@ -94,7 +94,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -108,7 +108,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -122,7 +122,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -136,7 +136,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -150,7 +150,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -164,7 +164,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }
@@ -178,7 +178,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
-        
+
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
         }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -1,0 +1,199 @@
+package io.customer.messagingpush.processor
+
+import androidx.work.Data
+import androidx.work.testing.TestListenableWorkerBuilder
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.PushDeliveryTracker
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.events.Metric
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PushDeliveryMetricsWorkerTest : IntegrationTest() {
+
+    private val mockPushDeliveryTracker = mockk<PushDeliveryTracker>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<PushDeliveryTracker>(mockPushDeliveryTracker)
+                    }
+                }
+            }
+        )
+    }
+
+    @Test
+    fun doWork_givenValidInputData_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+        
+        coEvery { 
+            mockPushDeliveryTracker.trackMetric(
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId,
+                token = deliveryToken
+            )
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId,
+                token = deliveryToken
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFails_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+        
+        coEvery { 
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(Exception("Network error"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+        
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId,
+                token = deliveryToken
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenNullDeliveryId_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = null, deliveryToken = String.random)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenEmptyDeliveryId_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = "", deliveryToken = String.random)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenNullDeliveryToken_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = String.random, deliveryToken = null)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenEmptyDeliveryToken_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = String.random, deliveryToken = "")
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenBothParametersEmpty_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = "", deliveryToken = "")
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenBothParametersNull_expectSuccessWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = null, deliveryToken = null)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenNoInputData_expectSuccessWithoutTracking() = runTest {
+        val inputData = Data.EMPTY
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    private fun createInputData(deliveryId: String?, deliveryToken: String?): Data {
+        val builder = Data.Builder()
+        deliveryId?.let { builder.putString("delivery-id", it) }
+        deliveryToken?.let { builder.putString("delivery-token", it) }
+        return builder.build()
+    }
+
+    private fun createWorker(inputData: Data): PushDeliveryMetricsWorker {
+        return TestListenableWorkerBuilder<PushDeliveryMetricsWorker>(applicationMock)
+            .setInputData(inputData)
+            .build()
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -11,6 +11,10 @@ import io.customer.sdk.events.Metric
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.security.cert.CertificateException
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
@@ -42,9 +46,9 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         coEvery {
             mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
                 event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                token = deliveryToken
+                deliveryId = deliveryId
             )
         } returns Result.success(Unit)
 
@@ -55,22 +59,22 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         coVerify(exactly = 1) {
             mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
                 event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                token = deliveryToken
+                deliveryId = deliveryId
             )
         }
     }
 
     @Test
-    fun doWork_givenTrackingFails_expectWorkerFailure() = runTest {
+    fun doWork_givenTrackingFailsWithGenericException_expectWorkerFailure() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
         val inputData = createInputData(deliveryId, deliveryToken)
 
         coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
-        } returns Result.failure(Exception("Network error"))
+        } returns Result.failure(Exception("Generic network error"))
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
@@ -79,21 +83,21 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         coVerify(exactly = 1) {
             mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
                 event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                token = deliveryToken
+                deliveryId = deliveryId
             )
         }
     }
 
     @Test
-    fun doWork_givenNullDeliveryId_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenNullDeliveryId_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = null, deliveryToken = String.random)
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -101,13 +105,13 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenEmptyDeliveryId_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenEmptyDeliveryId_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = "", deliveryToken = String.random)
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -115,13 +119,13 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenNullDeliveryToken_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenNullDeliveryToken_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = String.random, deliveryToken = null)
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -129,13 +133,13 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenEmptyDeliveryToken_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenEmptyDeliveryToken_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = String.random, deliveryToken = "")
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -143,13 +147,13 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenBothParametersEmpty_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenBothParametersEmpty_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = "", deliveryToken = "")
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -157,13 +161,13 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenBothParametersNull_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenBothParametersNull_expectFailureWithoutTracking() = runTest {
         val inputData = createInputData(deliveryId = null, deliveryToken = null)
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
 
         coVerify(exactly = 0) {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -171,16 +175,255 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenNoInputData_expectSuccessWithoutTracking() = runTest {
+    fun doWork_givenNoInputData_expectFailureWithoutTracking() = runTest {
         val inputData = Data.EMPTY
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithIOException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IOException("Network timeout"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithNonIOException_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IllegalArgumentException("Invalid argument"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithSocketTimeoutException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(SocketTimeoutException("Connection timeout"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithUnknownHostException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(UnknownHostException("Host not found"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithCertificateException_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(CertificateException("Certificate error"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenVeryLongDeliveryId_expectSuccessfulTracking() = runTest {
+        val deliveryId = "a".repeat(1000) // Very long delivery ID
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
 
         val worker = createWorker(inputData)
         val result = worker.doWork()
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
 
-        coVerify(exactly = 0) {
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenVeryLongDeliveryToken_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = "b".repeat(1000) // Very long delivery token
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenSpecialCharactersInDeliveryId_expectSuccessfulTracking() = runTest {
+        val deliveryId = "test-delivery-id-with-special-chars-!@#$%^&*()_+-={}|[]\\:\";'<>?,./"
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenUnicodeCharactersInDeliveryToken_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = "test-token-with-unicode-\uD83D\uDE00\uD83D\uDE01\uD83E\uDD14\u4F60\u597D\u4E16\u754C" // Emojis and Chinese characters
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenMetricConstantValue_expectCorrectMetricPassed() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        // Verify that the exact metric constant is used
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = "Delivered", // Metric.Delivered.name is "Delivered"
+                deliveryId = deliveryId
+            )
         }
     }
 


### PR DESCRIPTION
Close: [MBL-1350](https://linear.app/customerio/issue/MBL-1350/android-improve-push-metrics-background-deliverability)


Implementation is split across multiple PRs, here's a list to navigate:
- Adding `WorkManager` to push module -> https://github.com/customerio/customerio-android/pull/604
- Move push messages delivery metrics to background -> https://github.com/customerio/customerio-android/pull/605
- Add tests for implementation -> **This PR**

## Problem Statement
Android's power management features (Doze mode and App Standby) severely restrict background processing, preventing immediate delivery metric tracking when push notifications are received. Doze mode suspends network access and background services when devices are stationary and unplugged, while App Standby blocks background network access for unused apps. These restrictions cause delivery metric HTTP requests to fail or be indefinitely deferred, resulting in incomplete analytics data.

- Doze Mode & App Standby: Android suspends network access and background services when device is idle or apps are unused, preventing immediate delivery metric tracking
- Android 15 Enhanced Restrictions: Apps starting network requests outside valid process lifecycle receive exceptions (UnknownHostException or IOException) as documented in Android 15 behavior changes
- Failed Push Metrics: Traditional immediate HTTP requests to track push notification delivery fail when app is backgrounded, causing incomplete analytics data

## Solution
`PushDeliveryMetricsBackgroundScheduler` uses `WorkManager` to defer delivery metric tracking until system constraints are satisfied. The scheduler queues metric tracking tasks with network connectivity requirements, allowing WorkManager to execute them during Doze mode maintenance windows or when the device exits power-saving states.

## Implementation Details
- Constraint-based scheduling: Tasks require `NetworkType.CONNECTED` before execution
- Duplicate prevention: Uses `ExistingWorkPolicy.KEEP` with delivery ID as unique work identifier
- Graceful degradation: Handles `WorkManager` initialization failures without app crashes
- Persistent execution: Tasks survive app process death and device reboots
- Background worker: `PushDeliveryMetricsWorker` executes the actual HTTP request to track delivery metrics

## Technical Benefits
- Ensures delivery metrics are eventually tracked despite Android background restrictions
- Prevents immediate network failures during Doze mode
- Reduces battery consumption by aligning with system power management policies
- Provides reliable metric delivery without blocking the main notification processing flow