### PR TITLE
chore: move HttpClient to core as CustomerIOHttpClient

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     api project(":base")
     api Dependencies.androidxCoreKtx
     implementation Dependencies.coroutinesAndroid
+    implementation Dependencies.workManager
     // Use this as API so customers can provide objects serializations without
     // needing to add it as a dependency to their app
     api(Dependencies.kotlinxSerializationJson)

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.CustomerIOHttpClientImpl
+import io.customer.sdk.core.util.WorkManagerProvider
 
 /**
  * The file contains extension functions for the SDKComponent object and its dependencies.
@@ -24,3 +25,7 @@ fun SDKComponent.setupAndroidComponent(
 @InternalCustomerIOApi
 val SDKComponent.httpClient: CustomerIOHttpClient
     get() = singleton<CustomerIOHttpClient> { CustomerIOHttpClientImpl() }
+
+@InternalCustomerIOApi
+val SDKComponent.workManagerProvider: WorkManagerProvider
+    get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, logger) }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.CustomerIOHttpClientImpl
-import io.customer.sdk.core.util.WorkManagerProvider
+import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 
 /**
  * The file contains extension functions for the SDKComponent object and its dependencies.
@@ -27,5 +27,5 @@ val SDKComponent.httpClient: CustomerIOHttpClient
     get() = singleton<CustomerIOHttpClient> { CustomerIOHttpClientImpl() }
 
 @InternalCustomerIOApi
-val SDKComponent.workManagerProvider: WorkManagerProvider
-    get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, logger) }
+val SDKComponent.workManagerProvider: CustomerIOWorkManagerProvider
+    get() = singleton<CustomerIOWorkManagerProvider> { CustomerIOWorkManagerProvider(android().applicationContext, logger) }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -1,6 +1,9 @@
 package io.customer.sdk.core.di
 
 import android.content.Context
+import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.CustomerIOHttpClientImpl
 
 /**
  * The file contains extension functions for the SDKComponent object and its dependencies.
@@ -17,3 +20,7 @@ fun SDKComponent.setupAndroidComponent(
 ) = registerDependency<AndroidSDKComponent> {
     AndroidSDKComponentImpl(context)
 }
+
+@InternalCustomerIOApi
+val SDKComponent.httpClient: CustomerIOHttpClient
+    get() = singleton<CustomerIOHttpClient> { CustomerIOHttpClientImpl() }

--- a/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
@@ -1,6 +1,7 @@
-package io.customer.messagingpush.network
+package io.customer.sdk.core.network
 
 import android.util.Base64
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.store.Client
 import io.customer.sdk.data.store.GlobalPreferenceStore
@@ -9,13 +10,16 @@ import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
 
-internal data class HttpRequestParams(
+@InternalCustomerIOApi
+data class HttpRequestParams(
     val path: String,
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null
 )
 
-internal interface HttpClient {
+/** HTTP client for Customer.io API calls with SDK authentication. */
+@InternalCustomerIOApi
+interface CustomerIOHttpClient {
     /**
      * Performs a POST request to [params.path] with [params.headers] and [params.body].
      *
@@ -27,7 +31,7 @@ internal interface HttpClient {
     suspend fun request(params: HttpRequestParams): Result<String>
 }
 
-internal class HttpClientImpl : HttpClient {
+internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
 
     private val connectTimeoutMs = 10_000
     private val readTimeoutMs = 10_000

--- a/core/src/main/kotlin/io/customer/sdk/core/util/CustomerIOWorkManagerProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/CustomerIOWorkManagerProvider.kt
@@ -26,7 +26,7 @@ import io.customer.base.internal.InternalCustomerIOApi
  * These scenarios are handled based on documented exceptions from WorkManager's getInstance() and initialize() methods.
  */
 @InternalCustomerIOApi
-class WorkManagerProvider(
+class CustomerIOWorkManagerProvider(
     private val context: Context,
     private val logger: Logger
 ) {

--- a/core/src/main/kotlin/io/customer/sdk/core/util/CustomerIOWorkManagerProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/CustomerIOWorkManagerProvider.kt
@@ -49,7 +49,7 @@ class CustomerIOWorkManagerProvider(
             // Try to get existing instance first
             WorkManager.getInstance(context)
         } catch (e: Exception) {
-            logger.error("WorkManager not initialized, attempting to initialize", throwable = e)
+            logger.error("WorkManager not initialized, attempting to initialize", tag = TAG, throwable = e)
             try {
                 // Check if host app implements Configuration.Provider, otherwise use default config
                 val config = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
@@ -57,9 +57,13 @@ class CustomerIOWorkManagerProvider(
                 // Now try to get the instance again
                 WorkManager.getInstance(context)
             } catch (initException: Exception) {
-                logger.error("Failed to initialize WorkManager", throwable = initException)
+                logger.error("Failed to initialize WorkManager", tag = TAG, throwable = initException)
                 null
             }
         }
+    }
+
+    internal companion object {
+        private const val TAG = "WorkManager"
     }
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/util/WorkManagerProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/WorkManagerProvider.kt
@@ -1,9 +1,9 @@
-package io.customer.messagingpush.util
+package io.customer.sdk.core.util
 
 import android.content.Context
 import androidx.work.Configuration
 import androidx.work.WorkManager
-import io.customer.messagingpush.logger.PushNotificationLogger
+import io.customer.base.internal.InternalCustomerIOApi
 
 /**
  * Provider for WorkManager instances with safe initialization.
@@ -25,9 +25,10 @@ import io.customer.messagingpush.logger.PushNotificationLogger
  *
  * These scenarios are handled based on documented exceptions from WorkManager's getInstance() and initialize() methods.
  */
-internal class WorkManagerProvider(
+@InternalCustomerIOApi
+class WorkManagerProvider(
     private val context: Context,
-    private val pushLogger: PushNotificationLogger
+    private val logger: Logger
 ) {
 
     /**
@@ -48,7 +49,7 @@ internal class WorkManagerProvider(
             // Try to get existing instance first
             WorkManager.getInstance(context)
         } catch (e: Exception) {
-            pushLogger.logWorkManagerInitializationAttempt(e)
+            logger.error("WorkManager not initialized, attempting to initialize", throwable = e)
             try {
                 // Check if host app implements Configuration.Provider, otherwise use default config
                 val config = (context.applicationContext as? Configuration.Provider)?.workManagerConfiguration ?: Configuration.Builder().build()
@@ -56,7 +57,7 @@ internal class WorkManagerProvider(
                 // Now try to get the instance again
                 WorkManager.getInstance(context)
             } catch (initException: Exception) {
-                pushLogger.logWorkManagerInitializationFailed(initException)
+                logger.error("Failed to initialize WorkManager", throwable = initException)
                 null
             }
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -1,9 +1,9 @@
 package io.customer.messagingpush
 
-import io.customer.messagingpush.di.httpClient
-import io.customer.messagingpush.network.HttpClient
-import io.customer.messagingpush.network.HttpRequestParams
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.httpClient
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.util.EventNames
 import kotlinx.coroutines.CoroutineScope
@@ -16,7 +16,7 @@ internal interface PushDeliveryTracker {
 
 internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 
-    private val httpClient: HttpClient
+    private val httpClient: CustomerIOHttpClient
         get() = SDKComponent.httpClient
 
     /**

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -20,9 +20,9 @@ import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.messagingpush.util.PushTrackingUtilImpl
-import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.workManagerProvider
 
 /*
 This file contains a series of extensions to the common module's Dependency injection (DI) graph. All extensions in this file simply add internal classes for this module into the DI graph.
@@ -51,9 +51,6 @@ internal val SDKComponent.deepLinkUtil: DeepLinkUtil
 @InternalCustomerIOApi
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
     get() = newInstance<PushTrackingUtil> { PushTrackingUtilImpl() }
-
-internal val SDKComponent.workManagerProvider: WorkManagerProvider
-    get() = singleton<WorkManagerProvider> { WorkManagerProvider(android().applicationContext, pushLogger) }
 
 internal val SDKComponent.asyncPushDeliveryTracker: AsyncPushDeliveryTracker
     get() = singleton<AsyncPushDeliveryTracker> { AsyncPushDeliveryTracker(pushDeliveryTracker) }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -11,8 +11,6 @@ import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.PushDeliveryTrackerImpl
 import io.customer.messagingpush.logger.PushNotificationLogger
-import io.customer.messagingpush.network.HttpClient
-import io.customer.messagingpush.network.HttpClientImpl
 import io.customer.messagingpush.processor.PushDeliveryMetricsBackgroundScheduler
 import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
@@ -72,9 +70,6 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
             deliveryMetricsScheduler = deliveryMetricsScheduler
         )
     }
-
-internal val SDKComponent.httpClient: HttpClient
-    get() = singleton<HttpClient> { HttpClientImpl() }
 
 internal val SDKComponent.pushDeliveryTracker: PushDeliveryTracker
     get() = singleton<PushDeliveryTracker> { PushDeliveryTrackerImpl() }

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -222,20 +222,4 @@ internal class PushNotificationLogger(private val logger: Logger) {
             appendLine("Data: ${message.data}")
         }
     }
-
-    fun logWorkManagerInitializationAttempt(exception: Exception) {
-        logger.error(
-            tag = TAG,
-            message = "WorkManager not initialized, attempting to initialize",
-            throwable = exception
-        )
-    }
-
-    fun logWorkManagerInitializationFailed(exception: Exception) {
-        logger.error(
-            tag = TAG,
-            message = "Failed to initialize WorkManager",
-            throwable = exception
-        )
-    }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -9,8 +9,8 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.di.pushDeliveryTracker
-import io.customer.messagingpush.util.WorkManagerProvider
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.WorkManagerProvider
 import io.customer.sdk.events.Metric
 import java.io.IOException
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -10,7 +10,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.util.WorkManagerProvider
+import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.events.Metric
 import java.io.IOException
 
@@ -18,7 +18,7 @@ private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
 
 internal class PushDeliveryMetricsBackgroundScheduler(
-    private val workManagerProvider: WorkManagerProvider,
+    private val workManagerProvider: CustomerIOWorkManagerProvider,
     private val asyncPushDeliveryTracker: AsyncPushDeliveryTracker
 ) {
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
@@ -2,9 +2,9 @@ package io.customer.messagingpush
 
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
-import io.customer.messagingpush.network.HttpClient
-import io.customer.messagingpush.network.HttpRequestParams
 import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpRequestParams
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -20,7 +20,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class PushDeliveryTrackingTest : IntegrationTest() {
 
-    private val httpClient: HttpClient = mockk(relaxed = true)
+    private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
     private val pushDeliveryTracker = PushDeliveryTrackerImpl()
 
     override fun setup(testConfig: TestConfig) {
@@ -29,7 +29,7 @@ class PushDeliveryTrackingTest : IntegrationTest() {
                 diGraph {
                     sdk {
                         // Override the httpClient in your DI so the SUT uses this mock.
-                        overrideDependency<HttpClient>(httpClient)
+                        overrideDependency<CustomerIOHttpClient>(httpClient)
                     }
                 }
             }

--- a/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/logger/PushNotificationLoggerTest.kt
@@ -426,34 +426,4 @@ class PushNotificationLoggerTest : JUnitTest() {
             )
         }
     }
-
-    @Test
-    fun test_logWorkManagerInitializationAttempt_forwardsCorrectCallToLogger() {
-        val exception = RuntimeException("WorkManager not available")
-
-        pushLogger.logWorkManagerInitializationAttempt(exception)
-
-        assertCalledOnce {
-            mockLogger.error(
-                tag = "Push",
-                message = "WorkManager not initialized, attempting to initialize",
-                throwable = exception
-            )
-        }
-    }
-
-    @Test
-    fun test_logWorkManagerInitializationFailed_forwardsCorrectCallToLogger() {
-        val exception = RuntimeException("Initialization failed")
-
-        pushLogger.logWorkManagerInitializationFailed(exception)
-
-        assertCalledOnce {
-            mockLogger.error(
-                tag = "Push",
-                message = "Failed to initialize WorkManager",
-                throwable = exception
-            )
-        }
-    }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -7,7 +7,7 @@ import androidx.work.WorkManager
 import io.customer.commontest.extensions.random
 import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.testutils.core.JUnitTest
-import io.customer.sdk.core.util.WorkManagerProvider
+import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.events.Metric
 import io.mockk.every
 import io.mockk.mockk
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 
 class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
 
-    private val mockWorkManagerProvider = mockk<WorkManagerProvider>(relaxed = true)
+    private val mockWorkManagerProvider = mockk<CustomerIOWorkManagerProvider>(relaxed = true)
     private val mockWorkManager = mockk<WorkManager>(relaxed = true)
     private val mockAsyncPushDeliveryTracker = mockk<AsyncPushDeliveryTracker>(relaxed = true)
     private val scheduler = PushDeliveryMetricsBackgroundScheduler(mockWorkManagerProvider, mockAsyncPushDeliveryTracker)

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -7,7 +7,7 @@ import androidx.work.WorkManager
 import io.customer.commontest.extensions.random
 import io.customer.messagingpush.AsyncPushDeliveryTracker
 import io.customer.messagingpush.testutils.core.JUnitTest
-import io.customer.messagingpush.util.WorkManagerProvider
+import io.customer.sdk.core.util.WorkManagerProvider
 import io.customer.sdk.events.Metric
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
part of: [MBL-1627](https://linear.app/customerio/issue/MBL-1627/android-send-geofence-transition-events)

> **Note:** This PR targets `main` directly since it moves shared files from `:messagingpush` to `:core`. Merging to `main` first ensures other feature branches working in parallel don't run into conflicts with the relocated files.

## Summary

Move shared infrastructure from `:messagingpush` to `:core` so all SDK modules can use them without depending on the push module.

### chore: move `HttpClient` to core as `CustomerIOHttpClient`

- Rename `HttpClient` → `CustomerIOHttpClient`, `HttpClientImpl` → `CustomerIOHttpClientImpl`
- Move from `messagingpush/network/` to `core/network/`
- Change visibility from `internal` to `public` with `@InternalCustomerIOApi`
- Move DI extension `SDKComponent.httpClient` to `SDKComponentExt.kt` in core
- Update push module imports

### chore: move `WorkManagerProvider` to core

- Move from `messagingpush/util/` to `core/util/`
- Move DI extension `SDKComponent.workManagerProvider` to `SDKComponentExt.kt` in core
- Change visibility from `internal` to `public` with `@InternalCustomerIOApi`
- Replace `PushNotificationLogger` dependency with generic `Logger`
- Remove unused `logWorkManagerInitializationAttempt` and `logWorkManagerInitializationFailed` from `PushNotificationLogger` and their tests
- Add WorkManager dependency to core
- Update push module imports

### chore: rename `WorkManagerProvider` to `CustomerIOWorkManagerProvider`

- Rename for consistency with `CustomerIOHttpClient` since it is now a public class in core
- Only import and type parameter changes in tests, no variable/function renames

### Why

The geofence module needs both direct HTTP and WorkManager for event delivery (same patterns as push delivery metrics). Without these moves, location module would need to depend on the push module or duplicate the implementations.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared networking/authenticated request plumbing and WorkManager initialization used by background delivery, so miswiring DI or package/visibility changes could break runtime behavior across modules.
> 
> **Overview**
> Moves shared infrastructure out of `:messagingpush` into `:core` by introducing `CustomerIOHttpClient` (renamed from `HttpClient`) and `CustomerIOWorkManagerProvider` (renamed from `WorkManagerProvider`) as `@InternalCustomerIOApi` types.
> 
> Updates DI so `SDKComponent.httpClient` and `SDKComponent.workManagerProvider` are provided from `core` (`SDKComponentExt.kt`), adds the WorkManager dependency to `core`, and switches push code/tests to the new packages/types. Also removes push-specific WorkManager init logging helpers/tests, with `CustomerIOWorkManagerProvider` now logging directly via the generic `Logger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5773e0c85ed6fdc6be99d2ebd4616043af62b725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->