### PR TITLE
chore: even name update

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
+++ b/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
@@ -13,5 +13,5 @@ object EventNames {
     const val APPLICATION_BACKGROUNDED = "Application Backgrounded"
 
     // Event name for location updates tracked by the Location module
-    const val LOCATION_UPDATE = "Location Update"
+    const val LOCATION_UPDATE = "CIO Location Update"
 }

--- a/location/src/main/kotlin/io/customer/location/LocationTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationTracker.kt
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
  *    location coordinates. This is unfiltered — a new user always gets
  *    the device's current location on their profile immediately.
  *
- * 2. **"Location Update" track event** — sent via [DataPipeline.track].
+ * 2. **"CIO Location Update" track event** — sent via [DataPipeline.track].
  *    Gated by a userId check and a sync filter (24h / 1km threshold)
  *    to avoid redundant events. This creates a discrete event in the
  *    user's activity timeline for journey/segment triggers.
@@ -99,7 +99,7 @@ internal class LocationTracker(
      *
      * The identify event itself already carries location via
      * [getIdentifyContext] — this method handles the supplementary
-     * "Location Update" track event, subject to the sync filter.
+     * "CIO Location Update" track event, subject to the sync filter.
      */
     fun onUserIdentified() {
         syncCachedLocationIfNeeded()

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -111,7 +111,7 @@ class ModuleLocation @JvmOverloads constructor(
         // the primary way location reaches a user's profile.
         SDKComponent.identifyHookRegistry.register(locationTracker)
 
-        // On identify, attempt to send a supplementary "Location Update" track event.
+        // On identify, attempt to send a supplementary "CIO Location Update" track event.
         // The identify event itself already carries location via context enrichment —
         // this track event is for journey/segment triggers in the user's timeline.
         eventBus.subscribe<Event.UserChangedEvent> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing the emitted track event name is potentially breaking for customers relying on the previous "Location Update" name in journeys/segments and analytics dashboards. No functional logic changes beyond the renamed event string and related docs/comments.
> 
> **Overview**
> Updates `EventNames.LOCATION_UPDATE` from `"Location Update"` to `"CIO Location Update"`, which changes the name used for the location module’s track events.
> 
> Aligns location module documentation/comments (`LocationTracker`, `ModuleLocation`) to reference the new event name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db40e302d796c527f4ac96b4989c2af46e6b478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->