### PR TITLE
chore: suppress duplicate geofence transitions via cooldown filter (MBL-1627)

### DIFF
--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -2,6 +2,7 @@ package io.customer.location
 
 import android.location.Location
 import androidx.lifecycle.ProcessLifecycleOwner
+import io.customer.location.geofence.di.geofenceCooldownFilter
 import io.customer.location.provider.FusedLocationProvider
 import io.customer.location.store.LocationPreferenceStoreImpl
 import io.customer.location.sync.LocationSyncFilter
@@ -118,6 +119,12 @@ class ModuleLocation @JvmOverloads constructor(
             if (!it.userId.isNullOrEmpty()) {
                 locationTracker.onUserIdentified()
             }
+        }
+
+        // Clear geofence cooldown state on user reset so a new user isn't suppressed
+        // by transitions emitted under the previous identity.
+        eventBus.subscribe<Event.ResetEvent> {
+            SDKComponent.android().geofenceCooldownFilter.clearAll()
         }
 
         // Register lifecycle observer for background cancellation and ON_APP_START.

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
+import io.customer.location.geofence.di.geofenceCooldownFilter
 import io.customer.location.geofence.di.geofenceEventScheduler
 import io.customer.location.geofence.di.geofenceLogger
 import io.customer.sdk.communication.Event
@@ -89,6 +90,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val timestamp = SDKComponent.clock.currentTimeSeconds()
         val androidComponent = SDKComponent.android()
         val scheduler = androidComponent.geofenceEventScheduler
