### PR TITLE
fix: drain pre-init buffer after modules subscribe; preserve setter ordering

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -87,9 +87,18 @@ class CustomerIO private constructor() :
     // initializeComponents() runs and replays them in order on init.
     private val preInitBuffer = PreInitEventBuffer()
 
+    // Single source of truth for "the SDK has finished initializing AND the
+    // pre-init buffer has been fully drained." Reading from the buffer means
+    // public setters that arrive during the drain window route through
+    // preInitBuffer.enqueue (which puts them on `pending`) instead of racing
+    // ahead of earlier buffered calls.
+    private val isReady: Boolean get() = preInitBuffer.isReady
+
+    // Latched at the start of [initializeComponents] to make the companion
+    // [initialize] idempotent. Distinct from [isReady] so the double-init
+    // guard fires even before the drain completes.
     @Volatile
-    private var componentsReady: Boolean = false
-    private val isReady: Boolean get() = componentsReady
+    private var initStarted: Boolean = false
 
     // Lateinit runtime components — populated by initializeComponents().
     // Access guarded by isReady; callers that route through a public method
@@ -130,12 +139,16 @@ class CustomerIO private constructor() :
     }
 
     /**
-     * Populate runtime components and transition the singleton from
-     * buffering mode to ready mode. Called exactly once from
+     * Populate runtime components. Called exactly once from
      * [Companion.createInstance] when [Companion.initialize] runs.
      *
-     * Buffered events are drained synchronously at the end of this method
-     * so that the first post-init call observes a non-empty pipeline state.
+     * Does **not** flip the readiness signal or drain the pre-init buffer —
+     * those are deferred to [finishInitialization] so that modules added by
+     * the companion `initialize` (e.g. `MessagingInApp`) have their EventBus
+     * subscribers installed before the buffered events replay. Without that
+     * deferral, a screen-heavy pre-init buffer can evict the initial
+     * UserChangedEvent from the SharedFlow replay window before late-added
+     * subscribers see it.
      */
     @Synchronized
     private fun initializeComponents(
@@ -143,7 +156,8 @@ class CustomerIO private constructor() :
         moduleConfig: DataPipelinesModuleConfig,
         overrideAnalytics: Analytics? = null
     ) {
-        if (componentsReady) return
+        if (initStarted) return
+        initStarted = true
 
         this._moduleConfig = moduleConfig
         this.globalPreferenceStore = androidSDKComponent.globalPreferenceStore
@@ -186,13 +200,20 @@ class CustomerIO private constructor() :
 
         // subscribe to journey events emitted from push/in-app module to send them via data pipelines
         subscribeToJourneyEvents()
-        // republish profile/anonymous events for late-added modules
+    }
+
+    /**
+     * Publish the initial identity to subscribers (in-app messaging, etc.) and
+     * drain the pre-init buffer. Called from the companion `initialize` **after**
+     * `module.initialize()` has run for every registered module, so that:
+     * - The UserChangedEvent reaches late-subscribing modules directly via the
+     *   live SharedFlow instead of via replay (replay can evict it when the
+     *   pre-init buffer was filled with screen events).
+     * - Public setters that arrive concurrently route through the buffer until
+     *   the drain completes, preserving FIFO order with earlier buffered calls.
+     */
+    internal fun finishInitialization() {
         postUserIdentificationEvents()
-
-        // Mark ready BEFORE draining so replayed events take the real-impl path.
-        componentsReady = true
-
-        // Drain any pre-init buffered calls in order against this now-ready instance.
         preInitBuffer.transitionToReady(this)
     }
 
@@ -261,12 +282,20 @@ class CustomerIO private constructor() :
 
     override fun setProfileAttributes(attributes: CustomAttributes) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.setProfileAttributes(attributes) }
+            preInitBuffer.enqueue { setProfileAttributesInternal(attributes) }
             return
         }
