### PR TITLE
chore: dedup identify(userId) within a session when no traits supplied

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -111,6 +111,11 @@ class CustomerIO private constructor(
 
     private val contextPlugin: ContextPlugin = ContextPlugin(deviceStore)
 
+    // Tracks the last userId successfully identified in this SDK session. Used to dedup
+    // back-to-back identify(userId) calls with no traits, which are no-ops server-side.
+    // Reset on clearIdentify so a subsequent identify of the same userId is not deduped.
+    private var lastIdentifiedUserIdThisSession: String? = null
+
     init {
         // Set analytics logger and debug logs based on SDK logger configuration
         Analytics.debugLogsEnabled = logger.logLevel == CioLogLevel.DEBUG
@@ -231,6 +236,18 @@ class CustomerIO private constructor(
             return
         }
 
+        // Dedup back-to-back identify calls for the same userId when no traits are supplied.
+        // Because the public API exposes identify(userId, traits = emptyMap()) as a single method
+        // with a defaulted parameter, identify("alice") and identify("alice", emptyMap()) are
+        // indistinguishable at runtime — both compile to the same call with traits = emptyMap().
+        // We treat any empty Map-shaped traits payload (including JsonObject) as the no-traits case;
+        // server-side merge of empty traits is a no-op, so deduping is behaviorally safe.
+        val traitsAreEmpty = traits is Map<*, *> && traits.isEmpty()
+        if (traitsAreEmpty && userId == lastIdentifiedUserIdThisSession) {
+            logger.debug("identify with userId $userId and no traits is a duplicate of the last identify in this session; skipping.")
+            return
+        }
+
         // this is the current userId that is identified in the SDK
         val currentlyIdentifiedProfile = this.userId.takeUnless { it.isNullOrBlank() }
         val isChangingIdentifiedProfile = currentlyIdentifiedProfile != null && currentlyIdentifiedProfile != userId
@@ -269,6 +286,10 @@ class CustomerIO private constructor(
                 trackDeviceAttributes(token = existingDeviceToken)
             }
         }
+
+        // Update the per-session marker after a successful identify (with or without traits)
+        // so that a subsequent no-traits identify of the same userId can be deduped.
+        lastIdentifiedUserIdThisSession = userId
     }
 
     /**
@@ -297,6 +318,9 @@ class CustomerIO private constructor(
 
     override fun clearIdentifyImpl() {
         logger.info("resetting user profile with id ${this.userId}")
+
+        // Reset the dedup marker so a subsequent identify of the same userId is not deduped.
+        lastIdentifiedUserIdThisSession = null
 
         logger.debug("deleting device token to remove device from user profile")
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelinesInteractionTests.kt
@@ -533,7 +533,9 @@ class DataPipelinesInteractionTests : JUnitTest() {
 
         sdkInstance.identify(givenIdentifier)
 
-        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        // The second identify with the same userId and no traits is deduped in this SDK session.
+        // See IdentifyDedupTests for the dedicated coverage of this behavior.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
         outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupRegressionTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupRegressionTests.kt
@@ -1,0 +1,96 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.identifyEvents
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.DataPipelinesLogger
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.GlobalPreferenceStore
+import io.customer.sdk.util.EventNames
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for the identify dedup change: the first identify must still publish
+ * [Event.UserChangedEvent] on the EventBus for downstream subscribers (push, in-app, location)
+ * to observe the profile change AND re-register the device token attached to the anonymous
+ * profile. The dedup short-circuit must not break either contract.
+ *
+ * The EventBus is mocked in [setup] (following the pattern used by [ConcurrentScreenViewTest])
+ * so we can capture publications without races on the real shared-flow buffer/replay.
+ */
+class IdentifyDedupRegressionTests : JUnitTest() {
+
+    private val capturedEvents = mutableListOf<Event>()
+    private val capturedEventsLock = Any()
+
+    private lateinit var globalPreferenceStore: GlobalPreferenceStore
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    private val mockDataPipelinesLogger = mockk<DataPipelinesLogger>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        val mockEventBus = mockk<EventBus>(relaxed = true)
+                        val eventSlot = slot<Event>()
+                        every { mockEventBus.publish(capture(eventSlot)) } answers {
+                            synchronized(capturedEventsLock) {
+                                capturedEvents.add(eventSlot.captured)
+                            }
+                        }
+                        overrideDependency<EventBus>(mockEventBus)
+                        overrideDependency<DataPipelinesLogger>(mockDataPipelinesLogger)
+                    }
+                }
+            }
+        )
+
+        val androidSDKComponent = SDKComponent.android()
+        globalPreferenceStore = androidSDKComponent.globalPreferenceStore
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+
+        // Drop the UserChangedEvent published during SDK init (postUserIdentificationEvents)
+        // so we only assert against events produced by the test body.
+        capturedEvents.clear()
+    }
+
+    @Test
+    fun identify_givenFirstIdentify_publishesUserChangedEventAndReregistersDeviceToken() {
+        val givenIdentifier = String.random
+        val givenToken = String.random
+        every { globalPreferenceStore.getDeviceToken() } returns givenToken
+
+        sdkInstance.identify(givenIdentifier)
+
+        // 1. UserChangedEvent published for the newly identified userId.
+        val userChangedEvents = synchronized(capturedEventsLock) {
+            capturedEvents.filterIsInstance<Event.UserChangedEvent>()
+                .filter { it.userId == givenIdentifier }
+        }
+        userChangedEvents.count() shouldBeEqualTo 1
+
+        // 2. Identify event reaches analytics.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+
+        // 3. Existing device token is re-registered to the newly identified profile, which
+        //    surfaces as a DEVICE_UPDATE track event attributed to the new userId.
+        val deviceUpdateEvents = outputReaderPlugin.trackEvents.filter { it.event == EventNames.DEVICE_UPDATE }
+        deviceUpdateEvents.count() shouldBeEqualTo 1
+        deviceUpdateEvents.last().userId shouldBeEqualTo givenIdentifier
+    }
+}

