### PR TITLE
chore: wire geofence nearby endpoint and encrypt location snapshots

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
@@ -1,5 +1,6 @@
 package io.customer.sdk.core.network
 
+import android.net.Uri
 import android.util.Base64
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
@@ -13,20 +14,21 @@ import java.net.URL
 @InternalCustomerIOApi
 data class HttpRequestParams(
     val path: String,
+    val method: HttpMethod = HttpMethod.POST,
+    val queryParams: Map<String, String> = emptyMap(),
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null
 )
+
+@InternalCustomerIOApi
+enum class HttpMethod { GET, POST }
 
 /** HTTP client for Customer.io API calls with SDK authentication. */
 @InternalCustomerIOApi
 interface CustomerIOHttpClient {
     /**
-     * Performs a POST request to [params.path] with [params.headers] and [params.body].
-     *
-     * @param params The request parameters (path, headers, body).
-     * @return A `Result<String>`:
-     *   - `Result.success(responseBody)` for 2xx response codes
-     *   - `Result.failure(exception)` for network errors or non-2xx codes
+     * Performs an HTTP request per [params]. Returns `Result.success(body)`
+     * for 2xx and `Result.failure(exception)` for network errors or non-2xx.
      */
     suspend fun request(params: HttpRequestParams): Result<String>
 }
@@ -49,9 +51,18 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
         val apiHost = settings.apiHost
         val writeKey = settings.writeKey
 
-        // Ensure we have exactly one slash
+        // `apiHost` already includes the API version prefix (e.g.,
+        // "cdp.customer.io/v1"), so `Uri.Builder().authority()` can't be used
+        // here — it would percent-encode the embedded `/`. Compose the base URL
+        // first, then layer query params on top via `buildUpon`.
         val cleanedPath = if (params.path.startsWith("/")) params.path else "/${params.path}"
