### PR TITLE
chore: add store for encrypted user identity caching

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -120,6 +120,7 @@ public abstract class io/customer/sdk/core/di/AndroidSDKComponent : io/customer/
 	public abstract fun getClient ()Lio/customer/sdk/data/store/Client;
 	public abstract fun getDeviceStore ()Lio/customer/sdk/data/store/DeviceStore;
 	public abstract fun getGlobalPreferenceStore ()Lio/customer/sdk/data/store/GlobalPreferenceStore;
+	public abstract fun getSecureUserStore ()Lio/customer/sdk/data/store/SecureUserStore;
 }
 
 public final class io/customer/sdk/core/di/AndroidSDKComponentImpl : io/customer/sdk/core/di/AndroidSDKComponent {
@@ -131,6 +132,7 @@ public final class io/customer/sdk/core/di/AndroidSDKComponentImpl : io/customer
 	public fun getClient ()Lio/customer/sdk/data/store/Client;
 	public fun getDeviceStore ()Lio/customer/sdk/data/store/DeviceStore;
 	public fun getGlobalPreferenceStore ()Lio/customer/sdk/data/store/GlobalPreferenceStore;
+	public fun getSecureUserStore ()Lio/customer/sdk/data/store/SecureUserStore;
 	public fun reset ()V
 }
 

--- a/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/AndroidSDKComponent.kt
@@ -12,6 +12,8 @@ import io.customer.sdk.data.store.DeviceStore
 import io.customer.sdk.data.store.DeviceStoreImpl
 import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.customer.sdk.data.store.GlobalPreferenceStoreImpl
