### PR TITLE
chore: prep infrastructure for live notifications

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -86,7 +86,8 @@ public final class io/customer/messagingpush/data/communication/CustomerIOPushNo
 
 public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayload : android/os/Parcelable {
 	public static final field CREATOR Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload$CREATOR;
-	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroid/os/Parcel;)V
 	public final fun component1 ()Landroid/os/Bundle;
 	public final fun component2 ()Ljava/lang/String;
@@ -94,10 +95,12 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
-	public static synthetic fun copy$default (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
 	public final fun getBody ()Ljava/lang/String;
 	public final fun getCioDeliveryId ()Ljava/lang/String;
 	public final fun getCioDeliveryToken ()Ljava/lang/String;

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
 
     <application>
         <!-- Transparent activity for push interactions 

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -5,7 +5,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import android.os.Build
 import android.os.Bundle
@@ -21,16 +20,13 @@ import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.extensions.*
 import io.customer.messagingpush.processor.PushMessageProcessor
+import io.customer.messagingpush.util.BitmapDownloader
 import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_TOKEN_KEY
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
-import java.net.URL
 import kotlin.math.abs
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 /**
  * Class to handle PushNotification.
@@ -226,19 +222,11 @@ internal class CustomerIOPushNotificationHandler(
         builder: NotificationCompat.Builder,
         body: String,
         defaultLargeIcon: Bitmap? = null
-    ) = runBlocking {
+    ) {
         val style = NotificationCompat.BigPictureStyle()
             .bigLargeIcon(defaultLargeIcon)
             .setSummaryText(body)
-        val url = URL(imageUrl)
-        withContext(Dispatchers.IO) {
-            try {
-                val input = url.openStream()
-                BitmapFactory.decodeStream(input)
-            } catch (e: Exception) {
-                null
-            }
-        }?.let { bitmap ->
+        BitmapDownloader.download(imageUrl)?.let { bitmap ->
             style.bigPicture(bitmap)
             builder.setLargeIcon(bitmap)
             builder.setStyle(style)

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
@@ -13,6 +13,7 @@ import android.os.Parcelable
  * @property cioDeliveryToken Customer.io message delivery token
  * @property title notification content title text
  * @property body notification content body text
+ * @property activityId stable id identifying a live notification (null for standard push)
  */
 data class CustomerIOParsedPushPayload(
     val extras: Bundle,
@@ -20,7 +21,8 @@ data class CustomerIOParsedPushPayload(
     val cioDeliveryId: String,
     val cioDeliveryToken: String,
     val title: String,
-    val body: String
+    val body: String,
+    val activityId: String? = null
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
         extras = parcel.readBundle(Bundle::class.java.classLoader) ?: Bundle(),
@@ -28,7 +30,8 @@ data class CustomerIOParsedPushPayload(
         cioDeliveryId = parcel.readString().orEmpty(),
         cioDeliveryToken = parcel.readString().orEmpty(),
         title = parcel.readString().orEmpty(),
-        body = parcel.readString().orEmpty()
+        body = parcel.readString().orEmpty(),
+        activityId = parcel.readString()
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -38,6 +41,7 @@ data class CustomerIOParsedPushPayload(
         parcel.writeString(cioDeliveryToken)
         parcel.writeString(title)
         parcel.writeString(body)
+        parcel.writeString(activityId)
     }
 
     override fun describeContents(): Int {

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/BitmapDownloader.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/BitmapDownloader.kt
@@ -1,0 +1,25 @@
+package io.customer.messagingpush.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import io.customer.sdk.core.di.SDKComponent
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+internal object BitmapDownloader {
+
+    fun download(imageUrl: String): Bitmap? = runBlocking {
+        withContext(Dispatchers.IO) {
+            try {
+                URL(imageUrl).openStream().use { input ->
+                    BitmapFactory.decodeStream(input)
+                }
+            } catch (e: Exception) {
+                SDKComponent.logger.error("Failed to download bitmap from '$imageUrl': ${e.message}")
+                null
+            }
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/NotificationChannelCreator.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/NotificationChannelCreator.kt
@@ -33,6 +33,18 @@ internal class NotificationChannelCreator(
         @VisibleForTesting
         internal const val METADATA_NOTIFICATION_CHANNEL_IMPORTANCE =
             "io.customer.notification_channel_importance"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_ID =
+            "io.customer.live_notification_channel_id"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_NAME =
+            "io.customer.live_notification_channel_name"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_IMPORTANCE =
+            "io.customer.live_notification_channel_importance"
     }
 
     /**
@@ -51,51 +63,98 @@ internal class NotificationChannelCreator(
         appMetaData: Bundle?,
         notificationManager: NotificationManager
     ): String {
-        val defaultChannelId = context.packageName
         val channelId = appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_ID)
-            ?: defaultChannelId
+            ?: context.packageName
 
         // Since android Oreo notification channel is needed.
         if (androidVersionChecker.isOreoOrHigher()) {
-            val existingChannel = notificationManager.getNotificationChannel(channelId)
-
-            val channelName =
-                appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_NAME)
-                    ?: "$applicationName Notifications"
-            val rawImportance = appMetaData?.getInt(
-                METADATA_NOTIFICATION_CHANNEL_IMPORTANCE,
-                NotificationManager.IMPORTANCE_DEFAULT
-            ) ?: NotificationManager.IMPORTANCE_DEFAULT
-
-            // Validate that the importance value is a valid NotificationManager constant
-            val importance = validateImportanceLevel(rawImportance)
-
-            // Only create or update the channel if it doesn't exist or the name is different
-            if (existingChannel == null || existingChannel.name != channelName) {
-                logger.logCreatingNotificationChannel(channelId, channelName, importance)
-                val channel = NotificationChannel(
-                    channelId,
-                    channelName,
-                    importance
-                )
-                notificationManager.createNotificationChannel(channel)
-            } else {
-                logger.logNotificationChannelAlreadyExists(channelId)
-            }
+            val channelName = appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_NAME)
+                ?: "$applicationName Notifications"
+            val importance = resolveImportance(
+                appMetaData = appMetaData,
+                metadataKey = METADATA_NOTIFICATION_CHANNEL_IMPORTANCE,
+                default = NotificationManager.IMPORTANCE_DEFAULT
+            )
+            createOrUpdateChannel(notificationManager, channelId, channelName, importance)
         }
 
         return channelId
     }
 
     /**
-     * Validates that the provided importance level is a valid NotificationManager importance constant.
-     * If the value is not valid, it returns the default importance level.
+     * Creates a notification channel for live notifications on Android Oreo+ and returns its ID.
      *
-     * @param importanceLevel The importance level to validate
-     * @return A valid NotificationManager importance constant
+     * Defaults to `{packageName}_cio_live` / `{appName} Live Updates` / `IMPORTANCE_HIGH`.
+     * Each value can be overridden via manifest `<meta-data>`:
+     * - `io.customer.live_notification_channel_id`
+     * - `io.customer.live_notification_channel_name`
+     * - `io.customer.live_notification_channel_importance` (integer, e.g. 4 for HIGH)
+     *
+     * `IMPORTANCE_HIGH` is the recommended default — it ensures the first "start" event
+     * surfaces as a heads-up notification. Note: channel importance cannot be changed
+     * programmatically after the channel is created on a device.
+     *
+     * @param context The application context
+     * @param applicationName The application name used to derive the default channel name
+     * @param appMetaData The application metadata bundle
+     * @param notificationManager The notification manager instance
+     * @return The channel ID to use in the notification builder
+     */
+    fun createLiveNotificationChannelIfNeededAndReturnChannelId(
+        context: Context,
+        applicationName: String,
+        appMetaData: Bundle?,
+        notificationManager: NotificationManager
+    ): String {
+        val channelId = appMetaData?.getMetaDataString(name = METADATA_LIVE_NOTIFICATION_CHANNEL_ID)
+            ?: "${context.packageName}_cio_live"
+
+        if (androidVersionChecker.isOreoOrHigher()) {
+            val channelName = appMetaData?.getMetaDataString(name = METADATA_LIVE_NOTIFICATION_CHANNEL_NAME)
+                ?: "$applicationName Live Updates"
+            val importance = resolveImportance(
+                appMetaData = appMetaData,
+                metadataKey = METADATA_LIVE_NOTIFICATION_CHANNEL_IMPORTANCE,
+                default = NotificationManager.IMPORTANCE_HIGH
+            )
+            createOrUpdateChannel(notificationManager, channelId, channelName, importance)
+        }
+
+        return channelId
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createOrUpdateChannel(
+        notificationManager: NotificationManager,
+        channelId: String,
+        channelName: String,
+        importance: Int
+    ) {
+        val existingChannel = notificationManager.getNotificationChannel(channelId)
+        // Only create or update the channel if it doesn't exist or the name is different
+        if (existingChannel == null || existingChannel.name != channelName) {
+            logger.logCreatingNotificationChannel(channelId, channelName, importance)
+            val channel = NotificationChannel(channelId, channelName, importance)
+            notificationManager.createNotificationChannel(channel)
+        } else {
+            logger.logNotificationChannelAlreadyExists(channelId)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun resolveImportance(appMetaData: Bundle?, metadataKey: String, default: Int): Int {
+        val rawImportance = appMetaData?.getInt(metadataKey, default) ?: default
+        return validateImportanceLevel(rawImportance, fallback = default)
+    }
+
+    /**
+     * Validates that the provided importance level is a valid NotificationManager importance constant.
+     * If the value is not valid, returns the supplied [fallback] so each caller preserves its own
+     * intended default (e.g. `IMPORTANCE_HIGH` for live notifications) rather than silently
+     * collapsing to `IMPORTANCE_DEFAULT`.
      */
     @RequiresApi(Build.VERSION_CODES.N)
-    private fun validateImportanceLevel(importanceLevel: Int): Int {
+    private fun validateImportanceLevel(importanceLevel: Int, fallback: Int): Int {
         return when (importanceLevel) {
             NotificationManager.IMPORTANCE_NONE,
             NotificationManager.IMPORTANCE_MIN,
@@ -106,7 +165,7 @@ internal class NotificationChannelCreator(
 
             else -> {
                 logger.logInvalidNotificationChannelImportance(importanceLevel)
-                NotificationManager.IMPORTANCE_DEFAULT
+                fallback
             }
         }
     }


### PR DESCRIPTION
Closes: [MBL-1643: Create path for detecting Live Activities notification](https://linear.app/customerio/issue/MBL-1643/create-path-for-detecting-live-activities-notification)

## PR Series — Live Notifications (Android Live Activities)

| # | Branch | PR |
|---|--------|----|
| **1** | `live-notifications-1-prep` | **← you are here** |
| 2 | `live-notifications-2-rendering` | https://github.com/customerio/customerio-android/pull/670 |
| 3 | `live-notifications-3-sample` | https://github.com/customerio/customerio-android/pull/671 |

---

## Context

This series introduces live notifications to the Android SDK — the Android counterpart of iOS Live Activities. Live notifications are ongoing notifications that update in-place via a stable ID, allowing the server to push real-time state changes (delivery tracking, sports scores, countdown timers) without creating duplicate notification entries.

The payload schema mirrors the iOS Live Activity contract:
- `activity_id` — stable identifier used to update the same notification slot
- `event` — lifecycle: `start` / `update` / `end`
- `activity_type` — rendering mode: `progress` / `countdown` / `text`
- `attributes` — JSON string of structural/static data (set once, e.g. `progress_max`, icons)
- `content_state` — JSON string of dynamic data that changes on every update (e.g. `title`, `body`, `progress`)

On Android 16 (API 36+) live notifications request promoted ongoing status via `POST_PROMOTED_NOTIFICATIONS`, giving them elevated treatment in the notification shade. On earlier versions they render as standard ongoing notifications using `NotificationCompat`.

---

## This PR — Infrastructure & foundations

Lays the groundwork consumed by the rendering PR. All changes compile against `main` with no dependency on the new live notification classes.

### `BitmapDownloader` utility
Extracts the repeated `URL.openStream() → BitmapFactory.decodeStream()` pattern into a shared `BitmapDownloader.download()` utility. Fixes an existing resource leak in standard push — the `InputStream` was never closed, risking file descriptor exhaustion under repeated rich push loads. Both `CustomerIOPushNotificationHandler.addImage` and the upcoming `LiveNotificationHandler` use this utility.

### `CustomerIOParsedPushPayload` — `activityId` field
Adds a nullable `activityId` field (replaces the POC's `liveNotificationId`) to carry the stable live notification ID through the click routing pipeline to `NotificationClickReceiverActivity`.

### `NotificationChannelCreator` — live notification channel
Adds `createLiveNotificationChannelIfNeededAndReturnChannelId()` for the dedicated live notification channel. Defaults to `{packageName}_cio_live` / `{appName} Live Updates` / `IMPORTANCE_HIGH`. `IMPORTANCE_HIGH` is required so the first `start` event surfaces as a heads-up; note that channel importance cannot be changed programmatically after first creation on a device.

All three values are overridable via manifest `<meta-data>`:
```xml
<meta-data android:name="io.customer.live_notification_channel_id"         android:value="my_live_channel" />
<meta-data android:name="io.customer.live_notification_channel_name"       android:value="Live Updates" />
<meta-data android:name="io.customer.live_notification_channel_importance" android:value="4" />
```
Channel config is **not** accepted from the FCM payload — this prevents the server from downgrading channel importance on the device.

### `AndroidManifest.xml` — `POST_PROMOTED_NOTIFICATIONS`
Declares `POST_PROMOTED_NOTIFICATIONS` in the SDK's own manifest. Host apps inherit it automatically via Android's manifest merger — no manual step needed. The permission is `Normal | AppOps` (install-time, no user prompt). On API < 36 it is silently ignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new manifest permission and extends notification payload/channel infrastructure; while mostly additive, the `Parcelable` schema change and new channel defaults could affect notification click handling or channel behavior on existing apps/devices.
> 
> **Overview**
> Prepares the push module for upcoming *live notifications* by adding the `POST_PROMOTED_NOTIFICATIONS` permission to the library manifest and introducing a dedicated live-notification channel API (`createLiveNotificationChannelIfNeededAndReturnChannelId`) with manifest-overridable id/name/importance defaults.
> 
> Refactors rich-push image loading to use a new shared `BitmapDownloader` (closing streams via `use`) and extends `CustomerIOParsedPushPayload` with an optional `activityId` field to carry a stable live-notification identifier through the click-routing payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 720f96e180f06748f9ecf247f3fd3916a2e520fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->