### PR TITLE
fix: Defined a working range of versions for the Segment Analytics

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -30,7 +30,7 @@ object Versions {
     internal const val KOTLINX_SERIALIZATION_JSON = "1.8.1"
     internal const val KOTLIN = "2.1.21"
     internal const val MOCKK = "1.13.13"
-    internal const val SEGMENT = "1.19.2"
+    internal const val SEGMENT = "[1.19.2, 1.25.0)"
     internal const val REDUX_KOTLIN = "0.6.0"
     internal const val ROBOLECTRIC = "4.16"
     internal const val OKHTTP = "4.12.0"

--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -30,7 +30,7 @@ object Versions {
     internal const val KOTLINX_SERIALIZATION_JSON = "1.8.1"
     internal const val KOTLIN = "2.1.21"
     internal const val MOCKK = "1.13.13"
-    internal const val SEGMENT = "[1.19.2, 1.25.0)"
+    internal const val SEGMENT = "1.24.1!!"
     internal const val REDUX_KOTLIN = "0.6.0"
     internal const val ROBOLECTRIC = "4.16"
     internal const val OKHTTP = "4.12.0"

--- a/datapipelines/api/datapipelines.api
+++ b/datapipelines/api/datapipelines.api
@@ -55,6 +55,7 @@ public final class io/customer/datapipelines/plugins/AutoTrackDeviceAttributesPl
 	public fun getType ()Lcom/segment/analytics/kotlin/core/platform/Plugin$Type;
 	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
 	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun shutdown ()V
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 
@@ -73,6 +74,7 @@ public final class io/customer/datapipelines/plugins/AutomaticActivityScreenTrac
 	public fun onActivityStopped (Landroid/app/Activity;)V
 	public fun setAnalytics (Lcom/segment/analytics/kotlin/core/Analytics;)V
 	public fun setup (Lcom/segment/analytics/kotlin/core/Analytics;)V
+	public fun shutdown ()V
 	public fun update (Lcom/segment/analytics/kotlin/core/Settings;Lcom/segment/analytics/kotlin/core/platform/Plugin$UpdateType;)V
 }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -927,4 +927,67 @@ class DataPipelinesInteractionTests : JUnitTest() {
         assertCalledOnce { mockDataPipelinesLogger.logTrackingDevicesAttributesWithoutValidToken() }
     }
     //endregion Logging
+
+    //region Event serialization
+
+    @Test
+    fun givenComplexEventWithNestedNulls_expectSuccessfulEventProcessing() {
+        val eventName = "complex_event"
+        val properties: CustomAttributes = mapOf(
+            "customer" to mapOf(
+                "id" to 123,
+                "name" to "Test Customer",
+                "account" to mapOf(
+                    "type" to "premium",
+                    "paymentMethod" to null,
+                    "details" to mapOf(
+                        "active" to true,
+                        "lastPaymentDate" to null
+                    )
+                ),
+                "preferences" to null
+            ),
+            "products" to listOf(
+                mapOf("id" to 1, "name" to "Product A", "variants" to null),
+                mapOf(
+                    "id" to 2,
+                    "name" to "Product B",
+                    "variants" to listOf(
+                        mapOf("color" to "red", "size" to null),
+                        null
+                    )
+                ),
+                null
+            )
+        )
+
+        sdkInstance.track(eventName, properties)
+
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
+        val event = outputReaderPlugin.trackEvents.first()
+        event.shouldNotBeNull()
+        event.event shouldBeEqualTo eventName
+
+        val customer = event.properties["customer"] as? Map<*, *>
+        customer.shouldNotBeNull()
+
+        val account = customer["account"] as? Map<*, *>
+        account.shouldNotBeNull()
+
+        val details = account["details"] as? Map<*, *>
+        details.shouldNotBeNull()
+
+        val products = event.properties["products"] as? List<*>
+        products.shouldNotBeNull()
+        products.size shouldBeEqualTo 3
+
+        val productB = products[1] as? Map<*, *>
+        productB.shouldNotBeNull()
+
+        val variants = productB["variants"] as? List<*>
+        variants.shouldNotBeNull()
+        variants.size shouldBeEqualTo 2
+    }
+
+    //endregion Event serialization
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
@@ -54,12 +54,11 @@ class CustomerIODestinationTest : IntegrationTest() {
         // Verify plugin is present in analytics instance
         sdkInstance.analytics.find(CustomerIODestination::class) shouldNotBe null
 
-        // Track an event to verify it flows through the pipeline
-        sdkInstance.track("test_event")
-
-        // Verify event was processed
-        outputReaderPlugin.trackEvents.size shouldBe 1
-        outputReaderPlugin.trackEvents.first().event shouldBe "test_event"
+        // In 1.19.2, checkSettings() dispatched ToggleRunningAction(true) unconditionally,
+        // so StartupQueue released events even on settings failure. From 1.20.0 onward,
+        // ToggleRunningAction(true) is only dispatched on successful settings fetch, meaning
+        // events remain held in StartupQueue when settings fail. Asserting event flow here
+        // was validating that 1.19.2 bug, not an intentional contract.
     }
 
     @Test
@@ -74,66 +73,10 @@ class CustomerIODestinationTest : IntegrationTest() {
 
     @Test
     fun givenComplexEventWithNestedNulls_expectSuccessfulEventProcessingThroughDestination() {
-        // Create an event with complex nested structure containing nulls
-        val eventName = "complex_event"
-        val properties: CustomAttributes = mapOf(
-            "customer" to mapOf(
-                "id" to 123,
-                "name" to "Test Customer",
-                "account" to mapOf(
-                    "type" to "premium",
-                    "paymentMethod" to null, // Null at deeper level
-                    "details" to mapOf(
-                        "active" to true,
-                        "lastPaymentDate" to null // Another null at even deeper level
-                    )
-                ),
-                "preferences" to null // Null at second level
-            ),
-            "products" to listOf(
-                mapOf("id" to 1, "name" to "Product A", "variants" to null), // Null in list item
-                mapOf(
-                    "id" to 2,
-                    "name" to "Product B",
-                    "variants" to listOf(
-                        mapOf("color" to "red", "size" to null), // Null in nested list item
-                        null // Null list item in nested list
-                    )
-                ),
-                null // Null list item
-            )
-        )
-
-        // Track event with complex properties containing nulls
-        sdkInstance.track(eventName, properties)
-
-        // Verify the event was processed successfully
-        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        val event = outputReaderPlugin.trackEvents.first()
-        event.shouldNotBeNull()
-        event.event shouldBeEqualTo eventName
-
-        // Verify the nested structures were preserved
-        val customer = event.properties["customer"] as? Map<*, *>
-        customer.shouldNotBeNull()
-
-        val account = customer["account"] as? Map<*, *>
-        account.shouldNotBeNull()
-
-        val details = account["details"] as? Map<*, *>
-        details.shouldNotBeNull()
-
-        // Verify the list was properly processed
-        val products = event.properties["products"] as? List<*>
-        products.shouldNotBeNull()
-        products.size shouldBeEqualTo 3
-
-        // Verify an item with a nested list was processed correctly
-        val productB = products[1] as? Map<*, *>
-        productB.shouldNotBeNull()
-
-        val variants = productB["variants"] as? List<*>
-        variants.shouldNotBeNull()
-        variants.size shouldBeEqualTo 2
+        // Moved to DataPipelinesInteractionTests as givenComplexEventWithNestedNulls_expectSuccessfulEventProcessing.
+        // This fixture mocks HTTPClient to throw on settings fetch, so StartupQueue never releases events
+        // (same root cause as the first test above: ToggleRunningAction(true) is only dispatched on
+        // successful settings fetch from 1.20.0 onward). The moved test runs where settings succeed,
+        // making the assertion meaningful.
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
@@ -5,15 +5,11 @@ import io.customer.commontest.config.TestConfig
 import io.customer.datapipelines.testutils.core.IntegrationTest
 import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
-import io.customer.datapipelines.testutils.utils.trackEvents
-import io.customer.sdk.data.model.CustomAttributes
 import io.mockk.every
 import io.mockk.mockkConstructor
 import okio.IOException
 import org.amshove.kluent.shouldBe
-import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBe
-import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/CustomerIODestinationTest.kt
@@ -67,12 +67,10 @@ class CustomerIODestinationTest : IntegrationTest() {
         (integrations?.contains(CUSTOMER_IO_DATA_PIPELINES) ?: false) shouldBe true
     }
 
-    @Test
-    fun givenComplexEventWithNestedNulls_expectSuccessfulEventProcessingThroughDestination() {
-        // Moved to DataPipelinesInteractionTests as givenComplexEventWithNestedNulls_expectSuccessfulEventProcessing.
-        // This fixture mocks HTTPClient to throw on settings fetch, so StartupQueue never releases events
-        // (same root cause as the first test above: ToggleRunningAction(true) is only dispatched on
-        // successful settings fetch from 1.20.0 onward). The moved test runs where settings succeed,
-        // making the assertion meaningful.
-    }
+    // Moved givenComplexEventWithNestedNulls_expectSuccessfulEventProcessingThroughDestination
+    // to DataPipelinesInteractionTests as givenComplexEventWithNestedNulls_expectSuccessfulEventProcessing.
+    // This fixture mocks HTTPClient to throw on settings fetch, so StartupQueue never releases events
+    // (same root cause as the first test above: ToggleRunningAction(true) is only dispatched on
+    // successful settings fetch from 1.20.0 onward). The moved test runs where settings succeed,
+    // making the assertion meaningful.
 }


### PR DESCRIPTION
RE: MBL-1709

The SDK specifies only a minimum version of the Segment Analytics SDK, 1.19.2. This allows us to run off of any later version within SemVer rules. The issue is that the 1.25.0 release introduced a breaking change which prevents compilation. The best thing we can do to address this issue for the user is to give a range that we are compatible with (< 1.25.0) so that they can use v1.22 if they would like.

There are also some minor bug fixes in the versions between 1.19.2 and 1.25.0 which cause 2 of our tests to fail. The tests themselves were the issue and needed tweaks. This PR addresses those issues and places inline comments with more details about the change. 

**To be clear, this PR REDUCES the range of versions we are compatible with, not expanding it.** However, by doing this we are able to handle the user's issues. We can later deal with the breaking change in 1.25.0.


Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request and it will automatically be merged. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency change to Segment Analytics (and related public API surface via new `shutdown()` methods) can affect initialization/event dispatch behavior across integrations; test updates reduce coverage around settings-fetch failure behavior.
> 
> **Overview**
> Updates the Segment Analytics Kotlin dependency to a constrained compatible version (preventing upgrades into the breaking `1.25.x` line) and regenerates the `datapipelines.api` surface to match the newer Segment plugin lifecycle (adds `shutdown()` to plugins).
> 
> Adjusts datapipelines tests to align with Segment `1.20+` behavior: removes an assertion that events flow when settings fetch fails (now held in Segment’s startup queue), and moves/adds a complex nested-nulls event serialization test to a fixture where settings succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484e8111ba5b168d902bf9cb5d2d3ddd94821b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->