### PR TITLE
chore: switch deploy to GitHub App token and gate recursive runs

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -19,7 +19,21 @@ jobs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
+      - name: Generate App installation token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
+
+      # Pass the App token to checkout so the persisted git credentials are the
+      # App identity (the only bypass actor on the main ruleset). Without this,
+      # a default checkout persists GITHUB_TOKEN (= github-actions[bot]) and
+      # later git pushes are rejected with GH013.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
       - name: Install sd CLI to use later in the workflow
         uses: kenji-miyake/setup-sd@08c14e27d65a1c215342ef00c81583ae67f4c5ef # v2.0.0
@@ -38,13 +52,6 @@ jobs:
 #         env:
 #           # Use local version to make sure the report is generated for the current changes
 #           IS_DEVELOPMENT: 'true'
-
-      - name: 'Generate token'
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.
       #    For example, if the last deployment you made was version 1.3.5 and you are releasing a new feature

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,7 +45,7 @@
           "core/src/main/kotlin/io/customer/sdk/Version.kt",
           "reports/sdk-binary-size.json"
         ],
-        "message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
+        "message": "chore: prepare for ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     ["@semantic-release/github", {


### PR DESCRIPTION
## Overview

Migrate the `Deploy SDK` workflow to authenticate with the `cio-mobile-release` GitHub App so it can be the sole bypass actor on a forthcoming `main` ruleset (replacing classic branch protection). Without these workflow changes, locking down `main` would reject semantic-release's prepare-commit and tag push with `GH013`.

## What changed

1. **`.github/workflows/deploy-sdk.yml`**
   - Replaced deprecated `tibdex/github-app-token@v2.1.0` (Node 20 EOL) with `actions/create-github-app-token@v3.1.1` (SHA-pinned, Node 24).
   - Switched from the deprecated `app-id` input to `client-id` — needs a new repo secret `CIO_APP_CLIENT_ID`. Existing `CIO_APP_SECRET` (PEM) is reused for `private-key`.
   - **Critical:** added `with: token: ${{ steps.generate_token.outputs.token }}` to `actions/checkout`. By default checkout persists `GITHUB_TOKEN` (= `github-actions[bot]`) into local git config, and any later `git push` (including the one inside `@semantic-release/git`) uses those credentials regardless of the env var passed to semantic-release. That's the most common cause of `GH013` after wiring an App token.
   - Token is generated **before** checkout so checkout consumes it.

2. **`.releaserc.json`**
   - Added a CI-skip directive to the `@semantic-release/git` commit message template. App pushes don't get GitHub's recursion guard (which only suppresses `GITHUB_TOKEN` pushes), so without this each release would spawn a redundant deploy run on the prepare-commit.

## Required pre-merge actions (repo admin)

- [ ] Add repo secret `CIO_APP_CLIENT_ID` = the App's Client ID (the `Iv23li...` string from `https://github.com/organizations/customerio/settings/apps/cio-mobile-release`).
- [ ] Confirm the `cio-mobile-release` App is installed on this repo with `Contents: Read & write`, `Metadata: Read`, `Pull requests: Read & write`, and `Workflows: Read & write` (the last one is needed because release-prep commits may touch workflow files via assets).

## Required post-merge actions (repo admin)

- [ ] **Settings -> Rules -> Rulesets -> New branch ruleset** targeting `main` (and `beta` if used):
  - Enforcement: Active
  - Bypass list: add `cio-mobile-release` App, mode = **Always** (not "For pull requests only" — that mode rejects direct `git push`).
  - Rules: require PR (1+ approvals), require status checks, block force-pushes, require linear history, restrict deletions.
- [ ] Trigger a release; confirm the prepare-commit lands on `main` with pusher `cio-mobile-release[bot]`.
- [ ] Once verified, remove the legacy classic branch protection rule on `main` (Settings -> Branches).
- [ ] (Optional cleanup) Delete unused `CIO_APP_ID` numeric secret.

## Test plan

- [ ] Wait for a release-triggering merge into `main`.
- [ ] Verify `Deploy SDK` workflow generates an App token without warnings.
- [ ] Verify the prepare-commit and git tag are pushed by `cio-mobile-release[bot]` (not `github-actions[bot]`).
- [ ] Verify no recursive `Deploy SDK` run is queued for the prepare-commit (CI-skip directive applied).
- [ ] Maven Central deploy job runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation authentication and git push credentials, which can block tagging/releases if misconfigured (new secret required) or if token handling differs from previous action.
> 
> **Overview**
> Updates the `Deploy SDK` GitHub Actions workflow to authenticate via a GitHub App installation token and uses that token for both `actions/checkout` and `semantic-release` pushes, replacing the prior token action.
> 
> Adjusts the `@semantic-release/git` prepare-commit message to include `[skip ci]` to prevent the release-prep commit from triggering a recursive deploy run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104b0726325972c59a2dfe0f2c46e4ed8485f7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->