-        val identifier = this.userId
+        setProfileAttributesInternal(attributes)
+    }
+
+    private fun setProfileAttributesInternal(attributes: CustomAttributes) {
+        val identifier = analytics.userId().takeUnless { it.isNullOrBlank() }
         if (identifier != null) {
-            identify(userId = identifier, traits = attributes)
+            identifyInternal(
+                userId = identifier,
+                traits = attributes.sanitizeForJson(),
+                serializationStrategy = JsonAnySerializer.serializersModule.serializer()
+            )
         } else {
             logger.debug("No user profile found, updating sanitized traits for anonymous user ${analytics.anonymousId()}")
             analytics.identify(traits = attributes.sanitizeForJson())
@@ -279,29 +308,37 @@ class CustomerIO private constructor() :
      * and running any necessary hooks.
      * All other identify methods should call this method to ensure consistency.
      */
-    @Suppress("DEPRECATION")
     override fun <Traits> identifyImpl(
         userId: String,
         traits: Traits,
         serializationStrategy: SerializationStrategy<Traits>
     ) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.identify(userId, traits, serializationStrategy) }
+            preInitBuffer.enqueue { identifyInternal(userId, traits, serializationStrategy) }
             return
         }
+        identifyInternal(userId, traits, serializationStrategy)
+    }
+
+    private fun <Traits> identifyInternal(
+        userId: String,
+        traits: Traits,
+        serializationStrategy: SerializationStrategy<Traits>
+    ) {
         if (userId.isBlank()) {
             logger.debug("Profile cannot be identified: Identifier is blank. Please retry with a valid, non-empty identifier.")
             return
         }
 
-        // this is the current userId that is identified in the SDK
-        val currentlyIdentifiedProfile = this.userId.takeUnless { it.isNullOrBlank() }
+        // Raw reads against analytics/store — must not go through the gated
+        // public accessors, which return safe defaults during the drain window.
+        val currentlyIdentifiedProfile = analytics.userId().takeUnless { it.isNullOrBlank() }
         val isChangingIdentifiedProfile = currentlyIdentifiedProfile != null && currentlyIdentifiedProfile != userId
         val isFirstTimeIdentifying = currentlyIdentifiedProfile == null
 
         if (isChangingIdentifiedProfile) {
             logger.info("changing profile from id $currentlyIdentifiedProfile to $userId")
-            if (registeredDeviceToken != null) {
+            if (globalPreferenceStore.getDeviceToken() != null) {
                 dataPipelinesLogger.logDeletingTokenDueToNewProfileIdentification()
                 deleteDeviceToken { event ->
                     event?.apply {
@@ -325,7 +362,7 @@ class CustomerIO private constructor() :
 
         if (isFirstTimeIdentifying || isChangingIdentifiedProfile) {
             logger.debug("first time identified or changing identified profile")
-            val existingDeviceToken = registeredDeviceToken
+            val existingDeviceToken = globalPreferenceStore.getDeviceToken()
             if (existingDeviceToken != null) {
                 dataPipelinesLogger.automaticTokenRegistrationForNewProfile(existingDeviceToken, userId)
                 // register device to newly identified profile
@@ -338,19 +375,18 @@ class CustomerIO private constructor() :
      * Common method to track an event with traits.
      * All other track methods should call this method to ensure consistency.
      */
-    @Suppress("DEPRECATION")
     override fun <T> trackImpl(name: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.track(name, properties, serializationStrategy) }
+            preInitBuffer.enqueue { trackInternal(name, properties, serializationStrategy, null) }
             return
         }
-        track(name, properties, serializationStrategy, null)
+        trackInternal(name, properties, serializationStrategy, null)
     }
 
     /**
-     * Private method that support enrichment of generated track events.
+     * Private method that supports enrichment of generated track events.
      */
-    private fun <T> track(name: String, properties: T, serializationStrategy: SerializationStrategy<T>, enrichment: EnrichmentClosure?) {
+    private fun <T> trackInternal(name: String, properties: T, serializationStrategy: SerializationStrategy<T>, enrichment: EnrichmentClosure?) {
         logger.debug("track an event with name $name and attributes $properties")
         analytics.track(name = name, properties = properties, serializationStrategy = serializationStrategy, enrichment = enrichment)
     }
@@ -359,12 +395,15 @@ class CustomerIO private constructor() :
      * Common method to track an screen with properties.
      * All other screen methods should call this method to ensure consistency.
      */
-    @Suppress("DEPRECATION")
     override fun <T> screenImpl(title: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.screen(title, properties, serializationStrategy) }
+            preInitBuffer.enqueue { screenInternal(title, properties, serializationStrategy) }
             return
         }
+        screenInternal(title, properties, serializationStrategy)
+    }
+
+    private fun <T> screenInternal(title: String, properties: T, serializationStrategy: SerializationStrategy<T>) {
         logger.debug("track a screen with title $title, properties $properties")
         eventBus.publish(Event.ScreenViewedEvent(name = title))
         analytics.screen(title = title, properties = properties, serializationStrategy = serializationStrategy)
@@ -372,16 +411,21 @@ class CustomerIO private constructor() :
 
     override fun clearIdentifyImpl() {
         if (!isReady) {
-            preInitBuffer.enqueue { it.clearIdentify() }
+            preInitBuffer.enqueue { clearIdentifyInternal() }
             return
         }
-        logger.info("resetting user profile with id ${this.userId}")
+        clearIdentifyInternal()
+    }
+
+    private fun clearIdentifyInternal() {
+        // Raw read — userId getter would return null during the drain window.
+        val existingUserId = analytics.userId()
+        logger.info("resetting user profile with id $existingUserId")
 
         logger.debug("deleting device token to remove device from user profile")
 
-        // since the tasks are asynchronous, we need to store the userId before deleting the device token
+        // since the tasks are asynchronous, we need to capture the userId before deleting the device token
         // otherwise, the userId could be null when the delete task is executed
-        val existingUserId = userId
         deleteDeviceToken { event ->
             event?.apply { userId = existingUserId.toString() }
         }
@@ -417,26 +461,35 @@ class CustomerIO private constructor() :
 
     override fun setDeviceAttributes(attributes: CustomAttributes) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.setDeviceAttributes(attributes) }
+            preInitBuffer.enqueue { setDeviceAttributesInternal(attributes) }
             return
         }
-        trackDeviceAttributes(registeredDeviceToken, attributes)
+        setDeviceAttributesInternal(attributes)
+    }
+
+    private fun setDeviceAttributesInternal(attributes: CustomAttributes) {
+        trackDeviceAttributes(globalPreferenceStore.getDeviceToken(), attributes)
     }
 
     override fun registerDeviceTokenImpl(deviceToken: String) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.registerDeviceToken(deviceToken) }
+            preInitBuffer.enqueue { registerDeviceTokenInternal(deviceToken) }
             return
         }
+        registerDeviceTokenInternal(deviceToken)
+    }
+
+    private fun registerDeviceTokenInternal(deviceToken: String) {
         if (deviceToken.isBlank()) {
             dataPipelinesLogger.logStoringBlankPushToken()
             return
         }
 
-        dataPipelinesLogger.logStoringDevicePushToken(deviceToken, this.userId)
+        val currentUserId = analytics.userId()
+        dataPipelinesLogger.logStoringDevicePushToken(deviceToken, currentUserId)
         globalPreferenceStore.saveDeviceToken(deviceToken)
 
-        dataPipelinesLogger.logRegisteringPushToken(deviceToken, this.userId)
+        dataPipelinesLogger.logRegisteringPushToken(deviceToken, currentUserId)
         trackDeviceAttributes(token = deviceToken)
     }
 
@@ -465,17 +518,23 @@ class CustomerIO private constructor() :
         contextPlugin.deviceToken = token
 
         logger.info("updating device attributes: $attributes")
-        track(
+        trackInternal(
             name = EventNames.DEVICE_UPDATE,
-            properties = attributes
+            properties = attributes,
+            serializationStrategy = JsonAnySerializer.serializersModule.serializer(),
+            enrichment = null
         )
     }
 
     override fun deleteDeviceTokenImpl() {
         if (!isReady) {
-            preInitBuffer.enqueue { it.deleteDeviceToken() }
+            preInitBuffer.enqueue { deleteDeviceTokenInternal() }
             return
         }
+        deleteDeviceTokenInternal()
+    }
+
+    private fun deleteDeviceTokenInternal() {
         deleteDeviceToken(null)
     }
 
@@ -488,18 +547,32 @@ class CustomerIO private constructor() :
             return
         }
 
