### PR TITLE
chore: live notification demo activity

### DIFF
--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -139,6 +139,10 @@
             android:name=".ui.inbox.InboxMessagesActivity"
             android:exported="false"
             android:label="@string/label_inbox_messages_activity" />
+        <activity
+            android:name=".ui.livenotification.LiveNotificationDemoActivity"
+            android:exported="false"
+            android:label="@string/label_live_notification_demo_activity" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
@@ -34,6 +34,7 @@ import io.customer.android.sample.java_layout.sdk.CustomerIORepository;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.android.sample.java_layout.ui.inbox.InboxMessagesActivity;
 import io.customer.android.sample.java_layout.ui.inline.InlineExamplesActivity;
+import io.customer.android.sample.java_layout.ui.livenotification.LiveNotificationDemoActivity;
 import io.customer.android.sample.java_layout.ui.location.LocationTestActivity;
 import io.customer.android.sample.java_layout.ui.login.LoginActivity;
 import io.customer.android.sample.java_layout.ui.settings.InternalSettingsActivity;
@@ -159,6 +160,9 @@ public class DashboardActivity extends BaseActivity<ActivityDashboardBinding> {
         });
         binding.inboxMessagesButton.setOnClickListener(view -> {
             startInboxMessagesActivity();
+        });
+        binding.liveNotificationDemoButton.setOnClickListener(view -> {
+            startActivity(new Intent(DashboardActivity.this, LiveNotificationDemoActivity.class));
         });
         binding.logoutButton.setOnClickListener(view -> {
             authViewModel.clearLoggedInUser();

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -1,0 +1,360 @@
+package io.customer.android.sample.java_layout.ui.livenotification;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+
+import com.google.firebase.messaging.RemoteMessage;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.UUID;
+
+import io.customer.android.sample.java_layout.R;
+import io.customer.android.sample.java_layout.databinding.ActivityLiveNotificationDemoBinding;
+import io.customer.android.sample.java_layout.ui.core.BaseActivity;
+import io.customer.messagingpush.CustomerIOFirebaseMessagingService;
+
+/**
+ * Demo activity that simulates live notification updates by sending synthetic
+ * push messages through the SDK's actual push handling code path.
+ * <p>
+ * Select a notification type via radio buttons, then use manual controls
+ * (Start / Update / End) or auto-run all steps with a 2-second interval.
+ * <p>
+ * Payloads follow the iOS-style Live Activity schema: top-level keys
+ * ({@code activity_id}, {@code event}, {@code activity_type}) plus two
+ * JSON blobs: {@code attributes} (structural/static) and
+ * {@code content_state} (dynamic/mutable).
+ */
+public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotificationDemoBinding> {
+
+    private static final String DEMO_DELIVERY_TOKEN = "demo-token-live";
+    private static final long AUTO_STEP_DELAY_MS = 2000;
+
+    // Event values (lifecycle)
+    private static final String EVENT_START = "start";
+    private static final String EVENT_UPDATE = "update";
+    private static final String EVENT_END = "end";
+
+    // Activity types (rendering mode)
+    private static final String TYPE_PROGRESS = "progress";
+    private static final String TYPE_COUNTDOWN = "countdown";
+    private static final String TYPE_TEXT = "text";
+
+    // Shared demo assets
+    private static final String DEMO_ICON = "ic_notification";
+    // Lorem Picsum — free placeholder image service (https://picsum.photos).
+    // Using a fixed image id so the demo displays the same image on every run.
+    private static final String DEMO_LARGE_ICON_URL = "https://picsum.photos/id/237/400/400.jpg";
+    private static final long DEMO_DISMISS_DELAY_MS = 5000L;
+
+    // Delivery tracking config
+    private static final String DELIVERY_ID = "demo-delivery";
+    private static final String[] DELIVERY_TITLES = {"Ordered", "Preparing", "On the way", "Delivered"};
+    private static final String[] DELIVERY_BODIES = {
+            "Your order has been placed",
+            "Your order is being prepared",
+            "Your order is on the way",
+            "Your order has been delivered"
+    };
+    private static final String[] DELIVERY_SUBTEXTS = {
+            "Estimated delivery: 30 min",
+            "Estimated delivery: 25 min",
+            "Estimated delivery: 10 min",
+            "Enjoy your meal!"
+    };
+    private static final String DELIVERY_SEGMENTS = "[{\"length\":1},{\"length\":1},{\"length\":1},{\"length\":1}]";
+    private static final String DELIVERY_COLOR = "#1B5E20";
+
+    // Sports score config
+    private static final String SPORTS_ID = "demo-sports";
+    private static final String[] SPORTS_TITLES = {"Lakers 98 - Celtics 95", "Lakers 101 - Celtics 97", "Final: Lakers 105 - Celtics 99"};
+    private static final String[] SPORTS_BODIES = {"Q4 2:30 remaining", "Q4 1:15 remaining", "Game Over"};
+    private static final String[] SPORTS_SUBTEXTS = {"Live", "Live", "Final"};
+    private static final String SPORTS_COLOR = "#4A148C";
+    private static final String SPORTS_ACTIONS =
+            "[{\"label\":\"Open Scorecard\",\"link\":\"sample://sports/game/123\"}]";
+
+    // Parking timer config
+    private static final String TIMER_ID = "demo-parking";
+    private static final String[] TIMER_TITLES = {"Parking Session", "Parking Session", "Parking Expired"};
+    private static final String[] TIMER_BODIES = {"Zone A - Spot 42", "Zone A - Spot 42", "Your session has ended"};
+    private static final String[] TIMER_SUBTEXTS = {"Time remaining", "Expiring soon", "Expired"};
+    private static final String[] TIMER_COLORS = {"#2E7D32", "#E65100", "#B71C1C"};
+    private static final String TIMER_ACTIONS =
+            "[{\"label\":\"Extend Parking\",\"link\":\"sample://parking/extend\"}]";
+
+    // Delivery with actions config
+    private static final String ACTIONS_ID = "demo-delivery-actions";
+    private static final String[] ACTIONS_TITLES = {"Order confirmed", "Preparing", "On the way", "Delivered!"};
+    private static final String[] ACTIONS_BODIES = {
+            "Restaurant received your order",
+            "Your food is being prepared",
+            "Driver is heading to you",
+            "Enjoy your meal"
+    };
+    private static final String ACTIONS_SEGMENTS = "[{\"length\":1},{\"length\":1},{\"length\":1},{\"length\":1}]";
+    private static final String ACTIONS_COLOR = "#1B5E20";
+    private static final String ACTIONS_BUTTONS =
+            "[{\"label\":\"View Order\",\"link\":\"sample://order/456\"},{\"label\":\"Get Directions\",\"link\":\"sample://directions\"}]";
+
+    private enum NotificationType { DELIVERY, TIMER, SPORTS, DELIVERY_ACTIONS }
+
+    private int currentStep = 0;
+    private boolean isActive = false;
+    private final Handler autoHandler = new Handler(Looper.getMainLooper());
+    private boolean isAutoRunning = false;
+
+    @Override
+    protected ActivityLiveNotificationDemoBinding inflateViewBinding() {
+        return ActivityLiveNotificationDemoBinding.inflate(getLayoutInflater());
+    }
+
+    @Override
+    protected void setupContent() {
+        binding.topAppBar.setNavigationOnClickListener(v -> finish());
+
+        binding.startButton.setOnClickListener(v -> start());
+        binding.updateButton.setOnClickListener(v -> update());
+        binding.endButton.setOnClickListener(v -> end());
+        binding.autoButton.setOnClickListener(v -> autoRun());
+
+        binding.typeRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
+            // Reset state when switching type
+            if (isActive) {
+                autoHandler.removeCallbacksAndMessages(null);
+                isActive = false;
+                isAutoRunning = false;
+                currentStep = 0;
+                updateButtonStates();
+                binding.statusTextView.setText(R.string.live_notification_status_idle);
+            }
+        });
+    }
+
+    private NotificationType getSelectedType() {
+        int checkedId = binding.typeRadioGroup.getCheckedRadioButtonId();
+        if (checkedId == R.id.radio_timer) return NotificationType.TIMER;
+        if (checkedId == R.id.radio_sports) return NotificationType.SPORTS;
+        if (checkedId == R.id.radio_delivery_actions) return NotificationType.DELIVERY_ACTIONS;
+        return NotificationType.DELIVERY;
+    }
+
+    private int getStepCount() {
+        switch (getSelectedType()) {
+            case TIMER: return TIMER_TITLES.length;
+            case SPORTS: return SPORTS_TITLES.length;
+            case DELIVERY_ACTIONS: return ACTIONS_TITLES.length;
+            default: return DELIVERY_TITLES.length;
+        }
+    }
+
+    // --- Manual controls ---
+
+    private void start() {
+        currentStep = 0;
+        isActive = true;
+        updateButtonStates();
+        sendPush(EVENT_START, currentStep);
+        updateStatusText();
+    }
+
+    private void update() {
+        if (!isActive) return;
+        currentStep = Math.min(currentStep + 1, getStepCount() - 1);
+        updateButtonStates();
+        sendPush(EVENT_UPDATE, currentStep);
+        updateStatusText();
+    }
+
+    private void end() {
+        if (!isActive) return;
+        isActive = false;
+        updateButtonStates();
+        sendPush(EVENT_END, getStepCount() - 1);
+        binding.statusTextView.setText(R.string.live_notification_status_ended);
+    }
+
+    // --- Auto sequence ---
+
+    private void autoRun() {
+        if (isAutoRunning) return;
+        isAutoRunning = true;
+        binding.autoButton.setEnabled(false);
+        binding.startButton.setEnabled(false);
+
+        start();
+
+        int totalSteps = getStepCount();
+        for (int step = 1; step < totalSteps; step++) {
+            autoHandler.postDelayed(this::update, AUTO_STEP_DELAY_MS * step);
+        }
+        autoHandler.postDelayed(() -> {
+            end();
+            isAutoRunning = false;
+            updateButtonStates();
+        }, AUTO_STEP_DELAY_MS * totalSteps);
+    }
+
+    // --- Push construction ---
+
+    private void sendPush(String event, int step) {
+        switch (getSelectedType()) {
+            case DELIVERY:
+                sendDeliveryPush(event, step);
+                break;
+            case TIMER:
+                sendTimerPush(event, step);
+                break;
+            case SPORTS:
+                sendSportsPush(event, step);
+                break;
+            case DELIVERY_ACTIONS:
+                sendDeliveryActionsPush(event, step);
+                break;
+        }
+    }
+
+    private boolean isFullPayload() {
+        return binding.fullPayloadCheckbox.isChecked();
+    }
+
+    private void sendDeliveryPush(String event, int step) {
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            attributes.put("progress_max", DELIVERY_TITLES.length);
+            contentState.put("title", DELIVERY_TITLES[step]);
+            contentState.put("body", DELIVERY_BODIES[step]);
+            contentState.put("progress", step + 1);
+            if (isFullPayload()) {
+                attributes.put("segments", DELIVERY_SEGMENTS);
+                attributes.put("start_icon", DEMO_ICON);
+                attributes.put("end_icon", DEMO_ICON);
+                attributes.put("tracker_icon", DEMO_ICON);
+                attributes.put("large_icon", DEMO_LARGE_ICON_URL);
+                attributes.put("colorized", true);
+                attributes.put("dismiss_delay", DEMO_DISMISS_DELAY_MS);
+                contentState.put("subtext", DELIVERY_SUBTEXTS[step]);
+                contentState.put("color", DELIVERY_COLOR);
+            }
+        } catch (JSONException ignored) { }
+        fire(baseBundle(DELIVERY_ID, event, TYPE_PROGRESS, attributes, contentState));
+    }
+
+    private void sendTimerPush(String event, int step) {
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            contentState.put("title", TIMER_TITLES[step]);
+            contentState.put("body", TIMER_BODIES[step]);
+            if (!event.equals(EVENT_END)) {
+                long countdownUntil = System.currentTimeMillis() + 5 * 1000;
+                contentState.put("countdown_until", countdownUntil);
+            }
+            if (isFullPayload()) {
+                attributes.put("large_icon", DEMO_LARGE_ICON_URL);
+                attributes.put("colorized", true);
+                attributes.put("dismiss_delay", DEMO_DISMISS_DELAY_MS);
+                contentState.put("subtext", TIMER_SUBTEXTS[step]);
+                contentState.put("color", TIMER_COLORS[step]);
+                contentState.put("actions", TIMER_ACTIONS);
+            }
+        } catch (JSONException ignored) { }
+        fire(baseBundle(TIMER_ID, event, TYPE_COUNTDOWN, attributes, contentState));
+    }
+
+    private void sendSportsPush(String event, int step) {
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            contentState.put("title", SPORTS_TITLES[step]);
+            contentState.put("body", SPORTS_BODIES[step]);
+            if (isFullPayload()) {
+                attributes.put("large_icon", DEMO_LARGE_ICON_URL);
+                attributes.put("colorized", true);
+                attributes.put("dismiss_delay", DEMO_DISMISS_DELAY_MS);
+                contentState.put("subtext", SPORTS_SUBTEXTS[step]);
+                contentState.put("color", SPORTS_COLOR);
+                contentState.put("actions", SPORTS_ACTIONS);
+            }
+        } catch (JSONException ignored) { }
+        fire(baseBundle(SPORTS_ID, event, TYPE_TEXT, attributes, contentState));
+    }
+
+    private void sendDeliveryActionsPush(String event, int step) {
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            attributes.put("progress_max", ACTIONS_TITLES.length);
+            contentState.put("title", ACTIONS_TITLES[step]);
+            contentState.put("body", ACTIONS_BODIES[step]);
+            contentState.put("progress", step + 1);
+            if (isFullPayload()) {
+                attributes.put("segments", ACTIONS_SEGMENTS);
+                attributes.put("start_icon", DEMO_ICON);
+                attributes.put("end_icon", DEMO_ICON);
+                attributes.put("large_icon", DEMO_LARGE_ICON_URL);
+                attributes.put("colorized", true);
+                attributes.put("dismiss_delay", DEMO_DISMISS_DELAY_MS);
+                int minutesRemaining = Math.max(1, (ACTIONS_TITLES.length - step) * 3);
+                contentState.put("subtext", "ETA: " + minutesRemaining + " min");
+                contentState.put("color", ACTIONS_COLOR);
+                contentState.put("actions", ACTIONS_BUTTONS);
+            }
+        } catch (JSONException ignored) { }
+        Bundle bundle = baseBundle(ACTIONS_ID, event, TYPE_PROGRESS, attributes, contentState);
+        if (isFullPayload()) {
+            bundle.putString("link", "sample://order/456/details");
+        }
+        fire(bundle);
+    }
+
+    private Bundle baseBundle(String activityId, String event, String activityType,
+                              JSONObject attributes, JSONObject contentState) {
+        Bundle bundle = new Bundle();
+        bundle.putString("CIO-Delivery-ID", UUID.randomUUID().toString());
+        bundle.putString("CIO-Delivery-Token", DEMO_DELIVERY_TOKEN);
+        bundle.putString("activity_id", activityId);
+        bundle.putString("event", event);
+        bundle.putString("activity_type", activityType);
+        bundle.putString("attributes", attributes.toString());
+        bundle.putString("content_state", contentState.toString());
+        return bundle;
+    }
+
+    private void fire(Bundle bundle) {
+        RemoteMessage remoteMessage = new RemoteMessage(bundle);
+        CustomerIOFirebaseMessagingService.onMessageReceived(this, remoteMessage);
+    }
+
+    // --- UI state ---
+
+    private void updateButtonStates() {
+        int maxStep = getStepCount() - 1;
+        binding.startButton.setEnabled(!isActive && !isAutoRunning);
+        binding.updateButton.setEnabled(isActive && currentStep < maxStep);
+        binding.endButton.setEnabled(isActive);
+        binding.autoButton.setEnabled(!isAutoRunning);
+    }
+
+    private void updateStatusText() {
+        NotificationType type = getSelectedType();
+        String label;
+        switch (type) {
+            case TIMER: label = TIMER_TITLES[currentStep]; break;
+            case SPORTS: label = SPORTS_TITLES[currentStep]; break;
+            case DELIVERY_ACTIONS: label = ACTIONS_TITLES[currentStep]; break;
+            default: label = DELIVERY_TITLES[currentStep]; break;
+        }
+        binding.statusTextView.setText(getString(R.string.live_notification_status_format, label, currentStep + 1));
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        autoHandler.removeCallbacksAndMessages(null);
+    }
+}

