### PR TITLE
chore: skip periodic flush while backgrounded on Android 15+

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/CustomerIODestination.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/CustomerIODestination.kt
@@ -1,5 +1,6 @@
 package io.customer.datapipelines.plugins
 
+import android.os.Build
 import com.segment.analytics.kotlin.core.AliasEvent
 import com.segment.analytics.kotlin.core.Analytics
 import com.segment.analytics.kotlin.core.BaseEvent
@@ -18,6 +19,7 @@ import com.segment.analytics.kotlin.core.platform.plugins.DestinationMetadataPlu
 import com.segment.analytics.kotlin.core.platform.policies.CountBasedFlushPolicy
 import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
 import com.segment.analytics.kotlin.core.platform.policies.FrequencyFlushPolicy
+import io.customer.datapipelines.plugins.policies.BackgroundAwareFrequencyFlushPolicy
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import sovran.kotlin.Subscriber
@@ -82,9 +84,16 @@ class CustomerIODestination : DestinationPlugin(), VersionedPlugin, Subscriber {
 
         // convert flushAt and flushIntervals into FlushPolicies
         flushPolicies = analytics.configuration.flushPolicies.ifEmpty {
+            val flushIntervalMs = analytics.configuration.flushInterval * 1000L
+            // Android 15+ blocks background network; gate the periodic flush on foreground state.
+            val frequencyPolicy: FlushPolicy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                BackgroundAwareFrequencyFlushPolicy(flushIntervalMs)
+            } else {
+                FrequencyFlushPolicy(flushIntervalMs)
+            }
             listOf(
                 CountBasedFlushPolicy(analytics.configuration.flushAt),
-                FrequencyFlushPolicy(analytics.configuration.flushInterval * 1000L)
+                frequencyPolicy
             )
         }
 

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicy.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicy.kt
@@ -1,0 +1,38 @@
+package io.customer.datapipelines.plugins.policies
+
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.platform.policies.FlushPolicy
+import io.customer.datapipelines.util.AppForegroundState
+import io.customer.datapipelines.util.ProcessLifecycleForegroundState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/** Flush policy that skips ticks while the app is backgrounded — needed on Android 15+ where the OS blocks background network. */
+internal class BackgroundAwareFrequencyFlushPolicy(
+    private val flushIntervalInMillis: Long,
+    private val foregroundState: AppForegroundState = ProcessLifecycleForegroundState()
+) : FlushPolicy {
+
+    private var flushJob: Job? = null
+
+    override fun schedule(analytics: Analytics) {
+        if (flushJob?.isActive == true) return
+        flushJob = analytics.analyticsScope.launch(analytics.fileIODispatcher) {
+            while (isActive) {
+                if (foregroundState.isInForeground) {
+                    analytics.flush()
+                }
+                delay(flushIntervalInMillis)
+            }
+        }
+    }
+
+    override fun unschedule() {
+        flushJob?.cancel()
+        flushJob = null
+    }
+
+    override fun shouldFlush(): Boolean = false
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicy.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicy.kt
@@ -21,7 +21,7 @@ internal class BackgroundAwareFrequencyFlushPolicy(
         if (flushJob?.isActive == true) return
         flushJob = analytics.analyticsScope.launch(analytics.fileIODispatcher) {
             while (isActive) {
-                if (foregroundState.isInForeground) {
+                if (foregroundState.isInForeground()) {
                     analytics.flush()
                 }
                 delay(flushIntervalInMillis)

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
@@ -1,0 +1,21 @@
+package io.customer.datapipelines.util
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+
+/** Whether the app process is currently in foreground. */
+internal interface AppForegroundState {
+    val isInForeground: Boolean
+}
+
+/** [AppForegroundState] using [ProcessLifecycleOwner]; owner is lazy so the class is safe to construct in pure JVM unit tests. */
+internal class ProcessLifecycleForegroundState(
+    processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() }
+) : AppForegroundState {
+
+    private val processLifecycleOwner: LifecycleOwner by lazy(processLifecycleOwnerProvider)
+
+    override val isInForeground: Boolean
+        get() = processLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+}

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
@@ -13,14 +13,18 @@ internal interface AppForegroundState {
 }
 
 /**
- * [AppForegroundState] backed by [ProcessLifecycleOwner]. The `@MainThread`
- * `currentState` getter is invoked via `withContext(dispatchers.main)` so the
- * read happens on the main thread regardless of where the caller is suspended.
+ * [AppForegroundState] backed by [ProcessLifecycleOwner]. The `LifecycleOwner`
+ * is resolved lazily on first read of [isInForeground], which always happens
+ * inside `withContext(dispatchers.main)` — so `ProcessLifecycleOwner.get()`
+ * and the `@MainThread` `currentState` getter both run on the main thread
+ * regardless of where the SDK was initialized.
  */
 internal class ProcessLifecycleForegroundState(
-    private val processLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get(),
+    processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() },
     private val dispatchersProvider: DispatchersProvider = SDKComponent.dispatchersProvider
 ) : AppForegroundState {
+
+    private val processLifecycleOwner: LifecycleOwner by lazy(processLifecycleOwnerProvider)
 
     override suspend fun isInForeground(): Boolean = withContext(dispatchersProvider.main) {
         processLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/AppForegroundState.kt
@@ -3,19 +3,26 @@ package io.customer.datapipelines.util
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
+import kotlinx.coroutines.withContext
 
 /** Whether the app process is currently in foreground. */
 internal interface AppForegroundState {
-    val isInForeground: Boolean
+    suspend fun isInForeground(): Boolean
 }
 
-/** [AppForegroundState] using [ProcessLifecycleOwner]; owner is lazy so the class is safe to construct in pure JVM unit tests. */
+/**
+ * [AppForegroundState] backed by [ProcessLifecycleOwner]. The `@MainThread`
+ * `currentState` getter is invoked via `withContext(dispatchers.main)` so the
+ * read happens on the main thread regardless of where the caller is suspended.
+ */
 internal class ProcessLifecycleForegroundState(
-    processLifecycleOwnerProvider: () -> LifecycleOwner = { ProcessLifecycleOwner.get() }
+    private val processLifecycleOwner: LifecycleOwner = ProcessLifecycleOwner.get(),
+    private val dispatchersProvider: DispatchersProvider = SDKComponent.dispatchersProvider
 ) : AppForegroundState {
 
-    private val processLifecycleOwner: LifecycleOwner by lazy(processLifecycleOwnerProvider)
-
-    override val isInForeground: Boolean
-        get() = processLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    override suspend fun isInForeground(): Boolean = withContext(dispatchersProvider.main) {
+        processLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+    }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicyTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicyTest.kt
@@ -1,0 +1,171 @@
+package io.customer.datapipelines.plugins.policies
+
+import com.segment.analytics.kotlin.core.Analytics
+import io.customer.commontest.config.TestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.util.AppForegroundState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardTestDispatcher()) {
+
+    private val mockAnalytics = mockk<Analytics>(relaxed = true)
+    private val mockForegroundState = mockk<AppForegroundState>()
+
+    private val testScope get() = delegate.testScope
+
+    private val flushIntervalMs = 1000L
+
+    private fun newPolicy() = BackgroundAwareFrequencyFlushPolicy(
+        flushIntervalInMillis = flushIntervalMs,
+        foregroundState = mockForegroundState
+    )
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+        every { mockAnalytics.analyticsScope } returns testScope
+        every { mockAnalytics.fileIODispatcher } returns testDispatcher
+    }
+
+    @Test
+    fun schedule_givenForeground_expectsFlushOnEachTick() {
+        every { mockForegroundState.isInForeground } returns true
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        verify(exactly = 2) { mockAnalytics.flush() }
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun schedule_givenBackground_expectsNoFlush() {
+        every { mockForegroundState.isInForeground } returns false
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.advanceTimeBy(flushIntervalMs * 3 + 1)
+        testScope.runCurrent()
+
+        verify(exactly = 0) { mockAnalytics.flush() }
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun schedule_givenForegroundThenBackgroundThenForeground_expectsPauseAndResume() {
+        every { mockForegroundState.isInForeground } returns true
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        every { mockForegroundState.isInForeground } returns false
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        every { mockForegroundState.isInForeground } returns true
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        verify(exactly = 2) { mockAnalytics.flush() }
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun schedule_calledTwice_expectsOnlyOneCoroutine() {
+        every { mockForegroundState.isInForeground } returns true
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        // Two flushes (initial + one tick) confirms a single loop is running, not two.
+        verify(exactly = 2) { mockAnalytics.flush() }
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun schedule_calledAfterUnschedule_expectsNewCoroutineLaunched() {
+        every { mockForegroundState.isInForeground } returns true
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        policy.unschedule()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        verify(exactly = 2) { mockAnalytics.flush() }
+
+        testScope.advanceTimeBy(flushIntervalMs + 1)
+        testScope.runCurrent()
+        verify(exactly = 3) { mockAnalytics.flush() }
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun unschedule_givenScheduled_expectsCoroutineCancelled() {
+        every { mockForegroundState.isInForeground } returns true
+
+        val policy = newPolicy()
+
+        policy.schedule(mockAnalytics)
+        testScope.runCurrent()
+        verify(exactly = 1) { mockAnalytics.flush() }
+
+        policy.unschedule()
+        testScope.advanceTimeBy(flushIntervalMs * 5 + 1)
+        testScope.runCurrent()
+
+        verify(exactly = 1) { mockAnalytics.flush() }
+    }
+
+    @Test
+    fun unschedule_calledWithoutSchedule_expectsNoOp() {
+        val policy = newPolicy()
+
+        policy.unschedule()
+    }
+
+    @Test
+    fun shouldFlush_expectsFalse() {
+        val policy = newPolicy()
+
+        policy.shouldFlush() shouldBeEqualTo false
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicyTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/policies/BackgroundAwareFrequencyFlushPolicyTest.kt
@@ -4,6 +4,7 @@ import com.segment.analytics.kotlin.core.Analytics
 import io.customer.commontest.config.TestConfig
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.util.AppForegroundState
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -37,7 +38,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun schedule_givenForeground_expectsFlushOnEachTick() {
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
 
         val policy = newPolicy()
 
@@ -54,7 +55,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun schedule_givenBackground_expectsNoFlush() {
-        every { mockForegroundState.isInForeground } returns false
+        coEvery { mockForegroundState.isInForeground() } returns false
 
         val policy = newPolicy()
 
@@ -69,7 +70,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun schedule_givenForegroundThenBackgroundThenForeground_expectsPauseAndResume() {
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
 
         val policy = newPolicy()
 
@@ -77,7 +78,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
         testScope.runCurrent()
         verify(exactly = 1) { mockAnalytics.flush() }
 
-        every { mockForegroundState.isInForeground } returns false
+        coEvery { mockForegroundState.isInForeground() } returns false
         testScope.advanceTimeBy(flushIntervalMs + 1)
         testScope.runCurrent()
         verify(exactly = 1) { mockAnalytics.flush() }
@@ -86,7 +87,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
         testScope.runCurrent()
         verify(exactly = 1) { mockAnalytics.flush() }
 
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
         testScope.advanceTimeBy(flushIntervalMs + 1)
         testScope.runCurrent()
         verify(exactly = 2) { mockAnalytics.flush() }
@@ -96,7 +97,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun schedule_calledTwice_expectsOnlyOneCoroutine() {
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
 
         val policy = newPolicy()
 
@@ -117,7 +118,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun schedule_calledAfterUnschedule_expectsNewCoroutineLaunched() {
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
 
         val policy = newPolicy()
 
@@ -140,7 +141,7 @@ class BackgroundAwareFrequencyFlushPolicyTest : JUnitTest(dispatcher = StandardT
 
     @Test
     fun unschedule_givenScheduled_expectsCoroutineCancelled() {
-        every { mockForegroundState.isInForeground } returns true
+        coEvery { mockForegroundState.isInForeground() } returns true
 
         val policy = newPolicy()
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
@@ -1,0 +1,58 @@
+package io.customer.datapipelines.util
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class ProcessLifecycleForegroundStateTest : JUnitTest() {
+
+    @Test
+    fun constructor_expectsLifecycleOwnerNotResolved() {
+        var providerCalled = false
+
+        ProcessLifecycleForegroundState(
+            processLifecycleOwnerProvider = {
+                providerCalled = true
+                mockk()
+            }
+        )
+
+        providerCalled shouldBeEqualTo false
+    }
+
+    @Test
+    fun isInForeground_givenStartedState_expectsTrue() {
+        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.STARTED))
+            .isInForeground shouldBeEqualTo true
+    }
+
+    @Test
+    fun isInForeground_givenResumedState_expectsTrue() {
+        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.RESUMED))
+            .isInForeground shouldBeEqualTo true
+    }
+
+    @Test
+    fun isInForeground_givenCreatedState_expectsFalse() {
+        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.CREATED))
+            .isInForeground shouldBeEqualTo false
+    }
+
+    @Test
+    fun isInForeground_givenDestroyedState_expectsFalse() {
+        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.DESTROYED))
+            .isInForeground shouldBeEqualTo false
+    }
+
+    private fun ownerInState(state: Lifecycle.State): () -> LifecycleOwner = {
+        val mockLifecycle = mockk<Lifecycle>()
+        every { mockLifecycle.currentState } returns state
+        mockk<LifecycleOwner>().apply {
+            every { lifecycle } returns mockLifecycle
+        }
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
@@ -22,7 +22,7 @@ class ProcessLifecycleForegroundStateTest : JUnitTest() {
     }
 
     private fun newState() = ProcessLifecycleForegroundState(
-        processLifecycleOwner = mockOwner,
+        processLifecycleOwnerProvider = { mockOwner },
         dispatchersProvider = DispatchersProviderStub()
     )
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/util/ProcessLifecycleForegroundStateTest.kt
@@ -2,57 +2,62 @@ package io.customer.datapipelines.util
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 class ProcessLifecycleForegroundStateTest : JUnitTest() {
 
+    private val mockOwner = mockk<LifecycleOwner>()
+    private val mockLifecycle = mockk<Lifecycle>()
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+        every { mockOwner.lifecycle } returns mockLifecycle
+    }
+
+    private fun newState() = ProcessLifecycleForegroundState(
+        processLifecycleOwner = mockOwner,
+        dispatchersProvider = DispatchersProviderStub()
+    )
+
     @Test
-    fun constructor_expectsLifecycleOwnerNotResolved() {
-        var providerCalled = false
+    fun isInForeground_givenStartedState_expectsTrue() = runTest {
+        every { mockLifecycle.currentState } returns Lifecycle.State.STARTED
 
-        ProcessLifecycleForegroundState(
-            processLifecycleOwnerProvider = {
-                providerCalled = true
-                mockk()
-            }
-        )
-
-        providerCalled shouldBeEqualTo false
+        newState().isInForeground() shouldBeEqualTo true
     }
 
     @Test
-    fun isInForeground_givenStartedState_expectsTrue() {
-        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.STARTED))
-            .isInForeground shouldBeEqualTo true
+    fun isInForeground_givenResumedState_expectsTrue() = runTest {
+        every { mockLifecycle.currentState } returns Lifecycle.State.RESUMED
+
+        newState().isInForeground() shouldBeEqualTo true
     }
 
     @Test
-    fun isInForeground_givenResumedState_expectsTrue() {
-        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.RESUMED))
-            .isInForeground shouldBeEqualTo true
+    fun isInForeground_givenInitializedState_expectsFalse() = runTest {
+        every { mockLifecycle.currentState } returns Lifecycle.State.INITIALIZED
+
+        newState().isInForeground() shouldBeEqualTo false
     }
 
     @Test
-    fun isInForeground_givenCreatedState_expectsFalse() {
-        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.CREATED))
-            .isInForeground shouldBeEqualTo false
+    fun isInForeground_givenCreatedState_expectsFalse() = runTest {
+        every { mockLifecycle.currentState } returns Lifecycle.State.CREATED
+
+        newState().isInForeground() shouldBeEqualTo false
     }
 
     @Test
-    fun isInForeground_givenDestroyedState_expectsFalse() {
-        ProcessLifecycleForegroundState(processLifecycleOwnerProvider = ownerInState(Lifecycle.State.DESTROYED))
-            .isInForeground shouldBeEqualTo false
-    }
+    fun isInForeground_givenDestroyedState_expectsFalse() = runTest {
+        every { mockLifecycle.currentState } returns Lifecycle.State.DESTROYED
 
-    private fun ownerInState(state: Lifecycle.State): () -> LifecycleOwner = {
-        val mockLifecycle = mockk<Lifecycle>()
-        every { mockLifecycle.currentState } returns state
-        mockk<LifecycleOwner>().apply {
-            every { lifecycle } returns mockLifecycle
-        }
+        newState().isInForeground() shouldBeEqualTo false
     }
 }


### PR DESCRIPTION
## Summary

Linear: [MBL-1499 — Noisy error logs for background HTTP calls on Android 15](https://linear.app/customerio/issue/MBL-1499/noisy-error-logs-for-background-http-calls-on-android-15)

On Android 15+ the OS restricts background network access for non-foreground apps. The bundled Segment `analytics-kotlin` library's `FrequencyFlushPolicy` keeps polling every 30s regardless of app state, so each backgrounded flush attempt fails with `UnknownHostException` and produces three repeating `[CIO]` log lines until the next foreground:

```
D Customer.io Data Pipelines performing flush
E Unable to resolve host "cdp.customer.io": No address associated with hostname
E Error uploading events from batch file fileUrl=… msg=Unable to resolve host …
```

iOS already does the equivalent gating in [`IntervalBasedFlushPolicy.enterBackground/enterForeground`](https://github.com/customerio/cdp-analytics-swift/blob/main/Sources/Segment/Utilities/Policies/IntervalBasedFlushPolicy.swift) — this PR brings Android to parity.

## What changed

- **`BackgroundAwareFrequencyFlushPolicy`** — a `FlushPolicy` whose periodic loop calls `foregroundState.isInForeground()` on each tick and only flushes when the app is in foreground.
- **`AppForegroundState`** interface + **`ProcessLifecycleForegroundState`** impl — exposes a `suspend fun isInForeground()` that reads `Lifecycle.currentState` inside `withContext(dispatchers.main) { … }`, honoring the `@MainThread` contract regardless of caller's dispatcher.
- **`CustomerIODestination`** picks the new policy on API 35+ and keeps Segment's vanilla `FrequencyFlushPolicy` on older Android (no behavior change for pre-Android-15 devices).
- Default builder behavior, no opt-in flag.

## What didn't change

- The one-shot `analytics.flush()` triggered by `Application Backgrounded` still runs (it fires before OS network restrictions kick in, so it usually drains the queue successfully).
- Count-based and manual `flush()` paths are untouched.
- Foreground behavior — including airplane-mode error logging — is unchanged. Real network outages still log at ERROR.
- API < 35 behavior is bit-for-bit identical.

## Why this approach

Considered alternatives:
- **Suppress the noisy logs** — simpler in code, but still requires lifecycle plumbing for the gate, and string-matches Segment's log strings (brittle across upstream bumps).
- **Bump Segment to 1.25.0** — verified upstream's `EventPipeline` and `FrequencyFlushPolicy` are unchanged for this scenario. The fix would still be required.
- **Stop the entire `EventPipeline` on background** — drops events queued while backgrounded; unsafe.

This PR fixes the root cause at the smallest correct scope.

## Test plan

### Automated

- [x] `./gradlew :datapipelines:assembleDebug` — passes
- [x] `./gradlew :datapipelines:testDebugUnitTest` — 199 tests, 0 failures (13 new across 2 new test classes)
- [x] `make lint-no-format` — clean

### Manual

#### Android 15 (API 35) or higher — primary scenario

- [x] Build sample app: `./gradlew :samples:java_layout:installDebug` (or `:samples:kotlin_compose:installDebug`)
- [x] Open the app, identify a user, trigger a few events
- [x] Attach logcat: `adb logcat | grep '\[CIO\]'`
- [x] Background the app (Home button or Recents → switch to another app)
- [x] **Expected:** no recurring `[CIO]` log lines while backgrounded — specifically, no `performing flush` / `Unable to resolve host` / `Error uploading events from batch file` repeating every ~30 seconds
- [x] Wait at least 60 seconds in background to confirm
- [x] Bring the app back to foreground
- [x] **Expected:** within ~30s the periodic flush resumes; queued events upload on the next tick (or sooner if a count-based flush triggers)

#### Android 14 (API 34) — regression check

- [x] Repeat steps above on an API 34 device
- [x] **Expected:** behavior unchanged from before the PR — periodic flush continues in background (we use the upstream `FrequencyFlushPolicy` on this path)

#### minSdk 24 (Android 7) — boundary smoke test

- [x] Same flow on an API 24 device
- [x] **Expected:** no crash; behavior identical to API 34 (same code path)

#### Foreground network outage — sanity check (optional)

- [x] Disable network on an Android 15 device while in **foreground**, generate events, watch logs
- [x] **Expected:** real `Unable to resolve host` ERROR logs still appear (we only gate on app foreground state, not network availability — legitimate foreground errors still surface for debugging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes flush scheduling behavior on Android 15+ by skipping periodic flushes while backgrounded, which could delay event uploads if foreground detection is wrong. Adds lifecycle/main-thread checks and coroutine scheduling that could introduce edge-case timing/cancellation issues.
> 
> **Overview**
> Prevents recurring background network flush attempts on Android 15+ by switching `CustomerIODestination`’s default interval-based flush policy to a new `BackgroundAwareFrequencyFlushPolicy` when `SDK_INT` is API 35+.
> 
> Adds `AppForegroundState`/`ProcessLifecycleForegroundState` to detect foreground via `ProcessLifecycleOwner` (read on the main dispatcher), and includes unit tests validating flush is skipped in background, resumes in foreground, and scheduling/unscheduling doesn’t spawn duplicate coroutines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8170e13db3f58bcc645651df833ef4e1949e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->