-        track(name = EventNames.DEVICE_DELETE, properties = emptyJsonObject, serializationStrategy = JsonAnySerializer.serializersModule.serializer(), enrichment = enrichment)
+        trackInternal(
+            name = EventNames.DEVICE_DELETE,
+            properties = emptyJsonObject,
+            serializationStrategy = JsonAnySerializer.serializersModule.serializer(),
+            enrichment = enrichment
+        )
     }
 
     override fun trackMetricImpl(event: TrackMetric) {
         if (!isReady) {
-            preInitBuffer.enqueue { it.trackMetric(event) }
+            preInitBuffer.enqueue { trackMetricInternal(event) }
             return
         }
+        trackMetricInternal(event)
+    }
+
+    private fun trackMetricInternal(event: TrackMetric) {
         logger.info("${event.type} metric received for ${event.metric} event")
         logger.debug("tracking ${event.type} metric event with properties $event")
 
-        track(name = EventNames.METRIC_DELIVERY, properties = event.asMap())
+        trackInternal(
+            name = EventNames.METRIC_DELIVERY,
+            properties = event.asMap(),
+            serializationStrategy = JsonAnySerializer.serializersModule.serializer(),
+            enrichment = null
+        )
     }
 
     companion object {
@@ -582,11 +655,20 @@ class CustomerIO private constructor() :
                 screenViewUse = config.screenViewUse
             )
 
