### PR TITLE
chore: send geofence transition events via EventBus (MBL-1627) [1/3]

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -16,6 +16,29 @@ public final class io/customer/sdk/communication/Event$DeleteDeviceTokenEvent : 
 	public fun <init> ()V
 }
 
+public final class io/customer/sdk/communication/Event$GeofenceTransition : java/lang/Enum {
+	public static final field ENTER Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public static final field EXIT Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public static fun values ()[Lio/customer/sdk/communication/Event$GeofenceTransition;
+}
+
+public final class io/customer/sdk/communication/Event$GeofenceTransitionEvent : io/customer/sdk/communication/Event {
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGeofenceId ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getTransition ()Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/customer/sdk/communication/Event$RegisterDeviceTokenEvent : io/customer/sdk/communication/Event {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
+++ b/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
@@ -51,4 +51,19 @@ sealed class Event {
     ) : Event()
 
     class DeleteDeviceTokenEvent : Event()
+
+    enum class GeofenceTransition {
+        ENTER,
+        EXIT
+    }
+
+    /**
+     * Event published by the Location module when a geofence transition is received from the OS.
+     * Subscribers (e.g. data pipelines) translate this into a tracked event.
+     */
+    data class GeofenceTransitionEvent(
+        val geofenceId: String,
+        val transition: GeofenceTransition,
+        val properties: Map<String, Any>
+    ) : Event()
 }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.CustomerIOHttpClientImpl
+import io.customer.sdk.core.util.Clock
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
+import io.customer.sdk.core.util.SystemClock
 
 /**
  * The file contains extension functions for the SDKComponent object and its dependencies.
@@ -29,3 +31,7 @@ val SDKComponent.httpClient: CustomerIOHttpClient
 @InternalCustomerIOApi
 val SDKComponent.workManagerProvider: CustomerIOWorkManagerProvider
     get() = singleton<CustomerIOWorkManagerProvider> { CustomerIOWorkManagerProvider(android().applicationContext, logger) }
+
+@InternalCustomerIOApi
+val SDKComponent.clock: Clock
+    get() = singleton<Clock> { SystemClock() }

--- a/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/di/SDKComponentExt.kt
@@ -34,4 +34,4 @@ val SDKComponent.workManagerProvider: CustomerIOWorkManagerProvider
 
 @InternalCustomerIOApi
 val SDKComponent.clock: Clock
-    get() = singleton<Clock> { SystemClock() }
+    get() = newInstance<Clock> { SystemClock() }

--- a/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
@@ -1,0 +1,15 @@
+package io.customer.sdk.core.util
+
+import io.customer.base.internal.InternalCustomerIOApi
+import java.util.concurrent.TimeUnit
+
+/** Provides the current time. Injectable for testing. */
+@InternalCustomerIOApi
+interface Clock {
+    fun currentTimeMillis(): Long
+    fun currentTimeSeconds(): Long = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis())
+}
+
+internal class SystemClock : Clock {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
@@ -7,9 +7,10 @@ import java.util.concurrent.TimeUnit
 @InternalCustomerIOApi
 interface Clock {
     fun currentTimeMillis(): Long
-    fun currentTimeSeconds(): Long = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis())
+    fun currentTimeSeconds(): Long
 }
 
 internal class SystemClock : Clock {
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
+    override fun currentTimeSeconds(): Long = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis())
 }

