### PR TITLE
chore: live notification rendering and routing

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -86,7 +86,8 @@ public final class io/customer/messagingpush/data/communication/CustomerIOPushNo
 
 public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayload : android/os/Parcelable {
 	public static final field CREATOR Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload$CREATOR;
-	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroid/os/Parcel;)V
 	public final fun component1 ()Landroid/os/Bundle;
 	public final fun component2 ()Ljava/lang/String;
@@ -94,10 +95,12 @@ public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayl
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
-	public static synthetic fun copy$default (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
 	public final fun getBody ()Ljava/lang/String;
 	public final fun getCioDeliveryId ()Ljava/lang/String;
 	public final fun getCioDeliveryToken ()Ljava/lang/String;

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
 
     <application>
         <!-- Transparent activity for push interactions 

--- a/messagingpush/src/main/java/io/customer/messagingpush/ActionData.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ActionData.kt
@@ -1,0 +1,17 @@
+package io.customer.messagingpush
+
+import android.app.PendingIntent
+
+/**
+ * Represents a single action button on a live notification.
+ *
+ * @property label The user-visible button text (e.g. "View Order")
+ * @property link Deep link URI fired when the action is tapped
+ * @property pendingIntent The PendingIntent that routes through
+ *           [NotificationClickReceiverActivity] for tracking and deep link handling
+ */
+internal data class ActionData(
+    val label: String,
+    val link: String,
+    val pendingIntent: PendingIntent
+)

--- a/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
@@ -1,0 +1,221 @@
+package io.customer.messagingpush
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.os.Bundle
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.toColorInt
+import io.customer.sdk.core.di.SDKComponent
+import org.json.JSONArray
+import org.json.JSONException
+
+/**
+ * Parameters for building a promoted live notification on API 36+ (BAKLAVA).
+ *
+ * When [showProgress] is true, uses [Notification.ProgressStyle] with full
+ * segmented progress bar support. When false, uses [Notification.BigTextStyle]
+ * for text-only live updates (sports scores, auction bids, etc.).
+ *
+ * Both modes request promoted ongoing status for live update treatment.
+ */
+internal data class Api36LiveNotificationParams(
+    val context: Context,
+    val channelId: String,
+    val title: String,
+    val body: String,
+    val subText: String?,
+    @DrawableRes val smallIcon: Int,
+    @ColorInt val accentColor: Int?,
+    val segmentsJson: String?,
+    val pointsJson: String?,
+    val progress: Int,
+    val progressMax: Int,
+    @DrawableRes val startIconRes: Int?,
+    @DrawableRes val endIconRes: Int?,
+    @DrawableRes val trackerIconRes: Int?,
+    val pendingIntent: PendingIntent?,
+    val countdownUntil: Long?,
+    val largeIcon: Bitmap?,
+    val actions: List<ActionData>,
+    val showProgress: Boolean
+)
+
+/**
+ * Builds promoted live notifications on API 36+ (BAKLAVA).
+ *
+ * Uses [Notification.ProgressStyle] for progress-based notifications and
+ * [Notification.BigTextStyle] for text-only live updates. Both styles are
+ * valid for promoted live updates per Android documentation.
+ *
+ * Requirements for promoted live updates (customer responsibility):
+ * - App manifest must declare `android.permission.POST_PROMOTED_NOTIFICATIONS`
+ * - Notification must not be colorized (this builder does not call setColorized)
+ * - Notification must use an allowed style (ProgressStyle or BigTextStyle)
+ * - Notification must have a title and be ongoing
+ */
+internal object Api36LiveNotificationBuilder {
+
+    private const val MAX_ACTIONS = 3
+
+    // Notification.EXTRA_REQUEST_PROMOTED_ONGOING was added in extension SDK 36.1.
+    // Use the raw string value so we can compile against base API 36.
+    private const val EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing"
+    private const val POST_PROMOTED_NOTIFICATIONS_PERMISSION =
+        "android.permission.POST_PROMOTED_NOTIFICATIONS"
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    fun build(params: Api36LiveNotificationParams): Notification {
+        val builder = Notification.Builder(params.context, params.channelId)
+            .setSmallIcon(params.smallIcon)
+            .setContentTitle(params.title)
+            .setContentText(params.body)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+
+        // Request promoted ongoing status when the host app holds the permission.
+        // If missing, fall back silently to standard ongoing — the notification still posts.
+        if (canPostPromotedNotifications(params.context)) {
+            val extras = Bundle().apply {
+                putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true)
+            }
+            builder.addExtras(extras)
+        } else {
+            SDKComponent.logger.debug(
+                "POST_PROMOTED_NOTIFICATIONS not granted; posting as standard ongoing"
+            )
+        }
+
+        if (params.showProgress) {
+            builder.setCategory(Notification.CATEGORY_PROGRESS)
+
+            val segments = params.segmentsJson?.let { parseSegments(it) } ?: emptyList()
+            // When no segments are provided, create a single segment sized to progressMax
+            // so ProgressStyle knows the total range for the bar.
+            val effectiveSegments = segments.ifEmpty {
+                listOf(Notification.ProgressStyle.Segment(params.progressMax))
+            }
+            val maxProgress = effectiveSegments.sumOf { it.length }
+            val safeProgress = params.progress.coerceIn(0, maxProgress)
+
+            val progressStyle = Notification.ProgressStyle()
+                .setProgress(safeProgress)
+
+            progressStyle.progressSegments = effectiveSegments
+
+            params.pointsJson?.let { json ->
+                val points = parsePoints(json, maxProgress)
+                if (points.isNotEmpty()) {
+                    progressStyle.progressPoints = points
+                }
+            }
+
+            params.startIconRes?.let { res ->
+                progressStyle.setProgressStartIcon(Icon.createWithResource(params.context, res))
+            }
+            params.endIconRes?.let { res ->
+                progressStyle.setProgressEndIcon(Icon.createWithResource(params.context, res))
+            }
+            params.trackerIconRes?.let { res ->
+                progressStyle.setProgressTrackerIcon(Icon.createWithResource(params.context, res))
+            }
+
+            builder.style = progressStyle
+        } else {
+            builder.setCategory(Notification.CATEGORY_STATUS)
+            builder.style = Notification.BigTextStyle().bigText(params.body)
+        }
+
+        // Countdown timer
+        params.countdownUntil?.let { until ->
+            builder.setWhen(until)
+            builder.setUsesChronometer(true)
+            builder.setChronometerCountDown(true)
+            builder.setShowWhen(true)
+        }
+
+        // Large icon
+        params.largeIcon?.let { bitmap ->
+            builder.setLargeIcon(Icon.createWithBitmap(bitmap))
+        }
+
+        params.subText?.let { builder.setSubText(it) }
+        params.accentColor?.let { builder.setColor(it) }
+        params.pendingIntent?.let { builder.setContentIntent(it) }
+
+        // Action buttons (Android supports max 3)
+        val actionCount = minOf(params.actions.size, MAX_ACTIONS)
+        for (i in 0 until actionCount) {
+            val action = params.actions[i]
+            builder.addAction(
+                Notification.Action.Builder(null, action.label, action.pendingIntent).build()
+            )
+        }
+
+        return builder.build()
+    }
+
+    private fun canPostPromotedNotifications(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            POST_PROMOTED_NOTIFICATIONS_PERMISSION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun parseSegments(json: String): List<Notification.ProgressStyle.Segment> {
+        val segments = mutableListOf<Notification.ProgressStyle.Segment>()
+        try {
+            val array = JSONArray(json)
+            for (i in 0 until array.length()) {
+                val obj = array.getJSONObject(i)
+                val length = obj.optInt("length", 1).coerceAtLeast(1)
+                val segment = Notification.ProgressStyle.Segment(length)
+                val colorStr = obj.optString("color", "")
+                if (colorStr.isNotEmpty()) {
+                    try {
+                        segment.color = colorStr.toColorInt()
+                    } catch (e: IllegalArgumentException) {
+                        SDKComponent.logger.error("Invalid segment color '$colorStr': ${e.message}")
+                    }
+                }
+                segments.add(segment)
+            }
+        } catch (e: JSONException) {
+            SDKComponent.logger.error("Failed to parse live notification segments JSON: ${e.message}")
+        }
+        return segments
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun parsePoints(json: String, maxProgress: Int): List<Notification.ProgressStyle.Point> {
+        val points = mutableListOf<Notification.ProgressStyle.Point>()
+        try {
+            val array = JSONArray(json)
+            for (i in 0 until array.length()) {
+                val obj = array.getJSONObject(i)
+                val position = obj.optInt("position", 0).coerceIn(0, maxProgress)
+                val point = Notification.ProgressStyle.Point(position)
+                val colorStr = obj.optString("color", "")
+                if (colorStr.isNotEmpty()) {
+                    try {
+                        point.color = colorStr.toColorInt()
+                    } catch (e: IllegalArgumentException) {
+                        SDKComponent.logger.error("Invalid point color '$colorStr': ${e.message}")
+                    }
+                }
+                points.add(point)
+            }
+        } catch (e: JSONException) {
+            SDKComponent.logger.error("Failed to parse live notification points JSON: ${e.message}")
+        }
+        return points
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
@@ -1,0 +1,104 @@
+package io.customer.messagingpush
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Build
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import androidx.core.app.NotificationCompat
+
+/**
+ * Parameters for building a live notification on pre-API 36 devices using
+ * standard [NotificationCompat] styles.
+ *
+ * Supports:
+ * - Standard linear progress bar (determinate)
+ * - Accent color for notification chrome
+ * - Colorized mode (tints the entire notification background)
+ * - Title, body, and subtext via standard notification fields
+ * - Countdown timer (countdown direction requires API 24+)
+ *
+ * Not supported on this tier (use [Api36LiveNotificationParams] on API 36+):
+ * - Segmented progress bar with custom segment colors
+ * - Progress points, start/end/tracker icons
+ * - Promoted live update status
+ */
+internal data class BasicNotificationParams(
+    val context: Context,
+    val channelId: String,
+    val title: String,
+    val body: String,
+    val subText: String?,
+    @DrawableRes val smallIcon: Int,
+    @ColorInt val accentColor: Int?,
+    val colorized: Boolean,
+    val progress: Int,
+    val progressMax: Int,
+    val pendingIntent: PendingIntent?,
+    val countdownUntil: Long?,
+    val largeIcon: Bitmap?,
+    val actions: List<ActionData>,
+    val showProgress: Boolean
+)
+
+/**
+ * Builds live notifications for pre-API 36 devices using standard
+ * [NotificationCompat] styles with a native progress bar.
+ */
+internal object BasicNotificationBuilder {
+
+    private const val MAX_ACTIONS = 3
+
+    fun build(params: BasicNotificationParams): Notification {
+        val category = if (params.showProgress) {
+            NotificationCompat.CATEGORY_PROGRESS
+        } else {
+            NotificationCompat.CATEGORY_STATUS
+        }
+
+        val builder = NotificationCompat.Builder(params.context, params.channelId)
+            .setSmallIcon(params.smallIcon)
+            .setContentTitle(params.title)
+            .setContentText(params.body)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(category)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(params.body))
+
+        if (params.showProgress) {
+            val safeProgress = params.progress.coerceIn(0, params.progressMax)
+            builder.setProgress(params.progressMax, safeProgress, false)
+        }
+
+        // Countdown timer
+        params.countdownUntil?.let { until ->
+            builder.setWhen(until)
+            builder.setUsesChronometer(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                builder.setChronometerCountDown(true)
+            }
+            builder.setShowWhen(true)
+        }
+
+        // Large icon
+        params.largeIcon?.let { builder.setLargeIcon(it) }
+
+        params.subText?.let { builder.setSubText(it) }
+        params.accentColor?.let { builder.setColor(it) }
+        if (params.colorized) {
+            builder.setColorized(true)
+        }
+        params.pendingIntent?.let { builder.setContentIntent(it) }
+
+        // Action buttons (Android supports max 3)
+        val actionCount = minOf(params.actions.size, MAX_ACTIONS)
+        for (i in 0 until actionCount) {
+            val action = params.actions[i]
+            builder.addAction(0, action.label, action.pendingIntent)
+        }
+
+        return builder.build()
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -5,7 +5,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.media.RingtoneManager
 import android.os.Build
 import android.os.Bundle
@@ -21,16 +20,13 @@ import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.extensions.*
 import io.customer.messagingpush.processor.PushMessageProcessor
+import io.customer.messagingpush.util.BitmapDownloader
 import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_ID_KEY
 import io.customer.messagingpush.util.PushTrackingUtil.Companion.DELIVERY_TOKEN_KEY
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
-import java.net.URL
 import kotlin.math.abs
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 /**
  * Class to handle PushNotification.
@@ -226,19 +222,11 @@ internal class CustomerIOPushNotificationHandler(
         builder: NotificationCompat.Builder,
         body: String,
         defaultLargeIcon: Bitmap? = null
-    ) = runBlocking {
+    ) {
         val style = NotificationCompat.BigPictureStyle()
             .bigLargeIcon(defaultLargeIcon)
             .setSummaryText(body)
-        val url = URL(imageUrl)
-        withContext(Dispatchers.IO) {
-            try {
-                val input = url.openStream()
-                BitmapFactory.decodeStream(input)
-            } catch (e: Exception) {
-                null
-            }
-        }?.let { bitmap ->
+        BitmapDownloader.download(imageUrl)?.let { bitmap ->
             style.bigPicture(bitmap)
             builder.setLargeIcon(bitmap)
             builder.setStyle(style)

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -113,9 +113,6 @@ internal class CustomerIOPushNotificationHandler(
         pushLogger.logShowingPushNotification(remoteMessage)
 
         val applicationName = context.applicationInfo.loadLabel(context.packageManager).toString()
-        val requestCode = abs(System.currentTimeMillis().toInt())
-
-        bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)
 
         val appMetaData = context.applicationMetaData()
 
@@ -146,6 +143,33 @@ internal class CustomerIOPushNotificationHandler(
             appMetaData = appMetaData,
             notificationManager = notificationManager
         )
+
+        // Check if this is a live notification
+        val activityId = bundle.getString(LiveNotificationHandler.ACTIVITY_ID_KEY)
+        if (activityId != null) {
+            val liveChannelId = notificationChannelCreator.createLiveNotificationChannelIfNeededAndReturnChannelId(
+                context = context,
+                applicationName = applicationName,
+                appMetaData = appMetaData,
+                notificationManager = notificationManager
+            )
+            // onNotificationComposed is intentionally not called for live notifications —
+            // their layout is SDK-controlled and cannot be safely modified by host apps.
+            LiveNotificationHandler(bundle).handle(
+                context = context,
+                deliveryId = deliveryId,
+                deliveryToken = deliveryToken,
+                smallIcon = smallIcon,
+                tintColor = tintColor,
+                channelId = liveChannelId,
+                notificationManager = notificationManager
+            )
+            return
+        }
+
+        val requestCode = abs(System.currentTimeMillis().toInt())
+        bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)
+
         val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
         val notificationBuilder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(smallIcon)

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -1,0 +1,258 @@
+package io.customer.messagingpush
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import io.customer.messagingpush.activity.NotificationClickReceiverActivity
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+import io.customer.messagingpush.extensions.getDrawableByName
+import io.customer.messagingpush.extensions.toColorOrNull
+import io.customer.messagingpush.util.BitmapDownloader
+import io.customer.sdk.core.di.SDKComponent
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Handles live notification creation, updates, and dismissal.
+ *
+ * Live notifications are ongoing notifications that can be updated in-place
+ * (the Android counterpart of iOS Live Activities). They use a stable
+ * notification ID derived from [ACTIVITY_ID_KEY] so successive pushes
+ * replace the previous notification rather than creating new ones.
+ *
+ * Payload schema (iOS-style split):
+ * - [ACTIVITY_ID_KEY] — stable id
+ * - [EVENT_KEY] — "start" | "update" | "end"
+ * - [ACTIVITY_TYPE_KEY] — "progress" | "countdown" | "text"
+ * - [ATTRIBUTES_KEY] — JSON string: structural/static data (progress_max, icons, etc.)
+ * - [CONTENT_STATE_KEY] — JSON string: dynamic data (title, body, progress, subtext, etc.)
+ */
+internal class LiveNotificationHandler(
+    private val bundle: Bundle
+) {
+
+    companion object {
+        const val ACTIVITY_ID_KEY = "activity_id"
+        const val EVENT_KEY = "event"
+        const val ACTIVITY_TYPE_KEY = "activity_type"
+        const val CONTENT_STATE_KEY = "content_state"
+        const val ATTRIBUTES_KEY = "attributes"
+
+        private const val TYPE_PROGRESS = "progress"
+        private const val TYPE_COUNTDOWN = "countdown"
+
+        private const val EVENT_END = "end"
+
+        private const val DEFAULT_DISMISS_DELAY_MS = 3000L
+    }
+
+    fun handle(
+        context: Context,
+        deliveryId: String,
+        deliveryToken: String,
+        @DrawableRes smallIcon: Int,
+        @ColorInt tintColor: Int?,
+        channelId: String,
+        notificationManager: NotificationManager
+    ) {
+        // Log a warning on API 33+ if POST_NOTIFICATIONS is not granted. We do not
+        // bail out here — the system will silently drop the notification at notify()
+        // time, matching how standard push notifications behave in the same situation.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            SDKComponent.logger.error(
+                "POST_NOTIFICATIONS permission not granted; live notification will be dropped by the system. " +
+                    "The host app must request this permission on Android 13+."
+            )
+        }
+
+        val activityId = bundle.getString(ACTIVITY_ID_KEY) ?: return
+        val event = bundle.getString(EVENT_KEY) ?: "update"
+        val activityType = bundle.getString(ACTIVITY_TYPE_KEY) ?: TYPE_PROGRESS
+
+        val attributes = parseJson(ATTRIBUTES_KEY, bundle.getString(ATTRIBUTES_KEY))
+        val contentState = parseJson(CONTENT_STATE_KEY, bundle.getString(CONTENT_STATE_KEY))
+
+        // Structural fields (attributes — stable for the life of the activity)
+        val progressMax = attributes.optInt("progress_max", 100)
+        val segmentsJson = attributes.optString("segments").takeIf { it.isNotEmpty() }
+        val startIconRes = context.getDrawableByName(attributes.optString("start_icon").takeIf { it.isNotEmpty() })
+        val endIconRes = context.getDrawableByName(attributes.optString("end_icon").takeIf { it.isNotEmpty() })
+        val trackerIconRes = context.getDrawableByName(attributes.optString("tracker_icon").takeIf { it.isNotEmpty() })
+        val largeIconUrl = attributes.optString("large_icon").takeIf { it.isNotEmpty() }
+        val colorized = attributes.optBoolean("colorized", false)
+        val dismissDelay = attributes.optLong("dismiss_delay", DEFAULT_DISMISS_DELAY_MS)
+
+        // Dynamic fields (content_state — updated on every event)
+        val title = contentState.optString("title")
+        val body = contentState.optString("body")
+        val subText = contentState.optString("subtext").takeIf { it.isNotEmpty() }
+        val backgroundColor = contentState.optString("color").takeIf { it.isNotEmpty() }?.toColorOrNull()
+        val actionsJson = contentState.optString("actions").takeIf { it.isNotEmpty() }
+        val progress = contentState.optInt("progress", 0)
+        val pointsJson = contentState.optString("points").takeIf { it.isNotEmpty() }
+        val countdownUntil = if (activityType == TYPE_COUNTDOWN && contentState.has("countdown_until")) {
+            contentState.optLong("countdown_until").takeIf { it > 0 }
+        } else {
+            null
+        }
+
+        val showProgress = activityType == TYPE_PROGRESS
+
+        val largeIcon: Bitmap? = largeIconUrl?.let { url -> BitmapDownloader.download(url) }
+
+        val notifId = activityId.hashCode() and 0x7FFFFFFF
+
+        bundle.putInt(CustomerIOPushNotificationHandler.NOTIFICATION_REQUEST_CODE, notifId)
+
+        val payload = CustomerIOParsedPushPayload(
+            extras = Bundle(bundle),
+            deepLink = bundle.getString(CustomerIOPushNotificationHandler.DEEP_LINK_KEY),
+            cioDeliveryId = deliveryId,
+            cioDeliveryToken = deliveryToken,
+            title = title,
+            body = body,
+            activityId = activityId
+        )
+
+        val pendingIntent = createIntentForNotificationClick(context, notifId, payload)
+
+        val actions = parseActions(context, actionsJson, activityId, payload)
+
+        val notification = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA -> {
+                val params = Api36LiveNotificationParams(
+                    context = context,
+                    channelId = channelId,
+                    title = title,
+                    body = body,
+                    subText = subText,
+                    smallIcon = smallIcon,
+                    accentColor = backgroundColor ?: tintColor,
+                    segmentsJson = segmentsJson,
+                    pointsJson = pointsJson,
+                    progress = progress,
+                    progressMax = progressMax,
+                    startIconRes = startIconRes,
+                    endIconRes = endIconRes,
+                    trackerIconRes = trackerIconRes,
+                    pendingIntent = pendingIntent,
+                    countdownUntil = countdownUntil,
+                    largeIcon = largeIcon,
+                    actions = actions,
+                    showProgress = showProgress
+                )
+                Api36LiveNotificationBuilder.build(params)
+            }
+            else -> {
+                val params = BasicNotificationParams(
+                    context = context,
+                    channelId = channelId,
+                    title = title,
+                    body = body,
+                    subText = subText,
+                    smallIcon = smallIcon,
+                    accentColor = backgroundColor ?: tintColor,
+                    colorized = colorized,
+                    progress = progress,
+                    progressMax = progressMax,
+                    pendingIntent = pendingIntent,
+                    countdownUntil = countdownUntil,
+                    largeIcon = largeIcon,
+                    actions = actions,
+                    showProgress = showProgress
+                )
+                BasicNotificationBuilder.build(params)
+            }
+        }
+
+        notificationManager.notify(activityId, notifId, notification)
+
+        if (event == EVENT_END) {
+            Handler(Looper.getMainLooper()).postDelayed({
+                notificationManager.cancel(activityId, notifId)
+            }, dismissDelay)
+        }
+    }
+
+    private fun parseJson(key: String, raw: String?): JSONObject {
+        if (raw.isNullOrEmpty()) return JSONObject()
+        return try {
+            JSONObject(raw)
+        } catch (e: JSONException) {
+            SDKComponent.logger.error("Failed to parse live notification '$key' JSON: ${e.message}")
+            JSONObject()
+        }
+    }
+
+    private fun parseActions(
+        context: Context,
+        actionsJson: String?,
+        activityId: String,
+        payload: CustomerIOParsedPushPayload
+    ): List<ActionData> {
+        if (actionsJson.isNullOrBlank()) return emptyList()
+
+        val actions = mutableListOf<ActionData>()
+        try {
+            val array = JSONArray(actionsJson)
+            val count = minOf(array.length(), 3) // Android supports max 3 action buttons
+            for (i in 0 until count) {
+                val obj = array.getJSONObject(i)
+                val label = obj.optString("label", "").takeIf { it.isNotEmpty() } ?: continue
+                val link = obj.optString("link", "")
+
+                val actionPayload = CustomerIOParsedPushPayload(
+                    extras = payload.extras,
+                    deepLink = link.takeIf { it.isNotEmpty() },
+                    cioDeliveryId = payload.cioDeliveryId,
+                    cioDeliveryToken = payload.cioDeliveryToken,
+                    title = payload.title,
+                    body = payload.body,
+                    activityId = activityId
+                )
+
+                val requestCode = (activityId.hashCode() + i + 1) and 0x7FFFFFFF
+                val pendingIntent = createIntentForNotificationClick(context, requestCode, actionPayload)
+
+                actions.add(ActionData(label = label, link = link, pendingIntent = pendingIntent))
+            }
+        } catch (e: JSONException) {
+            SDKComponent.logger.error("Failed to parse live notification actions JSON: ${e.message}")
+        }
+        return actions
+    }
+
+    private fun createIntentForNotificationClick(
+        context: Context,
+        requestCode: Int,
+        payload: CustomerIOParsedPushPayload
+    ): PendingIntent {
+        val notifyIntent = Intent(context, NotificationClickReceiverActivity::class.java)
+        notifyIntent.putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, payload)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            notifyIntent,
+            flags
+        )
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
@@ -13,6 +13,7 @@ import android.os.Parcelable
  * @property cioDeliveryToken Customer.io message delivery token
  * @property title notification content title text
  * @property body notification content body text
+ * @property activityId stable id identifying a live notification (null for standard push)
  */
 data class CustomerIOParsedPushPayload(
     val extras: Bundle,
@@ -20,7 +21,8 @@ data class CustomerIOParsedPushPayload(
     val cioDeliveryId: String,
     val cioDeliveryToken: String,
     val title: String,
-    val body: String
+    val body: String,
+    val activityId: String? = null
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
         extras = parcel.readBundle(Bundle::class.java.classLoader) ?: Bundle(),
@@ -28,7 +30,8 @@ data class CustomerIOParsedPushPayload(
         cioDeliveryId = parcel.readString().orEmpty(),
         cioDeliveryToken = parcel.readString().orEmpty(),
         title = parcel.readString().orEmpty(),
-        body = parcel.readString().orEmpty()
+        body = parcel.readString().orEmpty(),
+        activityId = parcel.readString()
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -38,6 +41,7 @@ data class CustomerIOParsedPushPayload(
         parcel.writeString(cioDeliveryToken)
         parcel.writeString(title)
         parcel.writeString(body)
+        parcel.writeString(activityId)
     }
 
     override fun describeContents(): Int {

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/BitmapDownloader.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/BitmapDownloader.kt
@@ -1,0 +1,25 @@
+package io.customer.messagingpush.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import io.customer.sdk.core.di.SDKComponent
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+internal object BitmapDownloader {
+
+    fun download(imageUrl: String): Bitmap? = runBlocking {
+        withContext(Dispatchers.IO) {
+            try {
+                URL(imageUrl).openStream().use { input ->
+                    BitmapFactory.decodeStream(input)
+                }
+            } catch (e: Exception) {
+                SDKComponent.logger.error("Failed to download bitmap from '$imageUrl': ${e.message}")
+                null
+            }
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/util/NotificationChannelCreator.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/util/NotificationChannelCreator.kt
@@ -33,6 +33,18 @@ internal class NotificationChannelCreator(
         @VisibleForTesting
         internal const val METADATA_NOTIFICATION_CHANNEL_IMPORTANCE =
             "io.customer.notification_channel_importance"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_ID =
+            "io.customer.live_notification_channel_id"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_NAME =
+            "io.customer.live_notification_channel_name"
+
+        @VisibleForTesting
+        internal const val METADATA_LIVE_NOTIFICATION_CHANNEL_IMPORTANCE =
+            "io.customer.live_notification_channel_importance"
     }
 
     /**
@@ -51,51 +63,98 @@ internal class NotificationChannelCreator(
         appMetaData: Bundle?,
         notificationManager: NotificationManager
     ): String {
-        val defaultChannelId = context.packageName
         val channelId = appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_ID)
-            ?: defaultChannelId
+            ?: context.packageName
 
         // Since android Oreo notification channel is needed.
         if (androidVersionChecker.isOreoOrHigher()) {
-            val existingChannel = notificationManager.getNotificationChannel(channelId)
-
-            val channelName =
-                appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_NAME)
-                    ?: "$applicationName Notifications"
-            val rawImportance = appMetaData?.getInt(
-                METADATA_NOTIFICATION_CHANNEL_IMPORTANCE,
-                NotificationManager.IMPORTANCE_DEFAULT
-            ) ?: NotificationManager.IMPORTANCE_DEFAULT
-
-            // Validate that the importance value is a valid NotificationManager constant
-            val importance = validateImportanceLevel(rawImportance)
-
-            // Only create or update the channel if it doesn't exist or the name is different
-            if (existingChannel == null || existingChannel.name != channelName) {
-                logger.logCreatingNotificationChannel(channelId, channelName, importance)
-                val channel = NotificationChannel(
-                    channelId,
-                    channelName,
-                    importance
-                )
-                notificationManager.createNotificationChannel(channel)
-            } else {
-                logger.logNotificationChannelAlreadyExists(channelId)
-            }
+            val channelName = appMetaData?.getMetaDataString(name = METADATA_NOTIFICATION_CHANNEL_NAME)
+                ?: "$applicationName Notifications"
+            val importance = resolveImportance(
+                appMetaData = appMetaData,
+                metadataKey = METADATA_NOTIFICATION_CHANNEL_IMPORTANCE,
+                default = NotificationManager.IMPORTANCE_DEFAULT
+            )
+            createOrUpdateChannel(notificationManager, channelId, channelName, importance)
         }
 
         return channelId
     }
 
     /**
-     * Validates that the provided importance level is a valid NotificationManager importance constant.
-     * If the value is not valid, it returns the default importance level.
+     * Creates a notification channel for live notifications on Android Oreo+ and returns its ID.
      *
-     * @param importanceLevel The importance level to validate
-     * @return A valid NotificationManager importance constant
+     * Defaults to `{packageName}_cio_live` / `{appName} Live Updates` / `IMPORTANCE_HIGH`.
+     * Each value can be overridden via manifest `<meta-data>`:
+     * - `io.customer.live_notification_channel_id`
+     * - `io.customer.live_notification_channel_name`
+     * - `io.customer.live_notification_channel_importance` (integer, e.g. 4 for HIGH)
+     *
+     * `IMPORTANCE_HIGH` is the recommended default — it ensures the first "start" event
+     * surfaces as a heads-up notification. Note: channel importance cannot be changed
+     * programmatically after the channel is created on a device.
+     *
+     * @param context The application context
+     * @param applicationName The application name used to derive the default channel name
+     * @param appMetaData The application metadata bundle
+     * @param notificationManager The notification manager instance
+     * @return The channel ID to use in the notification builder
+     */
+    fun createLiveNotificationChannelIfNeededAndReturnChannelId(
+        context: Context,
+        applicationName: String,
+        appMetaData: Bundle?,
+        notificationManager: NotificationManager
+    ): String {
+        val channelId = appMetaData?.getMetaDataString(name = METADATA_LIVE_NOTIFICATION_CHANNEL_ID)
+            ?: "${context.packageName}_cio_live"
+
+        if (androidVersionChecker.isOreoOrHigher()) {
+            val channelName = appMetaData?.getMetaDataString(name = METADATA_LIVE_NOTIFICATION_CHANNEL_NAME)
+                ?: "$applicationName Live Updates"
+            val importance = resolveImportance(
+                appMetaData = appMetaData,
+                metadataKey = METADATA_LIVE_NOTIFICATION_CHANNEL_IMPORTANCE,
+                default = NotificationManager.IMPORTANCE_HIGH
+            )
+            createOrUpdateChannel(notificationManager, channelId, channelName, importance)
+        }
+
+        return channelId
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createOrUpdateChannel(
+        notificationManager: NotificationManager,
+        channelId: String,
+        channelName: String,
+        importance: Int
+    ) {
+        val existingChannel = notificationManager.getNotificationChannel(channelId)
+        // Only create or update the channel if it doesn't exist or the name is different
+        if (existingChannel == null || existingChannel.name != channelName) {
+            logger.logCreatingNotificationChannel(channelId, channelName, importance)
+            val channel = NotificationChannel(channelId, channelName, importance)
+            notificationManager.createNotificationChannel(channel)
+        } else {
+            logger.logNotificationChannelAlreadyExists(channelId)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun resolveImportance(appMetaData: Bundle?, metadataKey: String, default: Int): Int {
+        val rawImportance = appMetaData?.getInt(metadataKey, default) ?: default
+        return validateImportanceLevel(rawImportance, fallback = default)
+    }
+
+    /**
+     * Validates that the provided importance level is a valid NotificationManager importance constant.
+     * If the value is not valid, returns the supplied [fallback] so each caller preserves its own
+     * intended default (e.g. `IMPORTANCE_HIGH` for live notifications) rather than silently
+     * collapsing to `IMPORTANCE_DEFAULT`.
      */
     @RequiresApi(Build.VERSION_CODES.N)
-    private fun validateImportanceLevel(importanceLevel: Int): Int {
+    private fun validateImportanceLevel(importanceLevel: Int, fallback: Int): Int {
         return when (importanceLevel) {
             NotificationManager.IMPORTANCE_NONE,
             NotificationManager.IMPORTANCE_MIN,
@@ -106,7 +165,7 @@ internal class NotificationChannelCreator(
 
             else -> {
                 logger.logInvalidNotificationChannelImportance(importanceLevel)
-                NotificationManager.IMPORTANCE_DEFAULT
+                fallback
             }
         }
     }


### PR DESCRIPTION
Closes: [MBL-1644: Render templates on Android 16](https://linear.app/customerio/issue/MBL-1644/render-templates-on-android-16)

## PR Series — Live Notifications (Android Live Activities)

| # | Branch | PR |
|---|--------|----|
| 1 | `live-notifications-1-prep` | https://github.com/customerio/customerio-android/pull/669 |
| **2** | `live-notifications-2-rendering` | **← you are here** |
| 3 | `live-notifications-3-sample` | https://github.com/customerio/customerio-android/pull/671 |

---

## Context

This series introduces live notifications to the Android SDK — the Android counterpart of iOS Live Activities. Live notifications are ongoing notifications that update in-place via a stable ID, allowing the server to push real-time state changes (delivery tracking, sports scores, countdown timers) without creating duplicate notification entries.

The payload schema mirrors the iOS Live Activity contract:
- `activity_id` — stable identifier used to update the same notification slot
- `event` — lifecycle: `start` / `update` / `end`
- `activity_type` — rendering mode: `progress` / `countdown` / `text`
- `attributes` — JSON string of structural/static data (set once, e.g. `progress_max`, icons)
- `content_state` — JSON string of dynamic data that changes on every update (e.g. `title`, `body`, `progress`)

On Android 16 (API 36+) live notifications request promoted ongoing status via `POST_PROMOTED_NOTIFICATIONS`, giving them elevated treatment in the notification shade. On earlier versions they render as standard ongoing notifications using `NotificationCompat`.

---

## This PR — Rendering & routing

Implements the full live notification feature on top of the infrastructure from PR 1. Introduces the notification builders, the central handler, and the routing logic that detects a live notification payload and dispatches it away from the standard push path.

### `ActionData`
Simple data class representing a single action button (label, deep link URI, `PendingIntent`). Up to 3 actions are supported per Android's limit.

### `BasicNotificationBuilder` (pre-API 36)
Builds live notifications on API 26–35 using `NotificationCompat`. Supports a linear determinate progress bar, countdown timer via `Chronometer`, colorized background, large icon, subtext, and up to 3 action buttons. Uses a single `accentColor` parameter (matching the API 36 path) so callers make color precedence explicit rather than relying on sequential `setColor()` overwrites. Segmented progress bars and promoted ongoing status are not available on this tier.

### `Api36LiveNotificationBuilder` (API 36+)
Builds promoted ongoing notifications on Android 16+ using the native `Notification.Builder` with `Notification.ProgressStyle`. Supports segmented progress bars (with per-segment colors), progress point markers, start/end/tracker icons, and promoted ongoing status. Before requesting promoted ongoing, performs a runtime permission check for `POST_PROMOTED_NOTIFICATIONS` — if not granted, falls back silently to standard ongoing and logs a debug message.

### `LiveNotificationHandler`
Central handler that owns the full live notification lifecycle:
- Reads `activity_id`, `event`, `activity_type` from the top-level bundle
- Parses `attributes` and `content_state` as `JSONObject` — malformed JSON is caught, logged as an error, and replaced with an empty object so the notification still posts with safe defaults rather than crashing
- Dispatches to `Api36LiveNotificationBuilder` on API 36+ or `BasicNotificationBuilder` on earlier versions
- Posts the notification with a stable ID derived from `activity_id` so successive pushes update in-place
- On `event = "end"`, schedules cancellation after `dismiss_delay` ms (default 3000)
- On API 33+, logs a clear warning if `POST_NOTIFICATIONS` is not granted so developers can diagnose why no notification appeared. Behaviour then matches the standard push path — the system silently drops the notification at `notify()` time, so live and regular notifications degrade identically when the permission is missing.

### `CustomerIOPushNotificationHandler` — routing
Detects `activity_id` in the incoming bundle and routes to `LiveNotificationHandler`. The `onNotificationComposed` callback is intentionally not invoked for live notifications — their layout is SDK-controlled and cannot be safely modified by host apps (and the API 36 path uses the native `Notification.Builder`, not `NotificationCompat.Builder`, making the existing callback signature inapplicable anyway).

### Notable design decisions
- **Delivery tracking**: the `delivered` metric fires before `handleNotification()`, so it is tracked regardless of whether the notification is shown. This matches existing standard push behaviour and the iOS convention where "delivered" means "received by device".
- **`onNotificationClicked` / deep link routing**: live notifications go through the same `NotificationClickReceiverActivity` path as standard push, so click tracking and deep link handling work identically.