### PR TITLE
refactor: cache push-delivered metrics and flush via analytics pipeline

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -2,13 +2,19 @@ package io.customer.messagingpush
 
 import androidx.lifecycle.Lifecycle
 import io.customer.messagingpush.di.fcmTokenProvider
+import io.customer.messagingpush.di.pendingPushDeliveryStore
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.messagingpush.provider.DeviceTokenProvider
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.events.Metric
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 
 class ModuleMessagingPushFCM @JvmOverloads constructor(
     override val moduleConfig: MessagingPushModuleConfig = MessagingPushModuleConfig.default()
@@ -18,6 +24,10 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = SDKComponent.android().fcmTokenProvider
     private val pushTrackingUtil = SDKComponent.pushTrackingUtil
     private val activityLifecycleCallbacks = SDKComponent.activityLifecycleCallbacks
+    private val pendingPushDeliveryStore: PendingPushDeliveryStore
+        get() = SDKComponent.pendingPushDeliveryStore
+    private val dispatchers: DispatchersProvider
+        get() = SDKComponent.dispatchersProvider
 
     override val moduleName: String
         get() = MODULE_NAME
@@ -25,6 +35,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
     override fun initialize() {
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
+        flushPendingPushDeliveryMetrics()
     }
 
     private fun subscribeToLifecycleEvents() {
@@ -45,6 +56,36 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                         else -> {}
                     }
                 }
