### PR TITLE
feat: Improve push notificaiton delivery receipts delay

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -59,6 +59,8 @@ object Dependencies {
     const val okhttpLoggingInterceptor =
         "com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP}"
     const val segment = "com.segment.analytics.kotlin:android:${Versions.SEGMENT}"
+    const val workManager = "androidx.work:work-runtime-ktx:${Versions.WORK_MANAGER}"
+    const val workManagerTesting = "androidx.work:work-testing:${Versions.WORK_MANAGER}"
 
     // Compose dependencies
     const val composeBom = "androidx.compose:compose-bom:${Versions.COMPOSE_BOM}"

--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -2,7 +2,7 @@ package io.customer.android
 
 object Versions {
     // Android SDK versions
-    const val COMPILE_SDK = 34
+    const val COMPILE_SDK = 35
     const val TARGET_SDK = 33
     const val MIN_SDK = 21
 
@@ -44,4 +44,5 @@ object Versions {
     // Compose (using latest stable BOM compatible with Kotlin 2.1.20)
     internal const val COMPOSE_BOM = "2024.12.01"
     internal const val COMPOSE_COMPILER = "2.1.21"
+    internal const val WORK_MANAGER = "2.10.3"
 }

--- a/buildSrc/src/main/kotlin/io.customer/android/apkscale/MeasureAndroidLibrarySizeTask.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/apkscale/MeasureAndroidLibrarySizeTask.kt
@@ -147,7 +147,7 @@ abstract class MeasureAndroidLibrarySizeTask : DefaultTask() {
             }
 
             android {
-                compileSdk 34
+                compileSdk 35
                 namespace "com.apkscale.mock"
                 
                 defaultConfig {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/ApplicationStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/ApplicationStore.kt
@@ -28,7 +28,7 @@ internal class ApplicationStoreImpl(val context: Context) : ApplicationStore {
     override val isPushEnabled: Boolean
         get() = NotificationManagerCompat.from(context).areNotificationsEnabled()
 
-    private fun tryGetValueOrNull(tryGetValue: () -> String): String? {
+    private fun tryGetValueOrNull(tryGetValue: () -> String?): String? {
         return try {
             tryGetValue()
         } catch (e: Exception) {

--- a/messagingpush/build.gradle
+++ b/messagingpush/build.gradle
@@ -37,5 +37,8 @@ dependencies {
     implementation Dependencies.coroutinesCore
     implementation Dependencies.coroutinesAndroid
     implementation Dependencies.googlePlayServicesBase
+    implementation Dependencies.workManager
     api Dependencies.firebaseMessaging
+
+    testImplementation Dependencies.workManagerTesting
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -8,7 +8,7 @@ import io.customer.sdk.util.EventNames
 import org.json.JSONObject
 
 internal interface PushDeliveryTracker {
-    fun trackMetric(token: String, event: String, deliveryId: String, onComplete: ((Result<Unit>) -> Unit?)? = null)
+    suspend fun trackMetric(token: String, event: String, deliveryId: String): Result<Unit>
 }
 
 internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
@@ -20,12 +20,11 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
      * Tracks a metric by performing a single POST request with JSON.
      * Returns a `Result<Unit>`.
      */
-    override fun trackMetric(
+    override suspend fun trackMetric(
         token: String,
         event: String,
-        deliveryId: String,
-        onComplete: ((Result<Unit>) -> Unit?)?
-    ) {
+        deliveryId: String
+    ): Result<Unit> {
         val propertiesJson = JSONObject().apply {
             put("recipient", token)
             put("metric", event.lowercase())
@@ -45,12 +44,7 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
             body = topLevelJson.toString()
         )
 
-        // Perform request
-        httpClient.request(params) { result ->
-            val mappedResult = result.map { /* we only need success/failure */ }
-            if (onComplete != null) {
-                onComplete(mappedResult)
-            }
-        }
+        val result = httpClient.request(params)
+        return result.map { /* we only need success/failure */ }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -4,7 +4,10 @@ import io.customer.messagingpush.di.httpClient
 import io.customer.messagingpush.network.HttpClient
 import io.customer.messagingpush.network.HttpRequestParams
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.util.EventNames
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 internal interface PushDeliveryTracker {
@@ -46,5 +49,18 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 
         val result = httpClient.request(params)
         return result.map { /* we only need success/failure */ }
+    }
+}
+
+internal class AsyncPushDeliveryTracker(
+    private val deliveryTracker: PushDeliveryTrackerImpl
+) {
+    private val dispatcher: DispatchersProvider
+        get() = SDKComponent.dispatchersProvider
+
+    fun trackMetric(token: String, event: String, deliveryId: String) {
+        CoroutineScope(dispatcher.background).launch {
+            deliveryTracker.trackMetric(token, event, deliveryId)
+        }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -53,7 +53,7 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 }
 
 internal class AsyncPushDeliveryTracker(
-    private val deliveryTracker: PushDeliveryTrackerImpl
+    private val deliveryTracker: PushDeliveryTracker
 ) {
     private val dispatcher: DispatchersProvider
         get() = SDKComponent.dispatchersProvider

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -12,6 +12,7 @@ import io.customer.messagingpush.PushDeliveryTrackerImpl
 import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.network.HttpClient
 import io.customer.messagingpush.network.HttpClientImpl
+import io.customer.messagingpush.processor.PushDeliveryMetricsBackgroundScheduler
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
 import io.customer.messagingpush.provider.DeviceTokenProvider
@@ -20,6 +21,7 @@ import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
+import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 
@@ -51,12 +53,19 @@ internal val SDKComponent.deepLinkUtil: DeepLinkUtil
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
     get() = newInstance<PushTrackingUtil> { PushTrackingUtilImpl() }
 
+internal val SDKComponent.workManagerProvider: WorkManagerProvider
+    get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, pushLogger) }
+
+internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
+    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider) }
+
 internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {
         PushMessageProcessorImpl(
             pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
-            deepLinkUtil = deepLinkUtil
+            deepLinkUtil = deepLinkUtil,
+            deliveryMetricsScheduler = deliveryMetricsScheduler
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -5,6 +5,7 @@ package io.customer.messagingpush.di
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.PushDeliveryTracker
@@ -56,8 +57,11 @@ val SDKComponent.pushTrackingUtil: PushTrackingUtil
 internal val SDKComponent.workManagerProvider: WorkManagerProvider
     get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, pushLogger) }
 
+internal val SDKComponent.asyncPushDeliveryTracker: AsyncPushDeliveryTracker
+    get() = singleton<AsyncPushDeliveryTracker> { AsyncPushDeliveryTracker(pushDeliveryTracker) }
+
 internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
-    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider) }
+    get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider, asyncPushDeliveryTracker) }
 
 internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
     get() = singleton<PushMessageProcessor> {

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -222,4 +222,20 @@ internal class PushNotificationLogger(private val logger: Logger) {
             appendLine("Data: ${message.data}")
         }
     }
+
+    fun logWorkManagerInitializationAttempt(exception: Exception) {
+        logger.error(
+            tag = TAG,
+            message = "WorkManager not initialized, attempting to initialize",
+            throwable = exception
+        )
+    }
+
+    fun logWorkManagerInitializationFailed(exception: Exception) {
+        logger.error(
+            tag = TAG,
+            message = "Failed to initialize WorkManager",
+            throwable = exception
+        )
+    }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -1,0 +1,74 @@
+package io.customer.messagingpush.processor
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import io.customer.messagingpush.di.pushDeliveryTracker
+import io.customer.messagingpush.util.WorkManagerProvider
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.events.Metric
+import java.io.IOException
+
+private const val DELIVERY_ID = "delivery-id"
+private const val DELIVERY_TOKEN = "delivery-token"
+
+internal class PushDeliveryMetricsBackgroundScheduler(
+    private val workManagerProvider: WorkManagerProvider
+) {
+
+    companion object {
+        private const val WORK_MANAGER_TAG_CIO = "cio-requests"
+        private const val WORK_MANAGER_TAG_PUSH_DELIVERY = "cio-push-delivery"
+    }
+
+    fun scheduleDeliveredPushMetricsReceipt(deliveryId: String, deliveryToken: String) {
+        val input = Data.Builder()
+            .putString(DELIVERY_ID, deliveryId)
+            .putString(DELIVERY_TOKEN, deliveryToken)
+            .build()
+
+        val workRequest = OneTimeWorkRequestBuilder<PushDeliveryMetricsWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+            )
+            .setInputData(input)
+            .addTag(WORK_MANAGER_TAG_CIO)
+            .addTag(WORK_MANAGER_TAG_PUSH_DELIVERY)
+            .build()
+
+        workManagerProvider.getWorkManager()?.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
+    }
+}
+
+internal class PushDeliveryMetricsWorker(
+    appContext: Context,
+    params: androidx.work.WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val deliveryId = inputData.getString(DELIVERY_ID)
+        val deliveryToken = inputData.getString(DELIVERY_TOKEN)
+
+        if (deliveryId.isNullOrEmpty() || deliveryToken.isNullOrEmpty()) {
+            // Missing delivery data, prevent task from being retried
+            return Result.failure()
+        }
+
+        val result = SDKComponent.pushDeliveryTracker.trackMetric(
+            event = Metric.Delivered.name,
+            deliveryId = deliveryId,
+            token = deliveryToken
+        )
+
+        return when {
+            result.isSuccess -> Result.success()
+            result.exceptionOrNull() is IOException -> Result.retry()
+            else -> Result.failure()
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -7,6 +7,7 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.SDKComponent
@@ -17,7 +18,8 @@ private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
 
 internal class PushDeliveryMetricsBackgroundScheduler(
-    private val workManagerProvider: WorkManagerProvider
+    private val workManagerProvider: WorkManagerProvider,
+    private val asyncPushDeliveryTracker: AsyncPushDeliveryTracker
 ) {
 
     companion object {
@@ -42,7 +44,12 @@ internal class PushDeliveryMetricsBackgroundScheduler(
             .addTag(WORK_MANAGER_TAG_PUSH_DELIVERY)
             .build()
 
-        workManagerProvider.getWorkManager()?.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
+        val workManager = workManagerProvider.getWorkManager()
+        if (workManager != null) {
+            workManager.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
+        } else {
+            asyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+        }
     }
 }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -5,28 +5,23 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.TaskStackBuilder
 import io.customer.messagingpush.MessagingPushModuleConfig
-import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
-import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.messagingpush.extensions.parcelable
 import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.communication.Event
-import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 import io.customer.sdk.events.Metric
 
 internal class PushMessageProcessorImpl(
     private val pushLogger: PushNotificationLogger,
     private val moduleConfig: MessagingPushModuleConfig,
-    private val deepLinkUtil: DeepLinkUtil
+    private val deepLinkUtil: DeepLinkUtil,
+    private val deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
 ) : PushMessageProcessor {
-
-    private val pushDeliveryTracker: PushDeliveryTracker
-        get() = SDKComponent.pushDeliveryTracker
 
     /**
      * Responsible for storing and updating recent messages in queue atomically.
@@ -93,12 +88,8 @@ internal class PushMessageProcessorImpl(
         // Track delivered event only if auto-tracking is enabled
         if (moduleConfig.autoTrackPushEvents) {
             pushLogger.logTrackingPushMessageDelivered(deliveryId)
-            // Track delivered metrics via http
-            pushDeliveryTracker.trackMetric(
-                event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                token = deliveryToken
-            )
+
+            deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
 
             // Track delivered metrics via event bus
             eventBus.publish(

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/WorkManagerProvider.kt
@@ -1,0 +1,64 @@
+package io.customer.messagingpush.util
+
+import android.content.Context
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import io.customer.messagingpush.logger.PushNotificationLogger
+
+/**
+ * Provider for WorkManager instances with safe initialization.
+ * Handles various WorkManager initialization scenarios based on hosting app configuration:
+ *
+ * 1. If the hosting app doesn't use WorkManager:
+ *    - WorkManager should be initialized automatically through androidx.work.WorkManagerInitializer
+ *    - The first WorkManager.getInstance() should return a valid instance
+ *
+ * 2. If hosting app does use WorkManager:
+ *    a) If host app depends on auto initialization - same as scenario 1
+ *    b) If host app doesn't depend on auto initialization (removed androidx.work.WorkManagerInitializer):
+ *       - If host app always initializes WorkManager early before push handling - no problems
+ *       - If host app conditionally initializes or doesn't initialize by the time we need it:
+ *         * We attempt to initialize WorkManager ourselves
+ *         * We check if host app implements Configuration.Provider to use their config
+ *         * If host app uses manual WorkManager.initialize(), we can't determine their config
+ *           so we initialize with default configuration
+ *
+ * These scenarios are handled based on documented exceptions from WorkManager's getInstance() and initialize() methods.
+ */
+internal class WorkManagerProvider(
+    private val context: Context,
+    private val pushLogger: PushNotificationLogger
+) {
+
+    /**
+     * Gets a WorkManager instance with fallback initialization strategy.
+     *
+     * First attempts to get an existing WorkManager instance. If that fails (indicating
+     * WorkManager hasn't been initialized yet), attempts to initialize it ourselves:
+     * 1. Checks if the host app implements Configuration.Provider to respect their config
+     * 2. Falls back to default configuration if no custom config is available
+     * 3. Attempts to get the instance again after initialization
+     *
+     * This method is synchronized to prevent race conditions during initialization.
+     * @return WorkManager instance or null if initialization fails
+     */
+    @Synchronized
+    fun getWorkManager(): WorkManager? {
+        return try {
+            // Try to get existing instance first
+            WorkManager.getInstance(context)
+        } catch (e: Exception) {
+            pushLogger.logWorkManagerInitializationAttempt(e)
+            try {
+                // Check if host app implements Configuration.Provider, otherwise use default config
+                val config = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
+                WorkManager.initialize(context, config)
+                // Now try to get the instance again
+                WorkManager.getInstance(context)
+            } catch (initException: Exception) {
+                pushLogger.logWorkManagerInitializationFailed(initException)
+                null
+            }
+        }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -426,4 +426,34 @@ class PushNotificationLoggerTest : JUnitTest() {
             )
         }
     }
+
+    @Test
+    fun test_logWorkManagerInitializationAttempt_forwardsCorrectCallToLogger() {
+        val exception = RuntimeException("WorkManager not available")
+
+        pushLogger.logWorkManagerInitializationAttempt(exception)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "WorkManager not initialized, attempting to initialize",
+                throwable = exception
+            )
+        }
+    }
+
+    @Test
+    fun test_logWorkManagerInitializationFailed_forwardsCorrectCallToLogger() {
+        val exception = RuntimeException("Initialization failed")
+
+        pushLogger.logWorkManagerInitializationFailed(exception)
+
+        assertCalledOnce {
+            mockLogger.error(
+                tag = "Push",
+                message = "Failed to initialize WorkManager",
+                throwable = exception
+            )
+        }
+    }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -1,0 +1,110 @@
+package io.customer.messagingpush.processor
+
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkManager
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.AsyncPushDeliveryTracker
+import io.customer.messagingpush.testutils.core.JUnitTest
+import io.customer.messagingpush.util.WorkManagerProvider
+import io.customer.sdk.events.Metric
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBe
+import org.junit.jupiter.api.Test
+
+class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
+
+    private val mockWorkManagerProvider = mockk<WorkManagerProvider>(relaxed = true)
+    private val mockWorkManager = mockk<WorkManager>(relaxed = true)
+    private val mockAsyncPushDeliveryTracker = mockk<AsyncPushDeliveryTracker>(relaxed = true)
+    private val scheduler = PushDeliveryMetricsBackgroundScheduler(mockWorkManagerProvider, mockAsyncPushDeliveryTracker)
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenValidInputs_expectWorkRequestEnqueued() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val workRequestSlot = slot<OneTimeWorkRequest>()
+
+        every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
+
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        verify(exactly = 1) {
+            mockWorkManager.enqueueUniqueWork(
+                eq(deliveryId),
+                eq(ExistingWorkPolicy.KEEP),
+                capture(workRequestSlot)
+            )
+        }
+
+        val inputData = workRequestSlot.captured.workSpec.input
+        inputData.getString("delivery-id") shouldBeEqualTo deliveryId
+        inputData.getString("delivery-token") shouldBeEqualTo deliveryToken
+
+        val constraints = workRequestSlot.captured.workSpec.constraints
+        constraints shouldNotBe null
+        constraints.requiredNetworkType shouldBe NetworkType.CONNECTED
+    }
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectFallbackToAsyncTracker() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+
+        every { mockWorkManagerProvider.getWorkManager() } returns null
+
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        verify(exactly = 0) {
+            mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+        }
+
+        verify(exactly = 1) {
+            mockAsyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+        }
+    }
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectNoWorkManagerInteraction() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+
+        every { mockWorkManagerProvider.getWorkManager() } returns null
+
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        // Verify WorkManager is not called when null
+        verify(exactly = 0) {
+            mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+        }
+        // Verify async tracker is called as fallback
+        verify(exactly = 1) {
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerAvailable_expectNoAsyncTrackerCall() {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+
+        every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
+
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+
+        // Verify WorkManager is used when available
+        verify(exactly = 1) {
+            mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+        }
+        // Verify async tracker is NOT called when WorkManager is available
+        verify(exactly = 0) {
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -1,0 +1,442 @@
+package io.customer.messagingpush.processor
+
+import androidx.work.Data
+import androidx.work.testing.TestListenableWorkerBuilder
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.PushDeliveryTracker
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.events.Metric
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.security.cert.CertificateException
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PushDeliveryMetricsWorkerTest : IntegrationTest() {
+
+    private val mockPushDeliveryTracker = mockk<PushDeliveryTracker>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<PushDeliveryTracker>(mockPushDeliveryTracker)
+                    }
+                }
+            }
+        )
+    }
+
+    @Test
+    fun doWork_givenValidInputData_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithGenericException_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(Exception("Generic network error"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenNullDeliveryId_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = null, deliveryToken = String.random)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenEmptyDeliveryId_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = "", deliveryToken = String.random)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenNullDeliveryToken_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = String.random, deliveryToken = null)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenEmptyDeliveryToken_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = String.random, deliveryToken = "")
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenBothParametersEmpty_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = "", deliveryToken = "")
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenBothParametersNull_expectFailureWithoutTracking() = runTest {
+        val inputData = createInputData(deliveryId = null, deliveryToken = null)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenNoInputData_expectFailureWithoutTracking() = runTest {
+        val inputData = Data.EMPTY
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 0) {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithIOException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IOException("Network timeout"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithNonIOException_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IllegalArgumentException("Invalid argument"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithSocketTimeoutException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(SocketTimeoutException("Connection timeout"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithUnknownHostException_expectWorkerRetry() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(UnknownHostException("Host not found"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.retry()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenTrackingFailsWithCertificateException_expectWorkerFailure() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(CertificateException("Certificate error"))
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.failure()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenVeryLongDeliveryId_expectSuccessfulTracking() = runTest {
+        val deliveryId = "a".repeat(1000) // Very long delivery ID
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenVeryLongDeliveryToken_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = "b".repeat(1000) // Very long delivery token
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenSpecialCharactersInDeliveryId_expectSuccessfulTracking() = runTest {
+        val deliveryId = "test-delivery-id-with-special-chars-!@#$%^&*()_+-={}|[]\\:\";'<>?,./"
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenUnicodeCharactersInDeliveryToken_expectSuccessfulTracking() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = "test-token-with-unicode-\uD83D\uDE00\uD83D\uDE01\uD83E\uDD14\u4F60\u597D\u4E16\u754C" // Emojis and Chinese characters
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    @Test
+    fun doWork_givenMetricConstantValue_expectCorrectMetricPassed() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        // Verify that the exact metric constant is used
+        coVerify(exactly = 1) {
+            mockPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = "Delivered", // Metric.Delivered.name is "Delivered"
+                deliveryId = deliveryId
+            )
+        }
+    }
+
+    private fun createInputData(deliveryId: String?, deliveryToken: String?): Data {
+        val builder = Data.Builder()
+        deliveryId?.let { builder.putString("delivery-id", it) }
+        deliveryToken?.let { builder.putString("delivery-token", it) }
+        return builder.build()
+    }
+
+    private fun createWorker(inputData: Data): PushDeliveryMetricsWorker {
+        return TestListenableWorkerBuilder<PushDeliveryMetricsWorker>(applicationMock)
+            .setInputData(inputData)
+            .build()
+    }
+}

--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -12,7 +12,7 @@ apply from: "${rootDir}/samples/sample-app.gradle"
 
 android {
     namespace 'io.customer.android.sample.java_layout'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "io.customer.android.sample.java_layout"

--- a/samples/kotlin_compose/build.gradle.kts
+++ b/samples/kotlin_compose/build.gradle.kts
@@ -14,7 +14,7 @@ apply {
 
 android {
     namespace = "io.customer.android.sample.kotlin_compose"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "io.customer.android.sample.kotlin_compose"


### PR DESCRIPTION

This PR is only a collection of approved/merged PRs:
- #604
- #605
- #606
- #609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce WorkManager-backed scheduling for delivered push metrics with suspend-based HTTP/tracking APIs, update DI and logger, and bump compileSdk to 35.
> 
> - **Messaging Push**:
>   - **Background delivery metrics**: Add `PushDeliveryMetricsBackgroundScheduler` and `PushDeliveryMetricsWorker` to enqueue delivered receipts via `WorkManager`; add `WorkManagerProvider` for safe initialization.
>   - **API refactor**: Change `PushDeliveryTracker.trackMetric` to `suspend` returning `Result<Unit>`; add `AsyncPushDeliveryTracker` for off-main execution.
>   - **DI updates**: Provide `workManagerProvider`, `asyncPushDeliveryTracker`, `deliveryMetricsScheduler`; inject scheduler into `PushMessageProcessorImpl` and use it instead of direct HTTP call.
>   - **Logger**: Add `logWorkManagerInitializationAttempt` and `logWorkManagerInitializationFailed`.
>   - **Network**: Make `HttpClient.request` `suspend` returning `Result<String>` and simplify threading.
>   - **Gradle**: Add `androidx.work` runtime and testing deps in `messagingpush`.
> - **Core**:
>   - Relax `ApplicationStore.tryGetValueOrNull` to accept `() -> String?`.
> - **Build/Config**:
>   - Bump `compileSdk` to `35` (root Versions, samples, and APK scale mock project).
> - **Tests**:
>   - Update tests to coroutine (`coEvery`/`coVerify`), add new tests for scheduler and worker behavior, and logger additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3db371d055a52a269caf02d6a058b20155984a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->