--- a/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
+++ b/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
@@ -14,4 +14,8 @@ object EventNames {
 
     // Event name for location updates tracked by the Location module
     const val LOCATION_UPDATE = "CIO Location Update"
+
+    // Event names for geofence transitions tracked by the Location module
+    const val GEOFENCE_ENTERED = "GeoFence Entered"
+    const val GEOFENCE_EXITED = "GeoFence Exited"
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -167,6 +167,13 @@ class CustomerIO private constructor(
         eventBus.subscribe<Event.ResetEvent> {
             secureUserStore.clearAll()
         }
+        eventBus.subscribe<Event.GeofenceTransitionEvent> {
+            val eventName = when (it.transition) {
+                Event.GeofenceTransition.ENTER -> EventNames.GEOFENCE_ENTERED
+                Event.GeofenceTransition.EXIT -> EventNames.GEOFENCE_EXITED
+            }
+            track(name = eventName, properties = it.properties)
+        }
     }
 
     private fun migrateTrackingEvents() {

--- a/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
@@ -1,0 +1,81 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the EventBus subscription wired up in CustomerIO.subscribeToJourneyEvents
+ * correctly maps Event.GeofenceTransitionEvent → analytics track event with the right
+ * EventNames constant ("GeoFence Entered" / "GeoFence Exited") and forwards the properties.
+ *
+ * Captures the subscription handler with a mock EventBus at SDK init time, then invokes
+ * the captured handler directly so we exercise the mapping logic without depending on
+ * EventBus's async dispatching.
+ */
+class GeofenceEventSubscriptionTest : JUnitTest() {
+
+    // 'mock' prefix to avoid shadowing SDKComponent.eventBus inside the override lambda.
+    private val mockEventBus: EventBus = mockk(relaxed = true)
+    private val handlerSlot = slot<suspend (Event.GeofenceTransitionEvent) -> Unit>()
+
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        // Capture the handler before CustomerIO subscribes. relaxed mock handles other
+        // event subscriptions (UserChangedEvent etc.) without capture.
+        every {
+            mockEventBus.subscribe(
+                Event.GeofenceTransitionEvent::class,
+                capture(handlerSlot)
+            )
+        } returns mockk()
+
+        super.setup(
+            testConfiguration {
+                diGraph { sdk { overrideDependency<EventBus>(mockEventBus) } }
+            }
+        )
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun handler_givenEnterTransition_expectTrackWithGeoFenceEnteredEventName() = runTest {
+        val event = Event.GeofenceTransitionEvent(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            properties = mapOf("geofence_id" to "biz-1", "transition_type" to "enter")
+        )
+
+        handlerSlot.captured.invoke(event)
+
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "GeoFence Entered"
+    }
+
+    @Test
+    fun handler_givenExitTransition_expectTrackWithGeoFenceExitedEventName() = runTest {
+        val event = Event.GeofenceTransitionEvent(
+            geofenceId = "biz-2",
+            transition = Event.GeofenceTransition.EXIT,
+            properties = mapOf("geofence_id" to "biz-2", "transition_type" to "exit")
+        )
+
+        handlerSlot.captured.invoke(event)
+
+        outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "GeoFence Exited"
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -3,9 +3,13 @@ package io.customer.location.geofence
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
 import io.customer.location.geofence.di.geofenceLogger
+import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
 
 /** Receives OS geofence transition callbacks and dispatches them to the SDK. */
@@ -15,14 +19,15 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         SDKComponent.setupAndroidComponent(context = context)
 
         try {
-            handleGeofenceEvent(intent)
+            handleGeofencingEvent(GeofencingEvent.fromIntent(intent))
         } catch (e: Exception) {
             SDKComponent.geofenceLogger.logSyncFailed("BroadcastReceiver error: ${e.message}")
         }
     }
 
-    private fun handleGeofenceEvent(intent: Intent) {
-        val geofencingEvent = GeofencingEvent.fromIntent(intent) ?: return
+    @VisibleForTesting
+    internal fun handleGeofencingEvent(geofencingEvent: GeofencingEvent?) {
+        if (geofencingEvent == null) return
         val logger = SDKComponent.geofenceLogger
 
         if (geofencingEvent.hasError()) {
@@ -30,14 +35,62 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             return
         }
 
-        val transitionType = geofencingEvent.geofenceTransition
-        val triggeringGeofences = geofencingEvent.triggeringGeofences ?: return
+        val triggeringGeofenceIds = geofencingEvent.triggeringGeofences?.map { it.requestId } ?: return
         val location = geofencingEvent.triggeringLocation
+        if (location == null) {
+            logger.logTransitionWithoutLocation()
+        }
 
-        triggeringGeofences.forEach { geofence ->
-            logger.logTransitionReceived(
-                geofence.requestId,
-                "type=$transitionType at (${location?.latitude}, ${location?.longitude})"
+        dispatchTransition(
+            gmsTransitionType = geofencingEvent.geofenceTransition,
+            triggeringGeofenceIds = triggeringGeofenceIds,
+            latitude = location?.latitude,
+            longitude = location?.longitude
+        )
+    }
+
+    @VisibleForTesting
+    internal fun dispatchTransition(
+        gmsTransitionType: Int,
+        triggeringGeofenceIds: List<String>,
+        latitude: Double?,
+        longitude: Double?
+    ) {
+        val logger = SDKComponent.geofenceLogger
+        val timestamp = SDKComponent.clock.currentTimeSeconds()
+        val eventBus = SDKComponent.eventBus
+
+        triggeringGeofenceIds.forEach { geofenceId ->
+            if (geofenceId == GeofenceConstants.MOVEMENT_TRIGGER_ID) {
+                // TODO(MBL-1623): dispatch movement-trigger EXIT to GeofenceServices.onMovementTriggerExit
+                logger.logMovementTriggerSkipped()
+                return@forEach
+            }
+
+            val transition = when (gmsTransitionType) {
+                Geofence.GEOFENCE_TRANSITION_ENTER -> Event.GeofenceTransition.ENTER
+                Geofence.GEOFENCE_TRANSITION_EXIT -> Event.GeofenceTransition.EXIT
+                else -> {
+                    logger.logUnknownTransition(gmsTransitionType)
+                    return@forEach
+                }
+            }
+
+            logger.logTransitionEmitting(geofenceId, transition.name)
+
+            val properties = buildMap<String, Any> {
+                put("geofence_id", geofenceId)
+                put("transition_type", transition.name.lowercase())
+                latitude?.let { put("latitude", it) }
+                longitude?.let { put("longitude", it) }
+                put("timestamp", timestamp)
+            }
+            eventBus.publish(
+                Event.GeofenceTransitionEvent(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    properties = properties
+                )
             )
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -29,12 +29,24 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Cannot register geofences: $permission not granted. Host app must request this permission.", tag = TAG)
     }
 
-    fun logTransitionReceived(geofenceId: String, transitionName: String) {
-        logger.debug("Transition $transitionName for geofence $geofenceId", tag = TAG)
+    fun logTransitionEmitting(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: emitting tracked event via EventBus", tag = TAG)
+    }
+
+    fun logUnknownTransition(transitionType: Int) {
+        logger.debug("Ignoring geofence transition type=$transitionType (only ENTER and EXIT are tracked)", tag = TAG)
+    }
+
+    fun logTransitionWithoutLocation() {
+        logger.debug("Geofence transition fired but OS provided no location; emitting event with lat/lng omitted from properties", tag = TAG)
+    }
+
+    fun logMovementTriggerSkipped() {
+        logger.debug("Movement trigger geofence fired; movement-trigger handling lands in MBL-1623", tag = TAG)
     }
 
     fun logGeofencingError(errorCode: Int) {
-        logger.error("Geofencing error code: $errorCode", tag = TAG)
+        logger.error("OS reported geofencing error (code=$errorCode); see GeofenceStatusCodes for meaning", tag = TAG)
     }
 
     fun logSyncFailed(message: String?) {

--- a/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
@@ -1,0 +1,233 @@
+package io.customer.location.geofence
+
+import android.location.Location
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingEvent
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceBroadcastReceiverTest : RobolectricTest() {
+
+    // 'mock' prefix avoids shadowing SDKComponent.eventBus inside the `sdk { ... }`
+    // override lambda — bare `eventBus` would resolve to the receiver's property.
+    private val mockEventBus: EventBus = mockk(relaxed = true)
+
+    private lateinit var receiver: GeofenceBroadcastReceiver
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+                diGraph {
+                    sdk { overrideDependency<EventBus>(mockEventBus) }
+                }
+            }
+        )
+        receiver = GeofenceBroadcastReceiver()
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenNullEvent_expectNothingPublished() {
+        receiver.handleGeofencingEvent(null)
+
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenHasError_expectNothingPublished() {
+        val event = mockk<GeofencingEvent>(relaxed = true) {
+            every { hasError() } returns true
+            every { errorCode } returns 1000
+        }
+
+        receiver.handleGeofencingEvent(event)
+
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenNullTriggeringGeofences_expectNothingPublished() {
+        val event = mockk<GeofencingEvent>(relaxed = true) {
+            every { hasError() } returns false
+            every { geofenceTransition } returns Geofence.GEOFENCE_TRANSITION_ENTER
+            every { triggeringGeofences } returns null
+        }
+
+        receiver.handleGeofencingEvent(event)
+
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenNullTriggeringLocation_expectEventPublishedWithoutLatLng() {
+        val event = buildGeofencingEvent(
+            transition = Geofence.GEOFENCE_TRANSITION_ENTER,
+            geofenceIds = listOf("biz-1"),
+            location = null
+        )
+        val capturedEvent = slot<Event>()
+        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+
+        receiver.handleGeofencingEvent(event)
+
+        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.geofenceId shouldBeEqualTo "biz-1"
+        published.properties["latitude"].shouldBeNull()
+        published.properties["longitude"].shouldBeNull()
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenValidEnterEvent_expectEventPublishedWithLatLng() {
+        val event = buildGeofencingEvent(
+            transition = Geofence.GEOFENCE_TRANSITION_ENTER,
+            geofenceIds = listOf("biz-1"),
+            location = realLocation(37.7749, -122.4194)
+        )
+        val capturedEvent = slot<Event>()
+        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+
+        receiver.handleGeofencingEvent(event)
+
+        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
+        published.properties["latitude"] shouldBeEqualTo 37.7749
+        published.properties["longitude"] shouldBeEqualTo -122.4194
+    }
+
+    @Test
+    fun dispatchTransition_givenEnterTransition_expectGeofenceTransitionEventPublished() {
+        val capturedEvent = slot<Event>()
+        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-1"),
+            latitude = 37.7749,
+            longitude = -122.4194
+        )
+
+        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.geofenceId shouldBeEqualTo "biz-geofence-1"
+        published.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
+        published.properties["geofence_id"] shouldBeEqualTo "biz-geofence-1"
+        published.properties["transition_type"] shouldBeEqualTo "enter"
+        published.properties["latitude"] shouldBeEqualTo 37.7749
+        published.properties["longitude"] shouldBeEqualTo -122.4194
+        published.properties["timestamp"].shouldNotBeNull()
+    }
+
+    @Test
+    fun dispatchTransition_givenExitTransition_expectExitEventPublished() {
+        val capturedEvent = slot<Event>()
+        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.transition shouldBeEqualTo Event.GeofenceTransition.EXIT
+        published.properties["transition_type"] shouldBeEqualTo "exit"
+    }
+
+    @Test
+    fun dispatchTransition_givenMovementTriggerGeofence_expectNoEventPublished() {
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnknownTransitionType_expectNoEventPublished() {
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_DWELL,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenMissingLatLng_expectEventPublishedWithoutLatLng() {
+        val capturedEvent = slot<Event>()
+        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = null,
+            longitude = null
+        )
+
+        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.properties["latitude"].shouldBeNull()
+        published.properties["longitude"].shouldBeNull()
+        published.properties["geofence_id"] shouldBeEqualTo "biz-geofence"
+    }
+
+    @Test
+    fun dispatchTransition_givenBatchWithMovementTriggerAndBusiness_expectOnlyBusinessPublished() {
+        val capturedEvents = mutableListOf<Event>()
+        every { mockEventBus.publish(capture(capturedEvents)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        capturedEvents.size shouldBeEqualTo 1
+        val published = capturedEvents.first().shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
+        published.geofenceId shouldBeEqualTo "biz-geofence"
+    }
+
+    private fun buildGeofencingEvent(
+        transition: Int,
+        geofenceIds: List<String>,
+        location: Location?
+    ): GeofencingEvent {
+        val geofences = geofenceIds.map { id ->
+            mockk<Geofence>(relaxed = true) { every { requestId } returns id }
+        }
+        return mockk(relaxed = true) {
+            every { hasError() } returns false
+            every { geofenceTransition } returns transition
+            every { triggeringGeofences } returns geofences
+            every { triggeringLocation } returns location
+        }
+    }
+
+    private fun realLocation(lat: Double, lng: Double): Location =
+        Location("test-provider").apply {
+            latitude = lat
+            longitude = lng
+            time = System.currentTimeMillis()
+        }
+}


### PR DESCRIPTION
## Linear ticket

[MBL-1627: Android — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1627/android-send-geofence-transition-events)

## Stack

This is **PR 1 of 3** stacked PRs under MBL-1627. All three target `feature/geofence-on-device` and will be merged in order.

1. **This PR** — Event types, EventNames, EventBus subscription, receiver publishes to EventBus
2. **PR 2 (next)** — WorkManager-based direct HTTP delivery for events that survive process death
3. **PR 3** — 1-hour cooldown filter to suppress duplicate transitions

Each PR is self-contained but builds on the previous one.

## Summary

When the OS fires a geofence transition, the SDK now publishes a typed `Event.GeofenceTransitionEvent` to the in-process `EventBus`, and the DataPipelines module subscribes and forwards it to `track()` so the event lands in the customer's Customer.io dashboard.

This PR establishes the **EventBus delivery path**. The redundant WorkManager-based delivery (so events survive process death) lands in PR 2, mirroring the `PushMessageProcessorImpl.trackDeliveredMetrics` pattern (parallel WM + EventBus delivery).

### Changes

**Core**
- `Event.GeofenceTransition` enum (`ENTER`, `EXIT`) + `Event.GeofenceTransitionEvent` data class inside the sealed `Event`
- `EventNames.GEOFENCE_ENTERED = "GeoFence Entered"`, `GEOFENCE_EXITED = "GeoFence Exited"` (note the capital `F` — matches the platform's event naming convention)
- `Clock` interface + `SystemClock` impl + DI singleton — injectable time source, used here for event timestamp; used by the cooldown filter in PR 3

**Location module**
- `GeofenceBroadcastReceiver` refactored into three testable methods: `onReceive(context, intent)` → `handleGeofencingEvent(event: GeofencingEvent?)` → `dispatchTransition(...)`. The `@VisibleForTesting` split keeps the parsing layer separately verifiable from the dispatch logic and avoids needing to static-mock `GeofencingEvent.fromIntent` in tests.
- Receiver behavior:
  - Skips the movement-trigger geofence (`TODO(MBL-1623)` — full handling lands when the sync layer ships)
  - Maps GMS transition int → `Event.GeofenceTransition`; only `ENTER` and `EXIT` are tracked (other types like `DWELL` are logged and skipped)
  - When `triggeringLocation` is null, logs `logTransitionWithoutLocation` and **still emits** the event with `latitude`/`longitude` omitted from properties (campaign triggers should fire on `geofence_id` + `transition_type`, lat/lng is enrichment)
- `GeofenceLogger` gains action-oriented messages: `logTransitionEmitting`, `logUnknownTransition`, `logTransitionWithoutLocation`, `logMovementTriggerSkipped`. Existing `logGeofencingError` message tightened.

**Datapipelines**
- `CustomerIO.subscribeToJourneyEvents` adds a subscription for `Event.GeofenceTransitionEvent` that maps `transition` → `EventNames` and forwards to `track(name, properties)`.

### Event properties shape sent on `track`

```json
{
  "geofence_id": "<string>",
  "transition_type": "enter" | "exit",
  "latitude": <double, omitted if OS provided no location>,
  "longitude": <double, omitted if OS provided no location>,
  "timestamp": <unix seconds>
}
```

Note: backend API for geofence events isn't finalized yet — property key/casing may change in a follow-up if needed (purely additive change, doesn't affect this PR's structure).

## Verification

Automated tests added in this PR:
- [x] `GeofenceBroadcastReceiverTest` — 11 tests covering `handleGeofencingEvent` (null event, `hasError`, null `triggeringGeofences`, null `triggeringLocation`, valid event) and `dispatchTransition` (ENTER, EXIT, movement trigger skip, unknown transition skip, missing lat/lng, batch with movement+business)
- [x] `GeofenceEventSubscriptionTest` (datapipelines) — verifies the EventBus handler maps `ENTER` → `"GeoFence Entered"` and `EXIT` → `"GeoFence Exited"` and forwards properties to analytics via `OutputReaderPlugin`

End-to-end manual verification (trigger a real geofence, observe the tracked event in the Customer.io dashboard) is **deferred** — it's not feasible until the rest of the stack lands, since this PR alone doesn't provide:
- Public API to register geofences (MBL-1623)
- `LocationModuleConfig` flag to enable the feature (MBL-1629)
- Sync layer that decides which geofences to register (MBL-1623)

The earliest meaningful end-to-end check happens once **MBL-1629** lands. Until then, this PR is verified by unit tests only. A dev could in principle register geofences via the internal `GeofenceManager` and walk through a boundary to exercise the path, but that bypasses the intended SDK flow.

## Out of scope (handled in stacked PRs)

- WorkManager direct HTTP delivery (PR 2) — events survive process death
- Cooldown filter to dedupe rapid repeated transitions (PR 3)
- `goAsync()` hardening on the broadcast receiver — discussed, deferred to a follow-up since the existing push receiver doesn't use it either; will revisit together


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new geofence transition event pipeline from `GeofenceBroadcastReceiver` through `EventBus` into DataPipelines `track()`, which could affect analytics event volume and correctness if transition mapping/properties are wrong. Changes are localized but touch runtime broadcast handling and event naming.
> 
> **Overview**
> OS geofence callbacks are now translated into a typed `Event.GeofenceTransitionEvent` (`ENTER`/`EXIT`) and published on the in-process `EventBus`, including a standardized properties payload (`geofence_id`, `transition_type`, optional `latitude`/`longitude`, and `timestamp`).
> 
> DataPipelines subscribes to this new event and forwards it to `track()` using new `EventNames` constants (`GeoFence Entered`/`GeoFence Exited`). The location receiver was refactored into testable units, adds explicit handling for unknown transitions, missing location, and skips the movement-trigger geofence ID.
> 
> Adds an injectable `Clock` (with `SystemClock`) to DI for timestamping, updates the public API surface, and introduces unit tests covering receiver dispatch behavior and the DataPipelines subscription mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5948c4285a0d65fdc48113940e90aa0ff7f52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->