--- a/samples/java_layout/src/main/res/layout/activity_dashboard.xml
+++ b/samples/java_layout/src/main/res/layout/activity_dashboard.xml
@@ -233,10 +233,23 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_default"
                 android:text="@string/inbox_messages"
-                app:layout_constraintBottom_toTopOf="@id/logout_button"
+                app:layout_constraintBottom_toTopOf="@id/live_notification_demo_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/inline_examples_button"
+                app:layout_constraintWidth_max="@dimen/material_button_max_width" />
+
+            <Button
+                android:id="@+id/live_notification_demo_button"
+                style="?attr/materialButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_default"
+                android:text="@string/live_notification_demo"
+                app:layout_constraintBottom_toTopOf="@id/logout_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/inbox_messages_button"
                 app:layout_constraintWidth_max="@dimen/material_button_max_width" />
 
             <Button
@@ -249,7 +262,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/inbox_messages_button"
+                app:layout_constraintTop_toBottomOf="@id/live_notification_demo_button"
                 app:layout_constraintWidth_max="@dimen/material_button_max_width" />
 
             <TextView

--- a/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
+++ b/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/top_app_bar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurface"
+            app:navigationIcon="@drawable/ic_arrow_back_24"
+            app:title="@string/live_notification_demo" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="@dimen/margin_default"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <TextView
+            android:id="@+id/status_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/live_notification_status_idle"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+        <!-- Notification type selector -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/live_notification_section_type"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <RadioGroup
+            android:id="@+id/type_radio_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:id="@+id/radio_delivery"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/live_notification_type_delivery" />
+
+            <RadioButton
+                android:id="@+id/radio_timer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/live_notification_type_timer" />
+
+            <RadioButton
+                android:id="@+id/radio_sports"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/live_notification_type_sports" />
+
+            <RadioButton
+                android:id="@+id/radio_delivery_actions"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/live_notification_type_delivery_actions" />
+
+        </RadioGroup>
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/full_payload_checkbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:checked="true"
+            android:text="@string/live_notification_full_payload" />
+
+        <!-- Manual controls -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/live_notification_section_manual"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <Button
+            android:id="@+id/start_button"
+            style="?attr/materialButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:text="@string/live_notification_start" />
+
+        <Button
+            android:id="@+id/update_button"
+            style="?attr/materialButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:enabled="false"
+            android:text="@string/live_notification_update" />
+
+        <Button
+            android:id="@+id/end_button"
+            style="?attr/materialButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:enabled="false"
+            android:text="@string/live_notification_end" />
+
+        <!-- Auto controls -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/live_notification_section_auto"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <Button
+            android:id="@+id/auto_button"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:text="@string/live_notification_auto" />
+
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -157,4 +157,23 @@
     <string name="inbox_delete_cancel">Cancel</string>
     <string name="inbox_message_deleted">Message deleted</string>
 