-            // Initialize CustomerIO instance before initializing the modules
+            // Initialize CustomerIO instance before initializing the modules.
+            // Wires analytics + plugins + journey-event subscribers, but does
+            // NOT drain the pre-init buffer yet.
             val customerIO = createInstance(
                 androidSDKComponent = androidSDKComponent,
                 moduleConfig = dataPipelinesConfig
             )
+            // Double-init early-out: createInstance returns a cio that already
+            // had initializeComponents() run. The buffer is also Ready, so the
+            // module loop and drain below are no-ops too.
+            if (customerIO.isReady) {
+                logger.coreSdkInitSuccess()
+                return
+            }
 
             // Register DataPipelines module and all other modules with SDKComponent
             modules[MODULE_NAME] = customerIO
@@ -598,13 +680,23 @@ class CustomerIO private constructor() :
                 logger.moduleInitSuccess(module)
             }
 
+            // Finish initialization AFTER all modules have run their
+            // initialize() — so EventBus subscribers (e.g. MessagingInApp's
+            // UserChangedEvent/ScreenViewedEvent handlers) are installed before
+            // the initial identity is published and before the pre-init buffer
+            // drains. This is what prevents the initial UserChangedEvent from
+            // being evicted by a screen-heavy drain on the SharedFlow replay.
+            customerIO.finishInitialization()
+
             logger.coreSdkInitSuccess()
         }
 
         /**
-         * Wires real components into the singleton CustomerIO instance,
-         * transitioning it from buffering mode to ready mode. If the
-         * singleton is already in ready mode, logs and returns it as-is.
+         * Wires real components into the singleton CustomerIO instance. The
+         * pre-init buffer is **not** drained here — the companion `initialize`
+         * defers that to [finishInitialization] after all modules have run
+         * their own `initialize()`. If the singleton was already initialized,
+         * logs and returns it as-is.
          */
         @Synchronized
         @InternalCustomerIOApi
@@ -614,7 +706,7 @@ class CustomerIO private constructor() :
         ): CustomerIO {
             val logger = SDKComponent.dataPipelinesLogger
             val cio = instance()
-            if (cio.componentsReady) {
+            if (cio.initStarted) {
                 logger.coreSdkAlreadyInitialized()
                 return cio
             }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/PreInitEventBuffer.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/PreInitEventBuffer.kt
@@ -71,8 +71,13 @@ internal class PreInitEventBuffer(
                     }
                 }
                 is State.Draining -> {
-                    current.pending.add(block)
-                    EnqueueOutcome.Enqueued(current.pending.size)
+                    if (current.pending.size >= capacity) {
+                        droppedCount++
+                        EnqueueOutcome.Dropped(droppedCount)
+                    } else {
+                        current.pending.add(block)
+                        EnqueueOutcome.Enqueued(current.pending.size)
+                    }
                 }
                 is State.Ready -> EnqueueOutcome.ExecuteNow(current.impl)
             }