-        val urlString = "https://$apiHost$cleanedPath"
+        val urlString = Uri.parse("https://$apiHost$cleanedPath")
+            .buildUpon()
+            .apply {
+                params.queryParams.forEach { (k, v) -> appendQueryParameter(k, v) }
+            }
+            .build()
+            .toString()
 
         val connection = try {
             val urlObj = URL(urlString)
@@ -66,7 +77,7 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
             // Configure the connection
             connection.connectTimeout = connectTimeoutMs
             connection.readTimeout = readTimeoutMs
-            connection.requestMethod = "POST"
+            connection.requestMethod = params.method.name
             connection.setRequestProperty("User-Agent", client.toString())
 
             // Authorization: Basic <base64("writeKey:")>

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceConfig.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceConfig.kt
@@ -5,14 +5,31 @@ import kotlinx.serialization.Serializable
 
 /**
  * Server-driven geofence configuration. Overrides the fallback values in [GeofenceConstants].
- * Times are normalized to milliseconds at the API boundary. Persisted JSON keys are pinned
- * via [SerialName] so they survive Kotlin renames and R8 / obfuscation.
+ * Persisted JSON keys are pinned via [SerialName] so they survive Kotlin renames and R8 / obfuscation.
  */
 @Serializable
 internal data class GeofenceConfig(
-    @SerialName("localRefreshTriggerRadius") val localRefreshTriggerRadius: Float,
-    @SerialName("remoteFetchRefreshTriggerRadius") val remoteFetchRefreshTriggerRadius: Float,
-    @SerialName("remoteFetchRefreshExpiryMs") val remoteFetchRefreshExpiryMs: Long,
-    @SerialName("duplicateEventsExpiryMs") val duplicateEventsExpiryMs: Long,
-    @SerialName("maxBusinessGeofences") val maxBusinessGeofences: Int
-)
+    @SerialName("localRefreshTriggerRadius")
+    val localRefreshTriggerRadius: Float,
+    @SerialName("remoteFetchRefreshTriggerRadius")
+    val remoteFetchRefreshTriggerRadius: Float,
+    @SerialName("remoteFetchRefreshExpiry")
+    val remoteFetchRefreshExpiry: Long,
+    @SerialName("duplicateEventsExpiry")
+    val duplicateEventsExpiry: Long,
+    @SerialName("maxBusinessGeofences")
+    val maxBusinessGeofences: Int
+) {
+    internal companion object {
+        // Used when the cached server config is missing. Today that's the
+        // common case (backend doesn't ship `config` yet); long-term it
+        // covers cold-start / first-launch.
+        fun fallback(): GeofenceConfig = GeofenceConfig(
+            localRefreshTriggerRadius = GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
+            remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
+            remoteFetchRefreshExpiry = GeofenceConstants.STALE_THRESHOLD_MS,
+            duplicateEventsExpiry = GeofenceConstants.DEDUPE_COOLDOWN_MS,
+            maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+        )
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
@@ -21,12 +21,12 @@ internal object GeofenceConstants {
     // Minimum interval between server fetches. Non-forced refresh calls (identify,
     // app launch) skip the API call when a successful sync happened within this
     // window. Movement-trigger EXIT bypasses this so the loop can update the
-    // trigger's center. Doubles as the fallback for `remoteFetchRefreshExpiryMs`
+    // trigger's center. Doubles as the fallback for `remoteFetchRefreshExpiry`
     // when the API config field is missing or non-positive.
     const val STALE_THRESHOLD_MS = 24 * 60 * 60 * 1_000L
 
     // Duplicate-transition suppression window used by GeofenceCooldownFilter.
-    // Doubles as the fallback for `duplicateEventsExpiryMs` from the API config
+    // Doubles as the fallback for `duplicateEventsExpiry` from the API config
     // when the field is missing or non-positive.
     const val DEDUPE_COOLDOWN_MS = 60 * 60 * 1_000L
 

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceJsonSerializer.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceJsonSerializer.kt
@@ -5,27 +5,37 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
 /**
- * Project-owned wrapper around `Json { ignoreUnknownKeys = true }` so the geofence
- * sync pipeline doesn't ship a bare framework type.
+ * Project-owned JSON wrapper for the geofence sync pipeline.
  *
- * Two decode flavours for the two call sites:
- * - [decode] (strict) — for API responses, where a parse failure should propagate
- *   as a Result.failure to the caller.
- * - [decodeOrNull] (lenient) — for cached state, where schema drift / corruption
- *   should degrade to "no cached value" instead of crashing the sync path.
+ * Two decode entry points for the two failure modes:
+ * - [decode] — surface parse failures (API responses; failure → `Result.failure`).
+ * - [decodeOrNull] — swallow parse failures (cached state; failure → `null` and the
+ *   key gets wiped by the caller).
+ *
+ * Opt-in `lenient` flag accepts loose wire types (e.g. `"id": 123` or `"id": "abc-123"`)
+ * without committing the SDK to a specific shape. Cache reads stay strict — we wrote
+ * that JSON ourselves, so loose parsing would only mask corruption.
  */
 internal class GeofenceJsonSerializer {
 
-    private val json = Json { ignoreUnknownKeys = true }
+    private val strictJson = Json { ignoreUnknownKeys = true }
+    private val lenientJson = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
 
     fun <T> encode(serializer: KSerializer<T>, value: T): String =
-        json.encodeToString(serializer, value)
+        strictJson.encodeToString(serializer, value)
 
-    fun <T> decode(serializer: KSerializer<T>, raw: String): T =
-        json.decodeFromString(serializer, raw)
+    fun <T> decode(serializer: KSerializer<T>, raw: String, lenient: Boolean = false): T =
+        (if (lenient) lenientJson else strictJson).decodeFromString(serializer, raw)
 
-    fun <T> decodeOrNull(serializer: KSerializer<T>, raw: String): T? = try {
-        decode(serializer, raw)
+    fun <T> decodeOrNull(
+        serializer: KSerializer<T>,
+        raw: String,
+        lenient: Boolean = false
+    ): T? = try {
+        decode(serializer, raw, lenient)
     } catch (e: CancellationException) {
         // Always propagate coroutine cancellation; otherwise callers from a
         // suspending context could miss being cancelled.

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRegion.kt
@@ -5,19 +5,33 @@ import com.google.android.gms.location.Geofence
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** A geographic region to monitor for enter/exit transitions. */
+/**
+ * A geographic region to monitor for enter/exit transitions.
+ *
+ * `id` is the OS request ID — derived from the backend's numeric geofence ID
+ * so it stays stable and matches the `geofence_id` key on transition events.
+ */
 @Serializable
 internal data class GeofenceRegion(
-    @SerialName("id") val id: String,
-    @SerialName("latitude") val latitude: Double,
-    @SerialName("longitude") val longitude: Double,
-    @SerialName("radius") val radius: Float,
-    @SerialName("name") val name: String = "",
-    @SerialName("transitionTypes") val transitionTypes: List<GeofenceTransitionType> = listOf(
+    @SerialName("id")
+    val id: String,
+    @SerialName("latitude")
+    val latitude: Double,
+    @SerialName("longitude")
+    val longitude: Double,
+    @SerialName("radius")
+    val radius: Float,
+    @SerialName("name")
+    val name: String = "",
+    @SerialName("externalId")
+    val externalId: String? = null,
+    @SerialName("transitionTypes")
+    val transitionTypes: List<GeofenceTransitionType> = listOf(
         GeofenceTransitionType.ENTER,
         GeofenceTransitionType.EXIT
     ),
-    @SerialName("lastUpdated") val lastUpdated: Long = 0L
+    @SerialName("lastUpdated")
+    val lastUpdated: Long = 0L
 )
 
 /** Transition types a geofence can monitor, mapped to GMS constants. */

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -82,7 +82,7 @@ internal class GeofenceRepositoryImpl(
                 // Freshness window comes from the cached server config; falls back
                 // to STALE_THRESHOLD_MS when no cache exists or the value is
                 // non-positive (defensive against bad config).
-                val threshold = store.getCachedConfig()?.remoteFetchRefreshExpiryMs
+                val threshold = store.getCachedConfig()?.remoteFetchRefreshExpiry
                     ?.takeIf { it > 0 }
                     ?: GeofenceConstants.STALE_THRESHOLD_MS
                 if (clock.currentTimeMillis() - lastSync < threshold) {
@@ -109,16 +109,13 @@ internal class GeofenceRepositoryImpl(
                 return Result.success(Unit)
             }
             val anchor = store.getLastApiFetchLocation()
-            val cachedConfig = store.getCachedConfig()
+            val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
             // Tier B (remote fetch) when:
             // - no anchor yet (first EXIT after install / clearAll / sign-out), OR
             // - we've moved beyond the API threshold from the last fetch.
             // Otherwise Tier A: re-rank the cached regions for the new location.
-            val remoteFetchThreshold = cachedConfig?.remoteFetchRefreshTriggerRadius
-                ?: GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS
             val needsRemoteFetch = anchor == null ||
-                cachedConfig == null ||
-                anchor.distanceTo(latitude, longitude) >= remoteFetchThreshold
+                anchor.distanceTo(latitude, longitude) >= cachedConfig.remoteFetchRefreshTriggerRadius
             return if (needsRemoteFetch) {
                 performRemoteRefresh(userId, latitude, longitude)
             } else {
@@ -148,11 +145,11 @@ internal class GeofenceRepositoryImpl(
             // (older cache / first-ever boot restore).
             val effectiveLocation = store.getLastMovementTriggerLocation()
                 ?: store.getLastApiFetchLocation()
-            val cachedConfig = store.getCachedConfig()
-            if (effectiveLocation == null || cachedConfig == null) {
+            if (effectiveLocation == null) {
                 logger.logSyncSkipped("no cached state to restore")
                 return Result.success(Unit)
             }
+            val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
             // Boot-restore variant — see [GeofenceManager.addGeofencesForBootRestore].
             return performLocalRefresh(
                 userId = userId,
@@ -171,10 +168,14 @@ internal class GeofenceRepositoryImpl(
         userId: String,
         latitude: Double,
         longitude: Double
-    ): Result<Unit> = apiService.fetchGeofences(userId, latitude, longitude).fold(
+    ): Result<Unit> = apiService.fetchGeofences(latitude, longitude).fold(
         onSuccess = { response ->
             val regions = response.toDomainRegions()
-            val config = response.toDomainConfig()
+            // Config preference: server-shipped > last cached > constants.
+            val parsedConfig = response.toDomainConfig()
+            val config = parsedConfig
+                ?: store.getCachedConfig()
+                ?: GeofenceConfig.fallback()
             registerNearestAndPersist(
                 userId = userId,
                 latitude = latitude,
@@ -182,9 +183,11 @@ internal class GeofenceRepositoryImpl(
                 regions = regions,
                 config = config,
                 // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
+                // Skip the config save when backend didn't ship one this response —
+                // a null parse must not clobber a previously cached value.
                 onRegistered = {
                     store.saveCachedRegions(regions)
-                    store.saveCachedConfig(config)
+                    parsedConfig?.let { store.saveCachedConfig(it) }
                     store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
                     store.setLastSyncTimestamp(clock.currentTimeMillis())
                 }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -96,8 +96,8 @@ internal class GeofenceRepositoryImpl(
                     // new user has no geofences until stale-window expiry.
                     val cachedRegions = store.getCachedRegions()
                     val registered = store.getRegisteredIds()
-                    val cachedConfig = store.getCachedConfig()
-                    if (cachedRegions.isNotEmpty() && registered.isEmpty() && cachedConfig != null) {
+                    if (cachedRegions.isNotEmpty() && registered.isEmpty()) {
+                        val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
                         return performLocalRefresh(userId, latitude, longitude, cachedConfig)
                     }
                     logger.logSyncSkippedFresh()

--- a/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiResponse.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiResponse.kt
@@ -6,19 +6,24 @@ import io.customer.location.geofence.GeofenceRegion
 import io.customer.location.geofence.GeofenceTransitionType
 import io.customer.location.geofence.di.geofenceLogger
 import io.customer.sdk.core.di.SDKComponent
-import java.util.concurrent.TimeUnit
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Wire shape of `GET /v1/geofences/nearby`. Backend ships only `geofences`
+ * today; `config` and per-region `transition_types` / `last_updated` are
+ * nullable forward-compat slots the SDK will honor when backend adds them.
+ */
 @Serializable
 internal data class GeofenceApiResponse(
-    val config: GeofenceApiConfig,
+    @SerialName("config")
+    val config: GeofenceApiConfig? = null,
+    @SerialName("geofences")
     val geofences: List<GeofenceApiRegion>
 )
 
-// All config fields are nullable with defaults so the SDK keeps working if the
-// backend rolls out fields gradually or temporarily returns invalid values.
-// Per-field fallbacks are applied in [toDomain].
+// Every field nullable so backend can roll fields out gradually; per-field
+// fallbacks live in [toDomain].
 @Serializable
 internal data class GeofenceApiConfig(
     @SerialName("local_refresh_trigger_radius")
@@ -29,6 +34,7 @@ internal data class GeofenceApiConfig(
     val remoteFetchRefreshExpiryTime: Long? = null,
     @SerialName("duplicate_events_expiry_time")
     val duplicateEventsExpiryTime: Long? = null,
+    @SerialName("android")
     val android: GeofenceApiPlatformConfig? = null
 )
 
@@ -40,57 +46,72 @@ internal data class GeofenceApiPlatformConfig(
 
 @Serializable
 internal data class GeofenceApiRegion(
-    val id: String,
-    val name: String,
+    // Used as the OS request ID and the `geofence_id` key on transition events.
+    @SerialName("id")
+    val id: Int,
+    @SerialName("name")
+    val name: String = "",
+    @SerialName("latitude")
     val latitude: Double,
+    @SerialName("longitude")
     val longitude: Double,
-    val radius: Float,
+    @SerialName("radius")
+    val radius: Int,
+    @SerialName("external_id")
+    val externalId: String? = null,
     @SerialName("transition_types")
-    val transitionTypes: List<String>,
+    val transitionTypes: List<String>? = null,
     @SerialName("last_updated")
-    val lastUpdated: Long
+    val lastUpdated: Long? = null
 )
 
-internal fun GeofenceApiResponse.toDomainConfig(): GeofenceConfig = config.toDomain()
+/** Returns `null` when backend didn't send a `config` block — gates the cache save. */
+internal fun GeofenceApiResponse.toDomainConfig(): GeofenceConfig? =
+    config?.toDomain()
 
 internal fun GeofenceApiResponse.toDomainRegions(): List<GeofenceRegion> =
-    geofences.mapNotNull { it.toDomain() }
+    geofences.map { it.toDomain() }
 
 private fun GeofenceApiConfig.toDomain(): GeofenceConfig = GeofenceConfig(
     localRefreshTriggerRadius = localRefreshTriggerRadius?.takeIf { it > 0 }
         ?: GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
     remoteFetchRefreshTriggerRadius = remoteFetchRefreshTriggerRadius?.takeIf { it > 0 }
         ?: GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
-    remoteFetchRefreshExpiryMs = remoteFetchRefreshExpiryTime?.takeIf { it > 0 }
-        ?.let { TimeUnit.SECONDS.toMillis(it) }
+    remoteFetchRefreshExpiry = remoteFetchRefreshExpiryTime?.takeIf { it > 0 }
         ?: GeofenceConstants.STALE_THRESHOLD_MS,
-    duplicateEventsExpiryMs = duplicateEventsExpiryTime?.takeIf { it > 0 }
-        ?.let { TimeUnit.SECONDS.toMillis(it) }
+    duplicateEventsExpiry = duplicateEventsExpiryTime?.takeIf { it > 0 }
         ?: GeofenceConstants.DEDUPE_COOLDOWN_MS,
-    // Cap at OS per-app geofence limit (100 total slots, minus 1 for the
-    // movement trigger = 99 for business). Zero is a valid value (server-side
-    // kill switch — no business geofences and no movement trigger).
+    // Range is 0..99: zero is a valid server-side kill switch; 99 leaves one
+    // OS slot for the movement trigger. Out-of-range values fall back.
     maxBusinessGeofences = android?.maxBusinessGeofence?.takeIf { it in 0..99 }
         ?: GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
 )
 
-private fun GeofenceApiRegion.toDomain(): GeofenceRegion? {
-    val types = transitionTypes.mapNotNull { value ->
+private fun GeofenceApiRegion.toDomain(): GeofenceRegion = GeofenceRegion(
+    id = id.toString(),
+    name = name,
+    externalId = externalId,
+    latitude = latitude,
+    longitude = longitude,
+    radius = radius.toFloat(),
+    transitionTypes = resolveTransitionTypes(transitionTypes),
+    lastUpdated = lastUpdated ?: 0L
+)
+
+/**
+ * Null / empty / all-unknown values fall back to `[ENTER, EXIT]`; mixed
+ * valid + unknown keeps just the valid subset. Each unknown value is logged.
+ */
+private fun resolveTransitionTypes(raw: List<String>?): List<GeofenceTransitionType> {
+    val defaults = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT)
+    if (raw.isNullOrEmpty()) return defaults
+    val parsed = raw.mapNotNull { value ->
         parseTransitionType(value) ?: run {
             SDKComponent.geofenceLogger.logUnknownApiTransitionType(value)
             null
         }
     }
-    if (types.isEmpty()) return null
-    return GeofenceRegion(
-        id = id,
-        name = name,
-        latitude = latitude,
-        longitude = longitude,
-        radius = radius,
-        transitionTypes = types,
-        lastUpdated = lastUpdated
-    )
+    return parsed.takeIf { it.isNotEmpty() } ?: defaults
 }
 
 private fun parseTransitionType(value: String): GeofenceTransitionType? =

--- a/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiResponse.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiResponse.kt
@@ -48,7 +48,7 @@ internal data class GeofenceApiPlatformConfig(
 internal data class GeofenceApiRegion(
     // Used as the OS request ID and the `geofence_id` key on transition events.
     @SerialName("id")
-    val id: Int,
+    val id: String,
     @SerialName("name")
     val name: String = "",
     @SerialName("latitude")
@@ -88,7 +88,7 @@ private fun GeofenceApiConfig.toDomain(): GeofenceConfig = GeofenceConfig(
 )
 
 private fun GeofenceApiRegion.toDomain(): GeofenceRegion = GeofenceRegion(
-    id = id.toString(),
+    id = id,
     name = name,
     externalId = externalId,
     latitude = latitude,

--- a/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiService.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiService.kt
@@ -2,12 +2,11 @@ package io.customer.location.geofence.api
 
 import io.customer.location.geofence.GeofenceJsonSerializer
 import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpMethod
 import io.customer.sdk.core.network.HttpRequestParams
-import org.json.JSONObject
 
 internal interface GeofenceApiService {
     suspend fun fetchGeofences(
-        userId: String,
         latitude: Double,
         longitude: Double
     ): Result<GeofenceApiResponse>
@@ -19,27 +18,16 @@ internal class GeofenceApiServiceImpl(
 ) : GeofenceApiService {
 
     override suspend fun fetchGeofences(
-        userId: String,
         latitude: Double,
         longitude: Double
     ): Result<GeofenceApiResponse> {
-        // TODO(MBL-1623): delete this guard once ENDPOINT_PATH below is set.
-        if (ENDPOINT_PATH.isBlank()) {
-            return Result.failure(
-                IllegalStateException("Geofence API endpoint not yet available (MBL-1623)")
-            )
-        }
-
-        val body = JSONObject().apply {
-            put("userId", userId)
-            put("latitude", latitude)
-            put("longitude", longitude)
-        }.toString()
-
         val params = HttpRequestParams(
             path = ENDPOINT_PATH,
-            headers = mapOf("Content-Type" to "application/json; charset=utf-8"),
-            body = body
+            method = HttpMethod.GET,
+            queryParams = mapOf(
+                "latitude" to latitude.toString(),
+                "longitude" to longitude.toString()
+            )
         )
 
         return httpClient.request(params).mapCatching { responseBody ->
@@ -48,13 +36,6 @@ internal class GeofenceApiServiceImpl(
     }
 
     private companion object {
-        // TODO(MBL-1623): Backend endpoint for nearby-geofence fetch is not yet
-        //  defined. Empty path => the service short-circuits to Result.failure,
-        //  so no stray network calls to a placeholder URL. Replace with the
-        //  real path once backend exposes it; the request/decode pipeline above
-        //  will start serving live data with no other changes. When wiring
-        //  this, also add service tests: success decode, request body shape,
-        //  HTTP failure propagation, malformed-response failure.
-        const val ENDPOINT_PATH = ""
+        private const val ENDPOINT_PATH = "/geofences/nearby"
     }
 }

--- a/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiService.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/api/GeofenceApiService.kt
@@ -31,7 +31,9 @@ internal class GeofenceApiServiceImpl(
         )
 
         return httpClient.request(params).mapCatching { responseBody ->
-            jsonSerializer.decode(GeofenceApiResponse.serializer(), responseBody)
+            // Lenient at the wire boundary so the SDK doesn't pin a specific
+            // type for `id` — accepts either numeric or quoted-string form.
+            jsonSerializer.decode(GeofenceApiResponse.serializer(), responseBody, lenient = true)
         }
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -77,7 +77,11 @@ internal val AndroidSDKComponent.geofenceCooldownFilter: GeofenceCooldownFilter
 
 internal val AndroidSDKComponent.geofenceRegionStore: GeofenceRegionStore
     get() = singleton<GeofenceRegionStore> {
-        GeofenceRegionStoreImpl(applicationContext, SDKComponent.geofenceJsonSerializer)
+        GeofenceRegionStoreImpl(
+            context = applicationContext,
+            jsonSerializer = SDKComponent.geofenceJsonSerializer,
+            logger = SDKComponent.logger
+        )
     }
 
 internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository

--- a/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
@@ -6,6 +6,8 @@ import io.customer.location.geofence.GeofenceConfig
 import io.customer.location.geofence.GeofenceJsonSerializer
 import io.customer.location.geofence.GeofenceLocation
 import io.customer.location.geofence.GeofenceRegion
+import io.customer.sdk.core.util.Logger
+import io.customer.sdk.data.store.PreferenceCrypto
 import io.customer.sdk.data.store.PreferenceStore
 import io.customer.sdk.data.store.read
 import kotlinx.serialization.KSerializer
@@ -27,6 +29,11 @@ import kotlinx.serialization.builtins.serializer
  *
  * Decoding is schema-drift safe via [GeofenceJsonSerializer]: parse failures wipe the
  * key and return null/empty rather than propagating an exception up the sync path.
+ *
+ * Storage: SharedPreferences. Workspace configuration (geofence IDs, names,
+ * lat/lng, radii, external IDs) is plaintext — UID isolation keeps it
+ * app-private. The two user-location snapshots are encrypted at rest via
+ * [PreferenceCrypto] (AES-256-GCM, Android Keystore) and cleared on sign-out.
  */
 internal interface GeofenceRegionStore {
     fun saveCachedRegions(regions: List<GeofenceRegion>)
@@ -53,12 +60,15 @@ internal interface GeofenceRegionStore {
 
 internal class GeofenceRegionStoreImpl(
     context: Context,
-    private val jsonSerializer: GeofenceJsonSerializer
+    private val jsonSerializer: GeofenceJsonSerializer,
+    logger: Logger
 ) : PreferenceStore(context), GeofenceRegionStore {
 
     override val prefsName: String by lazy {
         "io.customer.sdk.geofence_regions.${context.packageName}"
     }
+
+    private val crypto = PreferenceCrypto(CRYPTO_KEY_ALIAS, logger)
 
     override fun saveCachedRegions(regions: List<GeofenceRegion>) =
         writeJson(KEY_CACHED_REGIONS, REGIONS_SERIALIZER, regions)
@@ -79,16 +89,16 @@ internal class GeofenceRegionStoreImpl(
         readJson(KEY_CACHED_CONFIG, GeofenceConfig.serializer())
 
     override fun saveLastApiFetchLocation(location: GeofenceLocation) =
-        writeJson(KEY_LAST_API_FETCH_LOCATION, GeofenceLocation.serializer(), location)
+        writeEncryptedJson(KEY_LAST_API_FETCH_LOCATION, GeofenceLocation.serializer(), location)
 
     override fun getLastApiFetchLocation(): GeofenceLocation? =
-        readJson(KEY_LAST_API_FETCH_LOCATION, GeofenceLocation.serializer())
+        readEncryptedJson(KEY_LAST_API_FETCH_LOCATION, GeofenceLocation.serializer())
 
     override fun saveLastMovementTriggerLocation(location: GeofenceLocation) =
-        writeJson(KEY_LAST_MOVEMENT_TRIGGER_LOCATION, GeofenceLocation.serializer(), location)
+        writeEncryptedJson(KEY_LAST_MOVEMENT_TRIGGER_LOCATION, GeofenceLocation.serializer(), location)
 
     override fun getLastMovementTriggerLocation(): GeofenceLocation? =
-        readJson(KEY_LAST_MOVEMENT_TRIGGER_LOCATION, GeofenceLocation.serializer())
+        readEncryptedJson(KEY_LAST_MOVEMENT_TRIGGER_LOCATION, GeofenceLocation.serializer())
 
     override fun clearLastMovementTriggerLocation() {
         prefs.edit { remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION) }
@@ -123,6 +133,24 @@ internal class GeofenceRegionStoreImpl(
         }
     }
 
+    private fun <T> writeEncryptedJson(key: String, serializer: KSerializer<T>, value: T) {
+        prefs.edit { putString(key, crypto.encrypt(jsonSerializer.encode(serializer, value))) }
+    }
+
+    /**
+     * Mirrors [readJson] but transparently decrypts via [PreferenceCrypto].
+     * On Keystore failure (unavailable, OEM bug), `decrypt` returns the input
+     * as-is and the JSON parse decides if it's readable — same self-healing
+     * wipe path as [readJson] for unparseable payloads.
+     */
+    private fun <T> readEncryptedJson(key: String, serializer: KSerializer<T>): T? = prefs.read {
+        val raw = getString(key, null) ?: return@read null
+        jsonSerializer.decodeOrNull(serializer, crypto.decrypt(raw)) ?: run {
+            prefs.edit { remove(key) }
+            null
+        }
+    }
+
     private companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"
         const val KEY_REGISTERED_IDS = "registered_ids"
@@ -130,6 +158,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"
         const val KEY_LAST_SYNC = "last_sync_timestamp"
+        const val CRYPTO_KEY_ALIAS = "cio_geofence_location_key"
         val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
         val ID_SET_SERIALIZER = SetSerializer(String.serializer())
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/GeofenceRegionStore.kt
@@ -168,9 +168,9 @@ internal class GeofenceRegionStoreImpl(
      * as-is and the JSON parse decides if it's readable — same self-healing
      * wipe path as [readJson] for unparseable payloads.
      */
-    private fun <T> readEncryptedJson(key: String, serializer: KSerializer<T>): T? = prefs.read {
-        val raw = getString(key, null) ?: return@read null
-        jsonSerializer.decodeOrNull(serializer, crypto.decrypt(raw)) ?: run {
+    private fun <T> readEncryptedJson(key: String, serializer: KSerializer<T>): T? {
+        val raw = prefs.read { getString(key, null) } ?: return null
+        return jsonSerializer.decodeOrNull(serializer, crypto.decrypt(raw)) ?: run {
             prefs.edit { remove(key) }
             null
         }

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -93,21 +93,23 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenFreshCacheAndOsRegsWipedButNullCachedConfig_expectSkip() = runTest {
-        // Defensive branch: if `cachedConfig` is null (can't happen on this
-        // branch but possible once backend stops shipping `config`), we can't
-        // drive a local re-register. Skip rather than crash.
+    fun refresh_givenFreshCacheAndOsRegsWipedButNullCachedConfig_expectLocalRefreshWithFallback() = runTest {
+        // Backend may not ship `config` yet — null cachedConfig must NOT skip
+        // re-registration, otherwise the new user has no geofences until the
+        // stale window expires. Falls back to default thresholds.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
-        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns null
+        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
-        verify { logger.logSyncSkippedFresh() }
+        coVerify { manager.replaceGeofences(any()) }
     }
 
     @Test
@@ -968,8 +970,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
               "config": {
                 "local_refresh_trigger_radius": $localRefreshTriggerRadius,
                 "remote_fetch_refresh_trigger_radius": 5000,
-                "remote_fetch_refresh_expiry_time": 86400,
-                "duplicate_events_expiry_time": 3600,
+                "remote_fetch_refresh_expiry_time": 86400000,
+                "duplicate_events_expiry_time": 3600000,
                 "android": { "max_business_geofence": $maxBusinessGeofences }
               },
               "geofences": [

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -701,22 +701,23 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun handleMovement_givenNoCachedConfig_expectRemoteFetch() = runTest {
-        // Defensive: anchor without cached config shouldn't happen in practice
-        // (both are written together), but if it does, fall back to remote fetch
-        // rather than guessing thresholds.
+    fun handleMovement_givenNoCachedConfig_expectTierAUsingFallbackThreshold() = runTest {
+        // Null cached config falls back to defaults — anchor within the
+        // fallback 5km radius still routes to Tier A (local re-rank), not B.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
         every { store.getCachedConfig() } returns null
+        every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
 
-        repository.handleMovement(latitude = 0.0, longitude = 0.0)
+        // ~111m from anchor — well within the fallback 5km threshold.
+        repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify { manager.replaceGeofences(any()) }
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -47,6 +47,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Default: mirror real time so tests using relative timestamps work
         // without churn. Override for deterministic timing.
         every { clock.currentTimeMillis() } answers { System.currentTimeMillis() }
+        // Default cached config so individual tests only wire this up when
+        // they want to vary the knobs.
+        every { store.getCachedConfig() } returns sampleConfig()
         repository = GeofenceRepositoryImpl(
             apiService = apiService,
             store = store,
@@ -67,7 +70,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -78,46 +81,46 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns
             System.currentTimeMillis() - GeofenceConstants.STALE_THRESHOLD_MS - 1_000L
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
     fun refresh_givenCachedConfigWithLongerExpiry_expectSkipWhenWithinIt() = runTest {
-        // Cached config's `remoteFetchRefreshExpiryMs` overrides the constant.
+        // Cached config's `remoteFetchRefreshExpiry` overrides the constant.
         // With expiry=72h and lastSync=25h ago we skip, whereas the 24h
         // constant alone would have triggered a fresh API call.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns
             System.currentTimeMillis() - (25 * 60 * 60 * 1_000L)
         every { store.getCachedConfig() } returns
-            sampleConfig(remoteFetchRefreshExpiryMs = 72 * 60 * 60 * 1_000L)
+            sampleConfig(remoteFetchRefreshExpiry = 72 * 60 * 60 * 1_000L)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
 
     @Test
     fun refresh_givenCachedConfigWithNonPositiveExpiry_expectFallbackToConstant() = runTest {
-        // Defense: a 0 or negative `remoteFetchRefreshExpiryMs` (bad server config)
+        // Defense: a 0 or negative `remoteFetchRefreshExpiry` (bad server config)
         // must NOT short-circuit the freshness check — falls back to the constant.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
-        every { store.getCachedConfig() } returns sampleConfig(remoteFetchRefreshExpiryMs = 0L)
+        every { store.getCachedConfig() } returns sampleConfig(remoteFetchRefreshExpiry = 0L)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -129,16 +132,16 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns
             System.currentTimeMillis() - (2 * 60 * 60 * 1_000L)
         every { store.getCachedConfig() } returns
-            sampleConfig(remoteFetchRefreshExpiryMs = 60 * 60 * 1_000L)
+            sampleConfig(remoteFetchRefreshExpiry = 60 * 60 * 1_000L)
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -147,14 +150,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -164,7 +167,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.addGeofences(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify { logger.logSyncSkipped(match { it.contains("no identified user") }) }
@@ -177,14 +180,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
     fun refresh_givenApiFailure_expectFailurePropagatedAndNoPersistOrRegister() = runTest {
         val error = IOException("network down")
         every { secureUserStore.getUserId() } returns "user-42"
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns Result.failure(error)
+        coEvery { apiService.fetchGeofences(any(), any()) } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -202,8 +205,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // restore reads it later as the effective coordinates.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
@@ -221,8 +224,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so any previously-stored location is stale and must be cleared.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
@@ -238,8 +241,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // last-known good movement location intact (next refresh retries).
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.failure(RuntimeException("boom"))
@@ -253,9 +256,10 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenBusinessGeofences_expectMovementTriggerPrependedAndRegistered() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig(localRefreshTriggerRadius = 1500f)
         val filtered = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { apiService.fetchGeofences("user-42", 12.34, 56.78) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        coEvery { apiService.fetchGeofences(12.34, 56.78) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns filtered
         val captured = slot<List<GeofenceRegion>>()
         coEvery { manager.addGeofences(capture(captured)) } returns Result.success(Unit)
@@ -283,28 +287,53 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenSuccess_expectCacheAndConfigAndAnchorPersisted() = runTest {
+    fun refresh_givenSuccess_expectCacheAndAnchorPersistedAndConfigNotResaved() = runTest {
+        // Backend's `GET /v1/geofences/nearby` doesn't return a config block, so
+        // a successful refresh persists the full region cache + anchor + sync
+        // timestamp but does NOT overwrite `saveCachedConfig` (we keep whatever
+        // the store already had, if anything).
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences("user-42", 12.34, 56.78) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        coEvery { apiService.fetchGeofences(12.34, 56.78) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
         val regionsSlot = slot<List<GeofenceRegion>>()
-        val configSlot = slot<GeofenceConfig>()
         val anchorSlot = slot<GeofenceLocation>()
         every { store.saveCachedRegions(capture(regionsSlot)) } returns Unit
-        every { store.saveCachedConfig(capture(configSlot)) } returns Unit
         every { store.saveLastApiFetchLocation(capture(anchorSlot)) } returns Unit
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
         // Cache stores the FULL backend response (from sampleResponse), not the
         // distance-filter output — the tier-A re-rank needs the unfiltered set.
-        regionsSlot.captured.map { it.id } shouldBeEqualTo listOf("g-1")
-        configSlot.captured.localRefreshTriggerRadius shouldBeEqualTo 1500f
+        // ID comes from the numeric backend `id`, not `external_id`.
+        regionsSlot.captured.map { it.id } shouldBeEqualTo listOf("1")
         anchorSlot.captured shouldBeEqualTo GeofenceLocation(latitude = 12.34, longitude = 56.78)
+        verify(exactly = 0) { store.saveCachedConfig(any()) }
+    }
+
+    @Test
+    fun refresh_givenResponseWithConfig_expectConfigSavedAndUsed() = runTest {
+        // When backend ships a config block, the parsed config takes precedence
+        // over the cached one AND is persisted to the store. Pins the
+        // forward-compat path that auto-activates once backend rolls out config.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponseWithConfig(maxBusinessGeofences = 7))
+        every { distanceFilter.nearest(any(), any(), any(), 7) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
+        val configSlot = slot<GeofenceConfig>()
+        every { store.saveCachedConfig(capture(configSlot)) } returns Unit
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Parsed config (max = 7) wins over the cached default (max = 3).
+        verify { distanceFilter.nearest(any(), any(), any(), 7) }
+        configSlot.captured.maxBusinessGeofences shouldBeEqualTo 7
     }
 
     @Test
@@ -313,8 +342,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // anchor stale so the next refresh retries instead of skipping as "fresh".
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.failure(RuntimeException("boom"))
@@ -343,8 +372,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceRegion("biz-shared", 0.0, 0.0, 100f),
             GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         )
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns newBusiness
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
@@ -365,8 +394,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenNoPreviousRegistration_expectNoRemoveCall() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
@@ -385,8 +414,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(newRegion)
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns
@@ -416,8 +445,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceConstants.MOVEMENT_TRIGGER_ID,
             "biz-old"
         )
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
@@ -435,8 +464,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // no movement trigger registered, no OS-side geofence activity.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         val captured = slot<List<GeofenceRegion>>()
         coEvery { manager.addGeofences(capture(captured)) } returns Result.success(Unit)
@@ -458,8 +487,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val error = RuntimeException("gms boom")
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-new", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.failure(error)
@@ -481,8 +510,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // a second OS registration.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
 
         val addGeofencesActive = AtomicInteger(0)
@@ -501,7 +530,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkipped(match { it.contains("refresh already in progress") }) }
     }
 
@@ -511,9 +540,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so a follow-up refresh isn't permanently locked out.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returnsMany listOf(
+        coEvery { apiService.fetchGeofences(any(), any()) } returnsMany listOf(
             Result.failure(IOException("first call fails")),
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+            Result.success(sampleResponse())
         )
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
@@ -523,7 +552,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         first.isFailure shouldBeEqualTo true
         second.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 2) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 2) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -532,8 +561,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // the userId recheck inside the state lock prevents writing the previous
         // user's geofences after a sign-out cleared state.
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", "user-B")
-        coEvery { apiService.fetchGeofences("user-A", any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -547,8 +576,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
     @Test
     fun refresh_givenUserSignsOutDuringApiCall_expectNoWriteToStoreOrManager() = runTest {
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", null)
-        coEvery { apiService.fetchGeofences("user-A", any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -612,7 +641,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.handleMovement(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.addGeofences(any()) }
     }
 
@@ -624,33 +653,34 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastApiFetchLocation() } returns null
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 1.0, longitude = 2.0)
 
-        coVerify { apiService.fetchGeofences("user-42", 1.0, 2.0) }
+        coVerify { apiService.fetchGeofences(1.0, 2.0) }
     }
 
     @Test
-    fun handleMovement_givenNoCachedConfig_expectRemoteFetch() = runTest {
-        // Defensive: anchor without cached config shouldn't happen in practice
-        // (both are written together), but if it does, fall back to remote fetch
-        // rather than guessing thresholds.
+    fun handleMovement_givenNoCachedConfig_expectTierAUsingFallbackThreshold() = runTest {
+        // Null cached config falls back to constants — anchor within the
+        // fallback 5km radius still routes to Tier A (local re-rank), not B.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
         every { store.getCachedConfig() } returns null
+        every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
-        repository.handleMovement(latitude = 0.0, longitude = 0.0)
+        // ~111m from anchor — well within the fallback 5km threshold.
+        repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify { manager.addGeofences(any()) }
     }
 
     @Test
@@ -672,7 +702,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.addGeofences(any()) }
         verify { distanceFilter.nearest(cached, 0.0, 0.001, any()) }
     }
@@ -685,26 +715,27 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.1)
 
-        coVerify { apiService.fetchGeofences("user-42", 0.0, 0.1) }
+        coVerify { apiService.fetchGeofences(0.0, 0.1) }
     }
 
     @Test
     fun handleMovement_givenAnchorBeyondThreshold_expectCacheAndAnchorPersisted() = runTest {
         // Tier B via handleMovement must wire through to the same persist path
-        // refresh() uses — new anchor is the current location, cache + config + timestamp written.
+        // refresh() uses — new anchor is the current location, cache + timestamp
+        // written. Config is NOT resaved because backend doesn't ship one.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse())
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
@@ -714,7 +745,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.handleMovement(latitude = 0.0, longitude = 0.1)
 
         verify { store.saveCachedRegions(any()) }
-        verify { store.saveCachedConfig(any()) }
+        verify(exactly = 0) { store.saveCachedConfig(any()) }
         verify { store.setLastSyncTimestamp(any()) }
         anchorSlot.captured shouldBeEqualTo GeofenceLocation(0.0, 0.1)
     }
@@ -750,12 +781,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         val concurrentApiCalls = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
-        coEvery { apiService.fetchGeofences(any(), any(), any()) } coAnswers {
+        coEvery { apiService.fetchGeofences(any(), any()) } coAnswers {
             val n = concurrentApiCalls.incrementAndGet()
             maxObservedConcurrency.updateAndGet { current -> maxOf(current, n) }
             delay(50)
             concurrentApiCalls.decrementAndGet()
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
+            Result.success(sampleResponse())
         }
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.addGeofences(any()) } returns Result.success(Unit)
@@ -766,7 +797,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
     }
 
     // ---------- restoreFromCache (boot path) ----------
@@ -796,15 +827,23 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun restoreFromCache_givenNoCachedConfig_expectSkip() = runTest {
+    fun restoreFromCache_givenNoCachedConfig_expectFallbackConfigUsed() = runTest {
+        // Null cached config must NOT skip restore — otherwise every reboot
+        // would leave the device with no OS registrations until the next EXIT.
+        val movementLoc = GeofenceLocation(latitude = 1.0, longitude = 2.0)
         every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(1.0, 2.0)
+        every { store.getLastMovementTriggerLocation() } returns movementLoc
         every { store.getCachedConfig() } returns null
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 1.0, 2.0, 100f))
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 1.0, 2.0, 100f))
+        coEvery { manager.addGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         val result = repository.restoreFromCache()
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.addGeofencesForBootRestore(any()) }
+        coVerify { manager.addGeofencesForBootRestore(any()) }
     }
 
     @Test
@@ -830,7 +869,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Pins the boot-restore manager variant, not the normal one.
         coVerify { manager.addGeofencesForBootRestore(any()) }
         coVerify(exactly = 0) { manager.addGeofences(any()) }
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -875,30 +914,38 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     private fun sampleConfig(
-        remoteFetchRefreshExpiryMs: Long = 86_400_000L
+        remoteFetchRefreshExpiry: Long = 86_400_000L,
+        maxBusinessGeofences: Int = 3,
+        localRefreshTriggerRadius: Float = 1_000f
     ): GeofenceConfig = GeofenceConfig(
-        localRefreshTriggerRadius = 1_000f,
+        localRefreshTriggerRadius = localRefreshTriggerRadius,
         remoteFetchRefreshTriggerRadius = 5_000f,
-        remoteFetchRefreshExpiryMs = remoteFetchRefreshExpiryMs,
-        duplicateEventsExpiryMs = 3_600_000L,
-        maxBusinessGeofences = 19
+        remoteFetchRefreshExpiry = remoteFetchRefreshExpiry,
+        duplicateEventsExpiry = 3_600_000L,
+        maxBusinessGeofences = maxBusinessGeofences
     )
 
-    private fun sampleResponse(
-        maxBusinessGeofences: Int,
-        localRefreshTriggerRadius: Float = 1000f
-    ): GeofenceApiResponse {
+    // Backend ships only `geofences` today; config knobs come from the
+    // cached config mock (default wired in [setup]).
+    private fun sampleResponse(): GeofenceApiResponse {
         val json = """
             {
-              "config": {
-                "local_refresh_trigger_radius": $localRefreshTriggerRadius,
-                "remote_fetch_refresh_trigger_radius": 5000,
-                "remote_fetch_refresh_expiry_time": 86400,
-                "duplicate_events_expiry_time": 3600,
-                "android": { "max_business_geofence": $maxBusinessGeofences }
-              },
               "geofences": [
-                { "id": "g-1", "name": "n1", "latitude": 0.0, "longitude": 0.0, "radius": 100, "transition_types": ["enter"], "last_updated": 1 }
+                { "id": 1, "name": "n1", "latitude": 0.0, "longitude": 0.0, "radius": 100, "external_id": "g-1" }
+              ]
+            }
+        """.trimIndent()
+        return jsonSerializer.decode(GeofenceApiResponse.serializer(), json)
+    }
+
+    // Forward-compat helper: response WITH a config block, for tests that
+    // exercise the parsed-config > cached-config preference + save path.
+    private fun sampleResponseWithConfig(maxBusinessGeofences: Int): GeofenceApiResponse {
+        val json = """
+            {
+              "config": { "android": { "max_business_geofence": $maxBusinessGeofences } },
+              "geofences": [
+                { "id": 1, "name": "n1", "latitude": 0.0, "longitude": 0.0, "radius": 100 }
               ]
             }
         """.trimIndent()

--- a/location/src/test/java/io/customer/location/geofence/api/GeofenceApiResponseTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/api/GeofenceApiResponseTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,26 +35,21 @@ class GeofenceApiResponseTest : RobolectricTest() {
         )
     }
 
+    // ---------- region shape ----------
+
     @Test
-    fun parseAndMap_givenFullSampleResponse_expectDomainValues() {
-        val (config, regions) = parseAndMap(
+    fun parseAndMap_givenFullSampleRegion_expectDomainValues() {
+        val regions = parseRegions(
             """
             {
-              "config": {
-                "local_refresh_trigger_radius": 1000,
-                "remote_fetch_refresh_trigger_radius": 5000,
-                "remote_fetch_refresh_expiry_time": 86400,
-                "duplicate_events_expiry_time": 3600,
-                "android": { "max_business_geofence": 19 },
-                "ios": { "max_business_geofence": 7 }
-              },
               "geofences": [
                 {
-                  "id": "id-123",
-                  "name": "name-123",
-                  "latitude": 12.34,
-                  "longitude": 56.78,
-                  "radius": 1000,
+                  "id": 42,
+                  "name": "NYC Store",
+                  "latitude": 40.7128,
+                  "longitude": -74.0060,
+                  "radius": 500,
+                  "external_id": "ext-abc",
                   "transition_types": ["enter", "exit"],
                   "last_updated": 1778760000
                 }
@@ -62,78 +58,202 @@ class GeofenceApiResponseTest : RobolectricTest() {
             """.trimIndent()
         )
 
-        config shouldBeEqualTo GeofenceConfig(
-            localRefreshTriggerRadius = 1000f,
-            remoteFetchRefreshTriggerRadius = 5000f,
-            remoteFetchRefreshExpiryMs = 86_400_000L,
-            duplicateEventsExpiryMs = 3_600_000L,
-            maxBusinessGeofences = 19
-        )
-
         regions.size shouldBeEqualTo 1
         regions[0] shouldBeEqualTo GeofenceRegion(
-            id = "id-123",
-            name = "name-123",
-            latitude = 12.34,
-            longitude = 56.78,
-            radius = 1000f,
+            id = "42",
+            name = "NYC Store",
+            latitude = 40.7128,
+            longitude = -74.0060,
+            radius = 500f,
+            externalId = "ext-abc",
             transitionTypes = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT),
             lastUpdated = 1_778_760_000L
         )
     }
 
     @Test
+    fun parseAndMap_givenMinimalRegion_expectDefaultsForOptionalFields() {
+        // Only required fields present; nullable / defaulted fields use SDK defaults.
+        val regions = parseRegions(
+            """
+            { "geofences": [ { "id": 9, "latitude": 1.0, "longitude": 2.0, "radius": 100 } ] }
+            """.trimIndent()
+        )
+
+        regions[0].id shouldBeEqualTo "9"
+        regions[0].name shouldBeEqualTo ""
+        regions[0].externalId.shouldBeNull()
+        regions[0].lastUpdated shouldBeEqualTo 0L
+        regions[0].transitionTypes shouldContainSame listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+    }
+
+    @Test
+    fun parseAndMap_givenEmptyGeofenceList_expectEmpty() {
+        parseRegions("""{ "geofences": [] }""").shouldBeEmpty()
+    }
+
+    @Test
     fun parseAndMap_givenUnknownTopLevelField_expectIgnoredAndParses() {
-        // Validates Json { ignoreUnknownKeys = true } — if a future backend adds new fields
-        // we keep decoding rather than throwing.
-        val (config, regions) = parseAndMap(
+        // Forward-compat: future top-level additions don't break decoding.
+        val regions = parseRegions(
             """
             {
               "version": "2",
+              "future_field": { "anything": 42 },
+              "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100 } ]
+            }
+            """.trimIndent()
+        )
+
+        regions.size shouldBeEqualTo 1
+    }
+
+    // ---------- external_id nullability ----------
+
+    @Test
+    fun parseAndMap_givenExplicitNullExternalId_expectNull() {
+        val regions = parseRegions(
+            """
+            { "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100, "external_id": null } ] }
+            """.trimIndent()
+        )
+
+        regions[0].externalId.shouldBeNull()
+    }
+
+    @Test
+    fun parseAndMap_givenEmptyExternalId_expectPreserved() {
+        // Empty string is preserved separately from null — "explicitly empty"
+        // is distinct from "never set."
+        val regions = parseRegions(
+            """
+            { "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100, "external_id": "" } ] }
+            """.trimIndent()
+        )
+
+        regions[0].externalId shouldBeEqualTo ""
+    }
+
+    // ---------- transition_types fallback rules ----------
+
+    @Test
+    fun parseAndMap_givenTransitionTypesEnterOnly_expectEnter() {
+        val regions = parseRegions(regionJsonWith(transitionTypes = """["enter"]"""))
+        regions[0].transitionTypes shouldContainSame listOf(GeofenceTransitionType.ENTER)
+    }
+
+    @Test
+    fun parseAndMap_givenTransitionTypesEmpty_expectDefault() {
+        val regions = parseRegions(regionJsonWith(transitionTypes = "[]"))
+        regions[0].transitionTypes shouldContainSame listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+    }
+
+    @Test
+    fun parseAndMap_givenAllUnknownTransitionTypes_expectDefaultAndAllLogged() {
+        // `[dwell]` → all unknown → fall back to [ENTER, EXIT], log each unknown.
+        val regions = parseRegions(regionJsonWith(transitionTypes = """["dwell"]"""))
+
+        regions[0].transitionTypes shouldContainSame listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+        verify { mockLogger.logUnknownApiTransitionType("dwell") }
+    }
+
+    @Test
+    fun parseAndMap_givenMixedValidAndUnknownTransitionTypes_expectOnlyValidKept() {
+        // `[enter, dwell]` → keep ENTER, drop "dwell", log it.
+        val regions = parseRegions(regionJsonWith(transitionTypes = """["enter", "dwell"]"""))
+
+        regions[0].transitionTypes shouldContainSame listOf(GeofenceTransitionType.ENTER)
+        verify { mockLogger.logUnknownApiTransitionType("dwell") }
+    }
+
+    @Test
+    fun parseAndMap_givenTransitionTypesCaseInsensitive_expectParsed() {
+        val regions = parseRegions(regionJsonWith(transitionTypes = """["ENTER", "Exit"]"""))
+        regions[0].transitionTypes shouldContainSame listOf(
+            GeofenceTransitionType.ENTER,
+            GeofenceTransitionType.EXIT
+        )
+    }
+
+    @Test
+    fun parseAndMap_givenOnlyValidTransitionTypes_expectNoUnknownLogged() {
+        // Inverse of the unknown-log test: no spurious logs on the happy path.
+        parseRegions(regionJsonWith(transitionTypes = """["enter", "exit"]"""))
+        verify(exactly = 0) { mockLogger.logUnknownApiTransitionType(any()) }
+    }
+
+    // ---------- last_updated ----------
+
+    @Test
+    fun parseAndMap_givenLastUpdatedNull_expectZero() {
+        val regions = parseRegions(
+            """
+            { "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100, "last_updated": null } ] }
+            """.trimIndent()
+        )
+
+        regions[0].lastUpdated shouldBeEqualTo 0L
+    }
+
+    // ---------- config block (nullable, field-level fallbacks) ----------
+
+    @Test
+    fun toDomainConfig_givenNoConfigBlock_expectNull() {
+        // When backend doesn't ship a config block, the SDK keeps using the
+        // last cached value (or constants). `null` is the signal that drives
+        // the cache-save gating in the repository.
+        val response = parseResponse("""{ "geofences": [] }""")
+        response.toDomainConfig().shouldBeNull()
+    }
+
+    @Test
+    fun toDomainConfig_givenFullConfig_expectDomainValues() {
+        val response = parseResponse(
+            """
+            {
               "config": {
-                "local_refresh_trigger_radius": 1000,
-                "remote_fetch_refresh_trigger_radius": 5000,
-                "remote_fetch_refresh_expiry_time": 86400,
-                "duplicate_events_expiry_time": 3600,
-                "android": { "max_business_geofence": 19 }
+                "local_refresh_trigger_radius": 1500,
+                "remote_fetch_refresh_trigger_radius": 7500,
+                "remote_fetch_refresh_expiry_time": 86400000,
+                "duplicate_events_expiry_time": 3600000,
+                "android": { "max_business_geofence": 25 }
               },
               "geofences": []
             }
             """.trimIndent()
         )
 
-        config.localRefreshTriggerRadius shouldBeEqualTo 1000f
-        regions.shouldBeEmpty()
-    }
-
-    @Test
-    fun parseAndMap_givenConfigFieldsMissing_expectAllFallbacksApplied() {
-        // Backend rollout safety: any/all config fields can be absent and the SDK
-        // must keep working with SDK-level defaults.
-        val (config, _) = parseAndMap(
-            """
-            {
-              "config": {},
-              "geofences": []
-            }
-            """.trimIndent()
-        )
-
-        config shouldBeEqualTo GeofenceConfig(
-            localRefreshTriggerRadius = GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
-            remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
-            remoteFetchRefreshExpiryMs = GeofenceConstants.STALE_THRESHOLD_MS,
-            duplicateEventsExpiryMs = GeofenceConstants.DEDUPE_COOLDOWN_MS,
-            maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+        response.toDomainConfig() shouldBeEqualTo GeofenceConfig(
+            localRefreshTriggerRadius = 1500f,
+            remoteFetchRefreshTriggerRadius = 7500f,
+            remoteFetchRefreshExpiry = 86_400_000L,
+            duplicateEventsExpiry = 3_600_000L,
+            maxBusinessGeofences = 25
         )
     }
 
     @Test
-    fun parseAndMap_givenConfigFieldsZeroOrNegative_expectAllFallbacksApplied() {
-        // Radii / expiry fields: zero or negative are bogus and fall back via
-        // `takeIf { it > 0 }`. `maxBusinessGeofence` has different semantics
-        // (zero is a valid kill switch) — covered in a dedicated test below.
-        val (config, _) = parseAndMap(
+    fun toDomainConfig_givenAllFieldsMissing_expectAllFallbacks() {
+        // Empty config object — every field-level fallback fires.
+        val response = parseResponse("""{ "config": {}, "geofences": [] }""")
+
+        response.toDomainConfig() shouldBeEqualTo fallbackConfig()
+    }
+
+    @Test
+    fun toDomainConfig_givenZeroOrNegativeNumericFields_expectFallbacks() {
+        // Radii / expiry fields: `takeIf { it > 0 }` rejects 0 and negative.
+        // `max_business_geofence = 0` is a valid kill switch (covered separately).
+        val response = parseResponse(
             """
             {
               "config": {
@@ -148,107 +268,65 @@ class GeofenceApiResponseTest : RobolectricTest() {
             """.trimIndent()
         )
 
-        config shouldBeEqualTo GeofenceConfig(
-            localRefreshTriggerRadius = GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
-            remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
-            remoteFetchRefreshExpiryMs = GeofenceConstants.STALE_THRESHOLD_MS,
-            duplicateEventsExpiryMs = GeofenceConstants.DEDUPE_COOLDOWN_MS,
-            maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
-        )
+        response.toDomainConfig() shouldBeEqualTo fallbackConfig()
     }
 
     @Test
-    fun parseAndMap_givenMaxBusinessGeofenceZero_expectRespected() {
-        // Zero is a valid server-side kill switch: "register no business
-        // geofences for this user." Distinct from missing / out-of-range
-        // (which fall back to the SDK default).
-        val (config, _) = parseAndMap(geofencesJsonWithMax(0))
-        config.maxBusinessGeofences shouldBeEqualTo 0
+    fun toDomainConfig_givenMaxBusinessGeofenceZero_expectRespected() {
+        // Zero is a valid server-side kill switch — "register no business
+        // geofences." Distinct from missing / out-of-range (which fall back).
+        val response = parseResponse(configJsonWithMax(0))
+        response.toDomainConfig()?.maxBusinessGeofences shouldBeEqualTo 0
     }
 
     @Test
-    fun parseAndMap_givenMaxBusinessGeofenceAtOrAboveOsLimit_expectFallback() {
-        // OS hard-caps at 100 geofences per app (movement trigger + business).
-        // Business cap of 100 would push total to 101 and the OS rejects it.
+    fun toDomainConfig_givenMaxBusinessGeofenceAtOrAboveOsLimit_expectFallback() {
+        // OS hard-caps at 100 geofences per app (movement trigger + business);
+        // business cap of 100 would push the total to 101 and the OS rejects.
         // 99 is the highest accepted value.
-        val (atLimit, _) = parseAndMap(geofencesJsonWithMax(100))
-        val (above, _) = parseAndMap(geofencesJsonWithMax(500))
+        val atLimit = parseResponse(configJsonWithMax(100)).toDomainConfig()
+        val above = parseResponse(configJsonWithMax(500)).toDomainConfig()
 
-        atLimit.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
-        above.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+        atLimit?.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+        above?.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
     }
 
-    private fun geofencesJsonWithMax(max: Int): String = """
+    // ---------- helpers ----------
+
+    private val jsonSerializer = GeofenceJsonSerializer()
+
+    private fun parseResponse(raw: String): GeofenceApiResponse =
+        jsonSerializer.decode(GeofenceApiResponse.serializer(), raw)
+
+    private fun parseRegions(raw: String): List<GeofenceRegion> =
+        parseResponse(raw).toDomainRegions()
+
+    private fun regionJsonWith(transitionTypes: String): String = """
         {
-          "config": {
-            "local_refresh_trigger_radius": 1000,
-            "remote_fetch_refresh_trigger_radius": 5000,
-            "remote_fetch_refresh_expiry_time": 86400,
-            "duplicate_events_expiry_time": 3600,
-            "android": { "max_business_geofence": $max }
-          },
+          "geofences": [
+            {
+              "id": 1,
+              "latitude": 0.0,
+              "longitude": 0.0,
+              "radius": 100,
+              "transition_types": $transitionTypes
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private fun configJsonWithMax(max: Int): String = """
+        {
+          "config": { "android": { "max_business_geofence": $max } },
           "geofences": []
         }
     """.trimIndent()
 
-    @Test
-    fun parseAndMap_givenMixedValidAndInvalidTransitionTypes_expectOnlyValidKeptAndUnknownsLogged() {
-        val (_, regions) = parseAndMap(geofencesJsonWith(transitionTypes = listOf("enter", "dwell", "unknown")))
-
-        regions.size shouldBeEqualTo 1
-        regions[0].transitionTypes shouldContainSame listOf(GeofenceTransitionType.ENTER)
-        // Each unknown string surfaces as a distinct log so a misconfigured backend
-        // (or SDK-vs-backend version drift) doesn't fail silently.
-        verify { mockLogger.logUnknownApiTransitionType("dwell") }
-        verify { mockLogger.logUnknownApiTransitionType("unknown") }
-    }
-
-    @Test
-    fun parseAndMap_givenAllInvalidTransitionTypes_expectRegionSkippedAndAllLogged() {
-        val (_, regions) = parseAndMap(geofencesJsonWith(transitionTypes = listOf("dwell")))
-
-        regions.shouldBeEmpty()
-        verify { mockLogger.logUnknownApiTransitionType("dwell") }
-    }
-
-    @Test
-    fun parseAndMap_givenOnlyValidTransitionTypes_expectNoUnknownLogged() {
-        // Pins the inverse: no spurious "unknown" logs on the happy path.
-        parseAndMap(geofencesJsonWith(transitionTypes = listOf("enter", "exit")))
-
-        verify(exactly = 0) { mockLogger.logUnknownApiTransitionType(any()) }
-    }
-
-    private val jsonSerializer = GeofenceJsonSerializer()
-
-    private fun parseAndMap(raw: String): Pair<GeofenceConfig, List<GeofenceRegion>> {
-        val response = jsonSerializer.decode(GeofenceApiResponse.serializer(), raw)
-        return response.toDomainConfig() to response.toDomainRegions()
-    }
-
-    private fun geofencesJsonWith(transitionTypes: List<String>): String {
-        val typesJson = transitionTypes.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
-        return """
-            {
-              "config": {
-                "local_refresh_trigger_radius": 1000,
-                "remote_fetch_refresh_trigger_radius": 5000,
-                "remote_fetch_refresh_expiry_time": 86400,
-                "duplicate_events_expiry_time": 3600,
-                "android": { "max_business_geofence": 19 }
-              },
-              "geofences": [
-                {
-                  "id": "biz-1",
-                  "name": "name",
-                  "latitude": 0.0,
-                  "longitude": 0.0,
-                  "radius": 100,
-                  "transition_types": $typesJson,
-                  "last_updated": 0
-                }
-              ]
-            }
-        """.trimIndent()
-    }
+    private fun fallbackConfig(): GeofenceConfig = GeofenceConfig(
+        localRefreshTriggerRadius = GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
+        remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
+        remoteFetchRefreshExpiry = GeofenceConstants.STALE_THRESHOLD_MS,
+        duplicateEventsExpiry = GeofenceConstants.DEDUPE_COOLDOWN_MS,
+        maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+    )
 }

--- a/location/src/test/java/io/customer/location/geofence/api/GeofenceApiResponseTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/api/GeofenceApiResponseTest.kt
@@ -96,6 +96,17 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parseAndMap_givenQuotedStringId_expectDecodedAsString() {
+        // Forward-compat: if backend ever ships ids as opaque strings (UUIDs etc.),
+        // the SDK consumes them unchanged.
+        val regions = parseRegions(
+            """{ "geofences": [ { "id": "abc-123", "latitude": 0.0, "longitude": 0.0, "radius": 100 } ] }"""
+        )
+
+        regions[0].id shouldBeEqualTo "abc-123"
+    }
+
+    @Test
     fun parseAndMap_givenUnknownTopLevelField_expectIgnoredAndParses() {
         // Forward-compat: future top-level additions don't break decoding.
         val regions = parseRegions(
@@ -295,8 +306,10 @@ class GeofenceApiResponseTest : RobolectricTest() {
 
     private val jsonSerializer = GeofenceJsonSerializer()
 
+    // Mirrors GeofenceApiServiceImpl's call site so tests exercise the same
+    // decode path (lenient at the wire boundary).
     private fun parseResponse(raw: String): GeofenceApiResponse =
-        jsonSerializer.decode(GeofenceApiResponse.serializer(), raw)
+        jsonSerializer.decode(GeofenceApiResponse.serializer(), raw, lenient = true)
 
     private fun parseRegions(raw: String): List<GeofenceRegion> =
         parseResponse(raw).toDomainRegions()

--- a/location/src/test/java/io/customer/location/geofence/store/GeofenceCooldownStoreTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/GeofenceCooldownStoreTest.kt
@@ -58,6 +58,17 @@ class GeofenceCooldownStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun recordEmit_givenNewStoreInstance_expectValuePersisted() {
+        // Cooldown state must survive across SDK / process restarts — otherwise a
+        // re-launch could fire a duplicate event still within the suppression window.
+        store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 1_234L)
+
+        val newInstance = GeofenceCooldownStoreImpl(applicationMock)
+
+        newInstance.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo 1_234L
+    }
+
+    @Test
     fun clearAll_expectAllValuesRemoved() {
         store.recordEmit("biz-1", Event.GeofenceTransition.ENTER, 100L)
         store.recordEmit("biz-2", Event.GeofenceTransition.EXIT, 200L)

--- a/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/GeofenceRegionStoreTest.kt
@@ -10,6 +10,7 @@ import io.customer.location.geofence.GeofenceJsonSerializer
 import io.customer.location.geofence.GeofenceLocation
 import io.customer.location.geofence.GeofenceRegion
 import io.customer.location.geofence.GeofenceTransitionType
+import io.mockk.mockk
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
@@ -30,7 +31,11 @@ class GeofenceRegionStoreTest : RobolectricTest() {
                 argument(ApplicationArgument(applicationMock))
             }
         )
-        store = GeofenceRegionStoreImpl(applicationMock, GeofenceJsonSerializer())
+        store = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
         store.clearAll()
     }
 
@@ -107,8 +112,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         val config = GeofenceConfig(
             localRefreshTriggerRadius = 1_000f,
             remoteFetchRefreshTriggerRadius = 5_000f,
-            remoteFetchRefreshExpiryMs = 86_400_000L,
-            duplicateEventsExpiryMs = 3_600_000L,
+            remoteFetchRefreshExpiry = 86_400_000L,
+            duplicateEventsExpiry = 3_600_000L,
             maxBusinessGeofences = 19
         )
 
@@ -131,6 +136,24 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveLastApiFetchLocation(location)
 
         store.getLastApiFetchLocation() shouldBeEqualTo location
+    }
+
+    @Test
+    fun saveLastApiFetchLocation_givenNewStoreInstance_expectValueDecryptedCorrectly() {
+        // Cross-instance round trip. Location snapshots are encrypted via
+        // [PreferenceCrypto] (Android Keystore); a fresh store must be able to
+        // decrypt what a prior store wrote — otherwise process restarts would
+        // wipe the anchor and break the Tier-B distance check.
+        val location = GeofenceLocation(latitude = 37.7749, longitude = -122.4194)
+        store.saveLastApiFetchLocation(location)
+
+        val newInstance = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+
+        newInstance.getLastApiFetchLocation() shouldBeEqualTo location
     }
 
     // --- Movement-trigger location ---
@@ -201,8 +224,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             GeofenceConfig(
                 localRefreshTriggerRadius = 1_000f,
                 remoteFetchRefreshTriggerRadius = 5_000f,
-                remoteFetchRefreshExpiryMs = 1L,
-                duplicateEventsExpiryMs = 1L,
+                remoteFetchRefreshExpiry = 1L,
+                duplicateEventsExpiry = 1L,
                 maxBusinessGeofences = 1
             )
         )
@@ -256,8 +279,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             GeofenceConfig(
                 localRefreshTriggerRadius = 1_000f,
                 remoteFetchRefreshTriggerRadius = 5_000f,
-                remoteFetchRefreshExpiryMs = 86_400_000L,
-                duplicateEventsExpiryMs = 3_600_000L,
+                remoteFetchRefreshExpiry = 86_400_000L,
+                duplicateEventsExpiry = 3_600_000L,
                 maxBusinessGeofences = 19
             )
         )
@@ -266,8 +289,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         listOf(
             "localRefreshTriggerRadius",
             "remoteFetchRefreshTriggerRadius",
-            "remoteFetchRefreshExpiryMs",
-            "duplicateEventsExpiryMs",
+            "remoteFetchRefreshExpiry",
+            "duplicateEventsExpiry",
             "maxBusinessGeofences"
         ).forEach { key -> raw shouldContain "\"$key\"" }
     }
@@ -315,8 +338,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             """{
               "localRefreshTriggerRadius": 1000.0,
               "remoteFetchRefreshTriggerRadius": 5000.0,
-              "remoteFetchRefreshExpiryMs": 86400000,
-              "duplicateEventsExpiryMs": 3600000,
+              "remoteFetchRefreshExpiry": 86400000,
+              "duplicateEventsExpiry": 3600000,
               "maxBusinessGeofences": 19,
               "future_field_we_dont_know": "ignore me"
             }
@@ -326,8 +349,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getCachedConfig() shouldBeEqualTo GeofenceConfig(
             localRefreshTriggerRadius = 1_000f,
             remoteFetchRefreshTriggerRadius = 5_000f,
-            remoteFetchRefreshExpiryMs = 86_400_000L,
-            duplicateEventsExpiryMs = 3_600_000L,
+            remoteFetchRefreshExpiry = 86_400_000L,
+            duplicateEventsExpiry = 3_600_000L,
             maxBusinessGeofences = 19
         )
     }


### PR DESCRIPTION
## Ticket

[MBL-1629](https://linear.app/customerio/issue/MBL-1629/smart-geofence-updates)

## Stack

Final piece of the MBL-1629 SDK work. Sits alongside the open #709 (review feedback) — they touch overlapping files (`GeofenceRepository.kt`, `GeofenceRegionStore.kt`, repo tests) but are independent in intent. Whichever lands first, the other will need a small rebase.

⚠️ **Blocked on backend** — the matching `GET /v1/geofences/nearby` endpoint isn't merged or deployed yet. E2E verification runs once backend lands. Unit tests + apiCheck pass locally.

## Summary

Aligns the Android SDK with the backend `GET /v1/geofences/nearby` contract. The endpoint is workspace-scoped (no `userId` on the wire — auth is the SDK writeKey), returns a flat `geofences` array, and currently does **not** ship a `config` block or per-region `transition_types` / `last_updated`. Those last three are modeled as forward-compat slots so the SDK adopts them automatically when backend ships them — no release required.

Also adds `PreferenceCrypto` (AES-256-GCM via Android Keystore) for the two user-location snapshots only. Workspace config + region cache stay in plaintext under UID isolation.

## Wire contract mapping

```
GET /v1/geofences/nearby?latitude={lat}&longitude={lng}
Authorization: Basic <base64("writeKey:")>

200 OK:
{
  "geofences": [
    {
      "id": 123,                  // int (Customer.io internal)
      "name": "NYC Store",
      "latitude": 40.7128,
      "longitude": -74.0060,
      "radius": 500,              // int meters, [100..10000]
      "external_id": "store-001"  // string, customer-supplied, nullable
    }
  ]
}
```

Backend defaults: `radius_km=10`, `limit=100`. SDK omits both.

## Forward-compat slots

| Field | Today | Future |
|---|---|---|
| `config` block | absent → null on the DTO → repo uses cached config or `GeofenceConfig.fallback()` | once shipped → SDK parses + persists + uses next refresh |
| `transition_types` per region | absent → SDK defaults to `[ENTER, EXIT]` | once shipped → SDK honors values, falls back on all-unknown, logs each unknown |
| `last_updated` per region | absent → `0L` sentinel | once shipped → preserved (currently unused but cached) |
| `external_id` | nullable, customer-supplied | preserved end-to-end so host apps can correlate |

`id` (numeric) is the OS request ID and matches the `geofence_id` key on the event-processing path (planned in the next backend PR).

## Change breakdown

### Core
- `HttpRequestParams` gains `method: HttpMethod` (enum `{ GET, POST }`, default POST) and `queryParams: Map<String, String>`.
- `CustomerIOHttpClientImpl` builds URLs via `android.net.Uri.Builder` (`appendQueryParameter` percent-encodes both key and value automatically). Method is sourced from `params.method.name`.

### Location module
- `GeofenceApiResponse.kt`: rewritten DTO matching the wire shape; `@SerialName` on every field for R8 safety; `config` / `transitionTypes` / `lastUpdated` / `externalId` are nullable with defaults; `toDomainConfig()` returns `GeofenceConfig?` (gates cache save); transition-type resolution is three-tier (null/empty/all-unknown → defaults; mixed → valid subset; unknowns logged).
- `GeofenceApiService.kt`: switched to `GET`, no `userId` parameter, query params via the new `Map`.
- `GeofenceConfig.kt`: new `fallback()` companion factory wrapping `GeofenceConstants.FALLBACK_*`.
- `GeofenceRepository.kt`: 3-tier config preference `parsedConfig ?: cached ?: fallback`; `saveCachedConfig` only fires when parsedConfig non-null (null parse must not clobber prior cached value); `handleMovement` + `restoreFromCache` consume `cachedConfig ?: fallback`.
- `GeofenceRegion.kt`: added `externalId: String?` (preserves null vs empty distinction); KDoc explains `id` vs `externalId` split.
- `GeofenceRegionStore.kt`: `PreferenceCrypto` instance with its own key alias `cio_geofence_location_key`; `writeEncryptedJson` / `readEncryptedJson` helpers wrap the two location-snapshot writes/reads only; rest stays plaintext.

### Tests
- `GeofenceApiResponseTest.kt` rewritten for the new contract: full sample, minimal/defaults, external_id null/empty/value, transition_types five-rule fallback, last_updated, config field-level fallbacks, max-business 0/100/500 edge cases.
- `GeofenceRepositoryTest.kt`: updated for the new API signature; new test for parsed-config-wins-over-cached path; new test for store-cross-instance encryption survival in `GeofenceRegionStoreTest.kt`.

Production: ~250 net LOC (most of it DTO + helpers). Tests: ~250 net LOC.

## Encryption rationale

Used the existing `PreferenceCrypto` (same one backing `SecureUserStore`), **not** `androidx.security:security-crypto` which is deprecated. Migration via `decrypt`'s catch-all → returns input on Keystore failure → JSON parser decides → next write rewrites encrypted. Threat model: defends against on-device forensics (file copied off rooted device). Doesn't defend against runtime memory access — but that's a different attack surface.

Only the two location snapshots (`lastApiFetchLocation`, `lastMovementTriggerLocation`) are encrypted. Region cache + config + timestamps stay plaintext — workspace config, not user PII.

## Test plan

- [x] `:location:test` passes (debug + release).
- [x] `:location:apiCheck` clean.
- [x] `:core:apiCheck` clean.
- [ ] E2E — blocked on the backend endpoint merging + deploying.

## Open caveats

- `GeofenceApiService.fetchGeofences` will return `Result.failure` until backend deploys. The SDK degrades to "no geofences" gracefully (no crashes, no events).
- Wire-up assumes the backend's response shape stays as drafted. If reviewers there ask for changes (e.g., camelCase, different field names, different `id` type), this PR will need a small DTO patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes request-building to support GET+query params and updates the geofence sync pipeline/DTOs to match a new backend contract, plus introduces encrypted persistence for location snapshots which could affect cache restore/migration behavior.
> 
> **Overview**
> **Wires the geofence sync to the new `GET /geofences/nearby` contract** by adding HTTP method + query-param support to `CustomerIOHttpClient` and switching `GeofenceApiService` from a POST body (with `userId`) to a GET with `latitude`/`longitude` query params.
> 
> **Reworks geofence API decoding and config handling for forward compatibility**: `GeofenceApiResponse` now models nullable `config` and optional per-region fields (`external_id`, `transition_types`, `last_updated`), applies defaults/logging for unknown transition types, and makes `toDomainConfig()` nullable so the repo only overwrites cached config when the server actually sends one.
> 
> **Hardens persistence and restore paths** by adding `GeofenceConfig.fallback()` and using it throughout refresh/movement/boot-restore when cached config is missing, and by encrypting the two stored user location snapshots in `GeofenceRegionStore` via `PreferenceCrypto` (workspace-level region/config cache remains plaintext). Tests are updated/expanded to cover the new wire shape, fallback behavior, and cross-instance persistence/encryption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271a305ba8e7c39ce2b0e55ba12da518a078b762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

