### PR TITLE
chore: align live notification envelope with cross-platform spec

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -26,11 +26,12 @@ import org.json.JSONObject
  * Dispatches templated live notifications.
  *
  * Live notifications are ongoing notifications that can be updated in-place
- * (the Android counterpart of iOS Live Activities). Each push declares a
- * `template` (one of the closed set in [TemplateRegistry]) plus a flat JSON
- * `payload` of template-specific fields. Pushes share a stable [ACTIVITY_ID_KEY]
- * so successive updates replace the previous notification rather than creating
- * new ones.
+ * (the Android counterpart of iOS Live Activities). Each push declares an
+ * `activity_type` (one of the closed set in [TemplateRegistry], prefixed with
+ * `io.customer.live.`) plus two JSON objects: `attributes` for static fields
+ * and `content_state` for dynamic fields. Pushes share a stable
+ * [ACTIVITY_ID_KEY] so successive updates replace the previous notification
+ * rather than creating new ones.
  */
 internal class LiveNotificationHandler(
     private val bundle: Bundle
@@ -39,8 +40,9 @@ internal class LiveNotificationHandler(
     companion object {
         const val ACTIVITY_ID_KEY = "activity_id"
         const val EVENT_KEY = "event"
-        const val TEMPLATE_KEY = "template"
-        const val PAYLOAD_KEY = "payload"
+        const val ACTIVITY_TYPE_KEY = "activity_type"
+        const val ATTRIBUTES_KEY = "attributes"
+        const val CONTENT_STATE_KEY = "content_state"
 
         private const val EVENT_END = "end"
 
@@ -67,22 +69,24 @@ internal class LiveNotificationHandler(
         }
 
         val activityId = bundle.getString(ACTIVITY_ID_KEY) ?: return
-        val templateName = bundle.getString(TEMPLATE_KEY)
-        val template = TemplateRegistry.find(templateName)
+        val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
+        val template = TemplateRegistry.find(activityType)
         if (template == null) {
             SDKComponent.logger.error(
-                "Unknown live notification template '$templateName'; dropping push for activity '$activityId'."
+                "Unknown live notification template '$activityType'; dropping push for activity '$activityId'."
             )
             return
         }
 
-        val payload = parsePayload(bundle.getString(PAYLOAD_KEY))
+        val attributes = parseJson(bundle.getString(ATTRIBUTES_KEY))
+        val contentState = parseJson(bundle.getString(CONTENT_STATE_KEY))
         val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
         val effectiveSmallIcon = resolveSmallIcon(context, branding, smallIcon)
 
         val result = template.render(
             context = context,
-            payload = payload,
+            attributes = attributes,
+            contentState = contentState,
             branding = branding,
             smallIcon = effectiveSmallIcon,
             fallbackTintColor = tintColor
@@ -162,12 +166,12 @@ internal class LiveNotificationHandler(
         }
     }
 
-    private fun parsePayload(raw: String?): JSONObject {
+    private fun parseJson(raw: String?): JSONObject {
         if (raw.isNullOrEmpty()) return JSONObject()
         return try {
             JSONObject(raw)
         } catch (e: JSONException) {
-            SDKComponent.logger.error("Failed to parse live notification payload JSON: ${e.message}")
+            SDKComponent.logger.error("Failed to parse live notification JSON: ${e.message}")
             JSONObject()
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
@@ -24,20 +24,21 @@ internal object AuctionBidTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val itemTitle = payload.optString("itemTitle")
-        val itemImageKey = payload.optString("itemImageKey").takeIf { it.isNotEmpty() }
-        val currencySymbol = payload.optString("currencySymbol").takeIf { it.isNotEmpty() } ?: "$"
-        val currentBid = payload.optString("currentBid")
-        val bidCount = payload.optInt("bidCount", 0)
-        val endTime = payload.optLong("endTime").takeIf { it > 0 }
-        val statusMessage = payload.optString("statusMessage")
-        val isUserHighBidder = payload.optBoolean("isUserHighBidder", false)
-        val userBidAmount = payload.optString("userBidAmount").takeIf { it.isNotEmpty() }
+        val itemTitle = attributes.optString("itemTitle")
+        val itemImageKey = attributes.optString("itemImageKey").takeIf { it.isNotEmpty() }
+        val currencySymbol = attributes.optString("currencySymbol").takeIf { it.isNotEmpty() } ?: "$"
+        val currentBid = contentState.optString("currentBid")
+        val bidCount = contentState.optInt("bidCount", 0)
+        val endTime = contentState.optLong("endTime").takeIf { it > 0 }
+        val statusMessage = contentState.optString("statusMessage")
+        val isUserHighBidder = contentState.optBoolean("isUserHighBidder", false)
+        val userBidAmount = contentState.optString("userBidAmount").takeIf { it.isNotEmpty() }
 
         val body = "$statusMessage · $currencySymbol$currentBid"
         val subText = userBidAmount

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
@@ -19,16 +19,17 @@ internal object CountdownTimerTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val title = payload.optString("title")
-        val heroImageKey = payload.optString("heroImageKey").takeIf { it.isNotEmpty() }
-        val targetDate = payload.optLong("targetDate").takeIf { it > 0 }
-        val statusMessage = payload.optString("statusMessage")
-        val expiredMessage = payload.optString("expiredMessage").takeIf { it.isNotEmpty() }
+        val title = attributes.optString("title")
+        val heroImageKey = attributes.optString("heroImageKey").takeIf { it.isNotEmpty() }
+        val targetDate = contentState.optLong("targetDate").takeIf { it > 0 }
+        val statusMessage = contentState.optString("statusMessage")
+        val expiredMessage = contentState.optString("expiredMessage").takeIf { it.isNotEmpty() }
 
         val now = System.currentTimeMillis()
         val isPostTarget = targetDate != null && now >= targetDate

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
@@ -17,19 +17,20 @@ internal object DeliveryTrackingTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val orderId = payload.optString("orderId")
-        val recipientName = payload.optString("recipientName").takeIf { it.isNotEmpty() }
-        val statusMessage = payload.optString("statusMessage")
-        val statusImageKey = payload.optString("statusImageKey").takeIf { it.isNotEmpty() }
-        val stepCurrent = payload.optInt("stepCurrent", 0)
-        val stepTotal = payload.optInt("stepTotal", 1).coerceAtLeast(1)
-        val estimatedArrival = payload.optLong("estimatedArrival").takeIf { it > 0 }
-        val driverName = payload.optString("driverName").takeIf { it.isNotEmpty() }
+        val orderId = attributes.optString("orderId")
+        val recipientName = attributes.optString("recipientName").takeIf { it.isNotEmpty() }
+        val statusMessage = contentState.optString("statusMessage")
+        val statusImageKey = contentState.optString("statusImageKey").takeIf { it.isNotEmpty() }
+        val stepCurrent = contentState.optInt("stepCurrent", 0)
+        val stepTotal = contentState.optInt("stepTotal", 1).coerceAtLeast(1)
+        val estimatedArrival = contentState.optLong("estimatedArrival").takeIf { it > 0 }
+        val driverName = contentState.optString("driverName").takeIf { it.isNotEmpty() }
 
         val title = recipientName?.let { "Delivery for $it" } ?: "Order #$orderId"
         val subText = when {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
@@ -20,26 +20,27 @@ internal object FlightStatusTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val flightNumber = payload.optString("flightNumber")
-        val origin = payload.optJSONObject("origin")
-        val destination = payload.optJSONObject("destination")
+        val flightNumber = attributes.optString("flightNumber")
+        val origin = attributes.optJSONObject("origin")
+        val destination = attributes.optJSONObject("destination")
         val originCode = origin?.optString("code").orEmpty()
         val destinationCode = destination?.optString("code").orEmpty()
 
-        val statusMessage = payload.optString("statusMessage")
-        val gate = payload.optString("gate").takeIf { it.isNotEmpty() }
-        val terminal = payload.optString("terminal").takeIf { it.isNotEmpty() }
-        val scheduledDeparture = payload.optLong("scheduledDeparture").takeIf { it > 0 }
-        val estimatedArrival = payload.optLong("estimatedArrival").takeIf { it > 0 }
+        val statusMessage = contentState.optString("statusMessage")
+        val gate = contentState.optString("gate").takeIf { it.isNotEmpty() }
+        val terminal = contentState.optString("terminal").takeIf { it.isNotEmpty() }
+        val scheduledDeparture = contentState.optLong("scheduledDeparture").takeIf { it > 0 }
+        val estimatedArrival = contentState.optLong("estimatedArrival").takeIf { it > 0 }
         val progressFractionRaw =
-            if (payload.has("progressFraction")) payload.optDouble("progressFraction") else Double.NaN
+            if (contentState.has("progressFraction")) contentState.optDouble("progressFraction") else Double.NaN
         val progressFraction = progressFractionRaw.takeIf { !it.isNaN() }
-        val delayMinutes = payload.optInt("delayMinutes", 0).takeIf { it > 0 }
+        val delayMinutes = contentState.optInt("delayMinutes", 0).takeIf { it > 0 }
 
         val title = "$flightNumber · $originCode → $destinationCode"
         val subText = "Gate ${gate ?: "TBA"} · Terminal ${terminal ?: "TBA"}"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationTemplate.kt
@@ -11,8 +11,12 @@ import org.json.JSONObject
  *
  * Each template owns its typed schema (e.g. `delivery_tracking` knows about
  * `orderId`, `stepCurrent`, `statusImageKey`). The handler dispatches to a
- * concrete subtype via [TemplateRegistry.find] using the `template` key from
- * the FCM payload.
+ * concrete subtype via [TemplateRegistry.find] using the `activity_type` key
+ * from the FCM envelope.
+ *
+ * Static fields arrive in the `attributes` JSON object; dynamic fields arrive
+ * in the `content_state` JSON object. Strict slotting is enforced — each
+ * template reads each documented field only from its designated slot.
  *
  * Sealed and `internal` — the v1 closed set of templates is the only path.
  * Adding a template means adding a subtype to this hierarchy and an entry to
@@ -23,7 +27,8 @@ internal sealed interface LiveNotificationTemplate {
 
     fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         @DrawableRes smallIcon: Int,
         @ColorInt fallbackTintColor: Int?

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
@@ -21,21 +21,22 @@ internal object LiveScoreTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        payload: JSONObject,
+        attributes: JSONObject,
+        contentState: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val homeTeam = payload.optJSONObject("homeTeam")
-        val awayTeam = payload.optJSONObject("awayTeam")
+        val homeTeam = attributes.optJSONObject("homeTeam")
+        val awayTeam = attributes.optJSONObject("awayTeam")
         val homeName = homeTeam?.optString("name").orEmpty()
         val awayName = awayTeam?.optString("name").orEmpty()
-        val homeScore = payload.optInt("homeScore", 0)
-        val awayScore = payload.optInt("awayScore", 0)
-        val period = payload.optString("period")
-        val clock = payload.optString("clock").takeIf { it.isNotEmpty() }
-        val statusMessage = payload.optString("statusMessage").takeIf { it.isNotEmpty() }
-        val leagueLogoKey = payload.optString("leagueLogoKey").takeIf { it.isNotEmpty() }
+        val homeScore = contentState.optInt("homeScore", 0)
+        val awayScore = contentState.optInt("awayScore", 0)
+        val period = contentState.optString("period")
+        val clock = contentState.optString("clock").takeIf { it.isNotEmpty() }
+        val statusMessage = contentState.optString("statusMessage").takeIf { it.isNotEmpty() }
+        val leagueLogoKey = attributes.optString("leagueLogoKey").takeIf { it.isNotEmpty() }
 
         val title = "$homeName $homeScore - $awayScore $awayName"
         val body = statusMessage

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
@@ -2,11 +2,11 @@ package io.customer.messagingpush.livenotification.template
 
 internal object TemplateRegistry {
 
-    const val DELIVERY_TRACKING = "delivery_tracking"
-    const val FLIGHT_STATUS = "flight_status"
-    const val LIVE_SCORE = "live_score"
-    const val COUNTDOWN_TIMER = "countdown_timer"
-    const val AUCTION_BID = "auction_bid"
+    const val DELIVERY_TRACKING = "io.customer.live.delivery_tracking"
+    const val FLIGHT_STATUS = "io.customer.live.flight_status"
+    const val LIVE_SCORE = "io.customer.live.live_score"
+    const val COUNTDOWN_TIMER = "io.customer.live.countdown_timer"
+    const val AUCTION_BID = "io.customer.live.auction_bid"
 
     fun find(name: String?): LiveNotificationTemplate? = when (name) {
         DELIVERY_TRACKING -> DeliveryTrackingTemplate

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -20,10 +20,12 @@ import io.customer.messagingpush.CustomerIOFirebaseMessagingService;
  * Demo activity that simulates templated live-notification updates by sending
  * synthetic push messages through the SDK's actual push handling code path.
  * <p>
- * Each scenario builds a templated FCM data bundle: top-level lifecycle keys
- * ({@code activity_id}, {@code event}, {@code template}) plus a {@code payload}
- * JSON string carrying template-specific fields. The static branding bundle
- * lives in {@code MessagingPushModuleConfig} and is registered once at SDK init.
+ * Each scenario builds a templated FCM data bundle that matches the
+ * cross-platform live-activity envelope: top-level lifecycle keys
+ * ({@code activity_id}, {@code event}, {@code activity_type}) plus two JSON
+ * strings, {@code attributes} (static fields) and {@code content_state}
+ * (dynamic fields). The static branding bundle lives in
+ * {@code MessagingPushModuleConfig} and is registered once at SDK init.
  */
 public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotificationDemoBinding> {
 
@@ -34,12 +36,13 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
     private static final String EVENT_UPDATE = "update";
     private static final String EVENT_END = "end";
 
-    // Templates
-    private static final String TEMPLATE_DELIVERY_TRACKING = "delivery_tracking";
-    private static final String TEMPLATE_FLIGHT_STATUS = "flight_status";
-    private static final String TEMPLATE_LIVE_SCORE = "live_score";
-    private static final String TEMPLATE_COUNTDOWN_TIMER = "countdown_timer";
-    private static final String TEMPLATE_AUCTION_BID = "auction_bid";
+    // activity_type values are prefixed per the cross-platform spec.
+    private static final String ACTIVITY_TYPE_DELIVERY_TRACKING = "io.customer.live.delivery_tracking";
+    private static final String ACTIVITY_TYPE_FLIGHT_STATUS = "io.customer.live.flight_status";
+    private static final String ACTIVITY_TYPE_LIVE_SCORE = "io.customer.live.live_score";
+    private static final String ACTIVITY_TYPE_COUNTDOWN_TIMER = "io.customer.live.countdown_timer";
+    private static final String ACTIVITY_TYPE_AUCTION_BID = "io.customer.live.auction_bid";
+    private static final String ACTIVITY_TYPE_UNKNOWN = "io.customer.live.bogus";
 
     private enum TemplateChoice {
         DELIVERY_TRACKING, FLIGHT_STATUS, LIVE_SCORE, COUNTDOWN_TIMER, AUCTION_BID
@@ -63,6 +66,7 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         binding.updateButton.setOnClickListener(v -> update());
         binding.endButton.setOnClickListener(v -> end());
         binding.autoButton.setOnClickListener(v -> autoRun());
+        binding.unknownActivityTypeButton.setOnClickListener(v -> sendUnknownActivityType());
 
         binding.typeRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
             if (isActive) {
@@ -87,11 +91,15 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
 
     private int getStepCount() {
         switch (getSelectedTemplate()) {
-            case DELIVERY_TRACKING: return 4; // ordered, preparing, on the way, delivered
-            case FLIGHT_STATUS: return 4;     // pre-departure, boarding, in-flight, arrived
-            case LIVE_SCORE: return 4;        // 4 score updates
-            case COUNTDOWN_TIMER: return 3;   // pre-target, near-target, expired
-            case AUCTION_BID: return 4;       // outbid, winning, outbid again, ended
+            // Delivery: ordered → preparing → out-for-delivery → delivered → missing-asset edge case
+            case DELIVERY_TRACKING: return 5;
+            // Flight: pre-departure → boarding → in-flight → arrived → delay-red variant
+            case FLIGHT_STATUS: return 5;
+            case LIVE_SCORE: return 4;
+            // Countdown: pre-target → near-target → expired (with message) → post-target dismiss
+            case COUNTDOWN_TIMER: return 4;
+            // Auction: outbid → winning → outbid again → ended → no-userBidAmount variant
+            case AUCTION_BID: return 5;
             default: return 1;
         }
     }
@@ -160,27 +168,41 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
                 "Your order has been placed",
                 "Your order is being prepared",
                 "Your order is out for delivery",
-                "Your order has been delivered"
+                "Your order has been delivered",
+                "Asset key missing — design-for-absence path"
         };
-        String[] imageKeys = {"delivery_warehouse", "delivery_warehouse", "delivery_truck", "delivery_door"};
-        JSONObject payload = new JSONObject();
+        // Step 4 intentionally points to a key the host app has not bundled, exercising
+        // TemplateAssets.resolveDrawable's "did not resolve" branch.
+        String[] imageKeys = {
+                "delivery_warehouse",
+                "delivery_warehouse",
+                "delivery_truck",
+                "delivery_door",
+                "unknown_key"
+        };
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
         try {
-            payload.put("orderId", "ABC-1234");
-            payload.put("recipientName", "Mahmoud");
-            payload.put("statusMessage", statuses[step]);
-            payload.put("statusImageKey", imageKeys[step]);
-            payload.put("stepCurrent", step + 1);
-            payload.put("stepTotal", statuses.length);
-            payload.put("estimatedArrival", System.currentTimeMillis() + 30L * 60 * 1000);
-            if (step == 2) payload.put("driverName", "Sam");
+            attributes.put("orderId", "ABC-1234");
+            attributes.put("recipientName", "Mahmoud");
+
+            contentState.put("statusMessage", statuses[step]);
+            contentState.put("statusImageKey", imageKeys[step]);
+            contentState.put("stepCurrent", step + 1);
+            contentState.put("stepTotal", statuses.length);
+            contentState.put("estimatedArrival", System.currentTimeMillis() + 30L * 60 * 1000);
+            if (step == 2) contentState.put("driverName", "Sam");
         } catch (JSONException ignored) { }
-        fire(buildBundle("demo-delivery-tracking", event, TEMPLATE_DELIVERY_TRACKING, payload));
+        fire(buildBundle("demo-delivery-tracking", event, ACTIVITY_TYPE_DELIVERY_TRACKING, attributes, contentState));
     }
 
     private void sendFlightStatus(String event, int step) {
-        String[] statuses = {"On time", "Boarding now", "In flight", "Arrived"};
-        Double[] progress = {null, null, 0.55, 1.0};
-        JSONObject payload = new JSONObject();
+        String[] statuses = {"On time", "Boarding now", "In flight", "Arrived", "Delayed at gate"};
+        Double[] progress = {null, null, 0.55, 1.0, null};
+        // Step 4 exercises the delay-red accent branch.
+        int[] delayMinutes = {0, 0, 0, 0, 25};
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
         try {
             JSONObject origin = new JSONObject();
             origin.put("code", "JFK");
@@ -189,18 +211,19 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
             destination.put("code", "LAX");
             destination.put("city", "Los Angeles");
 
-            payload.put("flightNumber", "AA1234");
-            payload.put("origin", origin);
-            payload.put("destination", destination);
-            payload.put("statusMessage", statuses[step]);
-            payload.put("gate", step >= 1 ? "B12" : JSONObject.NULL);
-            payload.put("terminal", step >= 1 ? "4" : JSONObject.NULL);
-            payload.put("scheduledDeparture", System.currentTimeMillis() + 45L * 60 * 1000);
-            payload.put("estimatedArrival", System.currentTimeMillis() + 6L * 60 * 60 * 1000);
-            if (progress[step] != null) payload.put("progressFraction", progress[step]);
-            if (step == 0) payload.put("delayMinutes", 0); // example: not delayed
+            attributes.put("flightNumber", "AA1234");
+            attributes.put("origin", origin);
+            attributes.put("destination", destination);
+
+            contentState.put("statusMessage", statuses[step]);
+            contentState.put("gate", step >= 1 ? "B12" : JSONObject.NULL);
+            contentState.put("terminal", step >= 1 ? "4" : JSONObject.NULL);
+            contentState.put("scheduledDeparture", System.currentTimeMillis() + 45L * 60 * 1000);
+            contentState.put("estimatedArrival", System.currentTimeMillis() + 6L * 60 * 60 * 1000);
+            if (progress[step] != null) contentState.put("progressFraction", progress[step]);
+            if (delayMinutes[step] > 0) contentState.put("delayMinutes", delayMinutes[step]);
         } catch (JSONException ignored) { }
-        fire(buildBundle("demo-flight-status", event, TEMPLATE_FLIGHT_STATUS, payload));
+        fire(buildBundle("demo-flight-status", event, ACTIVITY_TYPE_FLIGHT_STATUS, attributes, contentState));
     }
 
     private void sendLiveScore(String event, int step) {
@@ -208,70 +231,106 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         int[] awayScores = {0, 7, 21, 24};
         String[] periods = {"1st Quarter", "2nd Quarter", "3rd Quarter", "FT"};
         String[] clocks = {"12:00", "5:30", "0:42", null};
-        JSONObject payload = new JSONObject();
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
         try {
             JSONObject homeTeam = new JSONObject();
             homeTeam.put("name", "Lakers");
             JSONObject awayTeam = new JSONObject();
             awayTeam.put("name", "Celtics");
 
-            payload.put("homeTeam", homeTeam);
-            payload.put("awayTeam", awayTeam);
-            payload.put("sport", "basketball");
-            payload.put("leagueLogoKey", "league_nba");
-            payload.put("homeScore", homeScores[step]);
-            payload.put("awayScore", awayScores[step]);
-            payload.put("period", periods[step]);
-            if (clocks[step] != null) payload.put("clock", clocks[step]);
+            attributes.put("homeTeam", homeTeam);
+            attributes.put("awayTeam", awayTeam);
+            attributes.put("sport", "basketball");
+            attributes.put("leagueLogoKey", "league_nba");
+
+            contentState.put("homeScore", homeScores[step]);
+            contentState.put("awayScore", awayScores[step]);
+            contentState.put("period", periods[step]);
+            if (clocks[step] != null) contentState.put("clock", clocks[step]);
         } catch (JSONException ignored) { }
-        fire(buildBundle("demo-live-score", event, TEMPLATE_LIVE_SCORE, payload));
+        fire(buildBundle("demo-live-score", event, ACTIVITY_TYPE_LIVE_SCORE, attributes, contentState));
     }
 
     private void sendCountdownTimer(String event, int step) {
-        JSONObject payload = new JSONObject();
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
         try {
-            payload.put("title", "Flash Sale");
-            payload.put("heroImageKey", "flash_sale_hero");
+            attributes.put("title", "Flash Sale");
+            attributes.put("heroImageKey", "flash_sale_hero");
+
             // Step 0: 5 min out. Step 1: 30s out. Step 2: post-target with expired message.
+            // Step 3: post-target with NO expiredMessage — exercises cancelImmediately path.
             long now = System.currentTimeMillis();
-            long[] offsets = {5 * 60 * 1000L, 30 * 1000L, -1};
-            payload.put("targetDate", offsets[step] >= 0 ? now + offsets[step] : now - 1000);
-            payload.put("statusMessage", "Sale starts in");
-            if (step == 2) payload.put("expiredMessage", "Sale is live!");
+            long[] offsets = {5 * 60 * 1000L, 30 * 1000L, -1, -1};
+            contentState.put("targetDate", offsets[step] >= 0 ? now + offsets[step] : now - 1000);
+            contentState.put("statusMessage", "Sale starts in");
+            if (step == 2) contentState.put("expiredMessage", "Sale is live!");
+            // step == 3: deliberately omit expiredMessage
         } catch (JSONException ignored) { }
-        fire(buildBundle("demo-countdown-timer", event, TEMPLATE_COUNTDOWN_TIMER, payload));
+        fire(buildBundle("demo-countdown-timer", event, ACTIVITY_TYPE_COUNTDOWN_TIMER, attributes, contentState));
     }
 
     private void sendAuctionBid(String event, int step) {
         // Step 0: outbid, step 1: winning, step 2: outbid again, step 3: ended
-        boolean[] highBidder = {false, true, false, false};
-        String[] currentBids = {"1,200", "1,250", "1,300", "1,300"};
-        String[] userBids = {"1,150", "1,250", "1,250", "1,250"};
-        String[] statuses = {"You've been outbid", "You're winning", "You've been outbid", "Auction ended"};
-        int[] bidCounts = {7, 8, 9, 9};
-        JSONObject payload = new JSONObject();
+        // Step 4: user has no bid in flight — exercises subtext "no user bid" branch.
+        boolean[] highBidder = {false, true, false, false, false};
+        String[] currentBids = {"1,200", "1,250", "1,300", "1,300", "1,300"};
+        String[] userBids = {"1,150", "1,250", "1,250", "1,250", null};
+        String[] statuses = {
+                "You've been outbid",
+                "You're winning",
+                "You've been outbid",
+                "Auction ended",
+                "You haven't bid yet"
+        };
+        int[] bidCounts = {7, 8, 9, 9, 9};
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
         try {
-            payload.put("itemTitle", "Vintage Camera");
-            payload.put("itemImageKey", "auction_camera");
-            payload.put("currencySymbol", "$");
-            payload.put("currentBid", currentBids[step]);
-            payload.put("bidCount", bidCounts[step]);
-            payload.put("endTime", System.currentTimeMillis() + 10L * 60 * 1000);
-            payload.put("statusMessage", statuses[step]);
-            payload.put("isUserHighBidder", highBidder[step]);
-            payload.put("userBidAmount", userBids[step]);
+            attributes.put("itemTitle", "Vintage Camera");
+            attributes.put("itemImageKey", "auction_camera");
+            attributes.put("currencySymbol", "$");
+
+            contentState.put("currentBid", currentBids[step]);
+            contentState.put("bidCount", bidCounts[step]);
+            contentState.put("endTime", System.currentTimeMillis() + 10L * 60 * 1000);
+            contentState.put("statusMessage", statuses[step]);
+            contentState.put("isUserHighBidder", highBidder[step]);
+            if (userBids[step] != null) contentState.put("userBidAmount", userBids[step]);
         } catch (JSONException ignored) { }
-        fire(buildBundle("demo-auction-bid", event, TEMPLATE_AUCTION_BID, payload));
+        fire(buildBundle("demo-auction-bid", event, ACTIVITY_TYPE_AUCTION_BID, attributes, contentState));
     }
 
-    private Bundle buildBundle(String activityId, String event, String template, JSONObject payload) {
+    private void sendUnknownActivityType() {
+        // Exercises LiveNotificationHandler's "Unknown live notification template" log path.
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        Bundle bundle = buildBundle(
+                "demo-unknown-activity-type",
+                EVENT_START,
+                ACTIVITY_TYPE_UNKNOWN,
+                attributes,
+                contentState
+        );
+        fire(bundle);
+    }
+
+    private Bundle buildBundle(
+            String activityId,
+            String event,
+            String activityType,
+            JSONObject attributes,
+            JSONObject contentState
+    ) {
         Bundle bundle = new Bundle();
         bundle.putString("CIO-Delivery-ID", UUID.randomUUID().toString());
         bundle.putString("CIO-Delivery-Token", DEMO_DELIVERY_TOKEN);
         bundle.putString("activity_id", activityId);
         bundle.putString("event", event);
-        bundle.putString("template", template);
-        bundle.putString("payload", payload.toString());
+        bundle.putString("activity_type", activityType);
+        bundle.putString("attributes", attributes.toString());
+        bundle.putString("content_state", contentState.toString());
         return bundle;
     }
 

--- a/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
+++ b/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
@@ -130,5 +130,21 @@
             android:layout_marginTop="@dimen/margin_default"
             android:text="@string/live_notification_auto" />
 
+        <!-- Debug controls -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/live_notification_section_debug"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <Button
+            android:id="@+id/unknown_activity_type_button"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:text="@string/live_notification_debug_unknown_activity_type" />
+
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -175,5 +175,7 @@
     <string name="live_notification_type_live_score">Live Score</string>
     <string name="live_notification_type_countdown_timer">Countdown Timer</string>
     <string name="live_notification_type_auction_bid">Auction Bid</string>
+    <string name="live_notification_section_debug">Debug</string>
+    <string name="live_notification_debug_unknown_activity_type">Fire unknown activity_type</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- Migrates the FCM live-notification wire format from `template` + flat `payload` to the cross-platform spec: `activity_type` + `attributes` (static) + `content_state` (dynamic).
- Prefixes every template name with `io.customer.live.` and enforces strict slotting (each field reads only from its designated slot — no merge fallback).
- Rebuilds the `java_layout` sample to emit the new envelope and adds 5 new scenarios (delay-red flight, post-target dismissal, missing asset, unknown activity_type, auction without `userBidAmount`); adds `POST_PROMOTED_NOTIFICATIONS` permission.

Stacked above #676.

## Test plan
### Automated (done in this PR)
- [x] `./gradlew :messagingpush:testDebugUnitTest` green (existing 121 tests still pass)
- [x] `:messagingpush:apiCheck` green (no public-API changes)
- [x] `:messagingpush:assembleDebug` and `:messagingpush:lintDebug` green
- [x] Sample app builds with new envelope

### Manual (TODO — reviewer to run on emulator/device)
- [ ] On API 36+ (Baklava) emulator: Start → Update → End on each of the 5 templates renders correctly
- [ ] On API 33 device: Start → Update → End on each template renders correctly
- [ ] Delay-red flight scenario: accent forced red `#CC3330`, body suffixed `· Delayed 25 min`
- [ ] Post-target countdown scenario: notification dismisses immediately when target passes
- [ ] Missing-asset delivery scenario: renders without large icon; logcat shows `did not resolve to a drawable` warning
- [ ] Unknown activity_type scenario: no notification posted; logcat shows `Unknown live notification template`
- [ ] Wire-format conformance: bundle keys are exactly `activity_id`, `event`, `activity_type`, `attributes`, `content_state`
- [ ] Same-tier regression: standard (non-live) push still renders normally
- [ ] PR B (stacked) lands the test coverage for the new envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)