--- a/datapipelines/src/test/java/io/customer/datapipelines/FinishInitializationOrderTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/FinishInitializationOrderTest.kt
@@ -1,0 +1,96 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.config.TestConfig
+import io.customer.datapipelines.testutils.core.JUnitTest
+import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.sdk.CustomerIO
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.module.CustomerIOModule
+import io.customer.sdk.core.module.CustomerIOModuleConfig
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the ordering invariants restored by [CustomerIO.finishInitialization]:
+ *
+ * - Modules' `initialize()` runs BEFORE the initial `UserChangedEvent` is
+ *   published, so late-subscribing modules (e.g. MessagingInApp) receive the
+ *   event live instead of relying on the SharedFlow replay buffer.
+ * - The pre-init buffer is drained AFTER all modules have run their
+ *   `initialize()`, so buffered `screen()` events published during the drain
+ *   reach subscribers via the live flow rather than via replay (where they
+ *   could otherwise evict the initial identity event).
+ */
+class FinishInitializationOrderTest : JUnitTest() {
+    private lateinit var eventBus: EventBus
+    private val testModule = LateSubscribingTestModule()
+
+    override fun setup(testConfig: TestConfig) {
+        // Use a relaxed mock EventBus so subscribe/publish calls are recorded
+        // in deterministic order without depending on coroutine scheduling.
+        val mockEventBus = mockk<EventBus>(relaxed = true)
+
+        super.setup(
+            testConfiguration {
+                diGraph {
+                    sdk { overrideDependency<EventBus>(mockEventBus) }
+                }
+                sdkConfig {
+                    addCustomerIOModule(testModule)
+                    // Fill the pre-init buffer past the EventBus SharedFlow
+                    // replay cap (=100). Without the deferred-drain fix, the
+                    // initial UserChangedEvent would be evicted from replay
+                    // before the late-subscribing test module attaches.
+                    repeat(101) { index ->
+                        CustomerIO.instance().screen("preinit_screen_$index")
+                    }
+                }
+            }
+        )
+        eventBus = SDKComponent.eventBus
+    }
+
+    @Test
+    fun givenScreenHeavyPreInitBuffer_expectModuleSubscribesBeforeInitialUserChangedEvent() {
+        // The fix moves postUserIdentificationEvents() and the buffer drain
+        // into finishInitialization(), which runs AFTER modules.forEach{
+        // module.initialize() }. As a result, every module — including the
+        // test module here — has already subscribed by the time the initial
+        // UserChangedEvent is published.
+        verifyOrder {
+            eventBus.subscribe(Event.UserChangedEvent::class, any())
+            eventBus.publish(any<Event.UserChangedEvent>())
+        }
+    }
+
+    @Test
+    fun givenScreenHeavyPreInitBuffer_expectBufferedScreensPublishedAfterModuleSubscription() {
+        // Buffered screen events drain inside finishInitialization() too,
+        // so each replayed screen call publishes its ScreenViewedEvent after
+        // late-subscribing modules are attached.
+        verifyOrder {
+            eventBus.subscribe(Event.UserChangedEvent::class, any())
+            eventBus.publish(match<Event> { it is Event.ScreenViewedEvent })
+        }
+        // The buffer's capacity is 100; one of the 101 pre-init screens was
+        // dropped, so 100 ScreenViewedEvents should reach the bus.
+        verify(exactly = 100) { eventBus.publish(match<Event> { it is Event.ScreenViewedEvent }) }
+    }
+}
+
+private class LateSubscribingTestModule : CustomerIOModule<LateSubscribingTestModuleConfig> {
+    override val moduleName: String = "FinishInitOrderTestModule"
+    override val moduleConfig: LateSubscribingTestModuleConfig = LateSubscribingTestModuleConfig
+
+    override fun initialize() {
+        // The exact action body is irrelevant — the test asserts the order
+        // in which subscribe is called, not what the handler does.
+        SDKComponent.eventBus.subscribe(Event.UserChangedEvent::class) { }
+    }
+}
+
+private object LateSubscribingTestModuleConfig : CustomerIOModuleConfig