+    <!-- Live Notification Demo -->
+    <string name="live_notification_demo">Live Notification Demo</string>
+    <string name="label_live_notification_demo_activity">LiveNotificationDemoActivity</string>
+    <string name="live_notification_start">Start</string>
+    <string name="live_notification_update">Update</string>
+    <string name="live_notification_end">End</string>
+    <string name="live_notification_status_idle">Status: Idle</string>
+    <string name="live_notification_status_format">Status: %1$s (Step %2$d)</string>
+    <string name="live_notification_status_ended">Status: Ended</string>
+    <string name="live_notification_auto">Run All Steps (2s each)</string>
+    <string name="live_notification_section_type">Notification Type</string>
+    <string name="live_notification_section_manual">Manual Control</string>
+    <string name="live_notification_section_auto">Auto Sequence</string>
+    <string name="live_notification_type_delivery">Delivery Tracking</string>
+    <string name="live_notification_type_timer">Parking Timer (countdown)</string>
+    <string name="live_notification_type_sports">Sports Score (no progress bar)</string>
+    <string name="live_notification_type_delivery_actions">Delivery with Actions</string>
+    <string name="live_notification_full_payload">Send full payload (include optional fields)</string>
+
 </resources>


### PR DESCRIPTION
Closes: [MBL-1645: Create test page on sample app](https://linear.app/customerio/issue/MBL-1645/create-test-page-on-sample-app)

## PR Series — Live Notifications (Android Live Activities)

| # | Branch | PR |
|---|--------|----|
| 1 | `live-notifications-1-prep` | https://github.com/customerio/customerio-android/pull/670 |
| 2 | `live-notifications-2-rendering` | https://github.com/customerio/customerio-android/pull/669 |
| **3** | `live-notifications-3-sample` | **← you are here** |

---

## Context

This series introduces live notifications to the Android SDK — the Android counterpart of iOS Live Activities. Live notifications are ongoing notifications that update in-place via a stable ID, allowing the server to push real-time state changes (delivery tracking, sports scores, countdown timers) without creating duplicate notification entries.

The payload schema mirrors the iOS Live Activity contract:
- `activity_id` — stable identifier used to update the same notification slot
- `event` — lifecycle: `start` / `update` / `end`
- `activity_type` — rendering mode: `progress` / `countdown` / `text`
- `attributes` — JSON string of structural/static data (set once, e.g. `progress_max`, icons)
- `content_state` — JSON string of dynamic data that changes on every update (e.g. `title`, `body`, `progress`)

On Android 16 (API 36+) live notifications request promoted ongoing status via `POST_PROMOTED_NOTIFICATIONS`, giving them elevated treatment in the notification shade. On earlier versions they render as standard ongoing notifications using `NotificationCompat`.

---

## This PR — Sample app demo

Adds `LiveNotificationDemoActivity` to the `java_layout` sample app. The activity exercises the full live notification SDK path by constructing synthetic FCM payloads and firing them through `CustomerIOFirebaseMessagingService.onMessageReceived()`, so every code path from push receipt to notification display is covered without needing a real FCM message.

### Notification types
Four types are available via radio buttons:

| Type | `activity_type` | Demonstrates |
|------|----------------|--------------|
| Delivery Tracking | `progress` | Segmented progress bar, step-by-step updates |
| Parking Timer | `countdown` | Countdown chronometer, color changes per step |
| Sports Score | `text` | Text-only live update, action button |
| Delivery with Actions | `progress` | Progress bar + 2 action buttons, deep link on tap |

### Controls
- **Manual**: Start → Update (repeatable) → End — useful for inspecting each step individually
- **Auto**: runs all steps automatically at 2-second intervals
- **Full payload** checkbox — when checked, includes optional `attributes` fields (icons, segments, large icon, colorized, dismiss_delay) and optional `content_state` fields (subtext, color, actions); when unchecked sends only the minimum required fields

### Payload structure
Payloads are assembled as `JSONObject`s for both `attributes` and `content_state`, matching the iOS-style split schema. Example for a delivery step:

```json
// attributes (structural — same for the life of the activity)
{
  "progress_max": 4,
  "segments": "[{\"length\":1},{\"length\":1},{\"length\":1},{\"length\":1}]",
  "start_icon": "ic_notification",
  "colorized": true,
  "dismiss_delay": 5000
}

// content_state (dynamic — changes on every event)
{
  "title": "On the way",
  "body": "Your order is on the way",
  "progress": 3,
  "subtext": "Estimated delivery: 10 min",
  "color": "#1B5E20"
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are isolated to the `java_layout` sample app, mainly wiring a new demo screen and strings; it exercises push-handling code via synthetic `RemoteMessage`s but does not change SDK/library behavior.
> 
> **Overview**
> Adds a new `LiveNotificationDemoActivity` to the `java_layout` sample app to simulate **live notification** start/update/end flows by constructing synthetic FCM payloads and routing them through `CustomerIOFirebaseMessagingService.onMessageReceived()`.
> 
> Wires the demo into the app via a new dashboard button, a new layout for the demo UI (type selector, full-payload toggle, manual and auto-run controls), a manifest activity registration, and supporting `strings.xml` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec0dc7cebf7ea06ac1e4ae1d332f0de4eb00678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->