+        }
+    }
+
+    /**
+     * At app launch, drain any push-delivered metrics that were observed locally
+     * but never confirmed by the primary delivery path (WorkManager / direct
+     * HTTP). For each pending entry we publish a [Event.TrackPushMetricEvent] so
+     * the analytics pipeline can deliver it, then clear the store.
+     *
+     * Disk I/O (the JSON read and the post-flush clear) MUST happen off the main
+     * thread, so the entire load + publish + clear sequence is dispatched on the
+     * background dispatcher.
+     */
+    private fun flushPendingPushDeliveryMetrics() {
+        CoroutineScope(dispatchers.background).launch {
+            runCatching {
+                val pending = pendingPushDeliveryStore.loadAll()
+                if (pending.isEmpty()) return@runCatching
+
+                pending.forEach { entry ->
+                    eventBus.publish(
+                        Event.TrackPushMetricEvent(
+                            event = Metric.Delivered,
+                            deliveryId = entry.deliveryId,
+                            deviceToken = entry.token
+                        )
+                    )
+                }
+                pendingPushDeliveryStore.removeAll()
+            }
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -63,9 +63,10 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
      * At app launch, drain any push-delivered metrics that were observed locally
      * but never confirmed by the primary delivery path (WorkManager / direct
      * HTTP). For each pending entry we publish a [Event.TrackPushMetricEvent] so
-     * the analytics pipeline can deliver it, then remove that specific entry.
+     * the analytics pipeline can deliver it, then remove only the entries we
+     * actually loaded — entries appended mid-flush survive.
      *
-     * Disk I/O (the JSON read and per-entry removes) MUST happen off the main
+     * Disk I/O (the JSON read and targeted remove) MUST happen off the main
      * thread, so the sequence is dispatched on the background dispatcher.
      */
     private fun flushPendingPushDeliveryMetrics() {
@@ -74,6 +75,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                 val pending = pendingPushDeliveryStore.loadAll()
                 if (pending.isEmpty()) return@runCatching
 
+                val flushedIds = pending.map { it.deliveryId }
                 pending.forEach { entry ->
                     eventBus.publish(
                         Event.TrackPushMetricEvent(
@@ -82,11 +84,8 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                             deviceToken = entry.token
                         )
                     )
-                    // Remove only the entries we actually flushed. Using
-                    // removeAll() would race with append() and silently drop
-                    // pushes that arrived mid-flush.
-                    pendingPushDeliveryStore.remove(entry.deliveryId)
                 }
+                pendingPushDeliveryStore.removeAll(flushedIds)
             }
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -63,11 +63,10 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
      * At app launch, drain any push-delivered metrics that were observed locally
      * but never confirmed by the primary delivery path (WorkManager / direct
      * HTTP). For each pending entry we publish a [Event.TrackPushMetricEvent] so
-     * the analytics pipeline can deliver it, then clear the store.
+     * the analytics pipeline can deliver it, then remove that specific entry.
      *
-     * Disk I/O (the JSON read and the post-flush clear) MUST happen off the main
-     * thread, so the entire load + publish + clear sequence is dispatched on the
-     * background dispatcher.
+     * Disk I/O (the JSON read and per-entry removes) MUST happen off the main
+     * thread, so the sequence is dispatched on the background dispatcher.
      */
     private fun flushPendingPushDeliveryMetrics() {
         CoroutineScope(dispatchers.background).launch {
@@ -83,8 +82,11 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
                             deviceToken = entry.token
                         )
                     )
+                    // Remove only the entries we actually flushed. Using
+                    // removeAll() would race with append() and silently drop
+                    // pushes that arrived mid-flush.
+                    pendingPushDeliveryStore.remove(entry.deliveryId)
                 }
-                pendingPushDeliveryStore.removeAll()
             }
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -63,14 +63,15 @@ internal class AsyncPushDeliveryTracker(
     /**
      * Fire-and-forget direct-HTTP fallback used when WorkManager is not available.
      * Mirrors the WorkManager success contract: on a 2xx response the pending
-     * entry is removed; on any failure the entry is left in place so the
-     * app-launch flush will publish it via the analytics pipeline.
+     * entry keyed by [deliveryId] is removed; on any failure the entry is left
+     * in place so the app-launch flush will publish it via the analytics
+     * pipeline.
      */
-    fun trackMetric(token: String, event: String, deliveryId: String, pendingId: String) {
+    fun trackMetric(token: String, event: String, deliveryId: String) {
         CoroutineScope(dispatcher.background).launch {
             val result = deliveryTracker.trackMetric(token, event, deliveryId)
-            if (result.isSuccess && pendingId.isNotEmpty()) {
-                pendingStore.remove(pendingId)
+            if (result.isSuccess) {
+                pendingStore.remove(deliveryId)
             }
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/PushDeliveryTracker.kt
@@ -1,5 +1,6 @@
 package io.customer.messagingpush
 
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.httpClient
 import io.customer.sdk.core.network.CustomerIOHttpClient
@@ -53,14 +54,24 @@ internal class PushDeliveryTrackerImpl : PushDeliveryTracker {
 }
 
 internal class AsyncPushDeliveryTracker(
-    private val deliveryTracker: PushDeliveryTracker
+    private val deliveryTracker: PushDeliveryTracker,
+    private val pendingStore: PendingPushDeliveryStore
 ) {
     private val dispatcher: DispatchersProvider
         get() = SDKComponent.dispatchersProvider
 
-    fun trackMetric(token: String, event: String, deliveryId: String) {
+    /**
+     * Fire-and-forget direct-HTTP fallback used when WorkManager is not available.
+     * Mirrors the WorkManager success contract: on a 2xx response the pending
+     * entry is removed; on any failure the entry is left in place so the
+     * app-launch flush will publish it via the analytics pipeline.
+     */
+    fun trackMetric(token: String, event: String, deliveryId: String, pendingId: String) {
         CoroutineScope(dispatcher.background).launch {
-            deliveryTracker.trackMetric(token, event, deliveryId)
+            val result = deliveryTracker.trackMetric(token, event, deliveryId)
+            if (result.isSuccess && pendingId.isNotEmpty()) {
+                pendingStore.remove(pendingId)
+            }
         }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -16,6 +16,7 @@ import io.customer.messagingpush.processor.PushMessageProcessor
 import io.customer.messagingpush.processor.PushMessageProcessorImpl
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.provider.FCMTokenProviderImpl
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.DeepLinkUtilImpl
 import io.customer.messagingpush.util.PushTrackingUtil
@@ -52,8 +53,21 @@ internal val SDKComponent.deepLinkUtil: DeepLinkUtil
 val SDKComponent.pushTrackingUtil: PushTrackingUtil
     get() = newInstance<PushTrackingUtil> { PushTrackingUtilImpl() }
 
+internal val SDKComponent.pendingPushDeliveryStore: PendingPushDeliveryStore
+    get() = singleton<PendingPushDeliveryStore> {
+        PendingPushDeliveryStore(
+            context = android().applicationContext,
+            logger = logger
+        )
+    }
+
 internal val SDKComponent.asyncPushDeliveryTracker: AsyncPushDeliveryTracker
-    get() = singleton<AsyncPushDeliveryTracker> { AsyncPushDeliveryTracker(pushDeliveryTracker) }
+    get() = singleton<AsyncPushDeliveryTracker> {
+        AsyncPushDeliveryTracker(
+            deliveryTracker = pushDeliveryTracker,
+            pendingStore = pendingPushDeliveryStore
+        )
+    }
 
 internal val SDKComponent.deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
     get() = singleton<PushDeliveryMetricsBackgroundScheduler> { PushDeliveryMetricsBackgroundScheduler(workManagerProvider, asyncPushDeliveryTracker) }
@@ -64,7 +78,8 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
             pushLogger = pushLogger,
             moduleConfig = pushModuleConfig,
             deepLinkUtil = deepLinkUtil,
-            deliveryMetricsScheduler = deliveryMetricsScheduler
+            deliveryMetricsScheduler = deliveryMetricsScheduler,
+            pendingPushDeliveryStore = pendingPushDeliveryStore
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -8,6 +8,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import io.customer.messagingpush.AsyncPushDeliveryTracker
+import io.customer.messagingpush.di.pendingPushDeliveryStore
 import io.customer.messagingpush.di.pushDeliveryTracker
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
@@ -16,6 +17,7 @@ import java.io.IOException
 
 private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
+private const val PENDING_ID = "pending-id"
 
 internal class PushDeliveryMetricsBackgroundScheduler(
     private val workManagerProvider: CustomerIOWorkManagerProvider,
@@ -27,10 +29,15 @@ internal class PushDeliveryMetricsBackgroundScheduler(
         private const val WORK_MANAGER_TAG_PUSH_DELIVERY = "cio-push-delivery"
     }
 
-    fun scheduleDeliveredPushMetricsReceipt(deliveryId: String, deliveryToken: String) {
+    fun scheduleDeliveredPushMetricsReceipt(
+        deliveryId: String,
+        deliveryToken: String,
+        pendingId: String
+    ) {
         val input = Data.Builder()
             .putString(DELIVERY_ID, deliveryId)
             .putString(DELIVERY_TOKEN, deliveryToken)
+            .putString(PENDING_ID, pendingId)
             .build()
 
         val workRequest = OneTimeWorkRequestBuilder<PushDeliveryMetricsWorker>()
@@ -48,7 +55,12 @@ internal class PushDeliveryMetricsBackgroundScheduler(
         if (workManager != null) {
             workManager.enqueueUniqueWork(deliveryId, ExistingWorkPolicy.KEEP, workRequest)
         } else {
-            asyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+            asyncPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId,
+                pendingId = pendingId
+            )
         }
     }
 }
@@ -60,6 +72,7 @@ internal class PushDeliveryMetricsWorker(
     override suspend fun doWork(): Result {
         val deliveryId = inputData.getString(DELIVERY_ID)
         val deliveryToken = inputData.getString(DELIVERY_TOKEN)
+        val pendingId = inputData.getString(PENDING_ID)
 
         if (deliveryId.isNullOrEmpty() || deliveryToken.isNullOrEmpty()) {
             // Missing delivery data, prevent task from being retried
@@ -73,7 +86,13 @@ internal class PushDeliveryMetricsWorker(
         )
 
         return when {
-            result.isSuccess -> Result.success()
+            result.isSuccess -> {
+                // Only clear the pending entry once the backend has confirmed receipt.
+                pendingId?.takeIf { it.isNotEmpty() }?.let {
+                    SDKComponent.pendingPushDeliveryStore.remove(it)
+                }
+                Result.success()
+            }
             result.exceptionOrNull() is IOException -> Result.retry()
             else -> Result.failure()
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -17,7 +17,6 @@ import java.io.IOException
 
 private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
-private const val PENDING_ID = "pending-id"
 
 internal class PushDeliveryMetricsBackgroundScheduler(
     private val workManagerProvider: CustomerIOWorkManagerProvider,
@@ -31,13 +30,11 @@ internal class PushDeliveryMetricsBackgroundScheduler(
 
     fun scheduleDeliveredPushMetricsReceipt(
         deliveryId: String,
-        deliveryToken: String,
-        pendingId: String
+        deliveryToken: String
     ) {
         val input = Data.Builder()
             .putString(DELIVERY_ID, deliveryId)
             .putString(DELIVERY_TOKEN, deliveryToken)
-            .putString(PENDING_ID, pendingId)
             .build()
 
         val workRequest = OneTimeWorkRequestBuilder<PushDeliveryMetricsWorker>()
@@ -58,8 +55,7 @@ internal class PushDeliveryMetricsBackgroundScheduler(
             asyncPushDeliveryTracker.trackMetric(
                 token = deliveryToken,
                 event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                pendingId = pendingId
+                deliveryId = deliveryId
             )
         }
     }
@@ -72,7 +68,6 @@ internal class PushDeliveryMetricsWorker(
     override suspend fun doWork(): Result {
         val deliveryId = inputData.getString(DELIVERY_ID)
         val deliveryToken = inputData.getString(DELIVERY_TOKEN)
-        val pendingId = inputData.getString(PENDING_ID)
 
         if (deliveryId.isNullOrEmpty() || deliveryToken.isNullOrEmpty()) {
             // Missing delivery data, prevent task from being retried
@@ -88,9 +83,7 @@ internal class PushDeliveryMetricsWorker(
         return when {
             result.isSuccess -> {
                 // Only clear the pending entry once the backend has confirmed receipt.
-                pendingId?.takeIf { it.isNotEmpty() }?.let {
-                    SDKComponent.pendingPushDeliveryStore.remove(it)
-                }
+                SDKComponent.pendingPushDeliveryStore.remove(deliveryId)
                 Result.success()
             }
             result.exceptionOrNull() is IOException -> Result.retry()

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -93,9 +93,9 @@ internal class PushMessageProcessorImpl(
 
             // Persist a pending entry first so the metric can be replayed via the
             // analytics pipeline at the next app launch if the primary delivery
-            // path fails. The id is passed through to the scheduler / direct-HTTP
-            // fallback so it can be cleared on a successful response.
-            val pendingId = pendingPushDeliveryStore.append(
+            // path fails. The entry is keyed by deliveryId; the scheduler /
+            // direct-HTTP fallback removes it on a successful response.
+            pendingPushDeliveryStore.append(
                 deliveryId = deliveryId,
                 token = deliveryToken
             )
@@ -105,8 +105,7 @@ internal class PushMessageProcessorImpl(
             // pending-store + launch-flush handles the analytics-pipeline path.
             deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
                 deliveryId = deliveryId,
-                deliveryToken = deliveryToken,
-                pendingId = pendingId
+                deliveryToken = deliveryToken
             )
         } else {
             pushLogger.logPushMetricsAutoTrackingDisabled()

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -10,6 +10,7 @@ import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.extensions.parcelable
 import io.customer.messagingpush.logger.PushNotificationLogger
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.communication.Event
@@ -20,7 +21,8 @@ internal class PushMessageProcessorImpl(
     private val pushLogger: PushNotificationLogger,
     private val moduleConfig: MessagingPushModuleConfig,
     private val deepLinkUtil: DeepLinkUtil,
-    private val deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler
+    private val deliveryMetricsScheduler: PushDeliveryMetricsBackgroundScheduler,
+    private val pendingPushDeliveryStore: PendingPushDeliveryStore
 ) : PushMessageProcessor {
 
     /**
@@ -89,15 +91,22 @@ internal class PushMessageProcessorImpl(
         if (moduleConfig.autoTrackPushEvents) {
             pushLogger.logTrackingPushMessageDelivered(deliveryId)
 
-            deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+            // Persist a pending entry first so the metric can be replayed via the
+            // analytics pipeline at the next app launch if the primary delivery
+            // path fails. The id is passed through to the scheduler / direct-HTTP
+            // fallback so it can be cleared on a successful response.
+            val pendingId = pendingPushDeliveryStore.append(
+                deliveryId = deliveryId,
+                token = deliveryToken
+            )
 
-            // Track delivered metrics via event bus
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = deliveryId,
-                    deviceToken = deliveryToken
-                )
+            // WorkManager (or its direct-HTTP fallback) remains the primary
+            // delivery mechanism. The eventBus dual-emit was removed; the
+            // pending-store + launch-flush handles the analytics-pipeline path.
+            deliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = deliveryId,
+                deliveryToken = deliveryToken,
+                pendingId = pendingId
             )
         } else {
             pushLogger.logPushMetricsAutoTrackingDisabled()

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
@@ -4,13 +4,14 @@ package io.customer.messagingpush.store
  * Represents a push-delivered metric that has been observed locally but not yet
  * confirmed as tracked by the Customer.io backend.
  *
- * Entries are persisted by [PendingPushDeliveryStore] and removed only when the
- * primary delivery path (WorkManager job or its direct-HTTP fallback) reports a
- * successful response, or when the app-launch flush hands them off to the
- * analytics pipeline.
+ * Entries are keyed by [deliveryId] (the natural identifier carried on the push
+ * payload) and stamped with the [timestamp] captured at append time. Entries
+ * are removed only when the primary delivery path (WorkManager job or its
+ * direct-HTTP fallback) reports a successful response, or when the app-launch
+ * flush hands them off to the analytics pipeline.
  */
 internal data class PendingPushDeliveryMetric(
-    val id: String,
     val deliveryId: String,
-    val token: String
+    val token: String,
+    val timestamp: Long
 )

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryMetric.kt
@@ -1,0 +1,16 @@
+package io.customer.messagingpush.store
+
+/**
+ * Represents a push-delivered metric that has been observed locally but not yet
+ * confirmed as tracked by the Customer.io backend.
+ *
+ * Entries are persisted by [PendingPushDeliveryStore] and removed only when the
+ * primary delivery path (WorkManager job or its direct-HTTP fallback) reports a
+ * successful response, or when the app-launch flush hands them off to the
+ * analytics pipeline.
+ */
+internal data class PendingPushDeliveryMetric(
+    val id: String,
+    val deliveryId: String,
+    val token: String
+)

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
@@ -61,11 +61,18 @@ internal class PendingPushDeliveryStore(
      * Remove the entry with the given [deliveryId]. No-op if no such entry
      * exists (e.g. it was already flushed at launch or removed by an earlier
      * success).
+     *
+     * Skips the write when no entry was actually removed: if [readAll] returns
+     * empty (whether the file is genuinely empty or unreadable due to a
+     * transient IO failure / corruption), [writeAll] would otherwise wipe the
+     * file with an empty array. Matches iOS's `PendingPushDeliveryStore.remove`.
      */
     fun remove(deliveryId: String) {
         lock.withLock {
-            val entries = readAll().filterNot { it.deliveryId == deliveryId }
-            writeAll(entries)
+            val entries = readAll()
+            val filtered = entries.filterNot { it.deliveryId == deliveryId }
+            if (filtered.size == entries.size) return@withLock
+            writeAll(filtered)
         }
     }
 
@@ -74,13 +81,18 @@ internal class PendingPushDeliveryStore(
      * coordinated read-modify-write. Prefer this over calling [remove] in a
      * loop when flushing multiple metrics at once. Entries appended after
      * this call's read are not affected.
+     *
+     * Skips the write when no entry was actually removed — same protection as
+     * [remove] against transient [readAll] failures silently wiping the store.
      */
     fun removeAll(deliveryIds: Collection<String>) {
         if (deliveryIds.isEmpty()) return
         val idSet = deliveryIds.toSet()
         lock.withLock {
-            val entries = readAll().filterNot { it.deliveryId in idSet }
-            writeAll(entries)
+            val entries = readAll()
+            val filtered = entries.filterNot { it.deliveryId in idSet }
+            if (filtered.size == entries.size) return@withLock
+            writeAll(filtered)
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
@@ -3,7 +3,6 @@ package io.customer.messagingpush.store
 import android.content.Context
 import io.customer.sdk.core.util.Logger
 import java.io.File
-import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import org.json.JSONArray
@@ -12,17 +11,18 @@ import org.json.JSONObject
 /**
  * Disk-backed queue of push-delivered metrics waiting on a delivery confirmation.
  *
- * Each entry is the tuple `(id, deliveryId, token)` where `id` is generated at
- * [append] time and is the handle used to remove the entry once the metric has
- * been delivered. There is no timestamp and no age-based eviction; entries live
- * until [remove] / [removeAll] is called.
+ * Each entry is the tuple `(deliveryId, token, timestamp)` where [deliveryId]
+ * is the natural key used to remove the entry once the metric has been
+ * delivered, and [timestamp] is the epoch-millis value captured at [append]
+ * time. Entries live until [remove] / [removeAll] is called.
  *
  * Storage is a single JSON file in [Context.filesDir]. All read-modify-write
  * sequences are guarded by an in-process [ReentrantLock] so concurrent appends
  * from multiple FCM callbacks cannot corrupt the file.
  *
- * Capacity is capped at [MAX_ENTRIES]. On overflow the oldest entry is dropped
- * so the queue never grows without bound when delivery confirmation is failing.
+ * Capacity is capped at [MAX_ENTRIES]. On overflow the entry with the smallest
+ * timestamp is dropped so the queue never grows without bound when delivery
+ * confirmation is failing.
  */
 internal class PendingPushDeliveryStore(
     context: Context,
@@ -32,34 +32,39 @@ internal class PendingPushDeliveryStore(
     private val lock = ReentrantLock()
 
     /**
-     * Append a new pending entry and return its generated id. The id should be
-     * passed to the WorkManager job / direct-HTTP fallback so it can call
-     * [remove] on a successful response.
+     * Append a new pending entry, capturing [System.currentTimeMillis] as the
+     * entry's timestamp. The WorkManager job / direct-HTTP fallback uses
+     * [deliveryId] to call [remove] on a successful response.
      */
-    fun append(deliveryId: String, token: String): String {
-        val id = UUID.randomUUID().toString()
+    fun append(deliveryId: String, token: String) {
+        val entry = PendingPushDeliveryMetric(
+            deliveryId = deliveryId,
+            token = token,
+            timestamp = System.currentTimeMillis()
+        )
         lock.withLock {
             val entries = readAll().toMutableList()
-            entries.add(PendingPushDeliveryMetric(id = id, deliveryId = deliveryId, token = token))
-            // Drop oldest entries to keep the queue bounded.
+            entries.add(entry)
+            // Drop oldest (smallest-timestamp) entries to keep the queue bounded.
             while (entries.size > MAX_ENTRIES) {
-                entries.removeAt(0)
+                val oldestIndex = entries.indices.minBy { entries[it].timestamp }
+                entries.removeAt(oldestIndex)
             }
             writeAll(entries)
         }
-        return id
     }
 
     /** Returns all pending entries in insertion order. */
     fun loadAll(): List<PendingPushDeliveryMetric> = lock.withLock { readAll() }
 
     /**
-     * Remove the entry with the given [id]. No-op if no such entry exists
-     * (e.g. it was already flushed at launch or removed by an earlier success).
+     * Remove the entry with the given [deliveryId]. No-op if no such entry
+     * exists (e.g. it was already flushed at launch or removed by an earlier
+     * success).
      */
-    fun remove(id: String) {
+    fun remove(deliveryId: String) {
         lock.withLock {
-            val entries = readAll().filterNot { it.id == id }
+            val entries = readAll().filterNot { it.deliveryId == deliveryId }
             writeAll(entries)
         }
     }
@@ -80,10 +85,18 @@ internal class PendingPushDeliveryStore(
             buildList(array.length()) {
                 for (i in 0 until array.length()) {
                     val obj = array.optJSONObject(i) ?: continue
-                    val id = obj.optString(KEY_ID).takeIf { it.isNotBlank() } ?: continue
                     val deliveryId = obj.optString(KEY_DELIVERY_ID).takeIf { it.isNotBlank() } ?: continue
                     val token = obj.optString(KEY_TOKEN).takeIf { it.isNotBlank() } ?: continue
-                    add(PendingPushDeliveryMetric(id = id, deliveryId = deliveryId, token = token))
+                    if (!obj.has(KEY_TIMESTAMP)) continue
+                    val timestamp = obj.optLong(KEY_TIMESTAMP, Long.MIN_VALUE)
+                    if (timestamp == Long.MIN_VALUE) continue
+                    add(
+                        PendingPushDeliveryMetric(
+                            deliveryId = deliveryId,
+                            token = token,
+                            timestamp = timestamp
+                        )
+                    )
                 }
             }
         } catch (ex: Exception) {
@@ -101,9 +114,9 @@ internal class PendingPushDeliveryStore(
             val array = JSONArray()
             entries.forEach { entry ->
                 val obj = JSONObject().apply {
-                    put(KEY_ID, entry.id)
                     put(KEY_DELIVERY_ID, entry.deliveryId)
                     put(KEY_TOKEN, entry.token)
+                    put(KEY_TIMESTAMP, entry.timestamp)
                 }
                 array.put(obj)
             }
@@ -120,9 +133,9 @@ internal class PendingPushDeliveryStore(
     internal companion object {
         const val MAX_ENTRIES = 100
         private const val FILE_NAME = "cio_pending_push_delivery.json"
-        private const val KEY_ID = "id"
         private const val KEY_DELIVERY_ID = "deliveryId"
         private const val KEY_TOKEN = "token"
+        private const val KEY_TIMESTAMP = "timestamp"
         private const val TAG = "PendingPushDeliveryStore"
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
@@ -1,0 +1,128 @@
+package io.customer.messagingpush.store
+
+import android.content.Context
+import io.customer.sdk.core.util.Logger
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Disk-backed queue of push-delivered metrics waiting on a delivery confirmation.
+ *
+ * Each entry is the tuple `(id, deliveryId, token)` where `id` is generated at
+ * [append] time and is the handle used to remove the entry once the metric has
+ * been delivered. There is no timestamp and no age-based eviction; entries live
+ * until [remove] / [removeAll] is called.
+ *
+ * Storage is a single JSON file in [Context.filesDir]. All read-modify-write
+ * sequences are guarded by an in-process [ReentrantLock] so concurrent appends
+ * from multiple FCM callbacks cannot corrupt the file.
+ *
+ * Capacity is capped at [MAX_ENTRIES]. On overflow the oldest entry is dropped
+ * so the queue never grows without bound when delivery confirmation is failing.
+ */
+internal class PendingPushDeliveryStore(
+    context: Context,
+    private val logger: Logger
+) {
+    private val file: File = File(context.applicationContext.filesDir, FILE_NAME)
+    private val lock = ReentrantLock()
+
+    /**
+     * Append a new pending entry and return its generated id. The id should be
+     * passed to the WorkManager job / direct-HTTP fallback so it can call
+     * [remove] on a successful response.
+     */
+    fun append(deliveryId: String, token: String): String {
+        val id = UUID.randomUUID().toString()
+        lock.withLock {
+            val entries = readAll().toMutableList()
+            entries.add(PendingPushDeliveryMetric(id = id, deliveryId = deliveryId, token = token))
+            // Drop oldest entries to keep the queue bounded.
+            while (entries.size > MAX_ENTRIES) {
+                entries.removeAt(0)
+            }
+            writeAll(entries)
+        }
+        return id
+    }
+
+    /** Returns all pending entries in insertion order. */
+    fun loadAll(): List<PendingPushDeliveryMetric> = lock.withLock { readAll() }
+
+    /**
+     * Remove the entry with the given [id]. No-op if no such entry exists
+     * (e.g. it was already flushed at launch or removed by an earlier success).
+     */
+    fun remove(id: String) {
+        lock.withLock {
+            val entries = readAll().filterNot { it.id == id }
+            writeAll(entries)
+        }
+    }
+
+    /** Remove all pending entries (used after the launch flush hands them off). */
+    fun removeAll() {
+        lock.withLock {
+            writeAll(emptyList())
+        }
+    }
+
+    private fun readAll(): List<PendingPushDeliveryMetric> {
+        if (!file.exists()) return emptyList()
+        return try {
+            val text = file.readText()
+            if (text.isBlank()) return emptyList()
+            val array = JSONArray(text)
+            buildList(array.length()) {
+                for (i in 0 until array.length()) {
+                    val obj = array.optJSONObject(i) ?: continue
+                    val id = obj.optString(KEY_ID).takeIf { it.isNotBlank() } ?: continue
+                    val deliveryId = obj.optString(KEY_DELIVERY_ID).takeIf { it.isNotBlank() } ?: continue
+                    val token = obj.optString(KEY_TOKEN).takeIf { it.isNotBlank() } ?: continue
+                    add(PendingPushDeliveryMetric(id = id, deliveryId = deliveryId, token = token))
+                }
+            }
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to read pending push delivery store; treating as empty",
+                tag = TAG,
+                throwable = ex
+            )
+            emptyList()
+        }
+    }
+
+    private fun writeAll(entries: List<PendingPushDeliveryMetric>) {
+        try {
+            val array = JSONArray()
+            entries.forEach { entry ->
+                val obj = JSONObject().apply {
+                    put(KEY_ID, entry.id)
+                    put(KEY_DELIVERY_ID, entry.deliveryId)
+                    put(KEY_TOKEN, entry.token)
+                }
+                array.put(obj)
+            }
+            file.writeText(array.toString())
+        } catch (ex: Exception) {
+            logger.error(
+                "Failed to write pending push delivery store",
+                tag = TAG,
+                throwable = ex
+            )
+        }
+    }
+
+    internal companion object {
+        const val MAX_ENTRIES = 100
+        private const val FILE_NAME = "cio_pending_push_delivery.json"
+        private const val KEY_ID = "id"
+        private const val KEY_DELIVERY_ID = "deliveryId"
+        private const val KEY_TOKEN = "token"
+        private const val TAG = "PendingPushDeliveryStore"
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/store/PendingPushDeliveryStore.kt
@@ -69,7 +69,22 @@ internal class PendingPushDeliveryStore(
         }
     }
 
-    /** Remove all pending entries (used after the launch flush hands them off). */
+    /**
+     * Remove all entries whose deliveryIds are in [deliveryIds] in a single
+     * coordinated read-modify-write. Prefer this over calling [remove] in a
+     * loop when flushing multiple metrics at once. Entries appended after
+     * this call's read are not affected.
+     */
+    fun removeAll(deliveryIds: Collection<String>) {
+        if (deliveryIds.isEmpty()) return
+        val idSet = deliveryIds.toSet()
+        lock.withLock {
+            val entries = readAll().filterNot { it.deliveryId in idSet }
+            writeAll(entries)
+        }
+    }
+
+    /** Remove all pending entries. */
     fun removeAll() {
         lock.withLock {
             writeAll(emptyList())

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -79,7 +79,7 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
     }
 
     @Test
-    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndEachRemoved() {
+    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndOnlyLoadedIdsRemoved() {
         val pending = listOf(
             PendingPushDeliveryMetric(deliveryId = "d1", token = "t1", timestamp = 1L),
             PendingPushDeliveryMetric(deliveryId = "d2", token = "t2", timestamp = 2L)
@@ -98,9 +98,9 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
                     )
                 )
             }
-            verify(exactly = 1) { mockPendingStore.remove(entry.deliveryId) }
         }
-        verify(exactly = 0) { mockPendingStore.removeAll() }
+        verify(exactly = 1) { mockPendingStore.removeAll(listOf("d1", "d2")) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
     }
 
     @Test
@@ -111,7 +111,7 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
 
         verify(exactly = 0) { eventBus.publish(any<Event.TrackPushMetricEvent>()) }
         verify(exactly = 0) { mockPendingStore.remove(any()) }
-        verify(exactly = 0) { mockPendingStore.removeAll() }
+        verify(exactly = 0) { mockPendingStore.removeAll(any<Collection<String>>()) }
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -5,26 +5,37 @@ import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
+import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.messagingpush.di.fcmTokenProvider
 import io.customer.messagingpush.provider.DeviceTokenProvider
+import io.customer.messagingpush.store.PendingPushDeliveryMetric
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.JUnitTest
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.events.Metric
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 
 class ModuleMessagingPushFCMTest : JUnitTest() {
     private lateinit var eventBus: EventBus
     private lateinit var fcmTokenProviderMock: DeviceTokenProvider
     private lateinit var module: ModuleMessagingPushFCM
+    private val mockPendingStore: PendingPushDeliveryStore = mockk(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
             testConfigurationDefault {
                 diGraph {
-                    sdk { overrideDependency<EventBus>(mockk(relaxed = true)) }
+                    sdk {
+                        overrideDependency<EventBus>(mockk(relaxed = true))
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
+                    }
                     android { overrideDependency<DeviceTokenProvider>(mockk(relaxed = true)) }
                 }
             }
@@ -65,5 +76,52 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
         module.initialize()
 
         assertCalledOnce { eventBus.publish(Event.RegisterDeviceTokenEvent(token = givenToken)) }
+    }
+
+    @Test
+    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndCleared() {
+        val pending = listOf(
+            PendingPushDeliveryMetric(id = "p1", deliveryId = "d1", token = "t1"),
+            PendingPushDeliveryMetric(id = "p2", deliveryId = "d2", token = "t2")
+        )
+        every { mockPendingStore.loadAll() } returns pending
+
+        module.initialize()
+
+        pending.forEach { entry ->
+            verify(exactly = 1) {
+                eventBus.publish(
+                    Event.TrackPushMetricEvent(
+                        event = Metric.Delivered,
+                        deliveryId = entry.deliveryId,
+                        deviceToken = entry.token
+                    )
+                )
+            }
+        }
+        verify(exactly = 1) { mockPendingStore.removeAll() }
+    }
+
+    @Test
+    fun initialize_givenNoPendingPushDeliveries_expectNoPublishAndNoClear() {
+        every { mockPendingStore.loadAll() } returns emptyList()
+
+        module.initialize()
+
+        verify(exactly = 0) { eventBus.publish(any<Event.TrackPushMetricEvent>()) }
+        verify(exactly = 0) { mockPendingStore.removeAll() }
+    }
+
+    @Test
+    fun initialize_givenPendingFlush_expectDiskIoOnBackgroundDispatcher() {
+        // DispatchersProviderStub returns UnconfinedTestDispatcher (background) by default.
+        // We verify the flush runs by ensuring loadAll() is invoked at initialize() time,
+        // which is the disk read. The stub guarantees this happens on the background
+        // dispatcher, not on Dispatchers.Main.
+        every { mockPendingStore.loadAll() } returns emptyList()
+
+        module.initialize()
+
+        verify(exactly = 1) { mockPendingStore.loadAll() }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -79,7 +79,7 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
     }
 
     @Test
-    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndCleared() {
+    fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndEachRemoved() {
         val pending = listOf(
             PendingPushDeliveryMetric(deliveryId = "d1", token = "t1", timestamp = 1L),
             PendingPushDeliveryMetric(deliveryId = "d2", token = "t2", timestamp = 2L)
@@ -98,17 +98,19 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
                     )
                 )
             }
+            verify(exactly = 1) { mockPendingStore.remove(entry.deliveryId) }
         }
-        verify(exactly = 1) { mockPendingStore.removeAll() }
+        verify(exactly = 0) { mockPendingStore.removeAll() }
     }
 
     @Test
-    fun initialize_givenNoPendingPushDeliveries_expectNoPublishAndNoClear() {
+    fun initialize_givenNoPendingPushDeliveries_expectNoPublishAndNoRemove() {
         every { mockPendingStore.loadAll() } returns emptyList()
 
         module.initialize()
 
         verify(exactly = 0) { eventBus.publish(any<Event.TrackPushMetricEvent>()) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
         verify(exactly = 0) { mockPendingStore.removeAll() }
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -81,8 +81,8 @@ class ModuleMessagingPushFCMTest : JUnitTest() {
     @Test
     fun initialize_givenPendingPushDeliveriesOnDisk_expectFlushedViaEventBusAndCleared() {
         val pending = listOf(
-            PendingPushDeliveryMetric(id = "p1", deliveryId = "d1", token = "t1"),
-            PendingPushDeliveryMetric(id = "p2", deliveryId = "d2", token = "t2")
+            PendingPushDeliveryMetric(deliveryId = "d1", token = "t1", timestamp = 1L),
+            PendingPushDeliveryMetric(deliveryId = "d2", token = "t2", timestamp = 2L)
         )
         every { mockPendingStore.loadAll() } returns pending
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
@@ -2,13 +2,18 @@ package io.customer.messagingpush
 
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.commontest.util.DispatchersProviderStub
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
+import io.customer.sdk.core.util.DispatchersProvider
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContain
@@ -22,6 +27,8 @@ class PushDeliveryTrackingTest : IntegrationTest() {
 
     private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
     private val pushDeliveryTracker = PushDeliveryTrackerImpl()
+    private val mockPendingStore: PendingPushDeliveryStore = mockk(relaxed = true)
+    private val mockDeliveryTracker: PushDeliveryTracker = mockk(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
@@ -30,6 +37,7 @@ class PushDeliveryTrackingTest : IntegrationTest() {
                     sdk {
                         // Override the httpClient in your DI so the SUT uses this mock.
                         overrideDependency<CustomerIOHttpClient>(httpClient)
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
                     }
                 }
             }
@@ -78,5 +86,61 @@ class PushDeliveryTrackingTest : IntegrationTest() {
         val result = pushDeliveryTracker.trackMetric("token", "OPENED", "deliveryId")
 
         result.isFailure.shouldBeEqualTo(true)
+    }
+
+    /**
+     * Tests for the direct-HTTP fallback used when WorkManager is not available.
+     * Mirrors the WorkManager success-removal / failure-preservation contract.
+     */
+    @Test
+    fun asyncTrackMetric_givenHttpSuccess_expectPendingEntryRemoved() = runTest {
+        val token = String.random
+        val deliveryId = String.random
+        val pendingId = String.random
+
+        coEvery {
+            mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
+        } returns Result.success(Unit)
+
+        val asyncTracker = AsyncPushDeliveryTracker(
+            deliveryTracker = mockDeliveryTracker,
+            pendingStore = mockPendingStore
+        )
+
+        asyncTracker.trackMetric(
+            token = token,
+            event = "Delivered",
+            deliveryId = deliveryId,
+            pendingId = pendingId
+        )
+
+        coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }
+        verify(exactly = 1) { mockPendingStore.remove(pendingId) }
+    }
+
+    @Test
+    fun asyncTrackMetric_givenHttpFailure_expectPendingEntryPreserved() = runTest {
+        val token = String.random
+        val deliveryId = String.random
+        val pendingId = String.random
+
+        coEvery {
+            mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
+        } returns Result.failure(Exception("boom"))
+
+        val asyncTracker = AsyncPushDeliveryTracker(
+            deliveryTracker = mockDeliveryTracker,
+            pendingStore = mockPendingStore
+        )
+
+        asyncTracker.trackMetric(
+            token = token,
+            event = "Delivered",
+            deliveryId = deliveryId,
+            pendingId = pendingId
+        )
+
+        coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/PushDeliveryTrackingTest.kt
@@ -93,10 +93,9 @@ class PushDeliveryTrackingTest : IntegrationTest() {
      * Mirrors the WorkManager success-removal / failure-preservation contract.
      */
     @Test
-    fun asyncTrackMetric_givenHttpSuccess_expectPendingEntryRemoved() = runTest {
+    fun asyncTrackMetric_givenHttpSuccess_expectPendingEntryRemovedByDeliveryId() = runTest {
         val token = String.random
         val deliveryId = String.random
-        val pendingId = String.random
 
         coEvery {
             mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
@@ -110,19 +109,17 @@ class PushDeliveryTrackingTest : IntegrationTest() {
         asyncTracker.trackMetric(
             token = token,
             event = "Delivered",
-            deliveryId = deliveryId,
-            pendingId = pendingId
+            deliveryId = deliveryId
         )
 
         coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }
-        verify(exactly = 1) { mockPendingStore.remove(pendingId) }
+        verify(exactly = 1) { mockPendingStore.remove(deliveryId) }
     }
 
     @Test
     fun asyncTrackMetric_givenHttpFailure_expectPendingEntryPreserved() = runTest {
         val token = String.random
         val deliveryId = String.random
-        val pendingId = String.random
 
         coEvery {
             mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId)
@@ -136,8 +133,7 @@ class PushDeliveryTrackingTest : IntegrationTest() {
         asyncTracker.trackMetric(
             token = token,
             event = "Delivered",
-            deliveryId = deliveryId,
-            pendingId = pendingId
+            deliveryId = deliveryId
         )
 
         coVerify(exactly = 1) { mockDeliveryTracker.trackMetric(token, "Delivered", deliveryId) }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -29,11 +29,12 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenValidInputs_expectWorkRequestEnqueued() {
         val deliveryId = String.random
         val deliveryToken = String.random
+        val pendingId = String.random
         val workRequestSlot = slot<OneTimeWorkRequest>()
 
         every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
 
         verify(exactly = 1) {
             mockWorkManager.enqueueUniqueWork(
@@ -46,6 +47,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         val inputData = workRequestSlot.captured.workSpec.input
         inputData.getString("delivery-id") shouldBeEqualTo deliveryId
         inputData.getString("delivery-token") shouldBeEqualTo deliveryToken
+        inputData.getString("pending-id") shouldBeEqualTo pendingId
 
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
@@ -56,17 +58,23 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectFallbackToAsyncTracker() {
         val deliveryId = String.random
         val deliveryToken = String.random
+        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns null
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
 
         verify(exactly = 0) {
             mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
         }
 
         verify(exactly = 1) {
-            mockAsyncPushDeliveryTracker.trackMetric(deliveryToken, Metric.Delivered.name, deliveryId)
+            mockAsyncPushDeliveryTracker.trackMetric(
+                token = deliveryToken,
+                event = Metric.Delivered.name,
+                deliveryId = deliveryId,
+                pendingId = pendingId
+            )
         }
     }
 
@@ -74,10 +82,11 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectNoWorkManagerInteraction() {
         val deliveryId = String.random
         val deliveryToken = String.random
+        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns null
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
 
         // Verify WorkManager is not called when null
         verify(exactly = 0) {
@@ -85,7 +94,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         }
         // Verify async tracker is called as fallback
         verify(exactly = 1) {
-            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any(), any())
         }
     }
 
@@ -93,10 +102,11 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerAvailable_expectNoAsyncTrackerCall() {
         val deliveryId = String.random
         val deliveryToken = String.random
+        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
 
         // Verify WorkManager is used when available
         verify(exactly = 1) {
@@ -104,7 +114,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         }
         // Verify async tracker is NOT called when WorkManager is available
         verify(exactly = 0) {
-            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any(), any())
         }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundSchedulerTest.kt
@@ -29,12 +29,11 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenValidInputs_expectWorkRequestEnqueued() {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
         val workRequestSlot = slot<OneTimeWorkRequest>()
 
         every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
 
         verify(exactly = 1) {
             mockWorkManager.enqueueUniqueWork(
@@ -47,7 +46,6 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         val inputData = workRequestSlot.captured.workSpec.input
         inputData.getString("delivery-id") shouldBeEqualTo deliveryId
         inputData.getString("delivery-token") shouldBeEqualTo deliveryToken
-        inputData.getString("pending-id") shouldBeEqualTo pendingId
 
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
@@ -58,11 +56,10 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectFallbackToAsyncTracker() {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns null
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
 
         verify(exactly = 0) {
             mockWorkManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
@@ -72,8 +69,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
             mockAsyncPushDeliveryTracker.trackMetric(
                 token = deliveryToken,
                 event = Metric.Delivered.name,
-                deliveryId = deliveryId,
-                pendingId = pendingId
+                deliveryId = deliveryId
             )
         }
     }
@@ -82,11 +78,10 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerProviderReturnsNull_expectNoWorkManagerInteraction() {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns null
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
 
         // Verify WorkManager is not called when null
         verify(exactly = 0) {
@@ -94,7 +89,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         }
         // Verify async tracker is called as fallback
         verify(exactly = 1) {
-            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any(), any())
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
         }
     }
 
@@ -102,11 +97,10 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
     fun scheduleDeliveredPushMetricsReceipt_givenWorkManagerAvailable_expectNoAsyncTrackerCall() {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
 
         every { mockWorkManagerProvider.getWorkManager() } returns mockWorkManager
 
-        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken, pendingId)
+        scheduler.scheduleDeliveredPushMetricsReceipt(deliveryId, deliveryToken)
 
         // Verify WorkManager is used when available
         verify(exactly = 1) {
@@ -114,7 +108,7 @@ class PushDeliveryMetricsBackgroundSchedulerTest : JUnitTest() {
         }
         // Verify async tracker is NOT called when WorkManager is available
         verify(exactly = 0) {
-            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any(), any())
+            mockAsyncPushDeliveryTracker.trackMetric(any(), any(), any())
         }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -409,11 +409,10 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenHttpSuccessAndPendingId_expectPendingEntryRemoved() = runTest {
+    fun doWork_givenHttpSuccess_expectPendingEntryRemovedByDeliveryId() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
-        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+        val inputData = createInputData(deliveryId, deliveryToken)
 
         coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -424,15 +423,14 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
 
-        verify(exactly = 1) { mockPendingStore.remove(pendingId) }
+        verify(exactly = 1) { mockPendingStore.remove(deliveryId) }
     }
 
     @Test
-    fun doWork_givenHttpFailureAndPendingId_expectPendingEntryPreserved() = runTest {
+    fun doWork_givenHttpFailure_expectPendingEntryPreserved() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
-        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+        val inputData = createInputData(deliveryId, deliveryToken)
 
         coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -445,11 +443,10 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
-    fun doWork_givenHttpRetryableFailureAndPendingId_expectPendingEntryPreserved() = runTest {
+    fun doWork_givenHttpRetryableFailure_expectPendingEntryPreserved() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
-        val pendingId = String.random
-        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+        val inputData = createInputData(deliveryId, deliveryToken)
 
         coEvery {
             mockPushDeliveryTracker.trackMetric(any(), any(), any())
@@ -458,23 +455,6 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val worker = createWorker(inputData)
         worker.doWork()
 
-        verify(exactly = 0) { mockPendingStore.remove(any()) }
-    }
-
-    @Test
-    fun doWork_givenMissingPendingId_expectNoStoreInteraction() = runTest {
-        val deliveryId = String.random
-        val deliveryToken = String.random
-        val inputData = createInputData(deliveryId, deliveryToken, pendingId = null)
-
-        coEvery {
-            mockPushDeliveryTracker.trackMetric(any(), any(), any())
-        } returns Result.success(Unit)
-
-        val worker = createWorker(inputData)
-        val result = worker.doWork()
-
-        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
         verify(exactly = 0) { mockPendingStore.remove(any()) }
     }
 
@@ -503,13 +483,11 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
     private fun createInputData(
         deliveryId: String?,
-        deliveryToken: String?,
-        pendingId: String? = null
+        deliveryToken: String?
     ): Data {
         val builder = Data.Builder()
         deliveryId?.let { builder.putString("delivery-id", it) }
         deliveryToken?.let { builder.putString("delivery-token", it) }
-        pendingId?.let { builder.putString("pending-id", it) }
         return builder.build()
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -6,11 +6,13 @@ import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.random
 import io.customer.messagingpush.PushDeliveryTracker
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.events.Metric
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -25,6 +27,7 @@ import org.robolectric.RobolectricTestRunner
 class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
     private val mockPushDeliveryTracker = mockk<PushDeliveryTracker>(relaxed = true)
+    private val mockPendingStore = mockk<PendingPushDeliveryStore>(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
@@ -32,6 +35,7 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
                 diGraph {
                     sdk {
                         overrideDependency<PushDeliveryTracker>(mockPushDeliveryTracker)
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
                     }
                 }
             }
@@ -405,6 +409,76 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
     }
 
     @Test
+    fun doWork_givenHttpSuccessAndPendingId_expectPendingEntryRemoved() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val pendingId = String.random
+        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+
+        verify(exactly = 1) { mockPendingStore.remove(pendingId) }
+    }
+
+    @Test
+    fun doWork_givenHttpFailureAndPendingId_expectPendingEntryPreserved() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val pendingId = String.random
+        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IllegalStateException("boom"))
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
+    fun doWork_givenHttpRetryableFailureAndPendingId_expectPendingEntryPreserved() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val pendingId = String.random
+        val inputData = createInputData(deliveryId, deliveryToken, pendingId)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.failure(IOException("retry me"))
+
+        val worker = createWorker(inputData)
+        worker.doWork()
+
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
+    fun doWork_givenMissingPendingId_expectNoStoreInteraction() = runTest {
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken, pendingId = null)
+
+        coEvery {
+            mockPushDeliveryTracker.trackMetric(any(), any(), any())
+        } returns Result.success(Unit)
+
+        val worker = createWorker(inputData)
+        val result = worker.doWork()
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        verify(exactly = 0) { mockPendingStore.remove(any()) }
+    }
+
+    @Test
     fun doWork_givenMetricConstantValue_expectCorrectMetricPassed() = runTest {
         val deliveryId = String.random
         val deliveryToken = String.random
@@ -427,10 +501,15 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         }
     }
 
-    private fun createInputData(deliveryId: String?, deliveryToken: String?): Data {
+    private fun createInputData(
+        deliveryId: String?,
+        deliveryToken: String?,
+        pendingId: String? = null
+    ): Data {
         val builder = Data.Builder()
         deliveryId?.let { builder.putString("delivery-id", it) }
         deliveryToken?.let { builder.putString("delivery-token", it) }
+        pendingId?.let { builder.putString("pending-id", it) }
         return builder.build()
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
@@ -21,6 +21,7 @@ import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.deepLinkUtil
 import io.customer.messagingpush.di.pushMessageProcessor
 import io.customer.messagingpush.logger.PushNotificationLogger
+import io.customer.messagingpush.store.PendingPushDeliveryStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.messagingpush.util.DeepLinkUtil
 import io.customer.messagingpush.util.PushTrackingUtil
@@ -46,6 +47,7 @@ class PushMessageProcessorTest : IntegrationTest() {
     private lateinit var eventBus: EventBus
     private val mockPushLogger = mockk<PushNotificationLogger>(relaxed = true)
     private val mockDeliveryMetricsScheduler = mockk<PushDeliveryMetricsBackgroundScheduler>(relaxed = true)
+    private val mockPendingStore = mockk<PendingPushDeliveryStore>(relaxed = true)
 
     private fun pushMessageProcessor(): PushMessageProcessorImpl {
         return SDKComponent.pushMessageProcessor as PushMessageProcessorImpl
@@ -60,6 +62,7 @@ class PushMessageProcessorTest : IntegrationTest() {
                         overrideDependency<EventBus>(mockk(relaxed = true))
                         overrideDependency<PushNotificationLogger>(mockPushLogger)
                         overrideDependency<PushDeliveryMetricsBackgroundScheduler>(mockDeliveryMetricsScheduler)
+                        overrideDependency<PendingPushDeliveryStore>(mockPendingStore)
                     }
                 }
             }
@@ -236,7 +239,10 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertNoInteractions(eventBus)
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
+        }
+        verify(exactly = 0) {
+            mockPendingStore.append(any(), any())
         }
     }
 
@@ -244,6 +250,8 @@ class PushMessageProcessorTest : IntegrationTest() {
     fun processGCMMessageIntent_givenAutoTrackPushEventsEnabled_expectTrackPush() {
         val givenDeliveryId = String.random
         val givenDeviceToken = String.random
+        val givenPendingId = String.random
+        every { mockPendingStore.append(givenDeliveryId, givenDeviceToken) } returns givenPendingId
         val givenBundle = Bundle().apply {
             putString(PushTrackingUtil.DELIVERY_ID_KEY, givenDeliveryId)
             putString(PushTrackingUtil.DELIVERY_TOKEN_KEY, givenDeviceToken)
@@ -259,18 +267,24 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         processor.processGCMMessageIntent(gcmIntent)
 
-        assertCalledOnce {
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = givenDeliveryId,
-                    deviceToken = givenDeviceToken
-                )
-            )
+        // The initial delivery path no longer dual-emits via the event bus; the
+        // pending store + WorkManager (or fallback) carry the metric to the
+        // backend, and the analytics-pipeline emission happens at the next
+        // launch flush from `ModuleMessagingPushFCM.initialize()`.
+        verify(exactly = 0) {
+            eventBus.publish(any<Event.TrackPushMetricEvent>())
         }
 
         verify(exactly = 1) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(givenDeliveryId, givenDeviceToken)
+            mockPendingStore.append(givenDeliveryId, givenDeviceToken)
+        }
+
+        verify(exactly = 1) {
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = givenDeliveryId,
+                deliveryToken = givenDeviceToken,
+                pendingId = givenPendingId
+            )
         }
     }
 
@@ -289,7 +303,10 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertNoInteractions(eventBus)
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
+        }
+        verify(exactly = 0) {
+            mockPendingStore.append(any(), any())
         }
     }
 
@@ -308,7 +325,7 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertCalledOnce { mockPushLogger.logPushMetricsAutoTrackingDisabled() }
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
         }
     }
 
@@ -316,6 +333,8 @@ class PushMessageProcessorTest : IntegrationTest() {
     fun processRemoteMessageDeliveredMetrics_givenAutoTrackPushEventsEnabled_expectTrackPush() {
         val givenDeliveryId = String.random
         val givenDeviceToken = String.random
+        val givenPendingId = String.random
+        every { mockPendingStore.append(givenDeliveryId, givenDeviceToken) } returns givenPendingId
         ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder()
                 .setAutoTrackPushEvents(true)
@@ -325,18 +344,20 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         processor.processRemoteMessageDeliveredMetrics(givenDeliveryId, givenDeviceToken)
 
-        assertCalledOnce {
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Delivered,
-                    deliveryId = givenDeliveryId,
-                    deviceToken = givenDeviceToken
-                )
-            )
+        verify(exactly = 0) {
+            eventBus.publish(any<Event.TrackPushMetricEvent>())
         }
 
         verify(exactly = 1) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(givenDeliveryId, givenDeviceToken)
+            mockPendingStore.append(givenDeliveryId, givenDeviceToken)
+        }
+
+        verify(exactly = 1) {
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
+                deliveryId = givenDeliveryId,
+                deliveryToken = givenDeviceToken,
+                pendingId = givenPendingId
+            )
         }
     }
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
@@ -239,7 +239,7 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertNoInteractions(eventBus)
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
         }
         verify(exactly = 0) {
             mockPendingStore.append(any(), any())
@@ -250,8 +250,6 @@ class PushMessageProcessorTest : IntegrationTest() {
     fun processGCMMessageIntent_givenAutoTrackPushEventsEnabled_expectTrackPush() {
         val givenDeliveryId = String.random
         val givenDeviceToken = String.random
-        val givenPendingId = String.random
-        every { mockPendingStore.append(givenDeliveryId, givenDeviceToken) } returns givenPendingId
         val givenBundle = Bundle().apply {
             putString(PushTrackingUtil.DELIVERY_ID_KEY, givenDeliveryId)
             putString(PushTrackingUtil.DELIVERY_TOKEN_KEY, givenDeviceToken)
@@ -282,8 +280,7 @@ class PushMessageProcessorTest : IntegrationTest() {
         verify(exactly = 1) {
             mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
                 deliveryId = givenDeliveryId,
-                deliveryToken = givenDeviceToken,
-                pendingId = givenPendingId
+                deliveryToken = givenDeviceToken
             )
         }
     }
@@ -303,7 +300,7 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertNoInteractions(eventBus)
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
         }
         verify(exactly = 0) {
             mockPendingStore.append(any(), any())
@@ -325,7 +322,7 @@ class PushMessageProcessorTest : IntegrationTest() {
 
         assertCalledOnce { mockPushLogger.logPushMetricsAutoTrackingDisabled() }
         verify(exactly = 0) {
-            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any(), any())
+            mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(any(), any())
         }
     }
 
@@ -333,8 +330,6 @@ class PushMessageProcessorTest : IntegrationTest() {
     fun processRemoteMessageDeliveredMetrics_givenAutoTrackPushEventsEnabled_expectTrackPush() {
         val givenDeliveryId = String.random
         val givenDeviceToken = String.random
-        val givenPendingId = String.random
-        every { mockPendingStore.append(givenDeliveryId, givenDeviceToken) } returns givenPendingId
         ModuleMessagingPushFCM(
             moduleConfig = MessagingPushModuleConfig.Builder()
                 .setAutoTrackPushEvents(true)
@@ -355,8 +350,7 @@ class PushMessageProcessorTest : IntegrationTest() {
         verify(exactly = 1) {
             mockDeliveryMetricsScheduler.scheduleDeliveredPushMetricsReceipt(
                 deliveryId = givenDeliveryId,
-                deliveryToken = givenDeviceToken,
-                pendingId = givenPendingId
+                deliveryToken = givenDeviceToken
             )
         }
     }

--- a/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
@@ -7,6 +7,8 @@ import io.mockk.mockk
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessOrEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBe
@@ -30,14 +32,17 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
     fun append_givenSingleEntry_expectLoadAllReturnsIt() {
         val deliveryId = String.random
         val token = String.random
+        val before = System.currentTimeMillis()
 
-        val id = store.append(deliveryId = deliveryId, token = token)
+        store.append(deliveryId = deliveryId, token = token)
 
+        val after = System.currentTimeMillis()
         val entries = store.loadAll()
         entries.size shouldBeEqualTo 1
-        entries[0].id shouldBeEqualTo id
         entries[0].deliveryId shouldBeEqualTo deliveryId
         entries[0].token shouldBeEqualTo token
+        entries[0].timestamp shouldBeGreaterOrEqualTo before
+        entries[0].timestamp shouldBeLessOrEqualTo after
     }
 
     @Test
@@ -45,43 +50,39 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
         val deliveryIds = List(3) { String.random }
         val tokens = List(3) { String.random }
 
-        val ids = deliveryIds.zip(tokens).map { (deliveryId, token) ->
+        deliveryIds.zip(tokens).forEach { (deliveryId, token) ->
             store.append(deliveryId = deliveryId, token = token)
         }
 
         val entries = store.loadAll()
-        entries.map { it.id } shouldBeEqualTo ids
         entries.map { it.deliveryId } shouldBeEqualTo deliveryIds
         entries.map { it.token } shouldBeEqualTo tokens
     }
 
     @Test
-    fun append_givenGeneratedIds_expectUnique() {
-        val ids = List(50) { store.append(deliveryId = String.random, token = String.random) }
-        ids.toSet().size shouldBeEqualTo ids.size
-    }
+    fun remove_givenExistingDeliveryId_expectEntryRemoved() {
+        val keepDeliveryId = String.random
+        val removeDeliveryId = String.random
+        store.append(deliveryId = keepDeliveryId, token = String.random)
+        store.append(deliveryId = removeDeliveryId, token = String.random)
 
-    @Test
-    fun remove_givenExistingId_expectEntryRemoved() {
-        val keepId = store.append(deliveryId = String.random, token = String.random)
-        val removeId = store.append(deliveryId = String.random, token = String.random)
-
-        store.remove(removeId)
+        store.remove(removeDeliveryId)
 
         val entries = store.loadAll()
         entries.size shouldBeEqualTo 1
-        entries[0].id shouldBeEqualTo keepId
+        entries[0].deliveryId shouldBeEqualTo keepDeliveryId
     }
 
     @Test
-    fun remove_givenUnknownId_expectNoOp() {
-        val keepId = store.append(deliveryId = String.random, token = String.random)
+    fun remove_givenUnknownDeliveryId_expectNoOp() {
+        val keepDeliveryId = String.random
+        store.append(deliveryId = keepDeliveryId, token = String.random)
 
-        store.remove("not-a-real-id")
+        store.remove("not-a-real-delivery-id")
 
         val entries = store.loadAll()
         entries.size shouldBeEqualTo 1
-        entries[0].id shouldBeEqualTo keepId
+        entries[0].deliveryId shouldBeEqualTo keepDeliveryId
     }
 
     @Test
@@ -102,8 +103,10 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
 
     @Test
     fun append_givenOverCapacity_expectOldestDropped() {
-        val firstId = store.append(deliveryId = "first", token = String.random)
-        val secondId = store.append(deliveryId = "second", token = String.random)
+        val firstDeliveryId = "first"
+        val secondDeliveryId = "second"
+        store.append(deliveryId = firstDeliveryId, token = String.random)
+        store.append(deliveryId = secondDeliveryId, token = String.random)
         for (i in 0 until (PendingPushDeliveryStore.MAX_ENTRIES - 2)) {
             store.append(deliveryId = "fill-$i", token = String.random)
         }
@@ -111,18 +114,19 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
         // Store is now exactly at MAX_ENTRIES. Both anchors should still exist.
         val beforeOverflow = store.loadAll()
         beforeOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
-        beforeOverflow.first().id shouldBeEqualTo firstId
+        beforeOverflow.first().deliveryId shouldBeEqualTo firstDeliveryId
 
-        val lastId = store.append(deliveryId = "last", token = String.random)
+        val lastDeliveryId = "last"
+        store.append(deliveryId = lastDeliveryId, token = String.random)
 
         val afterOverflow = store.loadAll()
         afterOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
-        // Oldest must have been dropped.
-        afterOverflow.none { it.id == firstId }.shouldBeTrue()
+        // Oldest (smallest-timestamp) must have been dropped.
+        afterOverflow.none { it.deliveryId == firstDeliveryId }.shouldBeTrue()
         // Second oldest is now the head.
-        afterOverflow.first().id shouldBeEqualTo secondId
+        afterOverflow.first().deliveryId shouldBeEqualTo secondDeliveryId
         // Newest entry is at the tail.
-        afterOverflow.last().id shouldBeEqualTo lastId
+        afterOverflow.last().deliveryId shouldBeEqualTo lastDeliveryId
     }
 
     @Test
@@ -151,8 +155,8 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
         // so the store should be capped — confirming the capacity guard works
         // under concurrent access without throwing.
         entries.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
-        // Sanity-check that ids remain unique even across threads.
-        entries.map { it.id }.toSet().size shouldBeEqualTo entries.size
+        // Sanity-check that deliveryIds remain unique even across threads.
+        entries.map { it.deliveryId }.toSet().size shouldBeEqualTo entries.size
     }
 
     @Test
@@ -179,5 +183,6 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
         val raw = file.readText()
         raw shouldContain deliveryId
         raw shouldContain token
+        raw shouldContain "timestamp"
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
@@ -4,6 +4,7 @@ import io.customer.commontest.extensions.random
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.mockk
+import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import org.amshove.kluent.shouldBeEqualTo
@@ -149,6 +150,32 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
         val remaining = store.loadAll()
         remaining.size shouldBeEqualTo 1
         remaining[0].deliveryId shouldBeEqualTo appendedMidFlush
+    }
+
+    @Test
+    fun remove_givenCorruptedFile_expectStoreFilePreserved() {
+        // Reproduces the Bugbot finding: if readAll() fails to parse and
+        // returns an empty list, the subsequent writeAll() must NOT silently
+        // wipe the file. After the fix, remove() skips the write entirely
+        // when nothing was filtered out.
+        val file = File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val corrupted = "{not-valid-json"
+        file.writeText(corrupted)
+
+        store.remove("any-id")
+
+        file.readText() shouldBeEqualTo corrupted
+    }
+
+    @Test
+    fun removeAllIds_givenCorruptedFile_expectStoreFilePreserved() {
+        val file = File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val corrupted = "{not-valid-json"
+        file.writeText(corrupted)
+
+        store.removeAll(listOf("id1", "id2"))
+
+        file.readText() shouldBeEqualTo corrupted
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
@@ -1,0 +1,183 @@
+package io.customer.messagingpush.store
+
+import io.customer.commontest.extensions.random
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.util.Logger
+import io.mockk.mockk
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PendingPushDeliveryStoreTest : IntegrationTest() {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+    private lateinit var store: PendingPushDeliveryStore
+
+    override fun setup(testConfig: io.customer.commontest.config.TestConfig) {
+        super.setup(testConfig)
+        store = PendingPushDeliveryStore(context = applicationMock, logger = mockLogger)
+        store.removeAll()
+    }
+
+    @Test
+    fun append_givenSingleEntry_expectLoadAllReturnsIt() {
+        val deliveryId = String.random
+        val token = String.random
+
+        val id = store.append(deliveryId = deliveryId, token = token)
+
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].id shouldBeEqualTo id
+        entries[0].deliveryId shouldBeEqualTo deliveryId
+        entries[0].token shouldBeEqualTo token
+    }
+
+    @Test
+    fun append_givenMultipleEntries_expectAllPersistedInOrder() {
+        val deliveryIds = List(3) { String.random }
+        val tokens = List(3) { String.random }
+
+        val ids = deliveryIds.zip(tokens).map { (deliveryId, token) ->
+            store.append(deliveryId = deliveryId, token = token)
+        }
+
+        val entries = store.loadAll()
+        entries.map { it.id } shouldBeEqualTo ids
+        entries.map { it.deliveryId } shouldBeEqualTo deliveryIds
+        entries.map { it.token } shouldBeEqualTo tokens
+    }
+
+    @Test
+    fun append_givenGeneratedIds_expectUnique() {
+        val ids = List(50) { store.append(deliveryId = String.random, token = String.random) }
+        ids.toSet().size shouldBeEqualTo ids.size
+    }
+
+    @Test
+    fun remove_givenExistingId_expectEntryRemoved() {
+        val keepId = store.append(deliveryId = String.random, token = String.random)
+        val removeId = store.append(deliveryId = String.random, token = String.random)
+
+        store.remove(removeId)
+
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].id shouldBeEqualTo keepId
+    }
+
+    @Test
+    fun remove_givenUnknownId_expectNoOp() {
+        val keepId = store.append(deliveryId = String.random, token = String.random)
+
+        store.remove("not-a-real-id")
+
+        val entries = store.loadAll()
+        entries.size shouldBeEqualTo 1
+        entries[0].id shouldBeEqualTo keepId
+    }
+
+    @Test
+    fun removeAll_givenPopulatedStore_expectEmptyAfterCall() {
+        repeat(5) {
+            store.append(deliveryId = String.random, token = String.random)
+        }
+
+        store.removeAll()
+
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun loadAll_givenFreshStore_expectEmpty() {
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun append_givenOverCapacity_expectOldestDropped() {
+        val firstId = store.append(deliveryId = "first", token = String.random)
+        val secondId = store.append(deliveryId = "second", token = String.random)
+        for (i in 0 until (PendingPushDeliveryStore.MAX_ENTRIES - 2)) {
+            store.append(deliveryId = "fill-$i", token = String.random)
+        }
+
+        // Store is now exactly at MAX_ENTRIES. Both anchors should still exist.
+        val beforeOverflow = store.loadAll()
+        beforeOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        beforeOverflow.first().id shouldBeEqualTo firstId
+
+        val lastId = store.append(deliveryId = "last", token = String.random)
+
+        val afterOverflow = store.loadAll()
+        afterOverflow.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        // Oldest must have been dropped.
+        afterOverflow.none { it.id == firstId }.shouldBeTrue()
+        // Second oldest is now the head.
+        afterOverflow.first().id shouldBeEqualTo secondId
+        // Newest entry is at the tail.
+        afterOverflow.last().id shouldBeEqualTo lastId
+    }
+
+    @Test
+    fun append_givenConcurrentWriters_expectNoLostEntries() {
+        val threadCount = 8
+        val perThread = 25
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            val tasks = List(threadCount) { threadIndex ->
+                executor.submit {
+                    repeat(perThread) { i ->
+                        store.append(
+                            deliveryId = "thread-$threadIndex-$i",
+                            token = String.random
+                        )
+                    }
+                }
+            }
+            tasks.forEach { it.get(10, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        val entries = store.loadAll()
+        // Total writes (threadCount * perThread = 200) exceed MAX_ENTRIES (100),
+        // so the store should be capped — confirming the capacity guard works
+        // under concurrent access without throwing.
+        entries.size shouldBeEqualTo PendingPushDeliveryStore.MAX_ENTRIES
+        // Sanity-check that ids remain unique even across threads.
+        entries.map { it.id }.toSet().size shouldBeEqualTo entries.size
+    }
+
+    @Test
+    fun loadAll_givenCorruptOnDiskContent_expectEmptyAndDoesNotThrow() {
+        // Pre-fill with valid data, then corrupt the file directly.
+        store.append(deliveryId = String.random, token = String.random)
+        val file = java.io.File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        file.exists().shouldBeTrue()
+        file.writeText("this is not valid json {]")
+
+        val entries = store.loadAll()
+        entries shouldNotBe null
+        entries.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun append_givenSerializedContent_expectKeysPresent() {
+        val deliveryId = "delivery-${String.random}"
+        val token = "token-${String.random}"
+
+        store.append(deliveryId = deliveryId, token = token)
+
+        val file = java.io.File(applicationMock.applicationContext.filesDir, "cio_pending_push_delivery.json")
+        val raw = file.readText()
+        raw shouldContain deliveryId
+        raw shouldContain token
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/store/PendingPushDeliveryStoreTest.kt
@@ -97,6 +97,61 @@ class PendingPushDeliveryStoreTest : IntegrationTest() {
     }
 
     @Test
+    fun removeAllIds_givenSubsetOfEntries_expectOnlyMatchingRemoved() {
+        val keep = "keep-${String.random}"
+        val remove1 = "remove1-${String.random}"
+        val remove2 = "remove2-${String.random}"
+        store.append(deliveryId = remove1, token = String.random)
+        store.append(deliveryId = keep, token = String.random)
+        store.append(deliveryId = remove2, token = String.random)
+
+        store.removeAll(listOf(remove1, remove2))
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo keep
+    }
+
+    @Test
+    fun removeAllIds_givenIdsNotPresent_expectStoreUnchanged() {
+        val kept = listOf(String.random, String.random)
+        kept.forEach { store.append(deliveryId = it, token = String.random) }
+
+        store.removeAll(listOf("nonexistent-1", "nonexistent-2"))
+
+        store.loadAll().map { it.deliveryId } shouldBeEqualTo kept
+    }
+
+    @Test
+    fun removeAllIds_givenEmptyCollection_expectNoOp() {
+        val kept = String.random
+        store.append(deliveryId = kept, token = String.random)
+
+        store.removeAll(emptyList<String>())
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo kept
+    }
+
+    @Test
+    fun removeAllIds_givenEntryAppendedAfterLoad_expectAppendedEntrySurvives() {
+        val loaded = "loaded-${String.random}"
+        val appendedMidFlush = "midflush-${String.random}"
+        store.append(deliveryId = loaded, token = String.random)
+
+        // Simulate the flush sequence: snapshot ids before append, then remove
+        // only those ids — the entry appended afterward must survive.
+        val flushedIds = store.loadAll().map { it.deliveryId }
+        store.append(deliveryId = appendedMidFlush, token = String.random)
+        store.removeAll(flushedIds)
+
+        val remaining = store.loadAll()
+        remaining.size shouldBeEqualTo 1
+        remaining[0].deliveryId shouldBeEqualTo appendedMidFlush
+    }
+
+    @Test
     fun loadAll_givenFreshStore_expectEmpty() {
         store.loadAll().isEmpty().shouldBeTrue()
     }


### PR DESCRIPTION
Reworks the push-`delivered` metric path so a single delivery produces a single emit on the happy path.

- Append a pending entry to a local disk-backed store before scheduling the WorkManager job (or direct-HTTP fallback when WorkManager is unavailable).
- On WorkManager / HTTP success, remove the pending entry. On failure or any other case, keep it.
- On app launch, flush any remaining pending entries through the analytics pipeline (off the main thread) and clear them.

Removes the prior dual-emit (WorkManager direct HTTP + analytics event bus). Backend already dedupes `(deliveryID, delivered)` pairs server-side, so the motivation is bandwidth, analytics-queue load, and removing the two-path confusion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the push `Delivered` metric delivery flow by adding disk-backed persistence and altering when metrics are emitted, which could affect analytics correctness and duplicate/missed delivery behavior if edge cases are wrong.
> 
> **Overview**
> Refactors push `Delivered` metric tracking to **avoid dual-emitting** on the happy path by introducing a disk-backed `PendingPushDeliveryStore` that records `(deliveryId, token, timestamp)` before scheduling the primary delivery (WorkManager or direct HTTP fallback).
> 
> On successful backend receipt, the WorkManager worker and direct-HTTP fallback now **remove** the corresponding pending entry; on failure they leave it for retry. On app launch, `ModuleMessagingPushFCM.initialize()` now flushes any remaining pending entries by publishing `Event.TrackPushMetricEvent(Metric.Delivered)` on a background dispatcher and then removes only the IDs that were loaded, so mid-flush appends survive.
> 
> Updates DI wiring and tests accordingly, and adds comprehensive store tests (capacity cap, concurrency locking, corrupted-file handling, and targeted removals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cfe8d387798719710d22ce0110151ed40d95b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->