### PR TITLE
fix: optimize inline in-app reloading

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -420,9 +420,12 @@ public abstract interface annotation class io/customer/messaginginapp/ui/control
 	public abstract fun reason ()Ljava/lang/String;
 }
 
-public abstract class io/customer/messaginginapp/ui/core/BaseInlineInAppMessageView : android/widget/FrameLayout, io/customer/messaginginapp/ui/bridge/InlineInAppMessageViewCallback {
+public abstract class io/customer/messaginginapp/ui/core/BaseInlineInAppMessageView : android/widget/FrameLayout, androidx/lifecycle/DefaultLifecycleObserver, io/customer/messaginginapp/ui/bridge/InlineInAppMessageViewCallback {
 	public final fun getElementId ()Ljava/lang/String;
 	protected abstract fun getPlatformDelegate ()Lio/customer/messaginginapp/ui/bridge/InAppPlatformDelegate;
+	protected fun onAttachedToWindow ()V
+	public fun onCreate (Landroidx/lifecycle/LifecycleOwner;)V
+	public fun onDestroy (Landroidx/lifecycle/LifecycleOwner;)V
 	public fun onViewSizeChanged (II)V
 	public final fun setActionListener (Lio/customer/messaginginapp/type/InlineMessageActionListener;)V
 	public final fun setElementId (Ljava/lang/String;)V

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -12,9 +12,9 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import com.google.gson.Gson
 import io.customer.messaginginapp.di.inAppMessagingManager
@@ -29,7 +29,7 @@ import java.util.TimerTask
 internal class EngineWebView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
-) : FrameLayout(context, attrs), EngineWebViewListener, LifecycleObserver, EngineWebViewDelegate {
+) : FrameLayout(context, attrs), EngineWebViewListener, DefaultLifecycleObserver, EngineWebViewDelegate {
 
     override var listener: EngineWebViewListener? = null
     private var timer: Timer? = null
@@ -61,13 +61,21 @@ internal class EngineWebView @JvmOverloads constructor(
         return this
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        onLifecycleResumed()
+    }
+
     fun onLifecycleResumed() {
         logger.info("EngineWebView onLifecycleResumed")
         webView?.let { engineWebViewInterface.attach(webView = it) }
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
+        onLifecyclePaused()
+    }
+
     fun onLifecyclePaused() {
         logger.info("EngineWebView onLifecyclePaused")
         webView?.let { engineWebViewInterface.detach(webView = it) }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/InlineInAppMessageView.kt
@@ -78,11 +78,6 @@ class InlineInAppMessageView @JvmOverloads constructor(
         configureView()
     }
 
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        onViewDetached()
-    }
-
     private fun setupProgressIndicator(@ColorInt progressColor: Int) {
         progressIndicator.isIndeterminate = true
         progressIndicator.layoutParams = LayoutParams(

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/bridge/InAppPlatformDelegate.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/bridge/InAppPlatformDelegate.kt
@@ -34,7 +34,7 @@ interface InAppPlatformDelegate {
      * The view should be destroyed if the activity is finishing or not changing configurations.
      * This is useful for managing resources and preventing memory leaks.
      */
-    fun shouldDestroyViewOnDetach(): Boolean
+    fun shouldDestroyWithOwner(): Boolean
 
     /**
      * Converts the given size from dp to pixels based on the device's screen density.
@@ -106,10 +106,10 @@ open class AndroidInAppPlatformDelegate(
         context.startActivity(intent)
     }
 
-    override fun shouldDestroyViewOnDetach(): Boolean {
+    override fun shouldDestroyWithOwner(): Boolean {
         val activity = view.context?.findActivity()
-        return activity?.let {
-            it.isFinishing || !it.isChangingConfigurations
+        return activity?.let { act ->
+            !act.isChangingConfigurations
         } ?: true
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/core/WrapperInlineView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/core/WrapperInlineView.kt
@@ -41,18 +41,6 @@ abstract class WrapperInlineView<T : WrapperPlatformDelegate> @JvmOverloads cons
     }
 
     /**
-     * Lifecycle management - no more duplication!
-     *
-     * This method handles the common cleanup logic when the view is detached from its window.
-     * It ensures proper resource cleanup and prevents memory leaks by calling the base
-     * implementation and then performing consolidated cleanup operations.
-     */
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        onViewDetached()
-    }
-
-    /**
      * Loading state callbacks - no more duplication!
      * Routes through the platform delegate for consistent event handling.
      *


### PR DESCRIPTION
part of: [MBL-1329](https://linear.app/customerio/issue/MBL-1329/inline-in-app-message-flicker-on-return-navigation)

### Summary

Improves performance and lifecycle handling for inline in-app messages by avoiding unnecessary reloads and ensuring proper teardown when the view is destroyed. Also improves lifecycle usage to match current best practices.

### Changes

- Replaced deprecated `@OnLifecycleEvent` with `DefaultLifecycleObserver`
- Updated `InlineInAppMessageViewController` to dismiss message when view lifecycle owner is destroyed, instead of just detaching
- Skipped reloading if current message is already in `ReadyToEmbed` state and unchanged
- Cleared subscription job when the lifecycle owner is destroyed to prevent memory leaks
- Fixed relevant tests to reflect new behavior

### Testing

Can be tested on branch [mbl-1329-inline-with-tabs](https://github.com/customerio/customerio-android/tree/mbl-1329-inline-with-tabs)

#### Before

https://github.com/user-attachments/assets/520c62ff-69e4-4cda-b58a-611a2f58d8c4

#### After

https://github.com/user-attachments/assets/22fd38be-1309-4198-975b-29b31eeffa58

### Notes

- The message is not dismissed during configuration changes (e.g. screen rotation) and just recreated