### PR TITLE
chore: address geofence stack review feedback

### DIFF
--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceJsonSerializer.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceJsonSerializer.kt
@@ -1,5 +1,6 @@
 package io.customer.location.geofence
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
@@ -25,7 +26,11 @@ internal class GeofenceJsonSerializer {
 
     fun <T> decodeOrNull(serializer: KSerializer<T>, raw: String): T? = try {
         decode(serializer, raw)
-    } catch (_: Throwable) {
+    } catch (e: CancellationException) {
+        // Always propagate coroutine cancellation; otherwise callers from a
+        // suspending context could miss being cancelled.
+        throw e
+    } catch (_: Exception) {
         null
     }
 }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -36,24 +36,28 @@ internal class GeofenceManager(
         )
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
-    suspend fun addGeofences(regions: List<GeofenceRegion>): Result<Unit> =
-        addGeofencesInternal(regions, movementInitialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER)
-
     /**
-     * Boot-restore variant: registers the movement trigger with
-     * `INITIAL_TRIGGER_EXIT` so the OS evaluates current location at register
-     * time. If the user moved beyond the cached circle while the device was
-     * off, EXIT fires immediately and the next handleMovement self-heals with
-     * real coordinates. Normal re-registrations use [addGeofences] to avoid
-     * spurious EXITs.
+     * Replaces any currently-registered geofences with [regions]. An empty
+     * list disables the broadcast receiver — registering nothing leaves no
+     * events to listen for.
      */
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
-    suspend fun addGeofencesForBootRestore(regions: List<GeofenceRegion>): Result<Unit> =
-        addGeofencesInternal(regions, movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_EXIT)
+    suspend fun replaceGeofences(regions: List<GeofenceRegion>): Result<Unit> =
+        replaceGeofencesInternal(regions, movementInitialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER)
+
+    /**
+     * Boot-restore variant of [replaceGeofences]: registers the movement
+     * trigger with `INITIAL_TRIGGER_EXIT` so the OS evaluates current
+     * location at register time. If the user moved beyond the cached circle
+     * while the device was off, EXIT fires immediately and the next
+     * handleMovement self-heals with real coordinates.
+     */
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    suspend fun replaceGeofencesForBootRestore(regions: List<GeofenceRegion>): Result<Unit> =
+        replaceGeofencesInternal(regions, movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_EXIT)
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
-    private suspend fun addGeofencesInternal(
+    private suspend fun replaceGeofencesInternal(
         regions: List<GeofenceRegion>,
         movementInitialTrigger: Int
     ): Result<Unit> {

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -39,11 +39,16 @@ internal interface GeofenceRepository {
     suspend fun restoreFromCache(): Result<Unit>
 
     /**
-     * Clears all geofence state: persisted regions in the store and OS-side
-     * registrations via the manager. Called on user sign-out so the next user
-     * (or anonymous session) doesn't inherit the previous user's geofences.
+     * Drops OS-registered geofences + wipes user-specific store state on
+     * sign-out. Workspace cache (regions, config, last-sync) is preserved.
+     *
+     * [signedOutUserId] is the user being signed out, captured synchronously
+     * at the call site. Used to distinguish a normal sign-out (current user
+     * still matches because `secureUserStore` hasn't been cleared yet by its
+     * own ResetEvent subscriber) from a true re-login (different user signed
+     * in during the reset window, skip wipe).
      */
-    suspend fun reset(): Result<Unit>
+    suspend fun reset(signedOutUserId: String?): Result<Unit>
 }
 
 internal class GeofenceRepositoryImpl(
@@ -86,6 +91,15 @@ internal class GeofenceRepositoryImpl(
                     ?.takeIf { it > 0 }
                     ?: GeofenceConstants.STALE_THRESHOLD_MS
                 if (clock.currentTimeMillis() - lastSync < threshold) {
+                    // Cache fresh — if OS regs were wiped on sign-out, re-
+                    // register from cache instead of skipping; otherwise the
+                    // new user has no geofences until stale-window expiry.
+                    val cachedRegions = store.getCachedRegions()
+                    val registered = store.getRegisteredIds()
+                    val cachedConfig = store.getCachedConfig()
+                    if (cachedRegions.isNotEmpty() && registered.isEmpty() && cachedConfig != null) {
+                        return performLocalRefresh(userId, latitude, longitude, cachedConfig)
+                    }
                     logger.logSyncSkippedFresh()
                     return Result.success(Unit)
                 }
@@ -153,13 +167,13 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("no cached state to restore")
                 return Result.success(Unit)
             }
-            // Boot-restore variant — see [GeofenceManager.addGeofencesForBootRestore].
+            // Boot-restore variant — see [GeofenceManager.replaceGeofencesForBootRestore].
             return performLocalRefresh(
                 userId = userId,
                 latitude = effectiveLocation.latitude,
                 longitude = effectiveLocation.longitude,
                 cachedConfig = cachedConfig,
-                register = manager::addGeofencesForBootRestore
+                register = manager::replaceGeofencesForBootRestore
             )
         } finally {
             refreshInProgress.set(false)
@@ -202,7 +216,7 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::addGeofences
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::replaceGeofences
     ): Result<Unit> = registerNearestAndPersist(
         userId = userId,
         latitude = latitude,
@@ -219,7 +233,7 @@ internal class GeofenceRepositoryImpl(
         longitude: Double,
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::addGeofences,
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::replaceGeofences,
         onRegistered: () -> Unit = {}
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
@@ -275,25 +289,21 @@ internal class GeofenceRepositoryImpl(
         }
     }
 
-    override suspend fun reset(): Result<Unit> = stateMutex.withLock {
-        // Skip if a new user is signed in by the time this reset runs.
-        // geofenceScope runs on Dispatchers.Default, which doesn't order coroutines —
-        // a refresh queued after this reset may have already written the new user's
-        // state. Wiping now would clobber it; the new user's refresh handles previous-
-        // user cleanup via the stale-diff in registerNearestAndPersist.
+    override suspend fun reset(signedOutUserId: String?): Result<Unit> = stateMutex.withLock {
+        // Skip only when a DIFFERENT user is signed in — see KDoc on [reset].
         val currentUserId = secureUserStore.getUserId()
-        if (!currentUserId.isNullOrBlank()) {
+        if (!currentUserId.isNullOrBlank() && currentUserId != signedOutUserId) {
             logger.logSyncSkipped("reset superseded by signed-in user")
             return@withLock Result.success(Unit)
         }
-        // Order matters: clear OS-side FIRST, then the persisted record. If
-        // manager.clearAll fails (transient GMS error), preserving the store
-        // lets the next refresh's stale-cleanup diff see the previous regions
-        // and retry their removal — without it, OS state orphans with no
-        // record to drive the cleanup.
+        // Clear OS-side FIRST, then wipe user-specific store state. On
+        // manager.clearAll failure preserve everything so the next refresh's
+        // stale-cleanup diff retries removal — without it, unremoved OS regs
+        // orphan with no record to drive cleanup. Workspace cache (regions,
+        // config, lastSync) is always preserved.
         manager.clearAll().also { result ->
             if (result.isSuccess) {
-                store.clearAll()
+                store.clearUserScopedState()
             }
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceServices.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceServices.kt
@@ -1,6 +1,7 @@
 package io.customer.location.geofence
 
 import android.annotation.SuppressLint
+import io.customer.sdk.data.store.SecureUserStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -37,6 +38,7 @@ internal interface GeofenceServices {
 
 internal class GeofenceServicesImpl(
     private val repository: GeofenceRepository,
+    private val secureUserStore: SecureUserStore,
     private val scope: CoroutineScope,
     private val logger: GeofenceLogger,
     private val permissionChecker: GeofencePermissionChecker
@@ -70,9 +72,14 @@ internal class GeofenceServicesImpl(
     }
 
     override fun onUserSignedOut() {
+        // Snapshot the userId synchronously — the datapipelines `ResetEvent`
+        // subscriber races to clear `secureUserStore`, so a deferred read
+        // inside `reset()` could see null and misclassify a normal sign-out
+        // as a re-login.
+        val signedOutUserId = secureUserStore.getUserId()
         logger.logGeofenceStateResetOnSignOut()
         scope.launch {
-            repository.reset()
+            repository.reset(signedOutUserId)
         }
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -100,6 +100,7 @@ internal val AndroidSDKComponent.geofenceServices: GeofenceServices
     get() = singleton<GeofenceServices> {
         GeofenceServicesImpl(
             repository = geofenceRepository,
+            secureUserStore = secureUserStore,
             scope = SDKComponent.scopeProvider.geofenceScope,
             logger = SDKComponent.geofenceLogger,
             permissionChecker = geofencePermissionChecker

--- a/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
@@ -14,19 +14,28 @@ import kotlinx.serialization.builtins.SetSerializer
 import kotlinx.serialization.builtins.serializer
 
 /**
- * State for the geofence sync pipeline:
+ * State for the geofence sync pipeline. Keys are split into two lifecycles:
  *
- *   cachedRegions               — full backend response; source for tier-A re-rank.
+ * Workspace-level (survive sign-out — see [clearUserScopedState]):
+ *   cachedRegions     — full backend response; source for tier-A re-rank.
+ *   cachedConfig      — last server-driven thresholds.
+ *   lastSyncTimestamp — freshness throttle for identify / app-launch.
+ *
+ * User-specific (wiped on sign-out):
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
- *   cachedConfig                — last server-driven thresholds.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
  *                                  closer to the user's real position than the anchor.
- *   lastSyncTimestamp           — freshness throttle for identify / app-launch.
  *
- * Decoding is schema-drift safe via [GeofenceJsonSerializer]: parse failures wipe the
- * key and return null/empty rather than propagating an exception up the sync path.
+ * Split rationale: backend `/v1/geofences/nearby` is workspace-scoped (no
+ * userId on the wire), so the workspace cache is valid for any user in the
+ * same workspace. Preserving it across sign-out skips a redundant API call
+ * on a quick re-login. If backend ever adds per-user filtering, revisit.
+ *
+ * Decoding is schema-drift safe via [GeofenceJsonSerializer]: parse failures
+ * wipe the key and return null/empty rather than propagating an exception up
+ * the sync path.
  */
 internal interface GeofenceRegionStore {
     fun saveCachedRegions(regions: List<GeofenceRegion>)
@@ -47,6 +56,13 @@ internal interface GeofenceRegionStore {
 
     fun getLastSyncTimestamp(): Long?
     fun setLastSyncTimestamp(timestamp: Long)
+
+    /**
+     * Sign-out wipe. Drops user-specific keys (anchor, movement-trigger
+     * location, registered IDs); preserves workspace cache (regions, config,
+     * last-sync) so a quick re-login skips a redundant API call.
+     */
+    fun clearUserScopedState()
 
     fun clearAll()
 }
@@ -102,6 +118,14 @@ internal class GeofenceRegionStoreImpl(
         prefs.edit { putLong(KEY_LAST_SYNC, timestamp) }
     }
 
+    override fun clearUserScopedState() {
+        prefs.edit {
+            remove(KEY_LAST_API_FETCH_LOCATION)
+            remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
+            remove(KEY_REGISTERED_IDS)
+        }
+    }
+
     override fun clearAll() {
         prefs.edit { clear() }
     }
@@ -111,13 +135,14 @@ internal class GeofenceRegionStoreImpl(
     }
 
     /**
-     * Returns the decoded value, or `null` if the key is absent OR the stored
-     * payload can't be parsed (schema drift, corruption). On parse failure the
-     * key is wiped so a stale, unparseable value won't keep failing on every read.
+     * Returns the decoded value, or `null` if absent or unparseable. On parse
+     * failure the key is wiped so a stale value won't keep failing on every
+     * read. Read and remove are sequenced separately so the write doesn't
+     * nest inside the read block.
      */
-    private fun <T> readJson(key: String, serializer: KSerializer<T>): T? = prefs.read {
-        val raw = getString(key, null) ?: return@read null
-        jsonSerializer.decodeOrNull(serializer, raw) ?: run {
+    private fun <T> readJson(key: String, serializer: KSerializer<T>): T? {
+        val raw = prefs.read { getString(key, null) } ?: return null
+        return jsonSerializer.decodeOrNull(serializer, raw) ?: run {
             prefs.edit { remove(key) }
             null
         }

--- a/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
@@ -54,11 +54,11 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofences_givenEmptyList_expectReceiverDisabledAndNoClientCall() = runTest {
+    fun replaceGeofences_givenEmptyList_expectReceiverDisabledAndNoClientCall() = runTest {
         // Account with no geofences => receiver must be disabled so the SDK doesn't
         // burn resources listening for events that can't fire. Covers both fresh
         // accounts and accounts that transitioned to 0 after a refresh.
-        val result = manager.addGeofences(emptyList())
+        val result = manager.replaceGeofences(emptyList())
 
         result.isSuccess.shouldBeTrue()
         verify(exactly = 0) { client.addGeofences(any<GeofencingRequest>(), any()) }
@@ -66,56 +66,56 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofences_givenNoFineLocationPermission_expectFailure() = runTest {
+    fun replaceGeofences_givenNoFineLocationPermission_expectFailure() = runTest {
         denyPermission(Manifest.permission.ACCESS_FINE_LOCATION)
 
-        val result = manager.addGeofences(listOf(buildRegion()))
+        val result = manager.replaceGeofences(listOf(buildRegion()))
 
         result.isFailure.shouldBeTrue()
         verify(exactly = 0) { client.addGeofences(any<GeofencingRequest>(), any()) }
     }
 
     @Test
-    fun addGeofences_givenFineLocationGrantedNoBackgroundOnQ_expectFailure() = runTest {
+    fun replaceGeofences_givenFineLocationGrantedNoBackgroundOnQ_expectFailure() = runTest {
         grantPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         denyPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
 
-        val result = manager.addGeofences(listOf(buildRegion()))
+        val result = manager.replaceGeofences(listOf(buildRegion()))
 
         result.isFailure.shouldBeTrue()
     }
 
     @Test
-    fun addGeofences_givenAllPermissionsGranted_expectClientCalled() = runTest {
+    fun replaceGeofences_givenAllPermissionsGranted_expectClientCalled() = runTest {
         grantAllPermissions()
         stubClientAddSuccess()
 
-        val result = manager.addGeofences(listOf(buildRegion()))
+        val result = manager.replaceGeofences(listOf(buildRegion()))
 
         result.isSuccess.shouldBeTrue()
         verify { client.addGeofences(any<GeofencingRequest>(), any()) }
     }
 
     @Test
-    fun addGeofences_givenBusinessGeofences_expectInitialTriggerEnter() = runTest {
+    fun replaceGeofences_givenBusinessGeofences_expectInitialTriggerEnter() = runTest {
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
 
-        manager.addGeofences(listOf(buildRegion(id = "business-1")))
+        manager.replaceGeofences(listOf(buildRegion(id = "business-1")))
 
         requestSlot.captured.initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
     }
 
     @Test
-    fun addGeofences_givenMovementTrigger_expectNoInitialTrigger() = runTest {
+    fun replaceGeofences_givenMovementTrigger_expectNoInitialTrigger() = runTest {
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
 
-        manager.addGeofences(
+        manager.replaceGeofences(
             listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
         )
 
@@ -123,13 +123,13 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofencesForBootRestore_givenMovementTrigger_expectInitialTriggerExit() = runTest {
+    fun replaceGeofencesForBootRestore_givenMovementTrigger_expectInitialTriggerExit() = runTest {
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
 
-        manager.addGeofencesForBootRestore(
+        manager.replaceGeofencesForBootRestore(
             listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
         )
 
@@ -137,7 +137,7 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofencesForBootRestore_givenBusinessGeofences_expectInitialTriggerEnterUnchanged() = runTest {
+    fun replaceGeofencesForBootRestore_givenBusinessGeofences_expectInitialTriggerEnterUnchanged() = runTest {
         // Only the movement trigger differs between variants; business batch
         // still uses INITIAL_TRIGGER_ENTER.
         grantAllPermissions()
@@ -145,20 +145,20 @@ class GeofenceManagerTest : RobolectricTest() {
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
 
-        manager.addGeofencesForBootRestore(listOf(buildRegion(id = "business-1")))
+        manager.replaceGeofencesForBootRestore(listOf(buildRegion(id = "business-1")))
 
         requestSlot.captured.initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
     }
 
     @Test
-    fun addGeofences_givenMixedBatch_expectSeparateRequestsWithCorrectTriggers() = runTest {
+    fun replaceGeofences_givenMixedBatch_expectSeparateRequestsWithCorrectTriggers() = runTest {
         grantAllPermissions()
 
         val requests = mutableListOf<GeofencingRequest>()
         val task = immediateSuccessTask<Void>()
         every { client.addGeofences(capture(requests), any()) } returns task
 
-        manager.addGeofences(
+        manager.replaceGeofences(
             listOf(
                 buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID),
                 buildRegion(id = "business-1")
@@ -175,7 +175,7 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofences_givenMixedBatchWithBusinessFailure_expectMovementTriggerRolledBack() = runTest {
+    fun replaceGeofences_givenMixedBatchWithBusinessFailure_expectMovementTriggerRolledBack() = runTest {
         // Business-batch failure is a rare edge case (transient OS / GMS issue).
         // Rather than leave a stand-alone movement trigger in the OS, we roll it
         // back so we don't carry safety-net state we can't act on. Recovery
@@ -195,7 +195,7 @@ class GeofenceManagerTest : RobolectricTest() {
         val removeTask = immediateSuccessTask<Void>()
         every { client.removeGeofences(any<List<String>>()) } returns removeTask
 
-        val result = manager.addGeofences(
+        val result = manager.replaceGeofences(
             listOf(
                 buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID),
                 buildRegion(id = "business-1")
@@ -208,7 +208,7 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofences_givenRegion_expectGmsGeofenceBuiltCorrectly() = runTest {
+    fun replaceGeofences_givenRegion_expectGmsGeofenceBuiltCorrectly() = runTest {
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
@@ -221,7 +221,7 @@ class GeofenceManagerTest : RobolectricTest() {
             radius = 250f,
             transitionTypes = listOf(GeofenceTransitionType.ENTER)
         )
-        manager.addGeofences(listOf(region))
+        manager.replaceGeofences(listOf(region))
 
         val gmsGeofence = requestSlot.captured.geofences.first()
         gmsGeofence.requestId shouldBeEqualTo "geo-123"
@@ -230,31 +230,31 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun addGeofences_givenSuccess_expectReceiversEnabled() = runTest {
+    fun replaceGeofences_givenSuccess_expectReceiversEnabled() = runTest {
         grantAllPermissions()
         stubClientAddSuccess()
 
-        manager.addGeofences(listOf(buildRegion()))
+        manager.replaceGeofences(listOf(buildRegion()))
 
         verify { receiverToggle.setEnabled(true) }
     }
 
     @Test
-    fun addGeofences_givenFailure_expectReceiversNotToggled() = runTest {
+    fun replaceGeofences_givenFailure_expectReceiversNotToggled() = runTest {
         grantAllPermissions()
         stubClientAddFailure(RuntimeException("GMS error"))
 
-        manager.addGeofences(listOf(buildRegion()))
+        manager.replaceGeofences(listOf(buildRegion()))
 
         verify(exactly = 0) { receiverToggle.setEnabled(any()) }
     }
 
     @Test
-    fun addGeofences_givenClientFails_expectFailureResult() = runTest {
+    fun replaceGeofences_givenClientFails_expectFailureResult() = runTest {
         grantAllPermissions()
         stubClientAddFailure(RuntimeException("GMS error"))
 
-        val result = manager.addGeofences(listOf(buildRegion()))
+        val result = manager.replaceGeofences(listOf(buildRegion()))
 
         result.isFailure.shouldBeTrue()
     }

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -72,6 +72,45 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenFreshCacheButOsRegsWiped_expectLocalRefreshFromCache() = runTest {
+        // Sign-out → sign-in within the freshness window: workspace cache
+        // survived but OS regs + registeredIds were wiped. Must re-register
+        // from cache instead of skipping, otherwise the new user has no OS
+        // geofences until the next stale-window expiry.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify { manager.replaceGeofences(any()) }
+    }
+
+    @Test
+    fun refresh_givenFreshCacheAndOsRegsWipedButNullCachedConfig_expectSkip() = runTest {
+        // Defensive branch: if `cachedConfig` is null (can't happen on this
+        // branch but possible once backend stops shipping `config`), we can't
+        // drive a local re-register. Skip rather than crash.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns null
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
     fun refresh_givenStaleLastSync_expectApiCalled() = runTest {
         // Last sync older than threshold => proceed with refresh.
         every { secureUserStore.getUserId() } returns "user-42"
@@ -81,7 +120,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -134,7 +173,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -150,7 +189,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -165,7 +204,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify { logger.logSyncSkipped(match { it.contains("no identified user") }) }
     }
@@ -193,7 +232,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { logger.logSyncFailed(match { it?.contains("network down") == true }) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
     }
 
     @Test
@@ -206,7 +245,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         val capturedLoc = slot<GeofenceLocation>()
         every { store.saveLastMovementTriggerLocation(capture(capturedLoc)) } returns Unit
 
@@ -224,7 +263,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -242,7 +281,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.failure(RuntimeException("boom"))
+        coEvery { manager.replaceGeofences(any()) } returns Result.failure(RuntimeException("boom"))
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -258,7 +297,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns filtered
         val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.addGeofences(capture(captured)) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(capture(captured)) } returns Result.success(Unit)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -290,7 +329,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         val regionsSlot = slot<List<GeofenceRegion>>()
         val configSlot = slot<GeofenceConfig>()
         val anchorSlot = slot<GeofenceLocation>()
@@ -317,7 +356,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.failure(RuntimeException("boom"))
+        coEvery { manager.replaceGeofences(any()) } returns Result.failure(RuntimeException("boom"))
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -346,16 +385,16 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns newBusiness
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         // biz-old-1 and biz-old-2 are no longer in the new set; movement trigger and
-        // biz-shared survive (same IDs, will be replaced by addGeofences).
+        // biz-shared survive (same IDs, will be replaced by replaceGeofences).
         val staleSlot = slot<List<String>>()
         coVerifyOrder {
-            manager.addGeofences(any())
+            manager.replaceGeofences(any())
             manager.removeGeofencesByIds(capture(staleSlot))
         }
         staleSlot.captured shouldContainSame listOf("biz-old-1", "biz-old-2")
@@ -369,7 +408,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -388,7 +427,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(newRegion)
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns
             Result.failure(RuntimeException("remove boom"))
         val persisted = slot<Set<String>>()
@@ -398,7 +437,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerifyOrder {
-            manager.addGeofences(any())
+            manager.replaceGeofences(any())
             manager.removeGeofencesByIds(any())
         }
         verify { logger.logSyncSucceeded(1) }
@@ -419,7 +458,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -439,7 +478,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.addGeofences(capture(captured)) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(capture(captured)) } returns Result.success(Unit)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -450,7 +489,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
     @Test
     fun refresh_givenManagerAddFails_expectStaleRemovalNotAttemptedAndPreviousStatePreserved() = runTest {
-        // Critical 7g invariant: when addGeofences fails, removeGeofencesByIds must
+        // Critical 7g invariant: when replaceGeofences fails, removeGeofencesByIds must
         // NOT be called. Otherwise we'd destroy the last-known-good OS registrations
         // and leave the device with NO geofences at all until the next refresh.
         // Store and timestamp also stay untouched so the next refresh sees the same
@@ -462,7 +501,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-new", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.failure(error)
+        coEvery { manager.replaceGeofences(any()) } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -487,7 +526,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         val addGeofencesActive = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
-        coEvery { manager.addGeofences(any()) } coAnswers {
+        coEvery { manager.replaceGeofences(any()) } coAnswers {
             val n = addGeofencesActive.incrementAndGet()
             maxObservedConcurrency.updateAndGet { current -> maxOf(current, n) }
             delay(50)
@@ -516,7 +555,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         )
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         val first = repository.refresh(latitude = 0.0, longitude = 0.0)
         val second = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -540,7 +579,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
         verify { logger.logSyncSkipped(match { it.contains("user changed") }) }
     }
 
@@ -554,37 +593,62 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
         verify { logger.logSyncSkipped(match { it.contains("user changed") }) }
     }
 
     @Test
-    fun reset_givenManagerSucceeds_expectStoreAndManagerCleared() = runTest {
-        // Sign-out cleanup: the persisted set must be wiped AND OS-side state
-        // (registered geofences + receiver) cleared via manager.clearAll so a
-        // subsequent user doesn't inherit anything from the previous one.
+    fun reset_givenManagerSucceeds_expectUserScopedStateClearedAndWorkspaceCachePreserved() = runTest {
+        // Sign-out cleanup: drop OS registrations + wipe user-specific state
+        // (anchor, movement-trigger location, registered IDs). Workspace
+        // cache (regions, config, last-sync) survives so a quick re-login
+        // skips a redundant API hit.
+        every { secureUserStore.getUserId() } returns null
         coEvery { manager.clearAll() } returns Result.success(Unit)
 
-        val result = repository.reset()
+        val result = repository.reset(signedOutUserId = "user-A")
 
         result.isSuccess shouldBeEqualTo true
         coVerifyOrder {
             manager.clearAll()
-            store.clearAll()
+            store.clearUserScopedState()
         }
+        verify(exactly = 0) { store.clearAll() }
     }
 
     @Test
     fun reset_givenNewUserSignedInDuringWait_expectSkipWipe() = runTest {
-        // Sign-out + immediate-sign-in race — see reset() for the rationale.
+        // True re-login race: User A signed out, User B signed in before our
+        // reset ran. Current user differs from the one being reset → skip wipe
+        // so we don't clobber User B's freshly-written state.
         every { secureUserStore.getUserId() } returns "user-B"
 
-        val result = repository.reset()
+        val result = repository.reset(signedOutUserId = "user-A")
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { manager.clearAll() }
+        verify(exactly = 0) { store.clearUserScopedState() }
         verify(exactly = 0) { store.clearAll() }
         verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
+    }
+
+    @Test
+    fun reset_givenSecureUserStoreNotYetCleared_expectWipeProceeds() = runTest {
+        // The two ResetEvent subscribers (datapipelines clearing
+        // secureUserStore, location running reset) race. If our reset runs
+        // first, secureUserStore.getUserId() still returns the signed-out
+        // user — but it's the SAME id, not a different user signed in. Must
+        // proceed with wipe; this is the regression Cursor flagged on #706.
+        every { secureUserStore.getUserId() } returns "user-A"
+        coEvery { manager.clearAll() } returns Result.success(Unit)
+
+        val result = repository.reset(signedOutUserId = "user-A")
+
+        result.isSuccess shouldBeEqualTo true
+        coVerifyOrder {
+            manager.clearAll()
+            store.clearUserScopedState()
+        }
     }
 
     @Test
@@ -593,13 +657,15 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // preserved — otherwise OS-side registrations orphan with no record to
         // drive cleanup. The next refresh's stale-cleanup diff uses the store
         // to retry the removal.
+        every { secureUserStore.getUserId() } returns null
         val error = RuntimeException("gms clear boom")
         coEvery { manager.clearAll() } returns Result.failure(error)
 
-        val result = repository.reset()
+        val result = repository.reset(signedOutUserId = "user-A")
 
         result.isFailure shouldBeEqualTo true
         result.exceptionOrNull() shouldBeEqualTo error
+        verify(exactly = 0) { store.clearUserScopedState() }
         verify(exactly = 0) { store.clearAll() }
     }
 
@@ -613,7 +679,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
     }
 
     @Test
@@ -627,7 +693,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 1.0, longitude = 2.0)
 
@@ -646,7 +712,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.0)
 
@@ -668,12 +734,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(cached, any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
-        coVerify { manager.addGeofences(any()) }
+        coVerify { manager.replaceGeofences(any()) }
         verify { distanceFilter.nearest(cached, 0.0, 0.001, any()) }
     }
 
@@ -688,7 +754,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.1)
 
@@ -707,7 +773,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
         val anchorSlot = slot<GeofenceLocation>()
         every { store.saveLastApiFetchLocation(capture(anchorSlot)) } returns Unit
 
@@ -729,7 +795,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
@@ -758,7 +824,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         }
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         coroutineScope {
             launch { repository.handleMovement(latitude = 1.0, longitude = 1.0) }
@@ -778,7 +844,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.restoreFromCache()
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.addGeofencesForBootRestore(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofencesForBootRestore(any()) }
     }
 
     @Test
@@ -792,7 +858,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.restoreFromCache()
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.addGeofencesForBootRestore(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofencesForBootRestore(any()) }
     }
 
     @Test
@@ -804,7 +870,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.restoreFromCache()
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.addGeofencesForBootRestore(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofencesForBootRestore(any()) }
     }
 
     @Test
@@ -820,7 +886,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(cached, 50.0, 60.0, any()) } returns cached
-        coEvery { manager.addGeofencesForBootRestore(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         repository.restoreFromCache()
 
@@ -828,8 +894,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { distanceFilter.nearest(cached, 50.0, 60.0, any()) }
         verify(exactly = 0) { distanceFilter.nearest(any(), 12.34, 56.78, any()) }
         // Pins the boot-restore manager variant, not the normal one.
-        coVerify { manager.addGeofencesForBootRestore(any()) }
-        coVerify(exactly = 0) { manager.addGeofences(any()) }
+        coVerify { manager.replaceGeofencesForBootRestore(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
     }
 
@@ -846,12 +912,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(cached, 12.34, 56.78, any()) } returns cached
-        coEvery { manager.addGeofencesForBootRestore(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         repository.restoreFromCache()
 
         verify { distanceFilter.nearest(cached, 12.34, 56.78, any()) }
-        coVerify { manager.addGeofencesForBootRestore(any()) }
+        coVerify { manager.replaceGeofencesForBootRestore(any()) }
     }
 
     @Test
@@ -866,7 +932,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 50.0, 60.0, 100f))
-        coEvery { manager.addGeofencesForBootRestore(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         repository.restoreFromCache()
 

--- a/location/src/test/java/io/customer/location/geofence/GeofenceServicesTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceServicesTest.kt
@@ -1,6 +1,7 @@
 package io.customer.location.geofence
 
 import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -20,6 +21,7 @@ import org.robolectric.RobolectricTestRunner
 class GeofenceServicesTest : RobolectricTest() {
 
     private val repository: GeofenceRepository = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val permissionChecker: GeofencePermissionChecker = mockk(relaxed = true) {
         every { hasRequiredLocationPermissions() } returns true
@@ -28,6 +30,7 @@ class GeofenceServicesTest : RobolectricTest() {
     private fun servicesWith(scope: TestScope): GeofenceServicesImpl =
         GeofenceServicesImpl(
             repository = repository,
+            secureUserStore = secureUserStore,
             scope = scope,
             logger = logger,
             permissionChecker = permissionChecker
@@ -98,14 +101,18 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
-    fun onUserSignedOut_expectRepositoryResetLaunched() = runTest(StandardTestDispatcher()) {
-        coEvery { repository.reset() } returns Result.success(Unit)
+    fun onUserSignedOut_expectSignedOutUserIdCapturedSynchronouslyAndPassedToReset() = runTest(StandardTestDispatcher()) {
+        // The capture has to happen BEFORE scope.launch — otherwise a racing
+        // ResetEvent subscriber (datapipelines clears secureUserStore) could
+        // null it out by the time reset() reads it.
+        every { secureUserStore.getUserId() } returns "user-42"
+        coEvery { repository.reset(any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onUserSignedOut()
         advanceUntilIdle()
 
-        coVerify { repository.reset() }
+        coVerify { repository.reset("user-42") }
         verify { logger.logGeofenceStateResetOnSignOut() }
     }
 }

--- a/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
@@ -220,6 +220,37 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastSyncTimestamp().shouldBeNull()
     }
 
+    @Test
+    fun clearUserScopedState_expectUserKeysRemovedAndWorkspaceCachePreserved() {
+        // Sign-out path: drop user-specific state but keep workspace-level
+        // cache so a quick re-login skips a redundant API call.
+        val regions = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f))
+        val config = GeofenceConfig(
+            localRefreshTriggerRadius = 1_000f,
+            remoteFetchRefreshTriggerRadius = 5_000f,
+            remoteFetchRefreshExpiryMs = 86_400_000L,
+            duplicateEventsExpiryMs = 3_600_000L,
+            maxBusinessGeofences = 19
+        )
+        store.saveCachedRegions(regions)
+        store.saveCachedConfig(config)
+        store.saveRegisteredIds(setOf("biz-1"))
+        store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
+        store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
+        store.setLastSyncTimestamp(12_345L)
+
+        store.clearUserScopedState()
+
+        // User-specific: wiped.
+        store.getRegisteredIds().shouldBeEmpty()
+        store.getLastApiFetchLocation().shouldBeNull()
+        store.getLastMovementTriggerLocation().shouldBeNull()
+        // Workspace-level: preserved.
+        store.getCachedRegions() shouldBeEqualTo regions
+        store.getCachedConfig() shouldBeEqualTo config
+        store.getLastSyncTimestamp() shouldBeEqualTo 12_345L
+    }
+
     // --- Schema-drift / corruption safety ---
 
     @Test


### PR DESCRIPTION
## Ticket

[MBL-1629](https://linear.app/customerio/issue/MBL-1629/smart-geofence-updates)

## Stack

Follow-up to the merged stack #702–#708. Bundles all actionable review feedback in a single PR; ✓ items already addressed elsewhere in the stack are noted in thread replies.

## Summary

Four small review-driven fixes plus one design change discussed during the stack review:

1. **Rename `GeofenceManager.addGeofences` → `replaceGeofences`** (#702, Mahmoud) — name now signals the replace-semantics. Also renames the boot-restore variant.
2. **`GeofenceJsonSerializer.decodeOrNull` rethrows `CancellationException`** (#703, Mahmoud + Cursor) — catch `Throwable` is too broad. Now catches `Exception`, rethrowing `CancellationException` explicitly so a future suspending caller can't silently lose cancellation.
3. **`GeofenceRegionStore.readJson` decouples write from read** (#703, Mahmoud + Cursor) — `prefs.edit` no longer nests inside `prefs.read`; the failure-path remove is sequenced after the read closes.
4. **`GeofenceRepository.reset(signedOutUserId)` race fix** (#706, Cursor — real bug) — the two `ResetEvent` subscribers (datapipelines clearing `secureUserStore`, location running `reset()`) race on independent coroutines. `reset()` read of `secureUserStore.getUserId()` could see the signed-out user's id even on a normal sign-out, misclassifying it as a re-login and skipping the wipe — leaving orphan OS registrations. Fix: `GeofenceServicesImpl.onUserSignedOut()` snapshots the userId synchronously, passes it through, and `reset()` only skips when the current user is a *different* user.
5. **Workspace cache survives sign-out** (#702 design discussion) — backend `/v1/geofences/nearby` is workspace-scoped (no `userId` on the wire), so cached regions + config are valid for any user in the same workspace. `reset()` now calls a new `store.clearUserScopedState()` that wipes only user-specific state (anchor, movement-trigger location, registered IDs) and preserves `cachedRegions`, `cachedConfig`, `lastSyncTimestamp`. A new branch in `refresh()` re-registers from cache (Tier A) when the freshness window is intact but `registeredIds` is empty (sign-out → sign-in case), so a quick re-login skips the redundant API hit.

## Change breakdown

- `GeofenceManager.kt`: `addGeofences` → `replaceGeofences`, `addGeofencesForBootRestore` → `replaceGeofencesForBootRestore`. Internal `addGeofencesInternal` → `replaceGeofencesInternal`. KDoc clarified to signal the replace-semantics.
- `GeofenceJsonSerializer.kt`: catch tightened to `Exception` with explicit `CancellationException` rethrow.
- `GeofenceRegionStore.kt`: new `clearUserScopedState()`; `readJson` refactored so `prefs.edit` runs outside the `prefs.read` block; top-level KDoc rewritten to document the two lifecycles (workspace-level vs user-specific) and the workspace-scoped backend assumption.
- `GeofenceRepository.kt`: `reset(signedOutUserId)` new signature, only skips wipe on different-user re-login. New `refresh()` branch: when `lastSync` is fresh + `cachedRegions` non-empty + `registeredIds` empty + `cachedConfig` non-null → `performLocalRefresh` instead of skipping. `reset()` calls `clearUserScopedState()` on `manager.clearAll()` success; preserves everything on failure so the next refresh's stale-diff retries removal.
- `GeofenceServices.kt`: `GeofenceServicesImpl` now takes `SecureUserStore`. `onUserSignedOut()` captures the userId synchronously before launching `reset`.
- `DIGraphGeofence.kt`: passes `secureUserStore` to `GeofenceServicesImpl`.

Production: ~85 net LOC. Tests: ~200 net LOC.

## Threading audit

One narrow self-healing race noted; not fixed by design:

- Concurrent `reset()` + `refresh()`: the new refresh gate reads `cachedRegions` / `registeredIds` / `cachedConfig` **outside** `stateMutex`. If `refresh()` reads while `reset()` is mid-flight (between `manager.clearAll()` success and `store.clearUserScopedState()` running, both inside the mutex), it can see a stale view of `registeredIds` and skip when it should have local-refreshed. Self-heals on the next trigger (movement EXIT / next identify / app launch) because `registeredIds` is then empty. Cost of locking the hot read path outweighs benefit of avoiding one missed retry.

Otherwise:
- All persistence still goes through `stateMutex.withLock` (via `registerNearestAndPersist`).
- The userId-recheck inside the mutex still catches the user-change-during-refresh race.
- `refreshInProgress` `AtomicBoolean` still prevents re-entrant refresh.
- The new branch correctly retries on register failure (`registeredIds` stays empty until register succeeds → next refresh sees the same condition and retries).

## Test plan

- [x] `:location:test` passes (debug + release).
- [x] `:location:apiCheck` clean.
- New / updated tests:
  - `GeofenceServicesTest`: `onUserSignedOut_expectSignedOutUserIdCapturedSynchronouslyAndPassedToReset` pins the userId is read before the launch.
  - `GeofenceRepositoryTest`:
    - `reset_givenManagerSucceeds_expectUserScopedStateClearedAndWorkspaceCachePreserved` — happy path uses the partial wipe.
    - `reset_givenSecureUserStoreNotYetCleared_expectWipeProceeds` — pins the #706 regression: same userId → still wipe.
    - `reset_givenNewUserSignedInDuringWait_expectSkipWipe` — different userId → skip.
    - `reset_givenManagerFails_expectStorePreservedForSelfHeal` — failure preserves everything.
    - `refresh_givenFreshCacheButOsRegsWiped_expectLocalRefreshFromCache` — sign-out → sign-in cache hit re-registers.
    - `refresh_givenFreshCacheAndOsRegsWipedButNullCachedConfig_expectSkip` — defensive null-config fall-through.
  - `GeofenceRegionStoreTest`: `clearUserScopedState_expectUserKeysRemovedAndWorkspaceCachePreserved`.
- E2E manual verification deferred — the API endpoint isn't wired yet.

## Notes for reviewers

- The `cachedConfig != null` check in the new `refresh()` branch is defensive against a follow-up PR (API wire-up, currently parked on `mbl-1629-final-polish`) that makes the response `config` block nullable. On this branch the invariant "`lastSync` set ⟹ `cachedConfig` non-null" holds, but using `!!` would crash later; the explicit null check degrades gracefully.
- Workspace-cache-across-sign-out is an explicit design choice; documented as "revisit if backend ever ships per-user filtering" in the store KDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes sign-out/reset and refresh short-circuiting logic that controls OS geofence registrations; regressions could lead to missing or stale geofence events until the next sync.
> 
> **Overview**
> **Geofence registration semantics are clarified and propagated** by renaming `GeofenceManager.addGeofences` to `replaceGeofences` (including the boot-restore variant) and updating all call sites/tests to reflect replace-not-add behavior.
> 
> **Sign-out/reset behavior is changed**: `GeofenceRepository.reset` now takes a `signedOutUserId` snapshot (captured synchronously in `GeofenceServicesImpl.onUserSignedOut`) and only skips wiping when a *different* user is currently signed in, reducing a race that could previously skip cleanup. Reset now preserves workspace-level cache while clearing only user-scoped persisted state via new `GeofenceRegionStore.clearUserScopedState()`.
> 
> **Refresh logic is adjusted for quick re-login**: when the freshness window would normally skip remote fetch, the repository now re-registers OS geofences from cached regions/config if `registeredIds` is empty (e.g., after sign-out wiped OS registrations).
> 
> **Coroutine/prefs safety improvements**: `GeofenceJsonSerializer.decodeOrNull` now rethrows `CancellationException` and narrows catch to `Exception`, and `GeofenceRegionStore.readJson` avoids nesting `prefs.edit` inside `prefs.read` when clearing corrupted values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f490c85c84b9b2bff306066f9cc3f043f7f3156b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->