+import io.customer.sdk.data.store.SecureUserStore
+import io.customer.sdk.data.store.SecureUserStoreImpl
 
 abstract class AndroidSDKComponent : DiGraph() {
     abstract val client: Client
@@ -21,6 +23,7 @@ abstract class AndroidSDKComponent : DiGraph() {
     abstract val applicationStore: ApplicationStore
     abstract val deviceStore: DeviceStore
     abstract val globalPreferenceStore: GlobalPreferenceStore
+    abstract val secureUserStore: SecureUserStore
 }
 
 /**
@@ -57,6 +60,8 @@ class AndroidSDKComponentImpl(
         }
     override val globalPreferenceStore: GlobalPreferenceStore
         get() = singleton<GlobalPreferenceStore> { GlobalPreferenceStoreImpl(applicationContext) }
+    override val secureUserStore: SecureUserStore
+        get() = singleton<SecureUserStore> { SecureUserStoreImpl(applicationContext, SDKComponent.logger) }
 
     override fun reset() {
         super.reset()

--- a/core/src/main/kotlin/io/customer/sdk/data/store/SecureUserStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/SecureUserStore.kt
@@ -2,6 +2,7 @@ package io.customer.sdk.data.store
 
 import android.content.Context
 import androidx.core.content.edit
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.util.Logger
 
 /**
@@ -16,6 +17,7 @@ import io.customer.sdk.core.util.Logger
  * Currently stores user identity for direct API calls from WorkManager
  * workers and BroadcastReceivers (e.g., geofence events, push metrics).
  */
+@InternalCustomerIOApi
 interface SecureUserStore {
     fun saveUserId(userId: String?)
     fun getUserId(): String?

--- a/core/src/main/kotlin/io/customer/sdk/data/store/SecureUserStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/SecureUserStore.kt
@@ -1,0 +1,54 @@
+package io.customer.sdk.data.store
+
+import android.content.Context
+import androidx.core.content.edit
+import io.customer.sdk.core.util.Logger
+
+/**
+ * Encrypted, user-scoped preference store for sensitive data that must
+ * persist across app restarts and be accessible without full SDK init.
+ *
+ * Unlike [GlobalPreferenceStore] (device-scoped, survives reset), this
+ * store is cleared on clearIdentify/reset — all data is tied to the
+ * current user session.
+ *
+ * All values are encrypted at rest via [PreferenceCrypto] (AES-256-GCM).
+ * Currently stores user identity for direct API calls from WorkManager
+ * workers and BroadcastReceivers (e.g., geofence events, push metrics).
+ */
+interface SecureUserStore {
+    fun saveUserId(userId: String?)
+    fun getUserId(): String?
+    fun clearAll()
+}
+
+internal class SecureUserStoreImpl(
+    context: Context,
+    logger: Logger
+) : PreferenceStore(context), SecureUserStore {
+
+    private val crypto = PreferenceCrypto(KEY_ALIAS, logger)
+
+    override val prefsName: String by lazy {
+        "io.customer.sdk.secure_user.${context.packageName}"
+    }
+
+    override fun saveUserId(userId: String?) = prefs.edit {
+        if (userId != null) {
+            putString(KEY_USER_ID, crypto.encrypt(userId))
+        } else {
+            remove(KEY_USER_ID)
+        }
+    }
+
+    override fun getUserId(): String? = prefs.read {
+        getString(KEY_USER_ID, null)?.let { crypto.decrypt(it) }
+    }
+
+    override fun clearAll() = prefs.edit { clear() }
+
+    companion object {
+        private const val KEY_ALIAS = "cio_secure_user_key"
+        private const val KEY_USER_ID = "cio_secure_user_id"
+    }
+}

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -71,6 +71,7 @@ class CustomerIO private constructor(
     private val logger: Logger = SDKComponent.logger
     private val dataPipelinesLogger: DataPipelinesLogger = SDKComponent.dataPipelinesLogger
     private val globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+    private val secureUserStore = androidSDKComponent.secureUserStore
     private val deviceStore = androidSDKComponent.deviceStore
     private val eventBus = SDKComponent.eventBus
     internal var migrationProcessor: MigrationProcessor? = null
@@ -157,6 +158,14 @@ class CustomerIO private constructor(
         }
         eventBus.subscribe<Event.RegisterDeviceTokenEvent> {
             registerDeviceToken(deviceToken = it.token)
+        }
+        // Cache user identity encrypted for direct API calls (WorkManager workers,
+        // BroadcastReceivers) that run without full SDK initialization.
+        eventBus.subscribe<Event.UserChangedEvent> {
+            secureUserStore.saveUserId(it.userId)
+        }
+        eventBus.subscribe<Event.ResetEvent> {
+            secureUserStore.clearAll()
         }
     }
 


### PR DESCRIPTION
part of: [MBL-1627](https://linear.app/customerio/issue/MBL-1627/android-send-geofence-transition-events)

## Summary

Add `SecureUserStore` — an encrypted, user-scoped preference store in `:core` for persisting sensitive data that must survive app restarts and be accessible without full SDK initialization.

### Why

Geofence events need to include `userId` in direct API calls made from WorkManager workers and BroadcastReceivers. In killed state (especially RN/Flutter wrappers), the SDK isn't initialized so`analytics.userId()` is unavailable. This store caches the identity encrypted so workers can read it independently.

### What

- **`SecureUserStore`** interface + `SecureUserStoreImpl` in `core/data/store/`
  - Encrypted via `PreferenceCrypto` (AES-256-GCM, Android Keystore)
  - Separate prefs file (`io.customer.sdk.secure_user.<package>`) — no migration risk with existing stores
  - User-scoped: cleared on `clearIdentify`/`reset` (unlike `GlobalPreferenceStore` which is device-scoped)
- **`AndroidSDKComponent.secureUserStore`** — singleton, accessible via `SDKComponent.android().secureUserStore`
- **`CustomerIO`** wiring:
  - `UserChangedEvent` subscription saves `userId` on identify
  - `ResetEvent` subscription calls `clearAll()` on reset

### Design

| Store | Scope | Encrypted | Survives reset |
|---|---|---|---|
| `GlobalPreferenceStore` | Device | No | Yes |
| `SecureUserStore` | User | Yes | No |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistence for user identity and Keystore-backed encryption; mistakes could leak/retain IDs across sessions or break background flows if encryption/decryption fails.
> 
> **Overview**
> Adds a new `SecureUserStore` (and `SecureUserStoreImpl`) in `:core` to persist the current `userId` in a dedicated SharedPreferences file, encrypting values at rest via `PreferenceCrypto`.
> 
> Exposes the store through `AndroidSDKComponent` as a singleton dependency, and updates `CustomerIO` to keep it in sync by saving the `userId` on `Event.UserChangedEvent` and clearing it on `Event.ResetEvent` for use by background workers/receivers without full SDK initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a6098aa878593622f909de8d50250b3096a59f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->