+        val cooldownFilter = androidComponent.geofenceCooldownFilter
         val eventBus = SDKComponent.eventBus
 
         triggeringGeofenceIds.forEach { geofenceId ->
@@ -107,6 +109,10 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
+            if (!cooldownFilter.tryAcquire(geofenceId, transition)) {
+                logger.logTransitionSuppressed(geofenceId, transition.name)
+                return@forEach
+            }
             logger.logTransitionEmitting(geofenceId, transition.name)
 
             // Parallel delivery: WorkManager (survives process death) + EventBus (analytics pipeline).

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceCooldownFilter.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceCooldownFilter.kt
@@ -1,0 +1,30 @@
+package io.customer.location.geofence
+
+import io.customer.location.geofence.store.GeofenceCooldownStore
+import io.customer.sdk.communication.Event
+import io.customer.sdk.core.util.Clock
+
+/** Suppresses duplicate geofence events within a configurable cooldown window. */
+internal class GeofenceCooldownFilter(
+    private val store: GeofenceCooldownStore,
+    private val clock: Clock
+) {
+    /**
+     * Atomically checks the cooldown and records the emit if allowed. Returns true if the
+     * caller should proceed to emit, false if the transition is within the cooldown window.
+     */
+    @Synchronized
+    fun tryAcquire(
+        geofenceId: String,
+        transition: Event.GeofenceTransition
+    ): Boolean {
+        val last = store.getLastEmitTimestamp(geofenceId, transition)
+        val now = clock.currentTimeMillis()
+        if (last != null && (now - last) < GeofenceConstants.DEDUPE_COOLDOWN_MS) return false
+        store.recordEmit(geofenceId, transition, now)
+        return true
+    }
+
+    @Synchronized
+    fun clearAll() = store.clearAll()
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -33,6 +33,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' $transitionName: emitting tracked event via WorkManager + EventBus", tag = TAG)
     }
 
+    fun logTransitionSuppressed(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: suppressed — same transition fired within the cooldown window", tag = TAG)
+    }
+
     fun logUnknownTransition(transitionType: Int) {
         logger.debug("Ignoring geofence transition type=$transitionType (only ENTER and EXIT are tracked)", tag = TAG)
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -2,15 +2,19 @@ package io.customer.location.geofence.di
 
 import com.google.android.gms.location.GeofencingClient
 import com.google.android.gms.location.LocationServices
+import io.customer.location.geofence.GeofenceCooldownFilter
 import io.customer.location.geofence.GeofenceLogger
 import io.customer.location.geofence.GeofenceManager
 import io.customer.location.geofence.GeofenceReceiverToggle
+import io.customer.location.geofence.store.GeofenceCooldownStore
+import io.customer.location.geofence.store.GeofenceCooldownStoreImpl
 import io.customer.location.geofence.worker.AsyncGeofenceEventTracker
 import io.customer.location.geofence.worker.GeofenceEventScheduler
 import io.customer.location.geofence.worker.GeofenceEventTracker
 import io.customer.location.geofence.worker.GeofenceEventTrackerImpl
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.httpClient
 import io.customer.sdk.core.di.workManagerProvider
 
@@ -38,3 +42,9 @@ internal val AndroidSDKComponent.asyncGeofenceEventTracker: AsyncGeofenceEventTr
 
 internal val AndroidSDKComponent.geofenceEventScheduler: GeofenceEventScheduler
     get() = singleton { GeofenceEventScheduler(SDKComponent.workManagerProvider, asyncGeofenceEventTracker) }
+
+internal val AndroidSDKComponent.geofenceCooldownStore: GeofenceCooldownStore
+    get() = singleton<GeofenceCooldownStore> { GeofenceCooldownStoreImpl(applicationContext) }
+
+internal val AndroidSDKComponent.geofenceCooldownFilter: GeofenceCooldownFilter
+    get() = singleton<GeofenceCooldownFilter> { GeofenceCooldownFilter(geofenceCooldownStore, SDKComponent.clock) }

--- a/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceCooldownStore.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceCooldownStore.kt
@@ -1,0 +1,47 @@
+package io.customer.location.geofence.store
+
+import android.content.Context
+import androidx.core.content.edit
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.PreferenceStore
+import io.customer.sdk.data.store.read
+
+/** Persists last-emitted timestamps for geofence event cooldown. */
+internal interface GeofenceCooldownStore {
+    fun getLastEmitTimestamp(geofenceId: String, transition: Event.GeofenceTransition): Long?
+    fun recordEmit(geofenceId: String, transition: Event.GeofenceTransition, timestamp: Long)
+    fun clearAll()
+}
+
+internal class GeofenceCooldownStoreImpl(
+    context: Context
+) : PreferenceStore(context), GeofenceCooldownStore {
+
+    override val prefsName: String by lazy {
+        "io.customer.sdk.geofence_cooldown.${context.packageName}"
+    }
+
+    override fun getLastEmitTimestamp(
+        geofenceId: String,
+        transition: Event.GeofenceTransition
+    ): Long? = prefs.read {
+        val key = cooldownKey(geofenceId, transition)
+        if (contains(key)) getLong(key, 0L) else null
+    }
+
+    override fun recordEmit(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        timestamp: Long
+    ) {
+        prefs.edit { putLong(cooldownKey(geofenceId, transition), timestamp) }
+    }
+
+    override fun clearAll() {
+        prefs.edit { clear() }
+    }
+
+    private fun cooldownKey(geofenceId: String, transition: Event.GeofenceTransition): String {
+        return "cio_cooldown_${geofenceId}_${transition.name}"
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
@@ -12,6 +12,7 @@ import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -32,6 +33,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     // extension properties inside `sdk { ... }` / `android { ... }` override lambdas.
     private val mockEventBus: EventBus = mockk(relaxed = true)
     private val mockScheduler: GeofenceEventScheduler = mockk(relaxed = true)
+    private val mockCooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
 
     private lateinit var receiver: GeofenceBroadcastReceiver
 
@@ -41,10 +43,15 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                 argument(ApplicationArgument(applicationMock))
                 diGraph {
                     sdk { overrideDependency<EventBus>(mockEventBus) }
-                    android { overrideDependency<GeofenceEventScheduler>(mockScheduler) }
+                    android {
+                        overrideDependency<GeofenceEventScheduler>(mockScheduler)
+                        overrideDependency<GeofenceCooldownFilter>(mockCooldownFilter)
+                    }
                 }
             }
         )
+        // Default: cooldown allows emission. Tests override this to test suppression.
+        every { mockCooldownFilter.tryAcquire(any(), any()) } returns true
         receiver = GeofenceBroadcastReceiver()
     }
 
@@ -230,6 +237,37 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         published.properties["latitude"].shouldBeNull()
         published.properties["longitude"].shouldBeNull()
         published.properties["geofence_id"] shouldBeEqualTo "biz-geofence"
+    }
+
+    @Test
+    fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduledOrPublished() = runTest {
+        every { mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER) } returns false
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenCooldownAllows_expectTryAcquireBeforeScheduleAndPublish() = runTest {
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerifyOrder {
+            mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER)
+            mockScheduler.schedule(any(), any(), any(), any(), any())
+            mockEventBus.publish(any<Event.GeofenceTransitionEvent>())
+        }
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/GeofenceCooldownFilterTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceCooldownFilterTest.kt
@@ -1,0 +1,89 @@
+package io.customer.location.geofence
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.store.GeofenceCooldownStore
+import io.customer.sdk.communication.Event
+import io.customer.sdk.core.util.Clock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceCooldownFilterTest : RobolectricTest() {
+
+    private val mockStore: GeofenceCooldownStore = mockk(relaxed = true)
+    private val mockClock: Clock = mockk(relaxed = true)
+
+    private lateinit var filter: GeofenceCooldownFilter
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { })
+        filter = GeofenceCooldownFilter(mockStore, mockClock)
+    }
+
+    @Test
+    fun tryAcquire_givenNoPreviousEmit_expectTrueAndRecorded() {
+        every { mockStore.getLastEmitTimestamp(any(), any()) } returns null
+        every { mockClock.currentTimeMillis() } returns 100_000L
+
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        verify(exactly = 1) { mockStore.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 100_000L) }
+    }
+
+    @Test
+    fun tryAcquire_givenPreviousEmitWithinCooldown_expectFalseAndNotRecorded() {
+        val lastEmit = 100_000L
+        val now = lastEmit + (GeofenceConstants.DEDUPE_COOLDOWN_MS - 1)
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
+        every { mockClock.currentTimeMillis() } returns now
+
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        verify(exactly = 0) { mockStore.recordEmit(any(), any(), any()) }
+    }
+
+    @Test
+    fun tryAcquire_givenPreviousEmitExactlyAtCooldownBoundary_expectTrueAndRecorded() {
+        val lastEmit = 100_000L
+        val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
+        every { mockClock.currentTimeMillis() } returns now
+
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        verify(exactly = 1) { mockStore.recordEmit("biz-1", Event.GeofenceTransition.ENTER, now) }
+    }
+
+    @Test
+    fun tryAcquire_givenPreviousEmitOutsideCooldown_expectTrueAndRecorded() {
+        val lastEmit = 100_000L
+        val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS + 1
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
+        every { mockClock.currentTimeMillis() } returns now
+
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        verify(exactly = 1) { mockStore.recordEmit("biz-1", Event.GeofenceTransition.ENTER, now) }
+    }
+
+    @Test
+    fun tryAcquire_givenSameGeofenceDifferentTransition_keysIndependently() {
+        // ENTER fired recently, EXIT never fired — EXIT should still acquire
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) } returns 100L
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.EXIT) } returns null
+        every { mockClock.currentTimeMillis() } returns 200L
+
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.EXIT).shouldBeTrue()
+    }
+
+    @Test
+    fun clearAll_expectStoreCleared() {
+        filter.clearAll()
+        verify(exactly = 1) { mockStore.clearAll() }
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/store/GeofenceCooldownStoreTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/GeofenceCooldownStoreTest.kt
@@ -1,0 +1,70 @@
+package io.customer.location.geofence.store
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.communication.Event
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceCooldownStoreTest : RobolectricTest() {
+
+    private lateinit var store: GeofenceCooldownStoreImpl
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        store = GeofenceCooldownStoreImpl(applicationMock)
+        store.clearAll()
+    }
+
+    @Test
+    fun getLastEmitTimestamp_givenNothingStored_expectNull() {
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
+    }
+
+    @Test
+    fun recordEmit_thenGetLastEmitTimestamp_expectStoredValue() {
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 1_234L)
+
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo 1_234L
+    }
+
+    @Test
+    fun recordEmit_givenMultipleKeys_expectIndependentValues() {
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 100L)
+        store.recordEmit("biz-1", Event.GeofenceTransition.EXIT, 200L)
+        store.recordEmit("biz-2", Event.GeofenceTransition.ENTER, 300L)
+
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo 100L
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.EXIT) shouldBeEqualTo 200L
+        store.getLastEmitTimestamp("biz-2", Event.GeofenceTransition.ENTER) shouldBeEqualTo 300L
+    }
+
+    @Test
+    fun recordEmit_givenSameKey_expectOverwrite() {
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 100L)
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 200L)
+
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo 200L
+    }
+
+    @Test
+    fun clearAll_expectAllValuesRemoved() {
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 100L)
+        store.recordEmit("biz-2", Event.GeofenceTransition.EXIT, 200L)
+
+        store.clearAll()
+
+        store.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
+        store.getLastEmitTimestamp("biz-2", Event.GeofenceTransition.EXIT).shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Linear ticket

