### PR TITLE
fix: prevent GistModalActivity crash on early back press

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistModalActivity.kt
@@ -159,6 +159,13 @@ class GistModalActivity : AppCompatActivity(), ModalInAppMessageViewCallback, Tr
 
     override fun finish() {
         logger.debug("GistModelActivity finish")
+        // Prevent crash if finish() called before binding initialization (e.g., from back press during onCreate)
+        if (!::binding.isInitialized) {
+            logger.debug("GistModelActivity finish: binding not initialized, finishing immediately")
+            finishImmediately()
+            return
+        }
+
         runOnUiThread {
             val animationSet = if (messagePosition == MessagePosition.TOP) {
                 ModalAnimationUtil.createAnimationSetOutToTop(binding.modalGistViewLayout)


### PR DESCRIPTION
closes: [MBL-1347](https://linear.app/customerio/issue/MBL-1347/uninitializedpropertyaccessexception-on-gistmodalactivityfinish)

### Summary

Fixes a crash (`UninitializedPropertyAccessException`) that occurs when `finish()` is called before `binding` property is initialized in `GistModalActivity`.

### Crash Details

It looks like occurring when:

- `prepareActivity()` is triggered asynchronously in `onCreate()`
- User presses the back button before `initializeActivity()` completes
- `finish()` tries to access `binding.modalGistViewLayout`, which hasn't been initialized yet

#### Logs from `4.7.1`

```
at android.app.Activity.runOnUiThread(Activity.java:7762)
       at io.customer.messaginginapp.gist.presentation.GistModalActivity.finish(GistModalActivity.kt:162)
       at android.app.Activity.finishAfterTransition(Activity.java:7166)
       at android.app.Activity.onBackPressed(Activity.java:4590)
       at androidx.activity.ComponentActivity.access$onBackPressed$s1027565324(ComponentActivity.kt:111)
       at androidx.activity.ComponentActivity$onBackPressedDispatcher$2.invoke$lambda$0(ComponentActivity.kt:603)
       at androidx.activity.OnBackPressedDispatcher.onBackPressed(OnBackPressedDispatcher.kt:263)
       at androidx.activity.ComponentActivity.onBackPressed(ComponentActivity.kt:588)
       at android.app.Activity.onKeyUp(Activity.java:4561)
       at android.view.KeyEvent.dispatch(KeyEvent.java:2725)
       at android.app.Activity.dispatchKeyEvent(Activity.java:4844)
       at androidx.core.app.ComponentActivity.superDispatchKeyEvent(ComponentActivity.kt:96)
       at androidx.core.view.KeyEventDispatcher.dispatchKeyEvent(KeyEventDispatcher.java:86)
       at androidx.core.app.ComponentActivity.dispatchKeyEvent(ComponentActivity.kt:110)
       at androidx.appcompat.app.AppCompatActivity.dispatchKeyEvent(AppCompatActivity.java:591)
```

### Solution

- Added `::binding.isInitialized` check in `finish()` method
- If not initialized, fallback to `finishImmediately()` to avoid animation and safely exit
- Preserves animation behavior when binding is initialized

### Changes

- Added safe check in `GistModalActivity.finish()`
- Fallback logic skips animation if view isn't ready
- Added test `finish_givenBindingNotInitialized_expectNoExceptionThrown()` to validate behavior during race conditions

### Test Plan

- All existing tests pass
- New test covers crash scenario
- No change in modal message behavior