### PR TITLE
chore: add geofence OS listen layer

### DIFF
--- a/location/api/location.api
+++ b/location/api/location.api
@@ -43,3 +43,13 @@ public final class io/customer/location/ModuleLocation$Companion {
 	public final fun instance ()Lio/customer/location/ModuleLocation;
 }
 
+public final class io/customer/location/geofence/GeofenceBootReceiver : android/content/BroadcastReceiver {
+	public fun <init> ()V
+	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
+}
+
+public final class io/customer/location/geofence/GeofenceBroadcastReceiver : android/content/BroadcastReceiver {
+	public fun <init> ()V
+	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
+}
+

--- a/location/src/main/AndroidManifest.xml
+++ b/location/src/main/AndroidManifest.xml
@@ -4,4 +4,31 @@
     <!-- Coarse location is sufficient for city/timezone level tracking -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <!--
+        Geofence monitoring requires these permissions declared in the host app:
+        - android.permission.ACCESS_FINE_LOCATION
+        - android.permission.ACCESS_BACKGROUND_LOCATION
+        - android.permission.RECEIVE_BOOT_COMPLETED
+        The SDK does not declare them to avoid adding permissions for customers
+        not using geofencing.
+    -->
+
+    <application>
+        <!-- Disabled by default; dynamically enabled by GeofenceManager when geofences are registered -->
+        <receiver
+            android:name="io.customer.location.geofence.GeofenceBroadcastReceiver"
+            android:enabled="false"
+            android:exported="false" />
+
+        <!-- Disabled by default; enabled alongside GeofenceBroadcastReceiver -->
+        <receiver
+            android:name="io.customer.location.geofence.GeofenceBootReceiver"
+            android:enabled="false"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+    </application>
+
 </manifest>

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBootReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBootReceiver.kt
@@ -1,0 +1,21 @@
+package io.customer.location.geofence
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.customer.location.geofence.di.geofenceLogger
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.setupAndroidComponent
+
+/** Re-registers persisted geofences after device reboot. */
+class GeofenceBootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        SDKComponent.setupAndroidComponent(context = context)
+        val logger = SDKComponent.geofenceLogger
+
+        logger.logReceiverSkipped("restore not yet wired")
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -1,0 +1,44 @@
+package io.customer.location.geofence
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.google.android.gms.location.GeofencingEvent
+import io.customer.location.geofence.di.geofenceLogger
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.setupAndroidComponent
+
+/** Receives OS geofence transition callbacks and dispatches them to the SDK. */
+class GeofenceBroadcastReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        SDKComponent.setupAndroidComponent(context = context)
+
+        try {
+            handleGeofenceEvent(intent)
+        } catch (e: Exception) {
+            SDKComponent.geofenceLogger.logSyncFailed("BroadcastReceiver error: ${e.message}")
+        }
+    }
+
+    private fun handleGeofenceEvent(intent: Intent) {
+        val geofencingEvent = GeofencingEvent.fromIntent(intent) ?: return
+        val logger = SDKComponent.geofenceLogger
+
+        if (geofencingEvent.hasError()) {
+            logger.logGeofencingError(geofencingEvent.errorCode)
+            return
+        }
+
+        val transitionType = geofencingEvent.geofenceTransition
+        val triggeringGeofences = geofencingEvent.triggeringGeofences ?: return
+        val location = geofencingEvent.triggeringLocation
+
+        triggeringGeofences.forEach { geofence ->
+            logger.logTransitionReceived(
+                geofence.requestId,
+                "type=$transitionType at (${location?.latitude}, ${location?.longitude})"
+            )
+        }
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
@@ -8,6 +8,7 @@ internal object GeofenceConstants {
     const val MAX_BUSINESS_GEOFENCES = 19
     const val STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000L
     const val DEDUPE_COOLDOWN_MS = 60 * 60 * 1000L
+    const val NO_INITIAL_TRIGGER = 0
     const val GEOFENCE_EXPIRATION_NEVER = -1L
     const val PENDING_INTENT_REQUEST_CODE = 0x4765_6F10
 }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
@@ -1,0 +1,13 @@
+package io.customer.location.geofence
+
+/** Configurable thresholds and identifiers for geofence monitoring. */
+internal object GeofenceConstants {
+    const val MOVEMENT_TRIGGER_ID = "cio_movement_trigger"
+    const val MOVEMENT_TRIGGER_RADIUS_METERS = 1000f
+    const val SERVER_FETCH_DISTANCE_METERS = 5000f
+    const val MAX_BUSINESS_GEOFENCES = 19
+    const val STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000L
+    const val DEDUPE_COOLDOWN_MS = 60 * 60 * 1000L
+    const val GEOFENCE_EXPIRATION_NEVER = -1L
+    const val PENDING_INTENT_REQUEST_CODE = 0x4765_6F10
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -1,0 +1,51 @@
+package io.customer.location.geofence
+
+import io.customer.sdk.core.util.Logger
+
+/** Structured logger for geofence operations, tagged for logcat filtering. */
+internal class GeofenceLogger(private val logger: Logger) {
+
+    fun logGeofencesRegistered(count: Int) {
+        logger.debug("Registered $count geofences with OS", tag = TAG)
+    }
+
+    fun logGeofencesRemoved(count: Int) {
+        logger.debug("Removed $count geofences from OS", tag = TAG)
+    }
+
+    fun logGeofencesCleared() {
+        logger.debug("Cleared all geofences from OS", tag = TAG)
+    }
+
+    fun logRegistrationFailed(message: String?) {
+        logger.error("Failed to register geofences: $message", tag = TAG)
+    }
+
+    fun logRemovalFailed(message: String?) {
+        logger.error("Failed to remove geofences: $message", tag = TAG)
+    }
+
+    fun logMissingPermission(permission: String) {
+        logger.error("Cannot register geofences: $permission not granted. Host app must request this permission.", tag = TAG)
+    }
+
+    fun logTransitionReceived(geofenceId: String, transitionName: String) {
+        logger.debug("Transition $transitionName for geofence $geofenceId", tag = TAG)
+    }
+
+    fun logGeofencingError(errorCode: Int) {
+        logger.error("Geofencing error code: $errorCode", tag = TAG)
+    }
+
+    fun logSyncFailed(message: String?) {
+        logger.error("Geofence sync failed: $message", tag = TAG)
+    }
+
+    fun logReceiverSkipped(reason: String) {
+        logger.debug("Geofence receiver skipped: $reason", tag = TAG)
+    }
+
+    companion object {
+        private const val TAG = "Geofence"
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -1,0 +1,171 @@
+package io.customer.location.geofence
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingClient
+import com.google.android.gms.location.GeofencingRequest
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/** Wraps GeofencingClient to register/remove geofences with the OS. */
+internal class GeofenceManager(
+    private val context: Context,
+    private val client: GeofencingClient,
+    private val receiverToggle: GeofenceReceiverToggle,
+    private val logger: GeofenceLogger
+) {
+
+    private val pendingIntent: PendingIntent by lazy {
+        val intent = Intent(context, GeofenceBroadcastReceiver::class.java)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        PendingIntent.getBroadcast(
+            context,
+            GeofenceConstants.PENDING_INTENT_REQUEST_CODE,
+            intent,
+            flags
+        )
+    }
+
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    suspend fun addGeofences(regions: List<GeofenceRegion>): Result<Unit> {
+        if (regions.isEmpty()) return Result.success(Unit)
+        if (!hasRequiredPermissions()) {
+            return Result.failure(SecurityException("Required location permissions not granted"))
+        }
+
+        // Split into separate requests: GMS only supports one initial-trigger per request.
+        // Movement trigger uses no initial trigger to avoid spurious EXIT on re-registration.
+        // Business geofences use INITIAL_TRIGGER_ENTER for immediate detection if already inside.
+        val movementTrigger = regions.filter { it.id == GeofenceConstants.MOVEMENT_TRIGGER_ID }
+        val businessGeofences = regions.filter { it.id != GeofenceConstants.MOVEMENT_TRIGGER_ID }
+
+        if (movementTrigger.isNotEmpty()) {
+            val result = registerBatch(movementTrigger, initialTrigger = 0)
+            if (result.isFailure) return result
+        }
+
+        if (businessGeofences.isNotEmpty()) {
+            val result = registerBatch(businessGeofences, initialTrigger = GeofencingRequest.INITIAL_TRIGGER_ENTER)
+            if (result.isFailure) {
+                // Clean up movement trigger if business batch fails to avoid orphaned geofences
+                if (movementTrigger.isNotEmpty()) {
+                    removeGeofencesByIds(movementTrigger.map { it.id })
+                }
+                return result
+            }
+        }
+
+        receiverToggle.setEnabled(true)
+        logger.logGeofencesRegistered(regions.size)
+        return Result.success(Unit)
+    }
+
+    private suspend fun registerBatch(
+        regions: List<GeofenceRegion>,
+        initialTrigger: Int
+    ): Result<Unit> {
+        val request = GeofencingRequest.Builder()
+            .setInitialTrigger(initialTrigger)
+            .addGeofences(regions.map { it.toGmsGeofence() })
+            .build()
+
+        return suspendCancellableCoroutine { cont ->
+            try {
+                client.addGeofences(request, pendingIntent)
+                    .addOnSuccessListener {
+                        if (!cont.isActive) return@addOnSuccessListener
+                        cont.resume(Result.success(Unit))
+                    }
+                    .addOnFailureListener { e ->
+                        if (!cont.isActive) return@addOnFailureListener
+                        logger.logRegistrationFailed(e.message)
+                        cont.resume(Result.failure(e))
+                    }
+            } catch (e: SecurityException) {
+                logger.logRegistrationFailed(e.message)
+                cont.resume(Result.failure(e))
+            }
+        }
+    }
+
+    suspend fun removeGeofencesByIds(ids: List<String>): Result<Unit> {
+        if (ids.isEmpty()) return Result.success(Unit)
+
+        return suspendCancellableCoroutine { cont ->
+            client.removeGeofences(ids)
+                .addOnSuccessListener {
+                    if (!cont.isActive) return@addOnSuccessListener
+                    logger.logGeofencesRemoved(ids.size)
+                    cont.resume(Result.success(Unit))
+                }
+                .addOnFailureListener { e ->
+                    if (!cont.isActive) return@addOnFailureListener
+                    logger.logRemovalFailed(e.message)
+                    cont.resume(Result.failure(e))
+                }
+        }
+    }
+
+    suspend fun clearAll(): Result<Unit> {
+        return suspendCancellableCoroutine { cont ->
+            client.removeGeofences(pendingIntent)
+                .addOnSuccessListener {
+                    if (!cont.isActive) return@addOnSuccessListener
+                    receiverToggle.setEnabled(false)
+                    logger.logGeofencesCleared()
+                    cont.resume(Result.success(Unit))
+                }
+                .addOnFailureListener { e ->
+                    if (!cont.isActive) return@addOnFailureListener
+                    logger.logRemovalFailed(e.message)
+                    cont.resume(Result.failure(e))
+                }
+        }
+    }
+
+    private fun hasRequiredPermissions(): Boolean {
+        val hasFineLocation = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (!hasFineLocation) {
+            logger.logMissingPermission("ACCESS_FINE_LOCATION")
+            return false
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val hasBackgroundLocation = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if (!hasBackgroundLocation) {
+                logger.logMissingPermission("ACCESS_BACKGROUND_LOCATION (required on Android 10+)")
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private fun GeofenceRegion.toGmsGeofence(): Geofence {
+        return Geofence.Builder()
+            .setRequestId(id)
+            .setCircularRegion(latitude, longitude, radiusMeters)
+            .setTransitionTypes(toGmsTransitionTypes())
+            .setExpirationDuration(GeofenceConstants.GEOFENCE_EXPIRATION_NEVER)
+            .build()
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -39,7 +39,10 @@ internal class GeofenceManager(
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     suspend fun addGeofences(regions: List<GeofenceRegion>): Result<Unit> {
-        if (regions.isEmpty()) return Result.success(Unit)
+        if (regions.isEmpty()) {
+            logger.logGeofencesRegistered(0)
+            return Result.success(Unit)
+        }
         if (!hasRequiredPermissions()) {
             return Result.failure(SecurityException("Required location permissions not granted"))
         }
@@ -51,7 +54,7 @@ internal class GeofenceManager(
         val businessGeofences = regions.filter { it.id != GeofenceConstants.MOVEMENT_TRIGGER_ID }
 
         if (movementTrigger.isNotEmpty()) {
-            val result = registerBatch(movementTrigger, initialTrigger = 0)
+            val result = registerBatch(movementTrigger, initialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER)
             if (result.isFailure) return result
         }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceReceiverToggle.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceReceiverToggle.kt
@@ -5,15 +5,10 @@ import android.content.Context
 import android.content.pm.PackageManager
 
 /** Enables/disables geofence broadcast receivers via PackageManager. */
-internal interface GeofenceReceiverToggle {
-    fun setEnabled(enabled: Boolean)
-}
-
-internal class GeofenceReceiverToggleImpl(
+internal class GeofenceReceiverToggle(
     private val context: Context
-) : GeofenceReceiverToggle {
-
-    override fun setEnabled(enabled: Boolean) {
+) {
+    fun setEnabled(enabled: Boolean) {
         val state = if (enabled) {
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED
         } else {

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceReceiverToggle.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceReceiverToggle.kt
@@ -1,0 +1,31 @@
+package io.customer.location.geofence
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+/** Enables/disables geofence broadcast receivers via PackageManager. */
+internal interface GeofenceReceiverToggle {
+    fun setEnabled(enabled: Boolean)
+}
+
+internal class GeofenceReceiverToggleImpl(
+    private val context: Context
+) : GeofenceReceiverToggle {
+
+    override fun setEnabled(enabled: Boolean) {
+        val state = if (enabled) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        } else {
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        }
+        val pm = context.packageManager
+        listOf(GeofenceBroadcastReceiver::class.java, GeofenceBootReceiver::class.java).forEach {
+            pm.setComponentEnabledSetting(
+                ComponentName(context, it),
+                state,
+                PackageManager.DONT_KILL_APP
+            )
+        }
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
@@ -25,6 +25,10 @@ internal enum class GeofenceTransitionType(val gmsValue: Int) {
 
 /**
  * Straight-line distance in meters from this region's center to the given coordinates.
+ *
+ * @throws IllegalArgumentException if coordinates are out of range
+ * (latitude must be -90..90, longitude must be -180..180).
+ * Callers should validate coordinates at the API boundary.
  */
 internal fun GeofenceRegion.distanceTo(lat: Double, lng: Double): Float {
     val result = FloatArray(1)

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
@@ -1,0 +1,43 @@
+package io.customer.location.geofence
+
+import android.location.Location
+import com.google.android.gms.location.Geofence
+
+/** A geographic region to monitor for enter/exit transitions. */
+internal data class GeofenceRegion(
+    val id: String,
+    val latitude: Double,
+    val longitude: Double,
+    val radiusMeters: Float,
+    val name: String = "",
+    val transitionTypes: List<GeofenceTransitionType> = listOf(
+        GeofenceTransitionType.ENTER,
+        GeofenceTransitionType.EXIT
+    ),
+    val lastUpdated: Long = 0L
+)
+
+/** Transition types a geofence can monitor, mapped to GMS constants. */
+internal enum class GeofenceTransitionType(val gmsValue: Int) {
+    ENTER(Geofence.GEOFENCE_TRANSITION_ENTER),
+    EXIT(Geofence.GEOFENCE_TRANSITION_EXIT)
+}
+
+/**
+ * Straight-line distance in meters from this region's center to the given coordinates.
+ */
+internal fun GeofenceRegion.distanceTo(lat: Double, lng: Double): Float {
+    val result = FloatArray(1)
+    Location.distanceBetween(latitude, longitude, lat, lng, result)
+    return result[0]
+}
+
+/**
+ * Converts the SDK transition types to a GMS bitmask for [Geofence.Builder.setTransitionTypes].
+ * E.g., [ENTER, EXIT] → GEOFENCE_TRANSITION_ENTER | GEOFENCE_TRANSITION_EXIT.
+ */
+internal fun GeofenceRegion.toGmsTransitionTypes(): Int {
+    var mask = 0
+    transitionTypes.forEach { mask = mask or it.gmsValue }
+    return mask
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -5,7 +5,6 @@ import com.google.android.gms.location.LocationServices
 import io.customer.location.geofence.GeofenceLogger
 import io.customer.location.geofence.GeofenceManager
 import io.customer.location.geofence.GeofenceReceiverToggle
-import io.customer.location.geofence.GeofenceReceiverToggleImpl
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 
@@ -16,7 +15,7 @@ internal val AndroidSDKComponent.geofencingClient: GeofencingClient
     get() = newInstance { LocationServices.getGeofencingClient(applicationContext) }
 
 internal val AndroidSDKComponent.geofenceReceiverToggle: GeofenceReceiverToggle
-    get() = newInstance<GeofenceReceiverToggle> { GeofenceReceiverToggleImpl(applicationContext) }
+    get() = newInstance { GeofenceReceiverToggle(applicationContext) }
 
 internal val AndroidSDKComponent.geofenceManager: GeofenceManager
     get() = singleton {

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -1,0 +1,24 @@
+package io.customer.location.geofence.di
+
+import com.google.android.gms.location.GeofencingClient
+import com.google.android.gms.location.LocationServices
+import io.customer.location.geofence.GeofenceLogger
+import io.customer.location.geofence.GeofenceManager
+import io.customer.location.geofence.GeofenceReceiverToggle
+import io.customer.location.geofence.GeofenceReceiverToggleImpl
+import io.customer.sdk.core.di.AndroidSDKComponent
+import io.customer.sdk.core.di.SDKComponent
+
+internal val SDKComponent.geofenceLogger: GeofenceLogger
+    get() = singleton { GeofenceLogger(logger) }
+
+internal val AndroidSDKComponent.geofencingClient: GeofencingClient
+    get() = newInstance { LocationServices.getGeofencingClient(applicationContext) }
+
+internal val AndroidSDKComponent.geofenceReceiverToggle: GeofenceReceiverToggle
+    get() = newInstance<GeofenceReceiverToggle> { GeofenceReceiverToggleImpl(applicationContext) }
+
+internal val AndroidSDKComponent.geofenceManager: GeofenceManager
+    get() = singleton {
+        GeofenceManager(applicationContext, geofencingClient, geofenceReceiverToggle, SDKComponent.geofenceLogger)
+    }

--- a/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
@@ -1,0 +1,354 @@
+package io.customer.location.geofence
+
+import android.Manifest
+import android.app.PendingIntent
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingClient
+import com.google.android.gms.location.GeofencingRequest
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.di.geofenceLogger
+import io.customer.sdk.core.di.SDKComponent
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceManagerTest : RobolectricTest() {
+
+    private val client: GeofencingClient = mockk(relaxed = true)
+    private val receiverToggle: GeofenceReceiverToggle = mockk(relaxUnitFun = true)
+
+    private lateinit var manager: GeofenceManager
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        manager = GeofenceManager(applicationMock, client, receiverToggle, SDKComponent.geofenceLogger)
+    }
+
+    @Test
+    fun addGeofences_givenEmptyList_expectSuccessWithoutCallingClient() = runTest {
+        val result = manager.addGeofences(emptyList())
+
+        result.isSuccess.shouldBeTrue()
+        verify(exactly = 0) { client.addGeofences(any<GeofencingRequest>(), any()) }
+    }
+
+    @Test
+    fun addGeofences_givenNoFineLocationPermission_expectFailure() = runTest {
+        denyPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+
+        val result = manager.addGeofences(listOf(buildRegion()))
+
+        result.isFailure.shouldBeTrue()
+        verify(exactly = 0) { client.addGeofences(any<GeofencingRequest>(), any()) }
+    }
+
+    @Test
+    fun addGeofences_givenFineLocationGrantedNoBackgroundOnQ_expectFailure() = runTest {
+        grantPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+        denyPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        val result = manager.addGeofences(listOf(buildRegion()))
+
+        result.isFailure.shouldBeTrue()
+    }
+
+    @Test
+    fun addGeofences_givenAllPermissionsGranted_expectClientCalled() = runTest {
+        grantAllPermissions()
+        stubClientAddSuccess()
+
+        val result = manager.addGeofences(listOf(buildRegion()))
+
+        result.isSuccess.shouldBeTrue()
+        verify { client.addGeofences(any<GeofencingRequest>(), any()) }
+    }
+
+    @Test
+    fun addGeofences_givenBusinessGeofences_expectInitialTriggerEnter() = runTest {
+        grantAllPermissions()
+
+        val requestSlot = slot<GeofencingRequest>()
+        stubClientAddSuccess(requestSlot)
+
+        manager.addGeofences(listOf(buildRegion(id = "business-1")))
+
+        requestSlot.captured.initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+    }
+
+    @Test
+    fun addGeofences_givenMovementTrigger_expectNoInitialTrigger() = runTest {
+        grantAllPermissions()
+
+        val requestSlot = slot<GeofencingRequest>()
+        stubClientAddSuccess(requestSlot)
+
+        manager.addGeofences(
+            listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
+        )
+
+        requestSlot.captured.initialTrigger shouldNotContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+    }
+
+    @Test
+    fun addGeofences_givenMixedBatch_expectSeparateRequestsWithCorrectTriggers() = runTest {
+        grantAllPermissions()
+
+        val requests = mutableListOf<GeofencingRequest>()
+        val task = immediateSuccessTask<Void>()
+        every { client.addGeofences(capture(requests), any()) } returns task
+
+        manager.addGeofences(
+            listOf(
+                buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID),
+                buildRegion(id = "business-1")
+            )
+        )
+
+        requests.size shouldBeEqualTo 2
+        // First request: movement trigger with no initial trigger
+        requests[0].initialTrigger shouldNotContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requests[0].geofences.first().requestId shouldBeEqualTo GeofenceConstants.MOVEMENT_TRIGGER_ID
+        // Second request: business geofence with INITIAL_TRIGGER_ENTER
+        requests[1].initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requests[1].geofences.first().requestId shouldBeEqualTo "business-1"
+    }
+
+    @Test
+    fun addGeofences_givenMixedBatchWithBusinessFailure_expectMovementTriggerCleanedUp() = runTest {
+        grantAllPermissions()
+
+        var callCount = 0
+        val successTask = immediateSuccessTask<Void>()
+        val failureTask = immediateFailureTask<Void>(RuntimeException("GMS error"))
+
+        // First call (movement trigger) succeeds, second call (business) fails
+        every { client.addGeofences(any<GeofencingRequest>(), any()) } answers {
+            callCount++
+            if (callCount == 1) successTask else failureTask
+        }
+        val removeTask = immediateSuccessTask<Void>()
+        every { client.removeGeofences(any<List<String>>()) } returns removeTask
+
+        val result = manager.addGeofences(
+            listOf(
+                buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID),
+                buildRegion(id = "business-1")
+            )
+        )
+
+        result.isFailure.shouldBeTrue()
+        // Movement trigger should be cleaned up after business batch failure
+        verify { client.removeGeofences(listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)) }
+        verify(exactly = 0) { receiverToggle.setEnabled(any()) }
+    }
+
+    @Test
+    fun addGeofences_givenRegion_expectGmsGeofenceBuiltCorrectly() = runTest {
+        grantAllPermissions()
+
+        val requestSlot = slot<GeofencingRequest>()
+        stubClientAddSuccess(requestSlot)
+
+        val region = buildRegion(
+            id = "geo-123",
+            latitude = 40.7128,
+            longitude = -74.0060,
+            radiusMeters = 250f,
+            transitionTypes = listOf(GeofenceTransitionType.ENTER)
+        )
+        manager.addGeofences(listOf(region))
+
+        val gmsGeofence = requestSlot.captured.geofences.first()
+        gmsGeofence.requestId shouldBeEqualTo "geo-123"
+        gmsGeofence.transitionTypes shouldBeEqualTo Geofence.GEOFENCE_TRANSITION_ENTER
+        gmsGeofence.expirationTime shouldBeEqualTo GeofenceConstants.GEOFENCE_EXPIRATION_NEVER
+    }
+
+    @Test
+    fun addGeofences_givenSuccess_expectReceiversEnabled() = runTest {
+        grantAllPermissions()
+        stubClientAddSuccess()
+
+        manager.addGeofences(listOf(buildRegion()))
+
+        verify { receiverToggle.setEnabled(true) }
+    }
+
+    @Test
+    fun addGeofences_givenFailure_expectReceiversNotToggled() = runTest {
+        grantAllPermissions()
+        stubClientAddFailure(RuntimeException("GMS error"))
+
+        manager.addGeofences(listOf(buildRegion()))
+
+        verify(exactly = 0) { receiverToggle.setEnabled(any()) }
+    }
+
+    @Test
+    fun addGeofences_givenClientFails_expectFailureResult() = runTest {
+        grantAllPermissions()
+        stubClientAddFailure(RuntimeException("GMS error"))
+
+        val result = manager.addGeofences(listOf(buildRegion()))
+
+        result.isFailure.shouldBeTrue()
+    }
+
+    @Test
+    fun removeGeofencesByIds_givenEmptyIds_expectSuccessWithoutCallingClient() = runTest {
+        val result = manager.removeGeofencesByIds(emptyList())
+
+        result.isSuccess.shouldBeTrue()
+        verify(exactly = 0) { client.removeGeofences(any<List<String>>()) }
+    }
+
+    @Test
+    fun removeGeofencesByIds_givenIds_expectClientCalledWithIds() = runTest {
+        val idsSlot = slot<List<String>>()
+        stubClientRemoveByIdsSuccess(idsSlot)
+
+        manager.removeGeofencesByIds(listOf("geo-1", "geo-2"))
+
+        idsSlot.captured shouldContainAll listOf("geo-1", "geo-2")
+    }
+
+    @Test
+    fun clearAll_givenSuccess_expectClientCalledWithPendingIntent() = runTest {
+        stubClientRemoveByPendingIntentSuccess()
+
+        val result = manager.clearAll()
+
+        result.isSuccess.shouldBeTrue()
+        verify { client.removeGeofences(any<PendingIntent>()) }
+    }
+
+    @Test
+    fun clearAll_givenSuccess_expectReceiversDisabled() = runTest {
+        stubClientRemoveByPendingIntentSuccess()
+
+        manager.clearAll()
+
+        verify { receiverToggle.setEnabled(false) }
+    }
+
+    // -- Helpers: permission --
+
+    private fun grantPermission(permission: String) {
+        shadowOf(applicationMock).grantPermissions(permission)
+    }
+
+    private fun denyPermission(permission: String) {
+        shadowOf(applicationMock).denyPermissions(permission)
+    }
+
+    private fun grantAllPermissions() {
+        grantPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+        grantPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    }
+
+    // -- Helpers: GMS Task stubs --
+
+    private fun stubClientAddSuccess(requestSlot: CapturingSlot<GeofencingRequest>? = null) {
+        val task = immediateSuccessTask<Void>()
+        if (requestSlot != null) {
+            every { client.addGeofences(capture(requestSlot), any()) } returns task
+        } else {
+            every { client.addGeofences(any<GeofencingRequest>(), any()) } returns task
+        }
+    }
+
+    private fun stubClientAddFailure(exception: Exception) {
+        val task = immediateFailureTask<Void>(exception)
+        every { client.addGeofences(any<GeofencingRequest>(), any()) } returns task
+    }
+
+    private fun stubClientRemoveByIdsSuccess(idsSlot: CapturingSlot<List<String>>? = null) {
+        val task = immediateSuccessTask<Void>()
+        if (idsSlot != null) {
+            every { client.removeGeofences(capture(idsSlot)) } returns task
+        } else {
+            every { client.removeGeofences(any<List<String>>()) } returns task
+        }
+    }
+
+    private fun stubClientRemoveByPendingIntentSuccess() {
+        val task = immediateSuccessTask<Void>()
+        every { client.removeGeofences(any<PendingIntent>()) } returns task
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> immediateSuccessTask(): Task<T> {
+        val task = mockk<Task<T>>()
+        every { task.addOnSuccessListener(any()) } answers {
+            firstArg<OnSuccessListener<T>>().onSuccess(null as T)
+            task
+        }
+        every { task.addOnFailureListener(any()) } returns task
+        return task
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> immediateFailureTask(exception: Exception): Task<T> {
+        val task = mockk<Task<T>>()
+        every { task.addOnSuccessListener(any()) } returns task
+        every { task.addOnFailureListener(any()) } answers {
+            firstArg<OnFailureListener>().onFailure(exception)
+            task
+        }
+        return task
+    }
+
+    // -- Helpers: region builder + assertions --
+
+    private fun buildRegion(
+        id: String = "test-geofence",
+        latitude: Double = 37.7749,
+        longitude: Double = -122.4194,
+        radiusMeters: Float = 100f,
+        transitionTypes: List<GeofenceTransitionType> = listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+    ) = GeofenceRegion(
+        id = id,
+        latitude = latitude,
+        longitude = longitude,
+        radiusMeters = radiusMeters,
+        transitionTypes = transitionTypes
+    )
+
+    private infix fun Int.shouldContainFlag(flag: Int) {
+        (this and flag == flag).shouldBeTrue()
+    }
+
+    private infix fun Int.shouldNotContainFlag(flag: Int) {
+        (this and flag == flag).shouldBeFalse()
+    }
+
+    private infix fun <T> List<T>.shouldContainAll(expected: List<T>) {
+        expected.forEach { item ->
+            if (!this.contains(item)) throw AssertionError("Expected list to contain $item but it didn't: $this")
+        }
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRegionTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRegionTest.kt
@@ -1,0 +1,57 @@
+package io.customer.location.geofence
+
+import com.google.android.gms.location.Geofence
+import io.customer.commontest.core.RobolectricTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceRegionTest : RobolectricTest() {
+
+    @Test
+    fun toGmsTransitionTypes_givenEnterOnly_expectEnterBitmask() {
+        val region = buildRegion(transitionTypes = listOf(GeofenceTransitionType.ENTER))
+
+        region.toGmsTransitionTypes() shouldBeEqualTo Geofence.GEOFENCE_TRANSITION_ENTER
+    }
+
+    @Test
+    fun toGmsTransitionTypes_givenExitOnly_expectExitBitmask() {
+        val region = buildRegion(transitionTypes = listOf(GeofenceTransitionType.EXIT))
+
+        region.toGmsTransitionTypes() shouldBeEqualTo Geofence.GEOFENCE_TRANSITION_EXIT
+    }
+
+    @Test
+    fun toGmsTransitionTypes_givenBothTransitions_expectCombinedBitmask() {
+        val region = buildRegion(
+            transitionTypes = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT)
+        )
+
+        region.toGmsTransitionTypes() shouldBeEqualTo
+            (Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
+    }
+
+    @Test
+    fun toGmsTransitionTypes_givenDefaultTransitions_expectBothEnterAndExit() {
+        val region = buildRegion()
+
+        region.toGmsTransitionTypes() shouldBeEqualTo
+            (Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
+    }
+
+    private fun buildRegion(
+        transitionTypes: List<GeofenceTransitionType> = listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+    ) = GeofenceRegion(
+        id = "test-geofence",
+        latitude = 0.0,
+        longitude = 0.0,
+        radiusMeters = 100f,
+        transitionTypes = transitionTypes
+    )
+}


### PR DESCRIPTION
part of: [MBL-1625](https://linear.app/customerio/issue/MBL-1625/android-handle-os-geofence-monitoring)

## Summary

Foundation for geofence monitoring in `location` module. This PR introduces the OS integration layer, the classes needed to register geofences with Android's GeofencingClient, receive transition callbacks, and re-register after device reboot.


### What's included

- **GeofenceRegion**: Data model with `distanceTo()` and `toGmsTransitionTypes()` extensions
- **GeofenceManager**: Wraps `GeofencingClient` with suspend API for add/remove/clear operations, proper permission checks (`ACCESS_FINE_LOCATION` + `ACCESS_BACKGROUND_LOCATION` on Q+), and movement trigger initial-trigger handling
- **GeofenceReceiverToggle**: Injectable wrapper for `PackageManager.setComponentEnabledSetting`, enabling/disabling receivers dynamically when geofences are registered or cleared
- **GeofenceBroadcastReceiver**: Receives OS geofence transitions (stub, event delivery wired in next PR)
- **GeofenceBootReceiver**: Re-registers geofences after reboot (stub, restore logic wired in later PR)
- **GeofenceLogger**: Structured log methods following `PushNotificationLogger` pattern
- **GeofenceConstants**: All thresholds and identifiers
- **AndroidManifest**: Receiver declarations with `android:enabled="false"` (dynamically enabled by GeofenceManager). Geofence permissions not declared by SDK, host app must request them
- **DI wiring**: `GeofencingClient`, `GeofenceReceiverToggle`, `GeofenceManager`, `GeofenceLogger` on appropriate DI graphs (`AndroidSDKComponent` for Android-dependent, `SDKComponent` for pure)

### What's not included (coming in next PRs)

- Event delivery via WorkManager
- Persistence, sync, and movement trigger loop
- Module integration and lifecycle wiring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Android manifest receivers and permission-dependent geofencing registration logic, which can impact app behavior if enabled/misconfigured. Functionality is mostly additive and guarded (receivers disabled by default) with test coverage, reducing rollout risk.
> 
> **Overview**
> Adds the *Android OS integration layer* for geofencing in the `location` module, including a `GeofenceManager` wrapper around `GeofencingClient` (suspending add/remove/clear APIs, permission gating for fine + background location, request batching/initial-trigger handling, and receiver enable/disable).
> 
> Introduces new broadcast receivers for geofence transitions and reboot handling (`GeofenceBroadcastReceiver`, `GeofenceBootReceiver`), wires them into DI, and declares them in the manifest as **disabled by default** (host apps must supply required permissions). Adds supporting types/constants (`GeofenceRegion`, `GeofenceReceiverToggle`, `GeofenceLogger`, `GeofenceConstants`) plus Robolectric tests covering manager behavior and transition bitmask conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c454244020eacb5cf0f6bcc907a5c9e9d1f24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->