### PR TITLE
chore(in-app): dedupe onMessageShown metric by deliveryID per session

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPlugin.kt
@@ -12,12 +12,31 @@ import io.customer.sdk.tracking.TrackableScreen
 
 /**
  * Plugin that automatically tracks screens via ActivityLifecycleCallbacks `onActivityStarted` event of an activity.
+ *
+ * Emissions are deduped in-memory per plugin instance by screen name only (case-sensitive),
+ * mirroring the iOS `InMemoryAutoTrackingScreenViewStore` (see `AutoTrackingScreenViews.swift`
+ * lines ~250-268). Two consecutive `onActivityStarted` callbacks resolving to the same
+ * screen name produce only one emission; navigating away and back re-emits.
  */
 class AutomaticActivityScreenTrackingPlugin : Plugin, AndroidLifecycle {
 
     override val type: Plugin.Type = Plugin.Type.Utility
     override lateinit var analytics: Analytics
     private val logger: Logger = SDKComponent.logger
+
+    // Last screen name emitted by this plugin instance. Guarded by `@Synchronized` on
+    // the dedup helpers below — the codebase idiom (see CustomerIO.createInstance,
+    // IdentifyHookRegistry, PreferenceCrypto) is `@Synchronized` rather than ReentrantLock.
+    // Scope: per-plugin-instance, lifetime of the process; not persisted across launches.
+    private var lastScreenTracked: String? = null
+
+    @Synchronized
+    private fun isDuplicateScreen(screenName: String): Boolean = lastScreenTracked == screenName
+
+    @Synchronized
+    private fun markScreenTracked(screenName: String) {
+        lastScreenTracked = screenName
+    }
 
     override fun onActivityStarted(activity: Activity?) {
         val packageManager = activity?.packageManager
@@ -40,7 +59,18 @@ class AutomaticActivityScreenTrackingPlugin : Plugin, AndroidLifecycle {
             }
             // If screen name is null or blank, we do not track the screen
             if (!screenName.isNullOrBlank()) {
-                runCatching { CustomerIO.instance().screen(screenName) }.onFailure { analytics.screen(screenName) }
+                // Dedup by name only (case-sensitive), parity with iOS.
+                if (isDuplicateScreen(screenName)) return
+                // Mark only when the emit actually succeeds — if both the SDK call and the
+                // analytics fallback throw, the screen wasn't delivered and the next
+                // same-name screen must not be silently deduped.
+                runCatching {
+                    CustomerIO.instance().screen(screenName)
+                    markScreenTracked(screenName)
+                }.onFailure {
+                    analytics.screen(screenName)
+                    markScreenTracked(screenName)
+                }
             }
         } catch (e: PackageManager.NameNotFoundException) {
             logger.error(e.message ?: "Unable to activity screen NameNotFoundException, $activity")

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -111,6 +111,11 @@ class CustomerIO private constructor(
 
     private val contextPlugin: ContextPlugin = ContextPlugin(deviceStore)
 
+    // Tracks the last userId successfully identified in this SDK session. Used to dedup
+    // back-to-back identify(userId) calls with no traits, which are no-ops server-side.
+    // Reset on clearIdentify so a subsequent identify of the same userId is not deduped.
+    private var lastIdentifiedUserIdThisSession: String? = null
+
     init {
         // Set analytics logger and debug logs based on SDK logger configuration
         Analytics.debugLogsEnabled = logger.logLevel == CioLogLevel.DEBUG
@@ -231,6 +236,18 @@ class CustomerIO private constructor(
             return
         }
 
+        // Dedup back-to-back identify calls for the same userId when no traits are supplied.
+        // Because the public API exposes identify(userId, traits = emptyMap()) as a single method
+        // with a defaulted parameter, identify("alice") and identify("alice", emptyMap()) are
+        // indistinguishable at runtime — both compile to the same call with traits = emptyMap().
+        // We treat any empty Map-shaped traits payload (including JsonObject) as the no-traits case;
+        // server-side merge of empty traits is a no-op, so deduping is behaviorally safe.
+        val traitsAreEmpty = traits is Map<*, *> && traits.isEmpty()
+        if (traitsAreEmpty && userId == lastIdentifiedUserIdThisSession) {
+            logger.debug("identify with userId $userId and no traits is a duplicate of the last identify in this session; skipping.")
+            return
+        }
+
         // this is the current userId that is identified in the SDK
         val currentlyIdentifiedProfile = this.userId.takeUnless { it.isNullOrBlank() }
         val isChangingIdentifiedProfile = currentlyIdentifiedProfile != null && currentlyIdentifiedProfile != userId
@@ -269,6 +286,10 @@ class CustomerIO private constructor(
                 trackDeviceAttributes(token = existingDeviceToken)
             }
         }
+
+        // Update the per-session marker after a successful identify (with or without traits)
+        // so that a subsequent no-traits identify of the same userId can be deduped.
+        lastIdentifiedUserIdThisSession = userId
     }
 
     /**
@@ -297,6 +318,9 @@ class CustomerIO private constructor(
 
     override fun clearIdentifyImpl() {
         logger.info("resetting user profile with id ${this.userId}")
+
+        // Reset the dedup marker so a subsequent identify of the same userId is not deduped.
+        lastIdentifiedUserIdThisSession = null
 
         logger.debug("deleting device token to remove device from user profile")
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -533,7 +533,9 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         sdkInstance.identify(givenIdentifier)
 
-        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        // The second identify with the same userId and no traits is deduped in this SDK session.
+        // See IdentifyDedupTests for the dedicated coverage of this behavior.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
         outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupRegressionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupRegressionTests.kt
@@ -1,0 +1,96 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.identifyEvents
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.DataPipelinesLogger
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.customer.sdk.util.EventNames
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for the identify dedup change: the first identify must still publish
+ * [Event.UserChangedEvent] on the EventBus for downstream subscribers (push, in-app, location)
+ * to observe the profile change AND re-register the device token attached to the anonymous
+ * profile. The dedup short-circuit must not break either contract.
+ *
+ * The EventBus is mocked in [setup] (following the pattern used by [ConcurrentScreenViewTest])
+ * so we can capture publications without races on the real shared-flow buffer/replay.
+ */
+class IdentifyDedupRegressionTests : JUnitTest() {
+
+    private val capturedEvents = mutableListOf<Event>()
+    private val capturedEventsLock = Any()
+
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    private val mockDataPipelinesLogger = mockk<DataPipelinesLogger>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        val mockEventBus = mockk<EventBus>(relaxed = true)
+                        val eventSlot = slot<Event>()
+                        every { mockEventBus.publish(capture(eventSlot)) } answers {
+                            synchronized(capturedEventsLock) {
+                                capturedEvents.add(eventSlot.captured)
+                            }
+                        }
+                        overrideDependency<EventBus>(mockEventBus)
+                        overrideDependency<DataPipelinesLogger>(mockDataPipelinesLogger)
+                    }
+                }
+            }
+        )
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+
+        // Drop the UserChangedEvent published during SDK init (postUserIdentificationEvents)
+        // so we only assert against events produced by the test body.
+        capturedEvents.clear()
+    }
+
+    @Test
+    fun identify_givenFirstIdentify_publishesUserChangedEventAndReregistersDeviceToken() {
+        val givenIdentifier = String.random
+        val givenToken = String.random
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+
+        sdkInstance.identify(givenIdentifier)
+
+        // 1. UserChangedEvent published for the newly identified userId.
+        val userChangedEvents = synchronized(capturedEventsLock) {
+            capturedEvents.filterIsInstance<Event.UserChangedEvent>()
+                .filter { it.userId == givenIdentifier }
+        }
+        userChangedEvents.count() shouldBeEqualTo 1
+
+        // 2. Identify event reaches analytics.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+
+        // 3. Existing device token is re-registered to the newly identified profile, which
+        //    surfaces as a DEVICE_UPDATE track event attributed to the new userId.
+        val deviceUpdateEvents = outputReaderPlugin.trackEvents.filter { it.event == EventNames.DEVICE_UPDATE }
+        deviceUpdateEvents.count() shouldBeEqualTo 1
+        deviceUpdateEvents.last().userId shouldBeEqualTo givenIdentifier
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupTests.kt
@@ -1,0 +1,138 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.identifyEvents
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.DataPipelinesLogger
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the per-session identify dedup behavior added in `CustomerIO.identifyImpl`.
+ *
+ * Because the public `identify(userId, traits: Map<String, Any?> = emptyMap())` API exposes a
+ * single method with a defaulted parameter, `identify("alice")` and `identify("alice", emptyMap())`
+ * compile to the same call site at the impl layer — there is no runtime way to tell them apart.
+ * To keep the public API stable, both cases are deduped when the userId matches the last
+ * successfully identified userId in this SDK session. Server-side merge of empty traits is a
+ * no-op, so the behavioral collapse is immaterial in practice.
+ *
+ * See [IdentifyDedupRegressionTests] for the regression guard that the first identify still
+ * publishes UserChangedEvent on the EventBus and re-registers the device token.
+ */
+class IdentifyDedupTests : JUnitTest() {
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    private val mockDataPipelinesLogger = mockk<DataPipelinesLogger>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<DataPipelinesLogger>(mockDataPipelinesLogger)
+                    }
+                }
+            }
+        )
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun identify_givenFirstIdentifyNoTraits_callsAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdNoTraits_doesNotCallAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier)
+
+        // Second call is deduped; no new identify event is emitted to analytics.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
+        outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdEmptyTraits_doesNotCallAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        // Explicit empty map is indistinguishable from no traits at the impl layer because the
+        // public API exposes a single method with a defaulted parameter. Both are deduped.
+        sdkInstance.identify(givenIdentifier, emptyMap())
+
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
+        outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdWithTraits_callsAnalytics() {
+        val givenIdentifier = String.random
+        val givenTraits = mapOf("first_name" to "Dana", "ageInYears" to 30)
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier, givenTraits)
+
+        // Non-empty traits never dedup — the call must reach analytics so server-side
+        // attributes are updated for the existing profile.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenDifferentUserIdNoTraits_callsAnalytics() {
+        val firstIdentifier = String.random
+        val secondIdentifier = String.random
+
+        sdkInstance.identify(firstIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(secondIdentifier)
+
+        // Different userId is a profile change — dedup must NOT fire.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo secondIdentifier
+        analytics.userId() shouldBeEqualTo secondIdentifier
+    }
+
+    @Test
+    fun identify_givenSameUserIdAfterClearIdentify_callsAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        sdkInstance.clearIdentify()
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier)
+
+        // clearIdentify() must reset the dedup marker so that re-identifying the same user
+        // afterwards flows through to analytics again.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/AutomaticActivityScreenTrackingPluginTest.kt
@@ -1,0 +1,142 @@
+package io.customer.datapipelines.plugins
+
+import android.app.Activity
+import io.customer.commontest.config.TestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.customer.sdk.tracking.TrackableScreen
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the name-only dedup behavior in [AutomaticActivityScreenTrackingPlugin].
+ *
+ * Parity reference: iOS `InMemoryAutoTrackingScreenViewStore` in
+ * `AutoTrackingScreenViews.swift` (~lines 250-268). Comparison is name-only,
+ * case-sensitive, in-memory, scoped to the plugin instance lifetime.
+ *
+ * Captures screen emissions by mocking [EventBus] — `CustomerIO.instance().screen(name)`
+ * publishes [Event.ScreenViewedEvent] to the bus, so a single observed publish per
+ * name confirms a single emission. The concurrent test mirrors the style of
+ * `ConcurrentScreenViewTest` (latch-coordinated thread pool).
+ */
+class AutomaticActivityScreenTrackingPluginTest : JUnitTest() {
+
+    private val capturedEvents = mutableListOf<Event.ScreenViewedEvent>()
+    private val capturedEventsLock = Any()
+
+    private lateinit var plugin: AutomaticActivityScreenTrackingPlugin
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfiguration {
+                diGraph {
+                    sdk {
+                        val mockEventBus = mockk<EventBus>(relaxed = true)
+                        val eventSlot = slot<Event.ScreenViewedEvent>()
+                        every { mockEventBus.publish(capture(eventSlot)) } answers {
+                            synchronized(capturedEventsLock) {
+                                capturedEvents.add(eventSlot.captured)
+                            }
+                        }
+                        overrideDependency<EventBus>(mockEventBus)
+                    }
+                }
+            }
+        )
+
+        capturedEvents.clear()
+        plugin = AutomaticActivityScreenTrackingPlugin().apply {
+            analytics = this@AutomaticActivityScreenTrackingPluginTest.analytics
+        }
+    }
+
+    private fun activityForScreen(name: String?): Activity {
+        // Use TrackableScreen branch so we avoid touching PackageManager — the dedup
+        // logic is independent of how the screen name is resolved. `relaxed = true`
+        // lets the unused `activity.packageManager` access at the top of
+        // `onActivityStarted` return a relaxed default instead of crashing.
+        return mockk<Activity>(
+            relaxed = true,
+            moreInterfaces = arrayOf(TrackableScreen::class)
+        ).also { activity ->
+            every { (activity as TrackableScreen).getScreenName() } returns name
+        }
+    }
+
+    private fun publishedScreenNames(): List<String> =
+        synchronized(capturedEventsLock) { capturedEvents.map { it.name }.toList() }
+
+    @Test
+    fun onActivityStarted_givenSameScreenTwice_emitsOnce() {
+        val activity = activityForScreen("Home")
+
+        plugin.onActivityStarted(activity)
+        plugin.onActivityStarted(activity)
+
+        assertEquals(listOf("Home"), publishedScreenNames())
+    }
+
+    @Test
+    fun onActivityStarted_givenDifferentScreens_emitsEach() {
+        plugin.onActivityStarted(activityForScreen("Home"))
+        plugin.onActivityStarted(activityForScreen("Profile"))
+        plugin.onActivityStarted(activityForScreen("Settings"))
+
+        assertEquals(listOf("Home", "Profile", "Settings"), publishedScreenNames())
+    }
+
+    @Test
+    fun onActivityStarted_givenSameScreenAfterDifferent_emitsAgain() {
+        plugin.onActivityStarted(activityForScreen("Home"))
+        plugin.onActivityStarted(activityForScreen("Profile"))
+        plugin.onActivityStarted(activityForScreen("Home"))
+
+        // Home re-emits because the last tracked screen was Profile.
+        assertEquals(listOf("Home", "Profile", "Home"), publishedScreenNames())
+    }
+
+    @Test
+    fun onActivityStarted_givenSameNameAcrossThreads_isThreadSafe() {
+        // Probes the @Synchronized guard on the dedup helpers by hammering the same
+        // name from many threads. The guard prevents torn reads/writes on
+        // lastScreenTracked; dedup itself is best-effort under contention (mark
+        // happens after emit, so several threads may pass isDuplicateScreen before
+        // any of them mark). In practice onActivityStarted runs on the main thread,
+        // so this only verifies the helpers don't corrupt state — every captured
+        // emission is "Home", and at least one emission wins.
+        val threadCount = 16
+        val callsPerThread = 50
+        val sharedActivity = activityForScreen("Home")
+
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        repeat(threadCount) {
+            executor.submit {
+                startLatch.await()
+                repeat(callsPerThread) { plugin.onActivityStarted(sharedActivity) }
+                doneLatch.countDown()
+            }
+        }
+
+        startLatch.countDown()
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS))
+        executor.shutdown()
+        executor.awaitTermination(1, TimeUnit.SECONDS)
+
+        val names = publishedScreenNames()
+        assertTrue(names.isNotEmpty(), "expected at least one emission")
+        assertTrue(names.all { it == "Home" }, "all emissions should be \"Home\", got $names")
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -13,8 +13,8 @@ import io.customer.sdk.communication.subscribe
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.events.Metric
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 
 class ModuleMessagingInApp(
     config: MessagingInAppModuleConfig
@@ -30,10 +30,14 @@ class ModuleMessagingInApp(
     // Per-session set of deliveryIDs whose `Opened` metric has already been published.
     // Used to dedupe `onMessageShown` emissions so the same in-app view does not produce
     // multiple `TrackInAppMetricEvent`s within a single SDK process lifetime.
-    // Lifetime: scoped to this `ModuleMessagingInApp` instance (per-process). No persistence.
-    // Mirrors iOS `GistDelegateImpl` behavior — see Phase 1 PR 2.
-    private val shownDeliveryIdsLock = ReentrantLock()
-    private val shownDeliveryIds = mutableSetOf<String>()
+    // Lifetime: scoped to this `ModuleMessagingInApp` instance (per-process) and cleared on
+    // `ResetEvent` (logout) so a new session does not inherit a prior user's deliveryIDs.
+    // No persistence. Mirrors iOS `GistDelegateImpl` behavior — see Phase 1 PR 2.
+    // Thread-safe concurrent set: `onMessageShown` may be invoked off the main thread.
+    // `ConcurrentHashMap.newKeySet()` requires API 24; this form is equivalent and works
+    // at our minSdk (21).
+    private val shownDeliveryIds: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
 
     /**
      * Access the inbox messages instance for managing user inbox messages.
@@ -87,6 +91,9 @@ class ModuleMessagingInApp(
             logger.debug("Resetting user token")
             gistProvider.reset()
             clearCustomAttributes()
+            // Drop per-session dedup state so a subsequent user/session can re-emit
+            // `Opened` for the same deliveryID if it is shown again.
+            shownDeliveryIds.clear()
         }
     }
 
@@ -101,9 +108,7 @@ class ModuleMessagingInApp(
             // side-effects (eventListener.messageShown above) still fire on every call —
             // only the analytics publish is suppressed on duplicates. See PR 6 in
             // binary-tinkering-treasure-phase1.md.
-            val isFirstShown = shownDeliveryIdsLock.withLock {
-                shownDeliveryIds.add(deliveryID)
-            }
+            val isFirstShown = shownDeliveryIds.add(deliveryID)
             if (!isFirstShown) {
                 logger.debug("In-app message shown again with deliveryId $deliveryID — skipping duplicate metric publish")
                 return

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -13,6 +13,8 @@ import io.customer.sdk.communication.subscribe
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.events.Metric
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class ModuleMessagingInApp(
     config: MessagingInAppModuleConfig
@@ -24,6 +26,14 @@ class ModuleMessagingInApp(
     private val gistProvider: GistProvider
         get() = SDKComponent.gistProvider
     private val logger = SDKComponent.logger
+
+    // Per-session set of deliveryIDs whose `Opened` metric has already been published.
+    // Used to dedupe `onMessageShown` emissions so the same in-app view does not produce
+    // multiple `TrackInAppMetricEvent`s within a single SDK process lifetime.
+    // Lifetime: scoped to this `ModuleMessagingInApp` instance (per-process). No persistence.
+    // Mirrors iOS `GistDelegateImpl` behavior — see Phase 1 PR 2.
+    private val shownDeliveryIdsLock = ReentrantLock()
+    private val shownDeliveryIds = mutableSetOf<String>()
 
     /**
      * Access the inbox messages instance for managing user inbox messages.
@@ -87,6 +97,17 @@ class ModuleMessagingInApp(
         moduleConfig.eventListener?.messageShown(InAppMessage.getFromGistMessage(message))
 
         message.gistProperties.campaignId?.let { deliveryID ->
+            // Dedupe `Opened` metric emission per-deliveryID for this session. Host UI
+            // side-effects (eventListener.messageShown above) still fire on every call —
+            // only the analytics publish is suppressed on duplicates. See PR 6 in
+            // binary-tinkering-treasure-phase1.md.
+            val isFirstShown = shownDeliveryIdsLock.withLock {
+                shownDeliveryIds.add(deliveryID)
+            }
+            if (!isFirstShown) {
+                logger.debug("In-app message shown again with deliveryId $deliveryID — skipping duplicate metric publish")
+                return
+            }
             logger.debug("In-app message shown with deliveryId $deliveryID")
             eventBus.publish(
                 Event.TrackInAppMetricEvent(

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -277,6 +277,100 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
         }
     }
 
+    @Test
+    fun onMessageShown_givenSameDeliveryIdCalledTwice_expectOnePublish() {
+        val message = createInAppMessage(campaignId = "test_campaign_id")
+        val inAppMessage = InAppMessage(
+            messageId = message.messageId,
+            deliveryId = "test_campaign_id",
+            queueId = message.queueId
+        )
+
+        mockkObject(InAppMessage.Companion)
+        every { InAppMessage.getFromGistMessage(any()) } returns inAppMessage
+
+        module.initialize()
+        module.onMessageShown(message)
+        module.onMessageShown(message)
+
+        // eventListener.messageShown still fires on every call — host UI side-effects must remain unaffected.
+        verify(exactly = 2) {
+            inAppEventListenerMock.messageShown(inAppMessage)
+        }
+        // The TrackInAppMetricEvent should only be published once for the same deliveryID.
+        verify(exactly = 1) {
+            eventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = "test_campaign_id",
+                    event = Metric.Opened
+                )
+            )
+        }
+    }
+
+    @Test
+    fun onMessageShown_givenDifferentDeliveryIds_expectTwoPublishes() {
+        val firstMessage = createInAppMessage(campaignId = "campaign_one")
+        val secondMessage = createInAppMessage(campaignId = "campaign_two")
+        val firstInAppMessage = InAppMessage(
+            messageId = firstMessage.messageId,
+            deliveryId = "campaign_one",
+            queueId = firstMessage.queueId
+        )
+        val secondInAppMessage = InAppMessage(
+            messageId = secondMessage.messageId,
+            deliveryId = "campaign_two",
+            queueId = secondMessage.queueId
+        )
+
+        mockkObject(InAppMessage.Companion)
+        every { InAppMessage.getFromGistMessage(firstMessage) } returns firstInAppMessage
+        every { InAppMessage.getFromGistMessage(secondMessage) } returns secondInAppMessage
+
+        module.initialize()
+        module.onMessageShown(firstMessage)
+        module.onMessageShown(secondMessage)
+
+        verify(exactly = 1) {
+            eventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = "campaign_one",
+                    event = Metric.Opened
+                )
+            )
+            eventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = "campaign_two",
+                    event = Metric.Opened
+                )
+            )
+        }
+    }
+
+    @Test
+    fun onMessageShown_givenNullDeliveryId_doesNotCrashAndDoesNotPublish() {
+        val message = createInAppMessage(campaignId = null)
+        val inAppMessage = InAppMessage(
+            messageId = message.messageId,
+            deliveryId = null,
+            queueId = message.queueId
+        )
+
+        mockkObject(InAppMessage.Companion)
+        every { InAppMessage.getFromGistMessage(any()) } returns inAppMessage
+
+        module.initialize()
+        // Calling twice asserts both the no-crash contract and that the null-guard short-circuits
+        // before the dedup set is touched.
+        module.onMessageShown(message)
+        module.onMessageShown(message)
+
+        verify(exactly = 2) { inAppEventListenerMock.messageShown(inAppMessage) }
+        verify(exactly = 0) {
+            eventBus.publish(any<Event.TrackInAppMetricEvent>())
+        }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun onAction_givenCloseAction_expectNoTrackInAppMetricEventPublished() = runTest {

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ModuleMessagingInAppTest.kt
@@ -309,6 +309,36 @@ internal class ModuleMessagingInAppTest : JUnitTest() {
     }
 
     @Test
+    fun onMessageShown_givenSameDeliveryIdAcrossResetEvent_expectPublishAgainAfterReset() {
+        val message = createInAppMessage(campaignId = "test_campaign_id")
+        val inAppMessage = InAppMessage(
+            messageId = message.messageId,
+            deliveryId = "test_campaign_id",
+            queueId = message.queueId
+        )
+
+        mockkObject(InAppMessage.Companion)
+        every { InAppMessage.getFromGistMessage(any()) } returns inAppMessage
+
+        module.initialize()
+        module.onMessageShown(message)
+        // Logout/reset must drop per-session dedup state so the next session can re-emit.
+        eventBus.publish(Event.ResetEvent)
+        module.onMessageShown(message)
+
+        // Same deliveryID shown once before and once after reset -> two publishes,
+        // because the dedup set is cleared on ResetEvent.
+        verify(exactly = 2) {
+            eventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = "test_campaign_id",
+                    event = Metric.Opened
+                )
+            )
+        }
+    }
+
+    @Test
     fun onMessageShown_givenDifferentDeliveryIds_expectTwoPublishes() {
         val firstMessage = createInAppMessage(campaignId = "campaign_one")
         val secondMessage = createInAppMessage(campaignId = "campaign_two")

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -2,13 +2,19 @@ package io.customer.messagingpush
 
 import androidx.lifecycle.Lifecycle
 import io.customer.messagingpush.di.fcmTokenProvider
+import io.customer.messagingpush.di.pendingPushDeliveryStore
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.messagingpush.provider.DeviceTokenProvider
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.events.Metric
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 
 class ModuleMessagingPushFCM @JvmOverloads constructor(
     override val moduleConfig: MessagingPushModuleConfig = MessagingPushModuleConfig.default()
@@ -18,6 +24,10 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = SDKComponent.android().fcmTokenProvider
     private val pushTrackingUtil = SDKComponent.pushTrackingUtil
     private val activityLifecycleCallbacks = SDKComponent.activityLifecycleCallbacks
+    private val pendingPushDeliveryStore: PendingPushDeliveryStore
+        get() = SDKComponent.pendingPushDeliveryStore
+    private val dispatchers: DispatchersProvider
+        get() = SDKComponent.dispatchersProvider
 
     override val moduleName: String
         get() = MODULE_NAME
@@ -25,6 +35,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
     override fun initialize() {
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
+        flushPendingPushDeliveryMetrics()
     }
 
     private fun subscribeToLifecycleEvents() {
@@ -45,6 +56,37 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                         else -> {}
                     }
                 }
+        }
+    }
+
+    /**
+     * At app launch, drain any push-delivered metrics that were observed locally
+     * but never confirmed by the primary delivery path (WorkManager / direct
+     * HTTP). For each pending entry we publish a [Event.TrackPushMetricEvent] so
+     * the analytics pipeline can deliver it, then remove only the entries we
+     * actually loaded — entries appended mid-flush survive.
+     *
+     * Disk I/O (the JSON read and targeted remove) MUST happen off the main
+     * thread, so the sequence is dispatched on the background dispatcher.
+     */
+    private fun flushPendingPushDeliveryMetrics() {
+        CoroutineScope(dispatchers.background).launch {
+            runCatching {
+                val pending = pendingPushDeliveryStore.loadAll()
+                if (pending.isEmpty()) return@runCatching
+
+                val flushedIds = pending.map { it.deliveryId }
+                pending.forEach { entry ->
+                    eventBus.publish(
+                        Event.TrackPushMetricEvent(
+                            event = Metric.Delivered,
+                            deliveryId = entry.deliveryId,
+                            deviceToken = entry.token
+                        )
+                    )
+                }
+                pendingPushDeliveryStore.removeAll(flushedIds)
+            }
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -1,5 +1,6 @@
 package io.customer.messagingpush
 
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.httpClient
 import io.customer.sdk.core.network.CustomerIOHttpClient
@@ -53,14 +54,25 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 }
 
 internal class AsyncPushDeliveryTracker(
-    private val deliveryTracker: PushDeliveryTracker
+    private val deliveryTracker: PushDeliveryTracker,
+    private val pendingStore: PendingPushDeliveryStore
 ) {
     private val dispatcher: DispatchersProvider
         get() = SDKComponent.dispatchersProvider
 
+    /**
+     * Fire-and-forget direct-HTTP fallback used when WorkManager is not available.
+     * Mirrors the WorkManager success contract: on a 2xx response the pending
+     * entry keyed by [deliveryId] is removed; on any failure the entry is left
+     * in place so the app-launch flush will publish it via the analytics
+     * pipeline.
+     */
     fun trackMetric(token: String, event: String, deliveryId: String) {
         CoroutineScope(dispatcher.background).launch {
-            deliveryTracker.trackMetric(token, event, deliveryId)
+            val result = deliveryTracker.trackMetric(token, event, deliveryId)
+            if (result.isSuccess) {
+                pendingStore.remove(deliveryId)
+            }
         }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -16,6 +16,7 @@ import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.provider.FCMTokenProviderImpl
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
@@ -52,8 +53,21 @@ internal val SDKComponent.deepLinkUtil: DeepLinkUtil
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
     get() = newInstance<PushTrackingUtil> { PushTrackingUtilImpl() }
 
+internal val SDKComponent.pendingPushDeliveryStore: PendingPushDeliveryStore
+    get() = singleton<PendingPushDeliveryStore> {
+        PendingPushDeliveryStore(
+            context = android().applicationContext,
+            logger = logger
+        )
+    }
+
 internal val SDKComponent.asyncPushDeliveryTracker: AsyncPushDeliveryTracker
-    get() = singleton<AsyncPushDeliveryTracker> { AsyncPushDeliveryTracker(pushDeliveryTracker) }
+    get() = singleton<AsyncPushDeliveryTracker> {
+        AsyncPushDeliveryTracker(
+            deliveryTracker = pushDeliveryTracker,
+            pendingStore = pendingPushDeliveryStore
+        )
+    }
 
 internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
     get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider, asyncPushDeliveryTracker) }
@@ -64,7 +78,8 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
             pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
             deepLinkUtil = deepLinkUtil,
-            deliveryMetricsScheduler = deliveryMetricsScheduler
+            deliveryMetricsScheduler = deliveryMetricsScheduler,
+            pendingPushDeliveryStore = pendingPushDeliveryStore
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -8,6 +8,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import io.customer.messagingpush.AsyncPushDeliveryTracker
+import io.customer.messagingpush.di.pendingPushDeliveryStore
 import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
@@ -27,7 +28,10 @@ internal class PushDeliveryMetricsBackgroundScheduler(
         private const val WORK_MANAGER_TAG_PUSH_DELIVERY = "cio-push-delivery"
     }
 
-    fun scheduleDeliveredPushMetricsReceipt(deliveryId: String, deliveryToken: String) {
+    fun scheduleDeliveredPushMetricsReceipt(
+        deliveryId: String,
+        deliveryToken: String
+    ) {
         val input = Data.Builder()
             .putString(DELIVERY_ID, deliveryId)
             .putString(DELIVERY_TOKEN, deliveryToken)
@@ -48,7 +52,11 @@ internal class PushDeliveryMetricsBackgroundScheduler(
         if (workManager != null) {
             workManager.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
         } else {
-            asyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+            asyncPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
         }
     }
 }
@@ -73,7 +81,11 @@ internal class PushDeliveryMetricsWorker(
         )
 
         return when {
-            result.isSuccess -> Result.success()
+            result.isSuccess -> {
+                // Only clear the pending entry once the backend has confirmed receipt.
+                SDKComponent.pendingPushDeliveryStore.remove(deliveryId)
+                Result.success()
+            }
             result.exceptionOrNull() is IOException -> Result.retry()
             else -> Result.failure()
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -10,6 +10,7 @@ import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.extensions.parcelable
 import io.customer.messagingpush.logger.PushNotificationLogger
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.communication.Event
@@ -20,7 +21,8 @@ internal class PushMessageProcessorImpl(
     private val pushLogger: PushNotificationLogger,
     private val moduleConfig: MessagingPushModuleConfig,
     private val deepLinkUtil: DeepLinkUtil,
-    private val deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
+    private val deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler,
+    private val pendingPushDeliveryStore: PendingPushDeliveryStore
 ) : PushMessageProcessor {
 
     /**
@@ -89,15 +91,21 @@ internal class PushMessageProcessorImpl(
         if (moduleConfig.autoTrackPushEvents) {
             pushLogger.logTrackingPushMessageDelivered(deliveryId)
 
-            deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+            // Persist a pending entry first so the metric can be replayed via the
+            // analytics pipeline at the next app launch if the primary delivery
+            // path fails. The entry is keyed by deliveryId; the scheduler /
+            // direct-HTTP fallback removes it on a successful response.
+            pendingPushDeliveryStore.append(
+                deliveryId = deliveryId,
+                token = deliveryToken
+            )
 
-            // Track delivered metrics via event bus
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = deliveryId,
-                    deviceToken = deliveryToken
-                )
+            // WorkManager (or its direct-HTTP fallback) remains the primary
+            // delivery mechanism. The eventBus dual-emit was removed; the
+            // pending-store + launch-flush handles the analytics-pipeline path.
+            deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = deliveryId,
+                deliveryToken = deliveryToken
             )
         } else {
             pushLogger.logPushMetricsAutoTrackingDisabled()

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
@@ -1,0 +1,17 @@
+package io.customer.messagingpush.store
+
+/**
+ * Represents a push-delivered metric that has been observed locally but not yet
+ * confirmed as tracked by the Customer.io backend.
+ *
+ * Entries are keyed by [deliveryId] (the natural identifier carried on the push
+ * payload) and stamped with the [timestamp] captured at append time. Entries
+ * are removed only when the primary delivery path (WorkManager job or its
+ * direct-HTTP fallback) reports a successful response, or when the app-launch
+ * flush hands them off to the analytics pipeline.
+ */
+internal data class PendingPushDeliveryMetric(
+    val deliveryId: String,
+    val token: String,
+    val timestamp: Long
+)

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
@@ -1,0 +1,168 @@
+package io.customer.messagingpush.store
+
+import android.content.Context
+import io.customer.sdk.core.util.Logger
+import java.io.File
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Disk-backed queue of push-delivered metrics waiting on a delivery confirmation.
+ *
+ * Each entry is the tuple `(deliveryId, token, timestamp)` where [deliveryId]
+ * is the natural key used to remove the entry once the metric has been
+ * delivered, and [timestamp] is the epoch-millis value captured at [append]
+ * time. Entries live until [remove] / [removeAll] is called.
+ *
+ * Storage is a single JSON file in [Context.filesDir]. All read-modify-write
+ * sequences are guarded by an in-process [ReentrantLock] so concurrent appends
+ * from multiple FCM callbacks cannot corrupt the file.
+ *
+ * Capacity is capped at [MAX_ENTRIES]. On overflow the entry with the smallest
+ * timestamp is dropped so the queue never grows without bound when delivery
+ * confirmation is failing.
+ */
+internal class PendingPushDeliveryStore(
+    context: Context,
+    private val logger: Logger
+) {
+    private val file: File = File(context.applicationContext.filesDir, FILE_NAME)
+    private val lock = ReentrantLock()
+
+    /**
+     * Append a new pending entry, capturing [System.currentTimeMillis] as the
+     * entry's timestamp. The WorkManager job / direct-HTTP fallback uses
+     * [deliveryId] to call [remove] on a successful response.
+     */
+    fun append(deliveryId: String, token: String) {
+        val entry = PendingPushDeliveryMetric(
+            deliveryId = deliveryId,
+            token = token,
+            timestamp = System.currentTimeMillis()
+        )
+        lock.withLock {
+            val entries = readAll().toMutableList()
+            entries.add(entry)
+            // Drop oldest (smallest-timestamp) entries to keep the queue bounded.
+            while (entries.size > MAX_ENTRIES) {
+                val oldestIndex = entries.indices.minBy { entries[it].timestamp }
+                entries.removeAt(oldestIndex)
+            }
+            writeAll(entries)
+        }
+    }
+
+    /** Returns all pending entries in insertion order. */
+    fun loadAll(): List<PendingPushDeliveryMetric> = lock.withLock { readAll() }
+
+    /**
+     * Remove the entry with the given [deliveryId]. No-op if no such entry
+     * exists (e.g. it was already flushed at launch or removed by an earlier
+     * success).
+     *
+     * Skips the write when no entry was actually removed: if [readAll] returns
+     * empty (whether the file is genuinely empty or unreadable due to a
+     * transient IO failure / corruption), [writeAll] would otherwise wipe the
+     * file with an empty array. Matches iOS's `PendingPushDeliveryStore.remove`.
+     */
+    fun remove(deliveryId: String) {
+        lock.withLock {
+            val entries = readAll()
+            val filtered = entries.filterNot { it.deliveryId == deliveryId }
+            if (filtered.size == entries.size) return@withLock
+            writeAll(filtered)
+        }
+    }
+
+    /**
+     * Remove all entries whose deliveryIds are in [deliveryIds] in a single
+     * coordinated read-modify-write. Prefer this over calling [remove] in a
+     * loop when flushing multiple metrics at once. Entries appended after
+     * this call's read are not affected.
+     *
+     * Skips the write when no entry was actually removed — same protection as
+     * [remove] against transient [readAll] failures silently wiping the store.
+     */
+    fun removeAll(deliveryIds: Collection<String>) {
+        if (deliveryIds.isEmpty()) return
+        val idSet = deliveryIds.toSet()
+        lock.withLock {
+            val entries = readAll()
+            val filtered = entries.filterNot { it.deliveryId in idSet }
+            if (filtered.size == entries.size) return@withLock
+            writeAll(filtered)
+        }
+    }
+
+    /** Remove all pending entries. */
+    fun removeAll() {
+        lock.withLock {
+            writeAll(emptyList())
+        }
+    }
+
+    private fun readAll(): List<PendingPushDeliveryMetric> {
+        if (!file.exists()) return emptyList()
+        return try {
+            val text = file.readText()
+            if (text.isBlank()) return emptyList()
+            val array = JSONArray(text)
+            buildList(array.length()) {
+                for (i in 0 until array.length()) {
+                    val obj = array.optJSONObject(i) ?: continue
+                    val deliveryId = obj.optString(KEY_DELIVERY_ID).takeIf { it.isNotBlank() } ?: continue
+                    val token = obj.optString(KEY_TOKEN).takeIf { it.isNotBlank() } ?: continue
+                    if (!obj.has(KEY_TIMESTAMP)) continue
+                    val timestamp = obj.optLong(KEY_TIMESTAMP, Long.MIN_VALUE)
+                    if (timestamp == Long.MIN_VALUE) continue
+                    add(
+                        PendingPushDeliveryMetric(
+                            deliveryId = deliveryId,
+                            token = token,
+                            timestamp = timestamp
+                        )
+                    )
+                }
+            }
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to read pending push delivery store; treating as empty",
+                tag = TAG,
+                throwable = ex
+            )
+            emptyList()
+        }
+    }
+
+    private fun writeAll(entries: List<PendingPushDeliveryMetric>) {
+        try {
+            val array = JSONArray()
+            entries.forEach { entry ->
+                val obj = JSONObject().apply {
+                    put(KEY_DELIVERY_ID, entry.deliveryId)
+                    put(KEY_TOKEN, entry.token)
+                    put(KEY_TIMESTAMP, entry.timestamp)
+                }
+                array.put(obj)
+            }
+            file.writeText(array.toString())
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to write pending push delivery store",
+                tag = TAG,
+                throwable = ex
+            )
+        }
+    }
+
+    internal companion object {
+        const val MAX_ENTRIES = 100
+        private const val FILE_NAME = "cio_pending_push_delivery.json"
+        private const val KEY_DELIVERY_ID = "deliveryId"
+        private const val KEY_TOKEN = "token"
+        private const val KEY_TIMESTAMP = "timestamp"
+        private const val TAG = "PendingPushDeliveryStore"
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -5,26 +5,37 @@ import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
+import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.messagingpush.di.fcmTokenProvider
 import io.customer.messagingpush.provider.DeviceTokenProvider
+import io.customer.messagingpush.store.PendingPushDeliveryMetric
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.events.Metric
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 
 class ModuleMessagingPushFCMTest : JUnitTest() {
     private lateinit var eventBus: EventBus
     private lateinit var fcmTokenProviderMock: DeviceTokenProvider
     private lateinit var module: ModuleMessagingPushFCM
+    private val mockPendingStore: PendingPushDeliveryStore = mockk(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
             testConfigurationDefault {
                 diGraph {
-                    sdk { overrideDependency<EventBus>(mockk(relaxed = true)) }
+                    sdk {
+                        overrideDependency<EventBus>(mockk(relaxed = true))
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
+                    }
                     android { overrideDependency<DeviceTokenProvider>(mockk(relaxed = true)) }
                 }
             }
@@ -65,5 +76,54 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
         module.initialize()
 
         assertCalledOnce { eventBus.publish(Event.RegisterDeviceTokenEvent(token = givenToken)) }
+    }
+
+    @Test
+    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndOnlyLoadedIdsRemoved() {
+        val pending = listOf(
+            PendingPushDeliveryMetric(deliveryId = "d1", token = "t1", timestamp = 1L),
+            PendingPushDeliveryMetric(deliveryId = "d2", token = "t2", timestamp = 2L)
+        )
+        every { mockPendingStore.loadAll() } returns pending
+
+        module.initialize()
+
+        pending.forEach { entry ->
+            verify(exactly = 1) {
+                eventBus.publish(
+                    Event.TrackPushMetricEvent(
+                        event = Metric.Delivered,
+                        deliveryId = entry.deliveryId,
+                        deviceToken = entry.token
+                    )
+                )
+            }
+        }
+        verify(exactly = 1) { mockPendingStore.removeAll(listOf("d1", "d2")) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
+    fun initialize_givenNoPendingPushDeliveries_expectNoPublishAndNoRemove() {
+        every { mockPendingStore.loadAll() } returns emptyList()
+
+        module.initialize()
+
+        verify(exactly = 0) { eventBus.publish(any<Event.TrackPushMetricEvent>()) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+        verify(exactly = 0) { mockPendingStore.removeAll(any<Collection<String>>()) }
+    }
+
+    @Test
+    fun initialize_givenPendingFlush_expectDiskIoOnBackgroundDispatcher() {
+        // DispatchersProviderStub returns UnconfinedTestDispatcher (background) by default.
+        // We verify the flush runs by ensuring loadAll() is invoked at initialize() time,
+        // which is the disk read. The stub guarantees this happens on the background
+        // dispatcher, not on Dispatchers.Main.
+        every { mockPendingStore.loadAll() } returns emptyList()
+
+        module.initialize()
+
+        verify(exactly = 1) { mockPendingStore.loadAll() }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
@@ -2,13 +2,18 @@ package io.customer.messagingpush
 
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.commontest.util.DispatchersProviderStub
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
+import io.customer.sdk.core.util.DispatchersProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContain
@@ -22,6 +27,8 @@ class PushDeliveryTrackingTest : IntegrationTest() {
 
     private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
     private val pushDeliveryTracker = PushDeliveryTrackerImpl()
+    private val mockPendingStore: PendingPushDeliveryStore = mockk(relaxed = true)
+    private val mockDeliveryTracker: PushDeliveryTracker = mockk(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
@@ -30,6 +37,7 @@ class PushDeliveryTrackingTest : IntegrationTest() {
                     sdk {
                         // Override the httpClient in your DI so the SUT uses this mock.
                         overrideDependency<CustomerIOHttpClient>(httpClient)
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
                     }
                 }
             }
@@ -78,5 +86,57 @@ class PushDeliveryTrackingTest : IntegrationTest() {
         val result = pushDeliveryTracker.trackMetric("token", "OPENED", "deliveryId")
 
         result.isFailure.shouldBeEqualTo(true)
+    }
+
+    /**
+     * Tests for the direct-HTTP fallback used when WorkManager is not available.
+     * Mirrors the WorkManager success-removal / failure-preservation contract.
+     */
+    @Test
+    fun asyncTrackMetric_givenHttpSuccess_expectPendingEntryRemovedByDeliveryId() = runTest {
+        val token = String.random
+        val deliveryId = String.random
+
+        coEvery {
+            mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
+        } returns Result.success(Unit)
+
+        val asyncTracker = AsyncPushDeliveryTracker(
+            deliveryTracker = mockDeliveryTracker,
+            pendingStore = mockPendingStore
+        )
+
+        asyncTracker.trackMetric(
+            token = token,
+            event = "Delivered",
+            deliveryId = deliveryId
+        )
+
+        coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }
+        verify(exactly = 1) { mockPendingStore.remove(deliveryId) }
+    }
+
+    @Test
+    fun asyncTrackMetric_givenHttpFailure_expectPendingEntryPreserved() = runTest {
+        val token = String.random
+        val deliveryId = String.random
+
+        coEvery {
+            mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
+        } returns Result.failure(Exception("boom"))
+
+        val asyncTracker = AsyncPushDeliveryTracker(
+            deliveryTracker = mockDeliveryTracker,
+            pendingStore = mockPendingStore
+        )
+
+        asyncTracker.trackMetric(
+            token = token,
+            event = "Delivered",
+            deliveryId = deliveryId
+        )
+
+        coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -66,7 +66,11 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         }
 
         verify(exactly = 1) {
-            mockAsyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+            mockAsyncPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId
+            )
         }
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -6,11 +6,13 @@ import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.random
 import io.customer.messagingpush.PushDeliveryTracker
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.events.Metric
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -25,6 +27,7 @@ import org.robolectric.RobolectricTestRunner
 class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
     private val mockPushDeliveryTracker = mockk<PushDeliveryTracker>(relaxed = true)
+    private val mockPendingStore = mockk<PendingPushDeliveryStore>(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
@@ -32,6 +35,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
                 diGraph {
                     sdk {
                         overrideDependency<PushDeliveryTracker>(mockPushDeliveryTracker)
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
                     }
                 }
             }
@@ -405,6 +409,56 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
+    fun doWork_givenHttpSuccess_expectPendingEntryRemovedByDeliveryId() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        verify(exactly = 1) { mockPendingStore.remove(deliveryId) }
+    }
+
+    @Test
+    fun doWork_givenHttpFailure_expectPendingEntryPreserved() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IllegalStateException("boom"))
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
+    fun doWork_givenHttpRetryableFailure_expectPendingEntryPreserved() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IOException("retry me"))
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
     fun doWork_givenMetricConstantValue_expectCorrectMetricPassed() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
@@ -427,7 +481,10 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         }
     }
 
-    private fun createInputData(deliveryId: String?, deliveryToken: String?): Data {
+    private fun createInputData(
+        deliveryId: String?,
+        deliveryToken: String?
+    ): Data {
         val builder = Data.Builder()
         deliveryId?.let { builder.putString("delivery-id", it) }
         deliveryToken?.let { builder.putString("delivery-token", it) }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
@@ -21,6 +21,7 @@ import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.deepLinkUtil
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.logger.PushNotificationLogger
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil
@@ -46,6 +47,7 @@ class PushMessageProcessorTest : IntegrationTest() {
     private lateinit var eventBus: EventBus
     private val mockPushLogger = mockk<PushNotificationLogger>(relaxed = true)
     private val mockDeliveryMetricsScheduler = mockk<PushDeliveryMetricsBackgroundScheduler>(relaxed = true)
+    private val mockPendingStore = mockk<PendingPushDeliveryStore>(relaxed = true)
 
     private fun pushMessageProcessor(): PushMessageProcessorImpl {
         return SDKComponent.pushMessageProcessor as PushMessageProcessorImpl
@@ -60,6 +62,7 @@ class PushMessageProcessorTest : IntegrationTest() {
                         overrideDependency<EventBus>(mockk(relaxed = true))
                         overrideDependency<PushNotificationLogger>(mockPushLogger)
                         overrideDependency<PushDeliveryMetricsBackgroundScheduler>(mockDeliveryMetricsScheduler)
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
                     }
                 }
             }
@@ -238,6 +241,9 @@ class PushMessageProcessorTest : IntegrationTest() {
         verify(exactly = 0) {
             mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
         }
+        verify(exactly = 0) {
+            mockPendingStore.append(any(), any())
+        }
     }
 
     @Test
@@ -259,18 +265,23 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         processor.processGCMMessageIntent(gcmIntent)
 
-        assertCalledOnce {
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = givenDeliveryId,
-                    deviceToken = givenDeviceToken
-                )
-            )
+        // The initial delivery path no longer dual-emits via the event bus; the
+        // pending store + WorkManager (or fallback) carry the metric to the
+        // backend, and the analytics-pipeline emission happens at the next
+        // launch flush from `ModuleMessagingPushFCM.initialize()`.
+        verify(exactly = 0) {
+            eventBus.publish(any<Event.TrackPushMetricEvent>())
         }
 
         verify(exactly = 1) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(givenDeliveryId, givenDeviceToken)
+            mockPendingStore.append(givenDeliveryId, givenDeviceToken)
+        }
+
+        verify(exactly = 1) {
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = givenDeliveryId,
+                deliveryToken = givenDeviceToken
+            )
         }
     }
 
@@ -290,6 +301,9 @@ class PushMessageProcessorTest : IntegrationTest() {
         assertNoInteractions(eventBus)
         verify(exactly = 0) {
             mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
+        }
+        verify(exactly = 0) {
+            mockPendingStore.append(any(), any())
         }
     }
 
@@ -325,18 +339,19 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         processor.processRemoteMessageDeliveredMetrics(givenDeliveryId, givenDeviceToken)
 
-        assertCalledOnce {
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = givenDeliveryId,
-                    deviceToken = givenDeviceToken
-                )
-            )
+        verify(exactly = 0) {
+            eventBus.publish(any<Event.TrackPushMetricEvent>())
         }
 
         verify(exactly = 1) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(givenDeliveryId, givenDeviceToken)
+            mockPendingStore.append(givenDeliveryId, givenDeviceToken)
+        }
+
+        verify(exactly = 1) {
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = givenDeliveryId,
+                deliveryToken = givenDeviceToken
+            )
         }
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
@@ -1,0 +1,270 @@
+package io.customer.messagingpush.store
+
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.util.Logger
+import io.mockk.mockk
+import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PendingPushDeliveryStoreTest : IntegrationTest() {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+    private lateinit var store: PendingPushDeliveryStore
+
+    override fun setup(testConfig: io.customer.commontest.config.TestConfig) {
+        super.setup(testConfig)
+        store = PendingPushDeliveryStore(context = applicationMock, logger = mockLogger)
+        store.removeAll()
+    }
+
+    @Test
+    fun append_givenSingleEntry_expectLoadAllReturnsIt() {
+        val deliveryId = String.random
+        val token = String.random
+        val before = System.currentTimeMillis()
+
+        store.append(deliveryId = deliveryId, token = token)
+
+        val after = System.currentTimeMillis()
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].deliveryId shouldBeEqualTo deliveryId
+        entries[0].token shouldBeEqualTo token
+        entries[0].timestamp shouldBeGreaterOrEqualTo before
+        entries[0].timestamp shouldBeLessOrEqualTo after
+    }
+
+    @Test
+    fun append_givenMultipleEntries_expectAllPersistedInOrder() {
+        val deliveryIds = List(3) { String.random }
+        val tokens = List(3) { String.random }
+
+        deliveryIds.zip(tokens).forEach { (deliveryId, token) ->
+            store.append(deliveryId = deliveryId, token = token)
+        }
+
+        val entries = store.loadAll()
+        entries.map { it.deliveryId } shouldBeEqualTo deliveryIds
+        entries.map { it.token } shouldBeEqualTo tokens
+    }
+
+    @Test
+    fun remove_givenExistingDeliveryId_expectEntryRemoved() {
+        val keepDeliveryId = String.random
+        val removeDeliveryId = String.random
+        store.append(deliveryId = keepDeliveryId, token = String.random)
+        store.append(deliveryId = removeDeliveryId, token = String.random)
+
+        store.remove(removeDeliveryId)
+
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].deliveryId shouldBeEqualTo keepDeliveryId
+    }
+
+    @Test
+    fun remove_givenUnknownDeliveryId_expectNoOp() {
+        val keepDeliveryId = String.random
+        store.append(deliveryId = keepDeliveryId, token = String.random)
+
+        store.remove("not-a-real-delivery-id")
+
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].deliveryId shouldBeEqualTo keepDeliveryId
+    }
+
+    @Test
+    fun removeAll_givenPopulatedStore_expectEmptyAfterCall() {
+        repeat(5) {
+            store.append(deliveryId = String.random, token = String.random)
+        }
+
+        store.removeAll()
+
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun removeAllIds_givenSubsetOfEntries_expectOnlyMatchingRemoved() {
+        val keep = "keep-${String.random}"
+        val remove1 = "remove1-${String.random}"
+        val remove2 = "remove2-${String.random}"
+        store.append(deliveryId = remove1, token = String.random)
+        store.append(deliveryId = keep, token = String.random)
+        store.append(deliveryId = remove2, token = String.random)
+
+        store.removeAll(listOf(remove1, remove2))
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo keep
+    }
+
+    @Test
+    fun removeAllIds_givenIdsNotPresent_expectStoreUnchanged() {
+        val kept = listOf(String.random, String.random)
+        kept.forEach { store.append(deliveryId = it, token = String.random) }
+
+        store.removeAll(listOf("nonexistent-1", "nonexistent-2"))
+
+        store.loadAll().map { it.deliveryId } shouldBeEqualTo kept
+    }
+
+    @Test
+    fun removeAllIds_givenEmptyCollection_expectNoOp() {
+        val kept = String.random
+        store.append(deliveryId = kept, token = String.random)
+
+        store.removeAll(emptyList<String>())
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo kept
+    }
+
+    @Test
+    fun removeAllIds_givenEntryAppendedAfterLoad_expectAppendedEntrySurvives() {
+        val loaded = "loaded-${String.random}"
+        val appendedMidFlush = "midflush-${String.random}"
+        store.append(deliveryId = loaded, token = String.random)
+
+        // Simulate the flush sequence: snapshot ids before append, then remove
+        // only those ids — the entry appended afterward must survive.
+        val flushedIds = store.loadAll().map { it.deliveryId }
+        store.append(deliveryId = appendedMidFlush, token = String.random)
+        store.removeAll(flushedIds)
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo appendedMidFlush
+    }
+
+    @Test
+    fun remove_givenCorruptedFile_expectStoreFilePreserved() {
+        // Reproduces the Bugbot finding: if readAll() fails to parse and
+        // returns an empty list, the subsequent writeAll() must NOT silently
+        // wipe the file. After the fix, remove() skips the write entirely
+        // when nothing was filtered out.
+        val file = File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val corrupted = "{not-valid-json"
+        file.writeText(corrupted)
+
+        store.remove("any-id")
+
+        file.readText() shouldBeEqualTo corrupted
+    }
+
+    @Test
+    fun removeAllIds_givenCorruptedFile_expectStoreFilePreserved() {
+        val file = File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val corrupted = "{not-valid-json"
+        file.writeText(corrupted)
+
+        store.removeAll(listOf("id1", "id2"))
+
+        file.readText() shouldBeEqualTo corrupted
+    }
+
+    @Test
+    fun loadAll_givenFreshStore_expectEmpty() {
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun append_givenOverCapacity_expectOldestDropped() {
+        val firstDeliveryId = "first"
+        val secondDeliveryId = "second"
+        store.append(deliveryId = firstDeliveryId, token = String.random)
+        store.append(deliveryId = secondDeliveryId, token = String.random)
+        for (i in 0 until (PendingPushDeliveryStore.MAX_ENTRIES - 2)) {
+            store.append(deliveryId = "fill-$i", token = String.random)
+        }
+
+        // Store is now exactly at MAX_ENTRIES. Both anchors should still exist.
+        val beforeOverflow = store.loadAll()
+        beforeOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        beforeOverflow.first().deliveryId shouldBeEqualTo firstDeliveryId
+
+        val lastDeliveryId = "last"
+        store.append(deliveryId = lastDeliveryId, token = String.random)
+
+        val afterOverflow = store.loadAll()
+        afterOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        // Oldest (smallest-timestamp) must have been dropped.
+        afterOverflow.none { it.deliveryId == firstDeliveryId }.shouldBeTrue()
+        // Second oldest is now the head.
+        afterOverflow.first().deliveryId shouldBeEqualTo secondDeliveryId
+        // Newest entry is at the tail.
+        afterOverflow.last().deliveryId shouldBeEqualTo lastDeliveryId
+    }
+
+    @Test
+    fun append_givenConcurrentWriters_expectNoLostEntries() {
+        val threadCount = 8
+        val perThread = 25
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            val tasks = List(threadCount) { threadIndex ->
+                executor.submit {
+                    repeat(perThread) { i ->
+                        store.append(
+                            deliveryId = "thread-$threadIndex-$i",
+                            token = String.random
+                        )
+                    }
+                }
+            }
+            tasks.forEach { it.get(10, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        val entries = store.loadAll()
+        // Total writes (threadCount * perThread = 200) exceed MAX_ENTRIES (100),
+        // so the store should be capped — confirming the capacity guard works
+        // under concurrent access without throwing.
+        entries.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        // Sanity-check that deliveryIds remain unique even across threads.
+        entries.map { it.deliveryId }.toSet().size shouldBeEqualTo entries.size
+    }
+
+    @Test
+    fun loadAll_givenCorruptOnDiskContent_expectEmptyAndDoesNotThrow() {
+        // Pre-fill with valid data, then corrupt the file directly.
+        store.append(deliveryId = String.random, token = String.random)
+        val file = java.io.File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        file.exists().shouldBeTrue()
+        file.writeText("this is not valid json {]")
+
+        val entries = store.loadAll()
+        entries shouldNotBe null
+        entries.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun append_givenSerializedContent_expectKeysPresent() {
+        val deliveryId = "delivery-${String.random}"
+        val token = "token-${String.random}"
+
+        store.append(deliveryId = deliveryId, token = token)
+
+        val file = java.io.File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val raw = file.readText()
+        raw shouldContain deliveryId
+        raw shouldContain token
+        raw shouldContain "timestamp"
+    }
+}


### PR DESCRIPTION
Dedupes the in-app `onMessageShown` `opened` metric publish by `deliveryID` within the SDK process lifetime. First show of a given delivery publishes the metric; subsequent shows of the same delivery skip the publish.

The host `eventListener.messageShown` callback still fires on every call, so app-level UI side-effects are unaffected — only the analytics metric publish is deduped.

Backend already dedupes `(deliveryID, opened)` pairs server-side, so this is bandwidth and analytics-queue noise reduction, not a metric-correctness change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped analytics deduplication with explicit reset clearing; host callbacks unchanged and backend already dedupes opened metrics.
> 
> **Overview**
> **In-app `Opened` metrics** are now deduplicated per `deliveryID` for the lifetime of the SDK process. `ModuleMessagingInApp` keeps a thread-safe in-memory set; the first `onMessageShown` for a campaign publishes `TrackInAppMetricEvent` with `Metric.Opened`, and later shows of the same delivery skip that publish.
> 
> **Host behavior is unchanged:** `eventListener.messageShown` still runs on every show. Only the analytics bus publish is suppressed on repeats. **`ResetEvent`** clears the set so logout or reset allows a new session to emit `Opened` again for the same delivery. Messages without a `campaignId` still skip metric publish and do not touch the dedup set.
> 
> Unit tests cover duplicate delivery IDs, reset clearing, distinct campaigns, and null delivery ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1c00c686cd44e5c074a3fbc21f788b341b2072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->