[MBL-1627: Android — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1627/android-send-geofence-transition-events)

## Stack

This is **PR 3 of 3** stacked PRs under MBL-1627, targeting `feature/geofence-on-device`.

1. [PR 1 (#683)](https://github.com/customerio/customerio-android/pull/683) — Event types, EventNames, EventBus subscription
2. [PR 2 (#684)](https://github.com/customerio/customerio-android/pull/684) — WorkManager-based direct HTTP delivery
3. **This PR** — 1-hour cooldown filter to suppress duplicate transitions at the receiver

## Summary

PR 2's WorkManager-key dedup catches OS double-fire bursts within the same second (timestamp at second resolution). This PR adds an *application-level* cooldown filter at the receiver that suppresses identical transitions across a wider 1-hour window, applying to **both** delivery paths (WorkManager + EventBus) before either is invoked.

The filter exposes a single atomic `tryAcquire(geofenceId, transition): Boolean` method — check-and-record happens inside one `@Synchronized` block so two concurrent broadcasts can't both pass the cooldown check and emit duplicates.

### Changes

**Location module — new files**
- `GeofenceCooldownFilter.kt` — `tryAcquire(...)` reads the last-emit timestamp from the store, compares against `GeofenceConstants.DEDUPE_COOLDOWN_MS` (1h), records the new timestamp if allowed, returns true/false. Both `tryAcquire` and `clearAll` are `@Synchronized` so they share the filter monitor — `clearAll` waits for any in-flight `tryAcquire` to complete before wiping the store.
- `store/GeofenceCooldownStore.kt` — interface + `PreferenceStore`-backed impl. Keys are `cio_cooldown_${geofenceId}_${transition.name}`. Prefs file is namespaced per app (`io.customer.sdk.geofence_cooldown.${packageName}`).

**Location module — modified**
- `GeofenceBroadcastReceiver.dispatchTransition()` — between transition validation and the delivery paths, calls `cooldownFilter.tryAcquire(...)`; if it returns false, logs a `suppressed` event and skips both the scheduler and EventBus for that geofence.
- `ModuleLocation.initialize()` — subscribes to `Event.ResetEvent` and calls `geofenceCooldownFilter.clearAll()` so a new user isn't suppressed by transitions emitted under the previous identity.
- `GeofenceLogger` gains `logTransitionSuppressed` (debug). Wording is generic (`"within the cooldown window"`) so it doesn't lie if the constant changes.
- `DIGraphGeofence` adds `geofenceCooldownStore` and `geofenceCooldownFilter` singletons on `AndroidSDKComponent` (the store needs Android context).

### Notable design notes for reviewers

- **Atomic `tryAcquire`** — single `@Synchronized` method instead of separate `shouldEmit`/`recordEmit`. Prevents a TOCTOU race where two concurrent broadcasts could both pass the check and emit. Caller decides (`if (!tryAcquire(...)) return`).
- **Record-before-deliver** — `tryAcquire` records the timestamp before the receiver invokes the scheduler/EventBus. If delivery fails downstream (HTTP error, etc.), the WM worker retries; the cooldown protects against repeat *receiver invocations*, not against delivery failures.
- **`@Synchronized clearAll`** — closes the narrow window where `clearAll` could run between an in-flight `tryAcquire`'s read and write. A residual race (a new `tryAcquire` arriving immediately after `clearAll`) is acceptable: cooldown is a device-level anti-burst mechanism, and any stale entry self-heals within 1h. Backend dedup on `(geofence_id, transition_type, timestamp)` remains the strict-correctness layer.
- **Cooldown is shared across delivery paths** — the filter gates at the receiver, so a suppressed transition skips *both* WM and EventBus. This is by design — the two paths are redundant, not independent.

## Verification

Automated tests added in this PR:
- [x] `GeofenceCooldownFilterTest` — 6 tests covering `tryAcquire` boundary cases (null / within / exactly at / outside cooldown), per-key independence (ENTER vs EXIT not collapsed), and `clearAll` pass-through. Each `tryAcquire` test asserts both the return value and whether `store.recordEmit` was called.
- [x] `GeofenceCooldownStoreTest` — 5 tests covering null read, write+read round trip, multi-key independence, same-key overwrite, `clearAll`. Uses real SharedPreferences via Robolectric.
- [x] `GeofenceBroadcastReceiverTest` (updated) — 2 new tests covering the suppress branch (`tryAcquire` returns false → nothing scheduled or published) and the allow branch with `coVerifyOrder` proving `tryAcquire → scheduler.schedule → eventBus.publish` ordering.

End-to-end manual verification deferred to when MBL-1623 (sync layer) + MBL-1629 (module integration) land — same constraint as PR 1 and PR 2.

## Out of scope

- Sign-out wiring beyond `clearAll` — the `ResetEvent` subscription is wired in this PR, but full sign-out lifecycle integration belongs to MBL-1629.
- E2E manual verification — depends on MBL-1623 (sync) and MBL-1629 (module config flag).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence transition dispatch to suppress events for up to 1 hour using persisted state, which could inadvertently drop legitimate transitions if the cooldown logic/keying is wrong. Touches runtime event delivery (WorkManager + EventBus) and adds SharedPreferences persistence, but scope is limited and covered by new tests.
> 
> **Overview**
> Adds an application-level cooldown dedupe for geofence transitions: `GeofenceBroadcastReceiver.dispatchTransition()` now gates each geofenceId+transition with `GeofenceCooldownFilter.tryAcquire()` (backed by a new `SharedPreferences` store) and skips both WorkManager scheduling and EventBus publishing when suppressed.
> 
> Wires the new `geofenceCooldownStore`/`geofenceCooldownFilter` into the geofence DI graph, adds a suppression log line, and clears cooldown state on `Event.ResetEvent` to avoid a new identity inheriting the previous user’s suppression window. Includes new unit tests for the filter/store and updates receiver tests to cover suppression and call ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5fcd232007a3317cf7eb13c6f44e896e3716a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->