--- a/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/IdentifyDedupTests.kt
@@ -1,0 +1,138 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
+import io.customer.datapipelines.testutils.utils.identifyEvents
+import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.sdk.DataPipelinesLogger
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the per-session identify dedup behavior added in `CustomerIO.identifyImpl`.
+ *
+ * Because the public `identify(userId, traits: Map<String, Any?> = emptyMap())` API exposes a
+ * single method with a defaulted parameter, `identify("alice")` and `identify("alice", emptyMap())`
+ * compile to the same call site at the impl layer — there is no runtime way to tell them apart.
+ * To keep the public API stable, both cases are deduped when the userId matches the last
+ * successfully identified userId in this SDK session. Server-side merge of empty traits is a
+ * no-op, so the behavioral collapse is immaterial in practice.
+ *
+ * See [IdentifyDedupRegressionTests] for the regression guard that the first identify still
+ * publishes UserChangedEvent on the EventBus and re-registers the device token.
+ */
+class IdentifyDedupTests : JUnitTest() {
+    private lateinit var outputReaderPlugin: OutputReaderPlugin
+
+    private val mockDataPipelinesLogger = mockk<DataPipelinesLogger>(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<DataPipelinesLogger>(mockDataPipelinesLogger)
+                    }
+                }
+            }
+        )
+
+        outputReaderPlugin = OutputReaderPlugin()
+        analytics.add(outputReaderPlugin)
+    }
+
+    @Test
+    fun identify_givenFirstIdentifyNoTraits_callsAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdNoTraits_doesNotCallAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier)
+
+        // Second call is deduped; no new identify event is emitted to analytics.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
+        outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdEmptyTraits_doesNotCallAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        // Explicit empty map is indistinguishable from no traits at the impl layer because the
+        // public API exposes a single method with a defaulted parameter. Both are deduped.
+        sdkInstance.identify(givenIdentifier, emptyMap())
+
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 0
+        outputReaderPlugin.trackEvents.count() shouldBeEqualTo 0
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenSecondIdentifySameUserIdWithTraits_callsAnalytics() {
+        val givenIdentifier = String.random
+        val givenTraits = mapOf("first_name" to "Dana", "ageInYears" to 30)
+
+        sdkInstance.identify(givenIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier, givenTraits)
+
+        // Non-empty traits never dedup — the call must reach analytics so server-side
+        // attributes are updated for the existing profile.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+    }
+
+    @Test
+    fun identify_givenDifferentUserIdNoTraits_callsAnalytics() {
+        val firstIdentifier = String.random
+        val secondIdentifier = String.random
+
+        sdkInstance.identify(firstIdentifier)
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(secondIdentifier)
+
+        // Different userId is a profile change — dedup must NOT fire.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo secondIdentifier
+        analytics.userId() shouldBeEqualTo secondIdentifier
+    }
+
+    @Test
+    fun identify_givenSameUserIdAfterClearIdentify_callsAnalytics() {
+        val givenIdentifier = String.random
+
+        sdkInstance.identify(givenIdentifier)
+        sdkInstance.clearIdentify()
+        outputReaderPlugin.reset()
+
+        sdkInstance.identify(givenIdentifier)
+
+        // clearIdentify() must reset the dedup marker so that re-identifying the same user
+        // afterwards flows through to analytics again.
+        outputReaderPlugin.identifyEvents.count() shouldBeEqualTo 1
+        outputReaderPlugin.identifyEvents.last().userId shouldBeEqualTo givenIdentifier
+        analytics.userId() shouldBeEqualTo givenIdentifier
+    }
+}


### PR DESCRIPTION
First `identify(userId)` per session always fires fully — preserves device-token re-registration and Device Created or Updated cadence.

Subsequent `identify(userId)` calls with the same userId and empty traits short-circuit (no analytics call, no `UserChangedEvent` publish, no device-token re-registration). `clearIdentify()` resets the session marker. Calls with non-empty traits always pass through.

Targets the misuse pattern of identify-on-every-event within a session. Per-session scope ensures token rotation still propagates on cold start.

Internal-only change — no public API surface modification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `identify` behavior by skipping repeated same-user, empty-traits calls, which can affect downstream `UserChangedEvent` publications and device-token re-registration if the dedup conditions are incorrect.
> 
> **Overview**
> Adds **per-session `identify` deduping** in `CustomerIO.identifyImpl`: repeated `identify(userId)` calls with the *same* `userId` and *empty Map-shaped traits* now short-circuit (no analytics identify, no `UserChangedEvent`, no device re-registration), while profile changes or non-empty traits still flow through.
> 
> `clearIdentify()` now resets the session dedup marker. Tests were updated/added to cover the new dedup behavior and to regression-guard that the *first* identify still publishes `UserChangedEvent` and re-registers the device token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a85c3cf46be7c6c522d6165675c6bf0b0be3116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->