### PR TITLE
chore: add geofence region persistence store

### DIFF
--- a/location/build.gradle
+++ b/location/build.gradle
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.serialization'
 }
 
 ext {

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -166,7 +166,7 @@ internal class GeofenceManager(
     private fun GeofenceRegion.toGmsGeofence(): Geofence {
         return Geofence.Builder()
             .setRequestId(id)
-            .setCircularRegion(latitude, longitude, radiusMeters)
+            .setCircularRegion(latitude, longitude, radius)
             .setTransitionTypes(toGmsTransitionTypes())
             .setExpirationDuration(GeofenceConstants.GEOFENCE_EXPIRATION_NEVER)
             .build()

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
@@ -2,13 +2,15 @@ package io.customer.location.geofence
 
 import android.location.Location
 import com.google.android.gms.location.Geofence
+import kotlinx.serialization.Serializable
 
 /** A geographic region to monitor for enter/exit transitions. */
+@Serializable
 internal data class GeofenceRegion(
     val id: String,
     val latitude: Double,
     val longitude: Double,
-    val radiusMeters: Float,
+    val radius: Float,
     val name: String = "",
     val transitionTypes: List<GeofenceTransitionType> = listOf(
         GeofenceTransitionType.ENTER,
@@ -18,6 +20,7 @@ internal data class GeofenceRegion(
 )
 
 /** Transition types a geofence can monitor, mapped to GMS constants. */
+@Serializable
 internal enum class GeofenceTransitionType(val gmsValue: Int) {
     ENTER(Geofence.GEOFENCE_TRANSITION_ENTER),
     EXIT(Geofence.GEOFENCE_TRANSITION_EXIT)

--- a/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
@@ -1,0 +1,56 @@
+package io.customer.location.geofence.store
+
+import android.content.Context
+import androidx.core.content.edit
+import io.customer.location.geofence.GeofenceRegion
+import io.customer.sdk.data.store.PreferenceStore
+import io.customer.sdk.data.store.read
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/** Persists the set of geofence regions registered with the OS so they can be restored after process death. */
+internal interface GeofenceRegionStore {
+    fun saveAll(regions: List<GeofenceRegion>)
+    fun getAll(): List<GeofenceRegion>
+    fun clearAll()
+    fun getLastSyncTimestamp(): Long?
+    fun setLastSyncTimestamp(timestamp: Long)
+}
+
+internal class GeofenceRegionStoreImpl(
+    context: Context
+) : PreferenceStore(context), GeofenceRegionStore {
+
+    override val prefsName: String by lazy {
+        "io.customer.sdk.geofence_regions.${context.packageName}"
+    }
+
+    override fun saveAll(regions: List<GeofenceRegion>) {
+        prefs.edit {
+            putString(KEY_REGIONS, Json.encodeToString(REGIONS_SERIALIZER, regions))
+        }
+    }
+
+    override fun getAll(): List<GeofenceRegion> = prefs.read {
+        val json = getString(KEY_REGIONS, null) ?: return@read emptyList()
+        Json.decodeFromString(REGIONS_SERIALIZER, json)
+    } ?: emptyList()
+
+    override fun clearAll() {
+        prefs.edit { clear() }
+    }
+
+    override fun getLastSyncTimestamp(): Long? = prefs.read {
+        if (contains(KEY_LAST_SYNC)) getLong(KEY_LAST_SYNC, 0L) else null
+    }
+
+    override fun setLastSyncTimestamp(timestamp: Long) {
+        prefs.edit { putLong(KEY_LAST_SYNC, timestamp) }
+    }
+
+    private companion object {
+        const val KEY_REGIONS = "regions"
+        const val KEY_LAST_SYNC = "last_sync_timestamp"
+        val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
@@ -174,7 +174,7 @@ class GeofenceManagerTest : RobolectricTest() {
             id = "geo-123",
             latitude = 40.7128,
             longitude = -74.0060,
-            radiusMeters = 250f,
+            radius = 250f,
             transitionTypes = listOf(GeofenceTransitionType.ENTER)
         )
         manager.addGeofences(listOf(region))
@@ -325,7 +325,7 @@ class GeofenceManagerTest : RobolectricTest() {
         id: String = "test-geofence",
         latitude: Double = 37.7749,
         longitude: Double = -122.4194,
-        radiusMeters: Float = 100f,
+        radius: Float = 100f,
         transitionTypes: List<GeofenceTransitionType> = listOf(
             GeofenceTransitionType.ENTER,
             GeofenceTransitionType.EXIT
@@ -334,7 +334,7 @@ class GeofenceManagerTest : RobolectricTest() {
         id = id,
         latitude = latitude,
         longitude = longitude,
-        radiusMeters = radiusMeters,
+        radius = radius,
         transitionTypes = transitionTypes
     )
 

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRegionTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRegionTest.kt
@@ -51,7 +51,7 @@ class GeofenceRegionTest : RobolectricTest() {
         id = "test-geofence",
         latitude = 0.0,
         longitude = 0.0,
-        radiusMeters = 100f,
+        radius = 100f,
         transitionTypes = transitionTypes
     )
 }

--- a/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
@@ -1,0 +1,119 @@
+package io.customer.location.geofence.store
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.GeofenceRegion
+import io.customer.location.geofence.GeofenceTransitionType
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceRegionStoreTest : RobolectricTest() {
+
+    private lateinit var store: GeofenceRegionStoreImpl
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        store = GeofenceRegionStoreImpl(applicationMock)
+        store.clearAll()
+    }
+
+    @Test
+    fun getAll_givenNothingStored_expectEmptyList() {
+        store.getAll().shouldBeEmpty()
+    }
+
+    @Test
+    fun saveAll_thenGetAll_expectStoredRegionsRoundTripped() {
+        val regions = listOf(
+            GeofenceRegion(id = "biz-1", latitude = 37.7749, longitude = -122.4194, radius = 100f, name = "Coffee"),
+            GeofenceRegion(
+                id = "biz-2",
+                latitude = 51.5074,
+                longitude = -0.1278,
+                radius = 250f,
+                name = "Office",
+                transitionTypes = listOf(GeofenceTransitionType.ENTER),
+                lastUpdated = 1_700_000_000L
+            )
+        )
+
+        store.saveAll(regions)
+
+        store.getAll() shouldBeEqualTo regions
+    }
+
+    @Test
+    fun saveAll_givenSubsequentSave_expectOverwrite() {
+        val initial = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f))
+        val replacement = listOf(
+            GeofenceRegion("biz-2", 1.0, 2.0, 75f),
+            GeofenceRegion("biz-3", 3.0, 4.0, 100f)
+        )
+
+        store.saveAll(initial)
+        store.saveAll(replacement)
+
+        store.getAll() shouldBeEqualTo replacement
+    }
+
+    @Test
+    fun saveAll_givenEmptyList_expectGetAllReturnsEmpty() {
+        store.saveAll(listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f)))
+        store.saveAll(emptyList())
+
+        store.getAll().shouldBeEmpty()
+    }
+
+    @Test
+    fun clearAll_expectRegionsAndTimestampRemoved() {
+        store.saveAll(listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f)))
+        store.setLastSyncTimestamp(12_345L)
+
+        store.clearAll()
+
+        store.getAll().shouldBeEmpty()
+        store.getLastSyncTimestamp().shouldBeNull()
+    }
+
+    @Test
+    fun lastSyncTimestamp_givenNothingStored_expectNull() {
+        store.getLastSyncTimestamp().shouldBeNull()
+    }
+
+    @Test
+    fun setLastSyncTimestamp_thenGet_expectStoredValue() {
+        store.setLastSyncTimestamp(1_700_000_000L)
+
+        store.getLastSyncTimestamp() shouldBeEqualTo 1_700_000_000L
+    }
+
+    @Test
+    fun setLastSyncTimestamp_givenSubsequentSet_expectOverwrite() {
+        store.setLastSyncTimestamp(100L)
+        store.setLastSyncTimestamp(200L)
+
+        store.getLastSyncTimestamp() shouldBeEqualTo 200L
+    }
+
+    @Test
+    fun getAll_givenCorruptedJson_expectEmptyListNotThrow() {
+        // Simulate corruption by writing garbage into the same prefs key.
+        applicationMock.getSharedPreferences(
+            "io.customer.sdk.geofence_regions.${applicationMock.packageName}",
+            android.content.Context.MODE_PRIVATE
+        ).edit().putString("regions", "this is not valid json").commit()
+
+        store.getAll().shouldBeEmpty()
+    }
+}


### PR DESCRIPTION
## Linear ticket

[MBL-1623: Android — Fetch and Sync Geofences](https://linear.app/customerio/issue/MBL-1623/android-fetch-and-sync-geofences)

## Stack

This is **PR 1 of 5** stacked PRs under MBL-1623, targeting `feature/geofence-on-device`.

1. **This PR** — Region persistence store (foundation for the sync layer)
2. PR 2 (next) — Distance filter for selecting the nearest N regions
3. PR 3 — API service + DTO mapper (stub backend)
4. PR 4 — Repository: sync orchestration (staleness, distance triggers, diff updates)
5. PR 5 — Services entry point + movement-trigger EXIT wiring + DI

## Summary

Adds `GeofenceRegionStore` — persistence for the set of geofence regions fetched from the server so they can be restored after process death and re-registered with the OS without a fresh network call. Used by the repository (PR 4) as the source of truth for "what regions do we know about right now."

Also pre-emptively renames `GeofenceRegion.radiusMeters` → `radius` to match the agreed API field name, so the store's on-disk JSON keys align with the API JSON keys from day 1 (no migration needed later).

## Changes

**New files**
- `location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt` — interface + `PreferenceStore`-backed impl. Stores the region list as a single JSON-encoded string and tracks `lastSyncTimestamp` separately. Methods: `saveAll`, `getAll`, `clearAll`, `getLastSyncTimestamp`, `setLastSyncTimestamp`. `getAll` is corruption-tolerant — malformed JSON returns an empty list instead of throwing.
- `location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt` — 9 tests covering round trip, overwrite, empty list, clearAll, timestamp getter/setter/overwrite, null-when-unset, and corruption tolerance.

**Modified**
- `GeofenceRegion.kt` — `radiusMeters: Float` → `radius: Float`; added `@Serializable` to the data class and the `GeofenceTransitionType` enum so kotlinx.serialization can encode/decode the list.
- `GeofenceManager.kt` — single call site updated for the rename.
- `GeofenceManagerTest.kt` + `GeofenceRegionTest.kt` — test references updated for the rename.
- `location/build.gradle` — added `org.jetbrains.kotlin.plugin.serialization` plugin (the `kotlinxSerializationJson` dependency is already provided transitively by `:core`).

## Notable design notes for reviewers

- **`prefsName: io.customer.sdk.geofence_regions.${packageName}`** — namespaced per-app, separate file from other stores.
- **Serialization pattern** mirrors `GlobalPreferenceStore.saveSettings` in `:core` — `Json.encodeToString` for writes, `runCatching` (via `prefs.read` extension) for tolerant reads.
- **No DI entry yet** — the store will be wired into the DI graph in PR 4 (repository) where there is a consumer. Adding DI now would ship unused infrastructure.
- **Thread safety** — single read or single write per method; SharedPreferences atomicity is sufficient. No `@Synchronized` needed because there are no read-modify-write sequences (different from `GeofenceCooldownFilter`, where `tryAcquire` is atomic).

## Verification

- [x] `GeofenceRegionStoreTest` — 9 tests, all passing
- [x] `GeofenceManagerTest` + `GeofenceRegionTest` — existing tests pass with the rename
- [x] `:core`, `:datapipelines`, `:location` modules all build and test green

End-to-end manual verification deferred to when MBL-1623 PR 5 (services) and MBL-1629 (module config flag) land — no public API to register geofences yet.

## Out of scope

- DI graph wiring (lands in PR 4 with the repository)
- Server-side config overrides (lands in PR 3 with the API)
- Any consumer of the store — this PR is the persistence primitive only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new internal SharedPreferences-backed store and serialization annotations, with only a small internal rename (`radiusMeters` → `radius`) and corresponding test updates.
> 
> **Overview**
> Adds `GeofenceRegionStore`/`GeofenceRegionStoreImpl` to persist the current set of registered geofence regions (as JSON) plus a `lastSyncTimestamp`, including corruption-tolerant reads and new Robolectric tests covering round-trips, overwrite/clear semantics, and timestamp behavior.
> 
> Enables Kotlin serialization in the `location` module and marks `GeofenceRegion`/`GeofenceTransitionType` as `@Serializable`, while renaming `GeofenceRegion.radiusMeters` to `radius` and updating `GeofenceManager` plus existing tests to use the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e914ab873bbe84470bcac460f79c51590fb180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->