--- a/datapipelines/src/test/java/io/customer/sdk/PreInitEventBufferTest.kt
+++ b/datapipelines/src/test/java/io/customer/sdk/PreInitEventBufferTest.kt
@@ -165,6 +165,37 @@ class PreInitEventBufferTest : JUnitTest() {
     }
 
     @Test
+    fun drainingStateEnforcesCapacity() {
+        // While in Draining (i.e. the drain is replaying outer blocks), any
+        // reentrant enqueue must respect the same capacity as Buffering.
+        // Without this guarantee, a launch-time burst racing the drain could
+        // grow `pending` past the documented bound and bypass drop accounting.
+        val buffer = makeBuffer(capacity = 2)
+        val instance = mockInstance()
+
+        // First block triggers 4 reentrant enqueues while the buffer is in
+        // Draining. Only the first 2 should be retained; the remaining 2
+        // must be counted as drops.
+        buffer.enqueue { it.trackString("outer") }
+        buffer.enqueue { _ ->
+            repeat(4) { i ->
+                buffer.enqueue { inner -> inner.trackString("inner-$i") }
+            }
+        }
+        buffer.transitionToReady(instance)
+
+        verifyOrder {
+            instance.track("outer", emptyMap<String, Any?>())
+            instance.track("inner-0", emptyMap<String, Any?>())
+            instance.track("inner-1", emptyMap<String, Any?>())
+        }
+        verify(exactly = 0) { instance.track("inner-2", emptyMap<String, Any?>()) }
+        verify(exactly = 0) { instance.track("inner-3", emptyMap<String, Any?>()) }
+        // Drop counter is reset after drain.
+        buffer.droppedEventCount shouldBeEqualTo 0
+    }
+
+    @Test
     fun concurrentEnqueuesArePreservedUpToCap() {
         val buffer = makeBuffer(capacity = 200)
         val instance = mockInstance()

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/SampleApplication.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/SampleApplication.java
@@ -1,20 +1,103 @@
 package io.customer.android.sample.java_layout;
 
 import android.app.Application;
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import io.customer.android.sample.java_layout.di.ApplicationGraph;
+import io.customer.sdk.CustomerIO;
 
 public class SampleApplication extends Application {
     private final ApplicationGraph appGraph = new ApplicationGraph(this);
 
+    /**
+     * Pre-init buffer validation scenarios. Set this to one of the cases below,
+     * run the app, and watch logcat for "PreInitEventBuffer" entries. Server
+     * arrival is visible in the workspace's Activity Log using the configured
+     * cdpApiKey. Default is OFF, leaving normal app behavior unchanged.
+     */
+    enum PreInitBufferScenario {
+        OFF,
+        S1_SINGLE_EVENT,
+        S2_ORDERING_ACROSS_IDENTITIES,
+        S3_OVERFLOW,
+        S4_ZERO_EVENTS,
+        S5_SAFE_DEFAULTS,
+        S7_DOUBLE_INIT,
+    }
+
+    private static final PreInitBufferScenario PRE_INIT_SCENARIO = PreInitBufferScenario.OFF;
+    private static final String PRE_INIT_LOG_TAG = "PreInitBufferTest";
+
     @Override
     public void onCreate() {
         super.onCreate();
+        runPreInitScenario(PRE_INIT_SCENARIO);
+
         // Initialize Customer.io SDK on app start
         appGraph.getCustomerIORepository().initializeSdk(SampleApplication.this);
+
+        if (PRE_INIT_SCENARIO == PreInitBufferScenario.S7_DOUBLE_INIT) {
+            // Verify second initialize() is a no-op (no double drain).
+            appGraph.getCustomerIORepository().initializeSdk(SampleApplication.this);
+        }
     }
 
     public ApplicationGraph getApplicationGraph() {
         return appGraph;
+    }
+
+    private void runPreInitScenario(PreInitBufferScenario scenario) {
+        CustomerIO sdk = CustomerIO.instance();
+        switch (scenario) {
+            case OFF:
+                return;
+            case S1_SINGLE_EVENT: {
+                Map<String, String> props = new HashMap<>();
+                props.put("case", "S1");
+                sdk.track("preinit_single", props);
+                return;
+            }
+            case S2_ORDERING_ACROSS_IDENTITIES: {
+                Map<String, String> aliceTraits = new HashMap<>();
+                aliceTraits.put("case", "S2");
+                sdk.identify("alice", aliceTraits);
+
+                Map<String, String> eventA = new HashMap<>();
+                eventA.put("case", "S2");
+                sdk.track("eventA", eventA);
+
+                sdk.clearIdentify();
+
+                Map<String, String> bobTraits = new HashMap<>();
+                bobTraits.put("case", "S2");
+                sdk.identify("bob", bobTraits);
+
+                Map<String, String> eventB = new HashMap<>();
+                eventB.put("case", "S2");
+                sdk.track("eventB", eventB);
+                return;
+            }
+            case S3_OVERFLOW: {
+                for (int i = 0; i < 105; i++) {
+                    Map<String, String> overflowProps = new HashMap<>();
+                    overflowProps.put("index", Integer.toString(i));
+                    sdk.track("preinit_overflow", overflowProps);
+                }
+                return;
+            }
+            case S4_ZERO_EVENTS:
+            case S7_DOUBLE_INIT:
+                // No pre-init work; validation is in the post-init log output.
+                return;
+            case S5_SAFE_DEFAULTS: {
+                // Read-side accessor must not crash before CustomerIO.initialize() runs.
+                String token = sdk.getRegisteredDeviceToken();
+                Log.i(PRE_INIT_LOG_TAG, "S5 pre-init registeredDeviceToken: " + (token != null ? token : "null"));
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Addresses both P2 review comments on #700.

- **Deferred drain (P2 #2)** — A new `CustomerIO.finishInitialization()` publishes the initial `UserChangedEvent` and drains the pre-init buffer **after** every module has run its `initialize()`. Late-subscribing modules (e.g. `MessagingInApp`) attach before the identity event is published, so a screen-heavy buffer can no longer evict it from the SharedFlow replay window.
- **Setter ordering (P2 #1)** — `isReady` now sources from `preInitBuffer.isReady` instead of a separate `componentsReady` flag. The readiness signal flips atomically with the drain completing, so `setProfileAttributes` / `setDeviceAttributes` (which don't synchronize via `DataPipelineInstance`) route through the buffer for the entire pre-init and drain window, preserving FIFO order with earlier buffered calls.
- **Recursion-free replay** — Buffered closures now invoke private `*Internal` methods that contain the bodies without the readiness gate, so replay against the real impl doesn't re-enter `enqueue`. The companion-level double-init guard moved to a separate `initStarted` flag latched at the start of `initializeComponents()`.
- **Capacity during drain** — `PreInitEventBuffer.enqueue` now enforces capacity + drop accounting in the `Draining` state as well as `Buffering`, mirroring the iOS sister fix.

Aligned with `customerio-ios-tng` (no deliberate divergence): module wiring, identity broadcast, and event-stream drain occur in that order.

## Test plan
- [x] `./gradlew :datapipelines:testDebugUnitTest` — full suite green, including:
  - New `PreInitEventBufferTest.drainingStateEnforcesCapacity` — reentrant enqueues during drain hit the cap.
  - New `FinishInitializationOrderTest.givenScreenHeavyPreInitBuffer_*` — late-subscribing module receives the initial `UserChangedEvent` even when 101 pre-init screens are queued; buffered screens publish after subscription.
- [x] `./gradlew :messaginginapp:testDebugUnitTest` — green.
- [x] `./gradlew :datapipelines:lintDebug` — green.
- [x] `./ktlint --android` on changed files — clean.
- [ ] CI lint + tests (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)