### PR TITLE
chore: geofence followups — permissions, first-run, cooldown config

### DIFF
--- a/location/src/main/kotlin/io/customer/location/LocationTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationTracker.kt
@@ -47,6 +47,12 @@ internal class LocationTracker(
     internal var lastLocation: LocationCoordinates? = null
         private set
 
+    // Single-listener hook fired after every successful location update.
+    // Promote to a list-backed API or EventBus if multiple consumers or
+    // modularity needs emerge.
+    @Volatile
+    internal var onLocationReceivedListener: ((Double, Double) -> Unit)? = null
+
     override fun getIdentifyContext(): Map<String, Any> {
         val location = lastLocation ?: return emptyMap()
         return mapOf(
@@ -92,6 +98,7 @@ internal class LocationTracker(
         locationPreferenceStore.saveCachedLocation(latitude, longitude)
 
         trySendLocationTrack(latitude, longitude)
+        onLocationReceivedListener?.invoke(latitude, longitude)
     }
 
     /**

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -107,6 +107,13 @@ class ModuleLocation @JvmOverloads constructor(
 
         locationTracker.restorePersistedLocation()
 
+        // Recover from a first-run race where identify lands before the first
+        // GPS fix: GeofenceServices holds a "last skipped for no-location" flag
+        // and re-triggers a refresh when a fresh fix arrives.
+        locationTracker.onLocationReceivedListener = { lat, lng ->
+            SDKComponent.android().geofenceServices.onLocationAcquired(lat, lng)
+        }
+
         // Register as IdentifyHook so location is added to identify event context
         // and cleared synchronously during analytics.reset(). This ensures every
         // identify() call carries the device's current location in the event context —

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceCooldownFilter.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceCooldownFilter.kt
@@ -1,12 +1,14 @@
 package io.customer.location.geofence
 
 import io.customer.location.geofence.store.GeofenceCooldownStore
+import io.customer.location.geofence.store.GeofenceRegionStore
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 
-/** Suppresses duplicate geofence events within a configurable cooldown window. */
+/** Suppresses duplicate geofence events within the server-configured cooldown window. */
 internal class GeofenceCooldownFilter(
     private val store: GeofenceCooldownStore,
+    private val regionStore: GeofenceRegionStore,
     private val clock: Clock
 ) {
     /**
@@ -18,9 +20,11 @@ internal class GeofenceCooldownFilter(
         geofenceId: String,
         transition: Event.GeofenceTransition
     ): Boolean {
+        val cooldownMs = regionStore.getCachedConfig()?.duplicateEventsExpiry
+            ?: GeofenceConstants.DEDUPE_COOLDOWN_MS
         val last = store.getLastEmitTimestamp(geofenceId, transition)
         val now = clock.currentTimeMillis()
-        if (last != null && (now - last) < GeofenceConstants.DEDUPE_COOLDOWN_MS) return false
+        if (last != null && (now - last) < cooldownMs) return false
         store.recordEmit(geofenceId, transition, now)
         return true
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -69,6 +69,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence sync skipped ($reason): location permissions not granted", tag = TAG)
     }
 
+    fun logBackgroundDeliveryUnavailable(reason: String) {
+        logger.info("Geofence sync ($reason): ACCESS_BACKGROUND_LOCATION not granted — transitions will only fire while the app is in the foreground", tag = TAG)
+    }
+
     fun logGeofenceStateResetOnSignOut() {
         logger.debug("Geofence state reset on user sign-out: clearing persisted regions and OS registrations", tag = TAG)
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -9,6 +9,13 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Registered $count geofences with OS", tag = TAG)
     }
 
+    fun logBusinessGeofencesKept(count: Int) {
+        logger.debug(
+            "Kept $count business geofences unchanged in OS; skipped re-upsert to avoid GMS state reconciliation",
+            tag = TAG
+        )
+    }
+
     fun logGeofencesRemoved(count: Int) {
         logger.debug("Removed $count geofences from OS", tag = TAG)
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -37,13 +37,23 @@ internal class GeofenceManager(
     }
 
     /**
-     * Replaces any currently-registered geofences with [regions]. An empty
-     * list disables the broadcast receiver — registering nothing leaves no
-     * events to listen for.
+     * Replaces currently-registered geofences with [regions]; empty list
+     * disables the broadcast receiver. Business IDs in [existingBusinessIds]
+     * are left alone — only additions (regions − existing) are sent to GMS.
+     *
+     * Re-upserting a same-ID geofence triggers GMS state reconciliation that
+     * can fire spurious EXIT events; skipping the overlap avoids that.
+     * Default `emptySet()` means "OS state unknown, register everything".
      */
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
-    suspend fun replaceGeofences(regions: List<GeofenceRegion>): Result<Unit> =
-        replaceGeofencesInternal(regions, movementInitialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER)
+    suspend fun replaceGeofences(
+        regions: List<GeofenceRegion>,
+        existingBusinessIds: Set<String> = emptySet()
+    ): Result<Unit> = replaceGeofencesInternal(
+        regions = regions,
+        movementInitialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER,
+        existingBusinessIds = existingBusinessIds
+    )
 
     /**
      * Boot-restore variant of [replaceGeofences]: registers the movement
@@ -59,7 +69,8 @@ internal class GeofenceManager(
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     private suspend fun replaceGeofencesInternal(
         regions: List<GeofenceRegion>,
-        movementInitialTrigger: Int
+        movementInitialTrigger: Int,
+        existingBusinessIds: Set<String> = emptySet()
     ): Result<Unit> {
         if (regions.isEmpty()) {
             // No geofences to register => disable the receiver so we don't burn
@@ -75,25 +86,23 @@ internal class GeofenceManager(
             return Result.failure(SecurityException("Required location permissions not granted"))
         }
 
-        // GMS allows one initial-trigger per batch — split movement vs business.
-        // Business: INITIAL_TRIGGER_ENTER fires immediately if user is already inside.
-        // Movement: caller-controlled (NO_INITIAL_TRIGGER on normal paths, EXIT on boot restore).
+        // Split because GMS allows one initial-trigger per batch — business
+        // uses INITIAL_TRIGGER_ENTER, movement is caller-controlled.
         val movementTrigger = regions.filter { it.id == GeofenceConstants.MOVEMENT_TRIGGER_ID }
-        val businessGeofences = regions.filter { it.id != GeofenceConstants.MOVEMENT_TRIGGER_ID }
+        val (businessToAdd, businessKept) = regions
+            .filter { it.id != GeofenceConstants.MOVEMENT_TRIGGER_ID }
+            .partition { it.id !in existingBusinessIds }
 
         if (movementTrigger.isNotEmpty()) {
             val result = registerBatch(movementTrigger, initialTrigger = movementInitialTrigger)
             if (result.isFailure) return result
         }
 
-        if (businessGeofences.isNotEmpty()) {
-            val result = registerBatch(businessGeofences, initialTrigger = GeofencingRequest.INITIAL_TRIGGER_ENTER)
+        if (businessToAdd.isNotEmpty()) {
+            val result = registerBatch(businessToAdd, initialTrigger = GeofencingRequest.INITIAL_TRIGGER_ENTER)
             if (result.isFailure) {
-                // Roll back the movement trigger so we don't leave an unattended
-                // safety-net geofence in the OS without any business geofences to
-                // recover. Business-batch failure is a rare edge case (transient OS
-                // / GMS issue); recovery happens on the next identify or app-launch
-                // trigger past the freshness threshold.
+                // Roll back the movement trigger so we don't leave a safety-net
+                // geofence alone in the OS with no business regions to act on.
                 if (movementTrigger.isNotEmpty()) {
                     removeGeofencesByIds(movementTrigger.map { it.id })
                 }
@@ -102,7 +111,11 @@ internal class GeofenceManager(
         }
 
         receiverToggle.setEnabled(true)
-        logger.logGeofencesRegistered(regions.size)
+        val registeredCount = movementTrigger.size + businessToAdd.size
+        logger.logGeofencesRegistered(registeredCount)
+        if (businessKept.isNotEmpty()) {
+            logger.logBusinessGeofencesKept(businessKept.size)
+        }
         return Result.success(Unit)
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -71,7 +71,7 @@ internal class GeofenceManager(
             return Result.success(Unit)
         }
         if (!permissionChecker.hasRequiredLocationPermissions()) {
-            logger.logMissingPermission("ACCESS_FINE_LOCATION + ACCESS_BACKGROUND_LOCATION")
+            logger.logMissingPermission("ACCESS_FINE_LOCATION")
             return Result.failure(SecurityException("Required location permissions not granted"))
         }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofencePermissionChecker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofencePermissionChecker.kt
@@ -6,16 +6,29 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
-/** Runtime check for the location permissions geofence registration requires. */
+/**
+ * Runtime checks for location permissions related to geofence registration.
+ *
+ * `GeofencingClient.addGeofences()` only requires `ACCESS_FINE_LOCATION`. On API 29+,
+ * `ACCESS_BACKGROUND_LOCATION` separately gates whether transitions are delivered
+ * while the app is backgrounded — without it, transitions still fire in the
+ * foreground but are dropped once the app is backgrounded.
+ */
 internal class GeofencePermissionChecker(
     private val context: Context
 ) {
-    fun hasRequiredLocationPermissions(): Boolean {
-        val hasFine = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
-        if (!hasFine) return false
+    fun hasRequiredLocationPermissions(): Boolean = hasFineLocationPermission()
+
+    fun hasFineLocationPermission(): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.ACCESS_FINE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED
+
+    /**
+     * Returns true when background delivery is available — either the OS doesn't
+     * require a separate permission (API < 29) or the user has granted it.
+     */
+    fun isBackgroundDeliveryAvailable(): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return true
         return ContextCompat.checkSelfPermission(
             context,

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -141,39 +141,36 @@ internal class GeofenceRepositoryImpl(
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     override suspend fun restoreFromCache(): Result<Unit> {
-        if (!refreshInProgress.compareAndSet(false, true)) {
-            logger.logSyncSkipped("refresh already in progress")
+        // Bypasses the in-flight gate: after a reboot, app-launch refresh's
+        // registerWithBusinessDiff would see persisted registeredIds matching
+        // the incoming set and skip business as "unchanged" — but GMS was wiped
+        // by the reboot. Boot-restore must still run via
+        // replaceGeofencesForBootRestore (no diff); stateMutex serializes the
+        // concurrent writes.
+        val userId = secureUserStore.getUserId()
+        if (userId.isNullOrBlank()) {
+            logger.logSyncSkipped("no identified user")
             return Result.success(Unit)
         }
-        try {
-            val userId = secureUserStore.getUserId()
-            if (userId.isNullOrBlank()) {
-                logger.logSyncSkipped("no identified user")
-                return Result.success(Unit)
-            }
-            // Prefer the most recent movement-trigger center as the effective
-            // location — it tracks Tier A drift and is much closer to the user's
-            // real position than the anchor (only updated on Tier B fetches).
-            // Fall back to the anchor if there's no movement-trigger location yet
-            // (older cache / first-ever boot restore).
-            val effectiveLocation = store.getLastMovementTriggerLocation()
-                ?: store.getLastApiFetchLocation()
-            if (effectiveLocation == null) {
-                logger.logSyncSkipped("no cached state to restore")
-                return Result.success(Unit)
-            }
-            val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-            // Boot-restore variant — see [GeofenceManager.replaceGeofencesForBootRestore].
-            return performLocalRefresh(
-                userId = userId,
-                latitude = effectiveLocation.latitude,
-                longitude = effectiveLocation.longitude,
-                cachedConfig = cachedConfig,
-                register = manager::replaceGeofencesForBootRestore
-            )
-        } finally {
-            refreshInProgress.set(false)
+        // Prefer the most recent movement-trigger center as the effective
+        // location — it tracks Tier A drift and is much closer to the user's
+        // real position than the anchor (only updated on Tier B fetches).
+        // Fall back to the anchor if there's no movement-trigger location yet
+        // (older cache / first-ever boot restore).
+        val effectiveLocation = store.getLastMovementTriggerLocation()
+            ?: store.getLastApiFetchLocation()
+        if (effectiveLocation == null) {
+            logger.logSyncSkipped("no cached state to restore")
+            return Result.success(Unit)
         }
+        val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
+        return performLocalRefresh(
+            userId = userId,
+            latitude = effectiveLocation.latitude,
+            longitude = effectiveLocation.longitude,
+            cachedConfig = cachedConfig,
+            register = manager::replaceGeofencesForBootRestore
+        )
     }
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -230,15 +230,19 @@ internal class GeofenceRepositoryImpl(
     )
 
     /**
-     * Default register path for Tier A / Tier B refreshes — forwards the
-     * persisted business IDs as `existingBusinessIds` so the manager skips
-     * re-registering the overlap (see [GeofenceManager.replaceGeofences]).
+     * Default register path for Tier A / Tier B refreshes. An ID is treated
+     * as skip-safe only when the cached region equals the incoming one — any
+     * param drift forces a re-register so GMS doesn't keep stale values.
      * Boot restore bypasses this; OS state is empty after reboot.
      */
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     private suspend fun registerWithBusinessDiff(regions: List<GeofenceRegion>): Result<Unit> {
-        val existingBusinessIds =
-            store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+        val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+        val cachedById = store.getCachedRegions().associateBy { it.id }
+        val existingBusinessIds = regions
+            .filter { it.id in registeredBusinessIds && cachedById[it.id] == it }
+            .map { it.id }
+            .toSet()
         return manager.replaceGeofences(
             regions = regions,
             existingBusinessIds = existingBusinessIds

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -219,7 +219,7 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::replaceGeofences
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff
     ): Result<Unit> = registerNearestAndPersist(
         userId = userId,
         latitude = latitude,
@@ -229,6 +229,22 @@ internal class GeofenceRepositoryImpl(
         register = register
     )
 
+    /**
+     * Default register path for Tier A / Tier B refreshes — forwards the
+     * persisted business IDs as `existingBusinessIds` so the manager skips
+     * re-registering the overlap (see [GeofenceManager.replaceGeofences]).
+     * Boot restore bypasses this; OS state is empty after reboot.
+     */
+    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    private suspend fun registerWithBusinessDiff(regions: List<GeofenceRegion>): Result<Unit> {
+        val existingBusinessIds =
+            store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+        return manager.replaceGeofences(
+            regions = regions,
+            existingBusinessIds = existingBusinessIds
+        )
+    }
+
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     private suspend fun registerNearestAndPersist(
         userId: String,
@@ -236,7 +252,7 @@ internal class GeofenceRepositoryImpl(
         longitude: Double,
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = manager::replaceGeofences,
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
         onRegistered: () -> Unit = {}
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
@@ -259,24 +275,23 @@ internal class GeofenceRepositoryImpl(
             }
             register(regionsToRegister).also { result ->
                 if (result.isSuccess) {
-                    // Stale cleanup runs ONLY after add succeeds. If add fails we
-                    // leave previous OS registrations intact — better to keep
-                    // serving the last-known-good set than to wipe everything and
-                    // be unable to recover until the next refresh.
-                    val previouslyRegistered = store.getRegisteredIds()
-                    val newlyRegistered = regionsToRegister.map { it.id }.toSet()
-                    val staleIds = previouslyRegistered - newlyRegistered
+                    // Stale cleanup — Manager added new−existing, we remove
+                    // existing−new. Runs only on add success; on failure leave
+                    // previous registrations intact rather than wipe.
+                    val existingIds = store.getRegisteredIds()
+                    val newIds = regionsToRegister.map { it.id }.toSet()
+                    val staleIds = existingIds - newIds
                     val staleRemovalSucceeded = if (staleIds.isNotEmpty()) {
                         manager.removeGeofencesByIds(staleIds.toList()).isSuccess
                     } else {
                         true
                     }
-                    val currentlyRegistered = if (staleRemovalSucceeded) {
-                        newlyRegistered
+                    val idsToSave = if (staleRemovalSucceeded) {
+                        newIds
                     } else {
-                        newlyRegistered + staleIds
+                        newIds + staleIds
                     }
-                    store.saveRegisteredIds(currentlyRegistered)
+                    store.saveRegisteredIds(idsToSave)
                     // Track the user's location at each successful registration so
                     // boot restore can re-center close to their real position. Clear
                     // when the business set transitions to empty — no trigger exists.

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -84,11 +84,10 @@ internal class GeofenceRepositoryImpl(
             }
             val lastSync = store.getLastSyncTimestamp()
             if (lastSync != null) {
-                // Freshness window comes from the cached server config; falls back
-                // to STALE_THRESHOLD_MS when no cache exists or the value is
-                // non-positive (defensive against bad config).
+                // Freshness window from the cached server config; falls back to
+                // STALE_THRESHOLD_MS when no cache exists. Non-positive values
+                // are sanitized at parse time in GeofenceApiConfig.toDomain.
                 val threshold = store.getCachedConfig()?.remoteFetchRefreshExpiry
-                    ?.takeIf { it > 0 }
                     ?: GeofenceConstants.STALE_THRESHOLD_MS
                 if (clock.currentTimeMillis() - lastSync < threshold) {
                     // Cache fresh — if OS regs were wiped on sign-out, re-

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceServices.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceServices.kt
@@ -2,6 +2,7 @@ package io.customer.location.geofence
 
 import android.annotation.SuppressLint
 import io.customer.sdk.data.store.SecureUserStore
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -34,6 +35,14 @@ internal interface GeofenceServices {
      * user's geofences. Fired when [Event.UserChangedEvent] arrives with a null userId.
      */
     fun onUserSignedOut()
+
+    /**
+     * Re-attempts a refresh when a fresh GPS fix arrives after a prior sync was
+     * skipped for not-yet-available location. On fresh install identify can race
+     * ahead of the first fix; without this hook the SDK would self-heal only on
+     * sign-out / next cold launch.
+     */
+    fun onLocationAcquired(latitude: Double, longitude: Double)
 }
 
 internal class GeofenceServicesImpl(
@@ -43,6 +52,11 @@ internal class GeofenceServicesImpl(
     private val logger: GeofenceLogger,
     private val permissionChecker: GeofencePermissionChecker
 ) : GeofenceServices {
+
+    // Rearm flag: set when a sync skips for no-location, cleared on any
+    // successful trigger. onLocationAcquired only fires when this is set,
+    // so streamed location updates don't cause repeated refreshes.
+    private val lastSkippedForNoLocation = AtomicBoolean(false)
 
     override fun onMovementTriggerExit(latitude: Double?, longitude: Double?) {
         triggerSync(
@@ -71,6 +85,16 @@ internal class GeofenceServicesImpl(
         )
     }
 
+    override fun onLocationAcquired(latitude: Double, longitude: Double) {
+        // Only act on the rising edge of a no-location skip; otherwise this
+        // becomes a per-update refresh storm on hosts that stream locations.
+        if (!lastSkippedForNoLocation.compareAndSet(true, false)) return
+        val userId = secureUserStore.getUserId()
+        // No user: a future identify catches the now-cached location.
+        if (userId.isNullOrEmpty()) return
+        onUserIdentified(latitude, longitude)
+    }
+
     override fun onUserSignedOut() {
         // Snapshot the userId synchronously — the datapipelines `ResetEvent`
         // subscriber races to clear `secureUserStore`, so a deferred read
@@ -90,6 +114,7 @@ internal class GeofenceServicesImpl(
         action: suspend (Double, Double) -> Result<Unit>
     ) {
         if (latitude == null || longitude == null) {
+            lastSkippedForNoLocation.set(true)
             logger.logSyncSkippedNoLocation(reason)
             return
         }
@@ -97,6 +122,10 @@ internal class GeofenceServicesImpl(
             logger.logSyncSkippedNoPermission(reason)
             return
         }
+        if (!permissionChecker.isBackgroundDeliveryAvailable()) {
+            logger.logBackgroundDeliveryUnavailable(reason)
+        }
+        lastSkippedForNoLocation.set(false)
         logger.logSyncTriggered(reason)
         // Guarded by permissionChecker above; Android kills the process when
         // permissions are revoked, so no mid-flight revocation to handle.

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -73,7 +73,9 @@ internal val AndroidSDKComponent.geofenceCooldownStore: GeofenceCooldownStore
     get() = singleton<GeofenceCooldownStore> { GeofenceCooldownStoreImpl(applicationContext) }
 
 internal val AndroidSDKComponent.geofenceCooldownFilter: GeofenceCooldownFilter
-    get() = singleton<GeofenceCooldownFilter> { GeofenceCooldownFilter(geofenceCooldownStore, SDKComponent.clock) }
+    get() = singleton<GeofenceCooldownFilter> {
+        GeofenceCooldownFilter(geofenceCooldownStore, geofenceRegionStore, SDKComponent.clock)
+    }
 
 internal val AndroidSDKComponent.geofenceRegionStore: GeofenceRegionStore
     get() = singleton<GeofenceRegionStore> {

--- a/location/src/test/java/io/customer/location/LocationTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/LocationTrackerTest.kt
@@ -79,6 +79,25 @@ class LocationTrackerTest {
         verify { store.saveCachedLocation(37.7749, -122.4194) }
     }
 
+    @Test
+    fun givenLocationReceived_listenerRegistered_expectListenerInvokedWithCoordinates() {
+        var captured: Pair<Double, Double>? = null
+        tracker.onLocationReceivedListener = { lat, lng -> captured = lat to lng }
+
+        tracker.onLocationReceived(37.7749, -122.4194)
+
+        captured shouldBeEqualTo (37.7749 to -122.4194)
+    }
+
+    @Test
+    fun givenLocationReceived_noListener_expectNoException() {
+        tracker.onLocationReceivedListener = null
+
+        tracker.onLocationReceived(37.7749, -122.4194)
+
+        verify { store.saveCachedLocation(37.7749, -122.4194) }
+    }
+
     // -- syncCachedLocationIfNeeded --
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/GeofenceCooldownFilterTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceCooldownFilterTest.kt
@@ -4,6 +4,7 @@ import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
 import io.customer.location.geofence.store.GeofenceCooldownStore
+import io.customer.location.geofence.store.GeofenceRegionStore
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 import io.mockk.every
@@ -19,13 +20,17 @@ import org.robolectric.RobolectricTestRunner
 class GeofenceCooldownFilterTest : RobolectricTest() {
 
     private val mockStore: GeofenceCooldownStore = mockk(relaxed = true)
+    private val mockRegionStore: GeofenceRegionStore = mockk(relaxed = true) {
+        // Default to no cached config — exercises the fallback to DEDUPE_COOLDOWN_MS.
+        every { getCachedConfig() } returns null
+    }
     private val mockClock: Clock = mockk(relaxed = true)
 
     private lateinit var filter: GeofenceCooldownFilter
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfigurationDefault { })
-        filter = GeofenceCooldownFilter(mockStore, mockClock)
+        filter = GeofenceCooldownFilter(mockStore, mockRegionStore, mockClock)
     }
 
     @Test
@@ -79,6 +84,26 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
 
         filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
         filter.tryAcquire("biz-1", Event.GeofenceTransition.EXIT).shouldBeTrue()
+    }
+
+    @Test
+    fun tryAcquire_givenCachedConfig_expectServerConfiguredCooldownUsed() {
+        // Server-pushed cooldown is shorter than the fallback. Verifies the
+        // filter actually consults GeofenceConfig and isn't pinned to the constant.
+        val serverCooldownMs = 5_000L
+        every { mockRegionStore.getCachedConfig() } returns GeofenceConfig.fallback().copy(
+            duplicateEventsExpiry = serverCooldownMs
+        )
+        val lastEmit = 100_000L
+        every { mockStore.getLastEmitTimestamp("biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
+
+        // Inside the server window but well outside the constant fallback → must block.
+        every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs - 1
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+
+        // Past the server window but still inside the constant fallback → must allow.
+        every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs + 1
+        filter.tryAcquire("biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
@@ -76,13 +76,18 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun replaceGeofences_givenFineLocationGrantedNoBackgroundOnQ_expectFailure() = runTest {
+    fun replaceGeofences_givenFineLocationGrantedNoBackground_expectRegistrationProceeds() = runTest {
+        // GMS only requires FINE to register; BACKGROUND only gates whether
+        // transitions are delivered while the app is backgrounded. The host gets a
+        // foreground-only degraded mode rather than silent zero-registration.
         grantPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         denyPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        stubClientAddSuccess()
 
         val result = manager.replaceGeofences(listOf(buildRegion()))
 
-        result.isFailure.shouldBeTrue()
+        result.isSuccess.shouldBeTrue()
+        verify { client.addGeofences(any<GeofencingRequest>(), any()) }
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/GeofencePermissionCheckerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofencePermissionCheckerTest.kt
@@ -1,0 +1,80 @@
+package io.customer.location.geofence
+
+import android.Manifest
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class GeofencePermissionCheckerTest : RobolectricTest() {
+
+    private lateinit var checker: GeofencePermissionChecker
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        checker = GeofencePermissionChecker(applicationMock)
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun hasRequiredLocationPermissions_givenFineGranted_expectTrueEvenWithoutBackground() {
+        grant(Manifest.permission.ACCESS_FINE_LOCATION)
+        deny(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        checker.hasRequiredLocationPermissions().shouldBeTrue()
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun hasRequiredLocationPermissions_givenFineDenied_expectFalse() {
+        deny(Manifest.permission.ACCESS_FINE_LOCATION)
+        grant(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        checker.hasRequiredLocationPermissions().shouldBeFalse()
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun isBackgroundDeliveryAvailable_givenBackgroundGranted_expectTrue() {
+        grant(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        checker.isBackgroundDeliveryAvailable().shouldBeTrue()
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun isBackgroundDeliveryAvailable_givenBackgroundDenied_expectFalse() {
+        deny(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        checker.isBackgroundDeliveryAvailable().shouldBeFalse()
+    }
+
+    @Test
+    @Config(sdk = [28])
+    fun isBackgroundDeliveryAvailable_belowQ_expectTrueRegardlessOfPermission() {
+        // Pre-Q, FINE covers background delivery implicitly.
+        deny(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+
+        checker.isBackgroundDeliveryAvailable().shouldBeTrue()
+    }
+
+    private fun grant(permission: String) {
+        shadowOf(applicationMock).grantPermissions(permission)
+    }
+
+    private fun deny(permission: String) {
+        shadowOf(applicationMock).denyPermissions(permission)
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -600,6 +600,51 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenRemoteFetchAndCachedMatchesIncoming_expectIdForwardedAsExisting() = runTest {
+        // Tier B remote fetch where the cached region equals the incoming one — no
+        // backend-side edit. The diff helper forwards the overlap ID so the manager
+        // can skip the re-upsert that would otherwise trigger GMS state
+        // reconciliation and spurious EXITs.
+        val region = GeofenceRegion("biz-1", 1.0, 2.0, 100f)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(region)
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(region)
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun refresh_givenRemoteFetchAndCachedParamsDifferFromIncoming_expectIdExcludedFromExisting() = runTest {
+        // Backend edited biz-1's radius (100m → 200m). Cache still holds the old
+        // value at diff time; equality fails on the mismatch so biz-1 falls out of
+        // existingBusinessIds and gets re-registered. Without this, GMS would keep
+        // the 100m geofence after the cache moved to 200m.
+        val cached = GeofenceRegion("biz-1", 1.0, 2.0, 100f)
+        val incoming = cached.copy(radius = 200f)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(cached)
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(incoming)
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
     fun reset_givenManagerSucceeds_expectUserScopedStateClearedAndWorkspaceCachePreserved() = runTest {
         // Sign-out cleanup: drop OS registrations + wipe user-specific state
         // (anchor, movement-trigger location, registered IDs). Workspace

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -84,12 +84,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns sampleConfig()
         every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify { manager.replaceGeofences(any()) }
+        coVerify { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
@@ -104,12 +104,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns null
         every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify { manager.replaceGeofences(any()) }
+        coVerify { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
@@ -122,7 +122,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -175,7 +175,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -191,7 +191,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -206,7 +206,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify { logger.logSyncSkipped(match { it.contains("no identified user") }) }
     }
@@ -234,7 +234,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { logger.logSyncFailed(match { it?.contains("network down") == true }) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
@@ -247,7 +247,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         val capturedLoc = slot<GeofenceLocation>()
         every { store.saveLastMovementTriggerLocation(capture(capturedLoc)) } returns Unit
 
@@ -265,7 +265,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -283,7 +283,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.failure(RuntimeException("boom"))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(RuntimeException("boom"))
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -299,7 +299,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns filtered
         val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.replaceGeofences(capture(captured)) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -331,7 +331,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         val regionsSlot = slot<List<GeofenceRegion>>()
         val configSlot = slot<GeofenceConfig>()
         val anchorSlot = slot<GeofenceLocation>()
@@ -358,7 +358,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.failure(RuntimeException("boom"))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(RuntimeException("boom"))
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -387,7 +387,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns newBusiness
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -396,7 +396,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // biz-shared survive (same IDs, will be replaced by replaceGeofences).
         val staleSlot = slot<List<String>>()
         coVerifyOrder {
-            manager.replaceGeofences(any())
+            manager.replaceGeofences(any(), any())
             manager.removeGeofencesByIds(capture(staleSlot))
         }
         staleSlot.captured shouldContainSame listOf("biz-old-1", "biz-old-2")
@@ -410,7 +410,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -429,7 +429,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(newRegion)
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns
             Result.failure(RuntimeException("remove boom"))
         val persisted = slot<Set<String>>()
@@ -439,7 +439,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerifyOrder {
-            manager.replaceGeofences(any())
+            manager.replaceGeofences(any(), any())
             manager.removeGeofencesByIds(any())
         }
         verify { logger.logSyncSucceeded(1) }
@@ -460,7 +460,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -480,7 +480,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
         val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.replaceGeofences(capture(captured)) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -503,7 +503,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-new", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.failure(error)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -528,7 +528,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         val addGeofencesActive = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
-        coEvery { manager.replaceGeofences(any()) } coAnswers {
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
             val n = addGeofencesActive.incrementAndGet()
             maxObservedConcurrency.updateAndGet { current -> maxOf(current, n) }
             delay(50)
@@ -557,7 +557,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         )
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         val first = repository.refresh(latitude = 0.0, longitude = 0.0)
         val second = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -581,7 +581,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkipped(match { it.contains("user changed") }) }
     }
 
@@ -595,7 +595,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkipped(match { it.contains("user changed") }) }
     }
 
@@ -681,7 +681,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
@@ -695,7 +695,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 1.0, longitude = 2.0)
 
@@ -713,13 +713,13 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         // ~111m from anchor — well within the fallback 5km threshold.
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify { manager.replaceGeofences(any()) }
+        coVerify { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
@@ -737,12 +737,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(cached, any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        coVerify { manager.replaceGeofences(any()) }
+        coVerify { manager.replaceGeofences(any(), any()) }
         verify { distanceFilter.nearest(cached, 0.0, 0.001, any()) }
     }
 
@@ -757,7 +757,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.1)
 
@@ -776,7 +776,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         val anchorSlot = slot<GeofenceLocation>()
         every { store.saveLastApiFetchLocation(capture(anchorSlot)) } returns Unit
 
@@ -798,7 +798,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
@@ -827,7 +827,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         }
         every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any()) } returns Result.success(Unit)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         coroutineScope {
             launch { repository.handleMovement(latitude = 1.0, longitude = 1.0) }
@@ -906,7 +906,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify(exactly = 0) { distanceFilter.nearest(any(), 12.34, 56.78, any()) }
         // Pins the boot-restore manager variant, not the normal one.
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
-        coVerify(exactly = 0) { manager.replaceGeofences(any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
     }
 

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -981,6 +981,42 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
     }
 
+    @Test
+    fun restoreFromCache_givenRefreshInFlight_expectStillRunsViaBootRestoreVariant() = runTest {
+        // After a reboot GMS is wiped but persisted registeredIds aren't, so a
+        // concurrent refresh would skip business as "unchanged" via the equality
+        // diff and leave GMS empty. Boot-restore must run regardless of the gate,
+        // via the no-diff replaceGeofencesForBootRestore.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getLastSyncTimestamp() } returns null
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            // Hold the refresh path long enough that restoreFromCache enters mid-flight.
+            delay(100)
+            Result.success(Unit)
+        }
+        coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
+
+        coroutineScope {
+            launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+            launch {
+                delay(20)
+                repository.restoreFromCache()
+            }
+        }
+
+        // Without the bypass, the gate would have deduped restoreFromCache and
+        // replaceGeofencesForBootRestore would never have been called.
+        coVerify { manager.replaceGeofencesForBootRestore(any()) }
+    }
+
     private fun sampleConfig(
         remoteFetchRefreshExpiry: Long = 86_400_000L
     ): GeofenceConfig = GeofenceConfig(

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -148,21 +148,6 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenCachedConfigWithNonPositiveExpiry_expectFallbackToConstant() = runTest {
-        // Defense: a 0 or negative `remoteFetchRefreshExpiry` (bad server config)
-        // must NOT short-circuit the freshness check — falls back to the constant.
-        every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
-        every { store.getCachedConfig() } returns sampleConfig(remoteFetchRefreshExpiry = 0L)
-
-        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
-
-        result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
-        verify { logger.logSyncSkippedFresh() }
-    }
-
-    @Test
     fun refresh_givenCachedConfigWithShorterExpiry_expectApiCallSooner() = runTest {
         // Symmetric case: shorter server window (1h) trips earlier than the
         // 24h constant. A sync 2h ago now triggers an API call.

--- a/location/src/test/java/io/customer/location/geofence/GeofenceServicesTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceServicesTest.kt
@@ -25,6 +25,7 @@ class GeofenceServicesTest : RobolectricTest() {
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val permissionChecker: GeofencePermissionChecker = mockk(relaxed = true) {
         every { hasRequiredLocationPermissions() } returns true
+        every { isBackgroundDeliveryAvailable() } returns true
     }
 
     private fun servicesWith(scope: TestScope): GeofenceServicesImpl =
@@ -98,6 +99,78 @@ class GeofenceServicesTest : RobolectricTest() {
         coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
         coVerify(exactly = 0) { repository.refresh(any(), any()) }
         verify { logger.logSyncSkippedNoPermission(any()) }
+    }
+
+    @Test
+    fun onMovementTriggerExit_givenBackgroundLocationMissing_expectProceedAndWarn() = runTest(StandardTestDispatcher()) {
+        every { permissionChecker.isBackgroundDeliveryAvailable() } returns false
+        coEvery { repository.handleMovement(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onMovementTriggerExit(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        coVerify { repository.handleMovement(1.0, 2.0) }
+        verify { logger.logBackgroundDeliveryUnavailable("movement-trigger-exit") }
+        verify { logger.logSyncTriggered("movement-trigger-exit") }
+    }
+
+    @Test
+    fun onLocationAcquired_givenPriorSkipAndUserIdentified_expectRefresh() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        // Skip first, then deliver the fix.
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify { repository.refresh(12.0, 34.0) }
+    }
+
+    @Test
+    fun onLocationAcquired_givenNoPriorSkip_expectNoOp() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        val services = servicesWith(this)
+
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
+    }
+
+    @Test
+    fun onLocationAcquired_givenPriorSkipButUserNotIdentified_expectNoOp() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns null
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+    }
+
+    @Test
+    fun onLocationAcquired_givenPriorSuccessfulSync_expectNoRetriggerOnNewFix() = runTest(StandardTestDispatcher()) {
+        // Successful trigger must clear the rearm flag — otherwise hosts that
+        // stream location updates would refresh on every fix.
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+        services.onLocationAcquired(latitude = 3.0, longitude = 4.0)
+        advanceUntilIdle()
+
+        // Only the initial identify call should reach the repository.
+        coVerify(exactly = 1) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.refresh(3.0, 4.0) }
     }
 
     @Test

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.
     tools:replace is needed because SDK declares a network security config as well for automated tests.

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -8,6 +8,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.Settings;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -60,6 +61,19 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                 }
             });
 
+    // On API 30+, BACKGROUND can't be requested via the standard runtime dialog —
+    // the launcher returns immediately as "denied" and the user must toggle "Allow
+    // all the time" from app settings. This launcher handles the API 29 case where
+    // the runtime dialog still works.
+    private final ActivityResultLauncher<String> backgroundLocationLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
+                if (granted) {
+                    showSnackbar(getString(R.string.background_location_already_granted));
+                } else {
+                    showBackgroundLocationSettingsAlert();
+                }
+            });
+
     @Override
     protected ActivityLocationTestBinding inflateViewBinding() {
         return ActivityLocationTestBinding.inflate(getLayoutInflater());
@@ -76,6 +90,56 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
         setupSdkLocationButtons();
         setupDeviceLocationButton();
         setupManualEntrySection();
+        setupBackgroundPermissionButton();
+    }
+
+    private void setupBackgroundPermissionButton() {
+        binding.grantBackgroundLocation.setOnClickListener(v -> requestBackgroundLocation());
+    }
+
+    private void requestBackgroundLocation() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            showSnackbar(getString(R.string.background_location_not_required_pre_q));
+            return;
+        }
+        if (!hasFineLocation()) {
+            showSnackbar(getString(R.string.background_location_needs_fine_first));
+            return;
+        }
+        if (hasBackgroundLocation()) {
+            showSnackbar(getString(R.string.background_location_already_granted));
+            return;
+        }
+        // API 30+ requires the user to grant from Settings; the runtime dialog
+        // is not shown. Route them directly there.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            showBackgroundLocationSettingsAlert();
+            return;
+        }
+        backgroundLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+    }
+
+    private boolean hasFineLocation() {
+        return ContextCompat.checkSelfPermission(this,
+                Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private boolean hasBackgroundLocation() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return true;
+        return ContextCompat.checkSelfPermission(this,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void showBackgroundLocationSettingsAlert() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.geofence_permissions_section)
+                .setMessage(R.string.background_location_open_settings)
+                .setNeutralButton(R.string.open_settings, (dialog, which) -> {
+                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                    intent.setData(Uri.parse("package:" + getPackageName()));
+                    startActivity(intent);
+                })
+                .show();
     }
 
     private void setupPresetButtons() {

--- a/samples/java_layout/src/main/res/layout/activity_location_test.xml
+++ b/samples/java_layout/src/main/res/layout/activity_location_test.xml
@@ -255,6 +255,42 @@
                 android:textSize="12sp" />
         </LinearLayout>
 
+        <!-- OR separator -->
+        <include layout="@layout/or_separator" />
+
+        <!-- OPTION 5: GEOFENCE PERMISSIONS -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/section_background"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/geofence_permissions_section"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <Button
+                android:id="@+id/grant_background_location"
+                style="?attr/materialButtonStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/grant_background_location" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/background_location_description"
+                android:textColor="?android:attr/textColorTertiary"
+                android:textSize="12sp" />
+        </LinearLayout>
+
         <!-- Status section -->
         <TextView
             android:id="@+id/last_set_location_label"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -138,6 +138,15 @@
     <string name="location_not_available">Could not get device location</string>
     <string name="label_location_test_activity">LocationTestActivity</string>
 
+    <!-- Geofence permissions section -->
+    <string name="geofence_permissions_section">Geofence permissions</string>
+    <string name="grant_background_location">Grant background location</string>
+    <string name="background_location_description">Required on Android 10+ for geofence transitions to fire while the app is backgrounded. Without it, transitions only fire while the app is in the foreground.</string>
+    <string name="background_location_already_granted">Background location is already granted</string>
+    <string name="background_location_not_required_pre_q">Background location permission is not required on this Android version</string>
+    <string name="background_location_needs_fine_first">Grant fine location first, then re-tap this button</string>
+    <string name="background_location_open_settings">Open Settings and choose \"Allow all the time\"</string>
+
     <!-- Inbox Messages -->
     <string name="inbox_messages">Inbox Messages</string>
     <string name="label_inbox_messages_activity">InboxMessagesActivity</string>

--- a/samples/kotlin_compose/src/main/AndroidManifest.xml
+++ b/samples/kotlin_compose/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.
     tools:replace is needed because SDK declares a network security config as well for automated tests.


### PR DESCRIPTION
part of: [MBL-1735](https://linear.app/customerio/issue/MBL-1735/android-fix-geofencing-reliability-and-lifecycle-issues-identified)

## Summary

Six independent follow-up items surfaced while testing MBL-1629 end-to-end. Bundled here for review economy; each could split into a separate PR if preferred.

- Relax `GeofencePermissionChecker` so FINE-only registration works (foreground-only delivery) instead of silently no-opping when BACKGROUND is missing
- Recover from a first-run race where `identify()` lands before the first GPS fix: retry the geofence sync once a fix arrives
- Make `GeofenceCooldownFilter` honor the server-configured `duplicateEventsExpiry` — it was hardcoded to a constant despite the field being parsed and persisted
- Add the location permissions geofence registration requires to the sample app manifests
- Avoid spurious EXIT events by skipping re-registration of business geofences whose IDs are already in GMS — `GeofencingClient.addGeofences()` treats same-ID re-upserts as fresh state evaluations and can fire reconciliation EXITs
- Repair post-reboot GMS state when boot-restore races the app-launch refresh — boot-restore now bypasses the in-flight gate so business geofences aren't left out of GMS after a reboot

## Stack

```
main
 └─ feature/geofence-on-device   (open, target of this PR)
     └─ geofence-followups       ← THIS PR
```

Note: `feature/geofence-on-device` has not yet merged to main. All current geofence work targets that feature branch.

## Issues fixed

### 1. Permission gate over-demanded BACKGROUND for registration

**Before:** `hasRequiredLocationPermissions()` required both `ACCESS_FINE_LOCATION` AND (on API 29+) `ACCESS_BACKGROUND_LOCATION`. If a host granted only FINE, registration silently no-op'd — zero geofences registered, no clear signal to the host.

**GMS contract:** `GeofencingClient.addGeofences()` only requires FINE. `ACCESS_BACKGROUND_LOCATION` only controls whether transitions are delivered while the app is in the background. Foreground-only registration is a perfectly viable degraded mode.

**After:**
- `GeofencePermissionChecker.hasRequiredLocationPermissions()` returns `true` on FINE alone
- New `isBackgroundDeliveryAvailable()` separately reports whether transitions will survive backgrounding
- `GeofenceServicesImpl.triggerSync` proceeds with registration on FINE alone, but emits a new info log via `GeofenceLogger.logBackgroundDeliveryUnavailable()` when BACKGROUND is missing so hosts know transitions won't fire while backgrounded
- `GeofenceManager.replaceGeofencesInternal` log message updated to reflect that FINE alone gates registration

**Sample UX:** `samples/java_layout/LocationTestActivity` adds a "Grant background location" button. Walks the user through the FINE-first chain, hides on pre-Q, and routes to Settings on API 30+ where the runtime dialog no longer fires.

### 2. First-run no-location reliability hole

**Before:** On fresh install, `identify()` typically fires within milliseconds of app start. The GPS hardware takes 2–10 seconds to produce the first fix. If identify lands before the first fix:
- `LocationTracker.lastLocation` is still null
- `UserChangedEvent` subscriber calls `onUserIdentified(null, null)` → `triggerSync` skips with `logSyncSkippedNoLocation`
- The GPS fix eventually arrives but `LocationTracker.onLocationReceived` doesn't trigger any retry

The skip self-heals only on (a) next identify, (b) cold launch with persisted location, or (c) movement-trigger EXIT (chicken-and-egg — requires registration that requires this chain to have worked). For apps whose primary value is "welcome on first arrival", the first store visit on install day likely never fires.

**After:** Three pieces wired together:

- `LocationTracker.onLocationReceivedListener: ((Double, Double) -> Unit)?` — new internal callback fired after every successful `onLocationReceived` (NOT on `restorePersistedLocation()`, which is state recovery, not a new event)
- `GeofenceServicesImpl.lastSkippedForNoLocation: AtomicBoolean` — set on no-location skip, cleared on any successful trigger
- `onLocationAcquired(lat, lng)` — new interface method, CAS-protected so it only acts on the rising edge of skip (no refresh storm for hosts that stream locations)
- `ModuleLocation.initialize()` wires the listener at module init

The defensive `onAppLaunch` block in `ModuleLocation.initialize()` is preserved — it covers a different case (cached location from previous session + no new fix this session). The new listener handles only "new fix arrived after a skip"; the defensive read handles "we already have a fix on disk". Both are needed.

### 3. Cooldown filter ignored server-pushed config

**Before:** `GeofenceConfig.duplicateEventsExpiry` is parsed in `GeofenceApiResponse.toDomain()`, persisted via `GeofenceRegionStore.saveCachedConfig`, and readable via `getCachedConfig()`. But `GeofenceCooldownFilter.tryAcquire` used `GeofenceConstants.DEDUPE_COOLDOWN_MS` directly (60 min hardcoded fallback). The server-configured value was silently ignored.

**After:** `GeofenceCooldownFilter` consults `regionStore.getCachedConfig()?.duplicateEventsExpiry ?: GeofenceConstants.DEDUPE_COOLDOWN_MS`. Server can now tune the cooldown window without an SDK release.

**Audit:** Every `GeofenceConstants.X` reference in `location/src/main` was checked against `GeofenceConfig` field equivalents. Only `GeofenceCooldownFilter` was using a constant directly where a config field exists. All other constants are either sentinels (`MOVEMENT_TRIGGER_ID`), Android API flags (`NO_INITIAL_TRIGGER`, `GEOFENCE_EXPIRATION_NEVER`, `PENDING_INTENT_REQUEST_CODE`), or already use the `?:` fallback pattern.

### 4. Sample manifest gaps

- `samples/java_layout/src/main/AndroidManifest.xml`: added `ACCESS_BACKGROUND_LOCATION` (FINE was already there)
- `samples/kotlin_compose/src/main/AndroidManifest.xml`: added both `ACCESS_FINE_LOCATION` and `ACCESS_BACKGROUND_LOCATION` (had neither)

### 5. Spurious EXIT events from GMS state reconciliation

**Before:** Every Tier A / Tier B refresh sent the full nearest-set to `GeofencingClient.addGeofences` — including business IDs already registered with the same parameters. Observed on emulator during repeated Tier A refreshes: the OS fired EXIT for all 4 cached regions on every refresh despite no actual transition. The cooldown filter dedupes within the window, but every refresh outside the window flushes the same spurious events again.

**Root cause:** `GeofencingClient.addGeofences()` treats a same-ID re-upsert as a fresh state evaluation. GMS recomputes the region's inside/outside state from the current location; if the cached internal state has drifted from reality (e.g. a "should be inside" region that the OS now sees as "outside"), an EXIT fires immediately.

**After:**
- `GeofenceManager.replaceGeofences` accepts `existingBusinessIds: Set<String> = emptySet()` — caller tells the manager what's already in GMS
- Manager `partition`s incoming business regions into `businessToAdd` (new − existing) and `businessKept` (overlap); only `businessToAdd` is sent to GMS. Overlapping IDs are left untouched, so no reconciliation event fires for them.
- Movement trigger is always re-registered because its center moves with the user.
- `GeofenceRepository.registerWithBusinessDiff` reads the persisted registered IDs (minus movement trigger) and forwards them on the default Tier A / Tier B refresh path.
- Boot restore bypasses the diff via `replaceGeofencesForBootRestore` — after a reboot OS state is empty regardless of what the store says, so any "existing" set would leave us with no registrations in GMS.
- The Repository's existing stale-cleanup pass (existing − new for removes) is the symmetric inverse and is unchanged; KDoc now notes the symmetry.

**Logging:** New `GeofenceLogger.logBusinessGeofencesKept(count)` fires when overlap is skipped, so the kept-vs-added split is visible in logs.

**Param-drift handling (commit d2297e8):** Cursor Bugbot flagged that the initial diff would skip re-registering business geofences whose backend-side parameters had changed — the cache would update via `saveCachedRegions(regions)` but GMS would retain the stale values until boot, sign-out, or the geofence dropping out of the nearest set. Fixed by tightening `registerWithBusinessDiff` to treat an ID as skip-safe only when `cachedRegion == incomingRegion` (data-class equality on `GeofenceRegion`). Any param drift — radius, coords, transition types, name, or `lastUpdated` — falls out of `existingBusinessIds` and forces re-registration. Tier A (cache as input) is unaffected by construction; only Tier B (API refresh) can introduce drift.

**Tests (commit 26a84b3):** `GeofenceRepositoryTest` adds two Tier-B remote-refresh cases that pin the equality-based skip filter end-to-end — one where cached equals incoming (overlap ID forwarded as existing), one where the radius drifted from 100m to 200m (overlap ID excluded, forcing re-register). Removing the `cachedById[it.id] == it` check would fail the second assertion immediately. Existing 240 cases still pass against the updated 2-arg `replaceGeofences` matchers.

### 6. Post-reboot GMS state lost when boot-restore races app-launch

**Before:** After a device reboot GMS wipes all geofence registrations, but our persisted `registeredIds` still reflects pre-boot state. If the app launches around the same time the OS dispatches `ACTION_BOOT_COMPLETED` (common on emulator restarts, sometimes seen on real devices), the app-launch `refresh()` grabs the `refreshInProgress` gate first. The boot receiver's `restoreFromCache()` then fails its own `compareAndSet` and bails with `"refresh already in progress"`. Meanwhile `registerWithBusinessDiff` (the path refresh takes) treats every business region as "unchanged" via the equality diff (cached == incoming) and skips them — leaving GMS with only the movement trigger and zero business geofences until a sign-out, reinstall, or `remote_fetch_refresh_expiry` tick. End-to-end testing surfaced this as "no geofence ENTER/EXIT events fire after reboot even though movement-trigger still does."

**After:** `GeofenceRepositoryImpl.restoreFromCache` no longer takes the `refreshInProgress` gate. It still uses `replaceGeofencesForBootRestore` (which bypasses the equality diff) and goes through `registerNearestAndPersist → stateMutex.withLock { ... }` so writes against `GeofencingClient` and the persisted `registeredIds` remain serialized. The two orderings now converge on the correct GMS state:

- *Refresh wins the mutex first:* registers movement, skips business via diff. Boot-restore then acquires the mutex and `replaceGeofencesForBootRestore` adds the 4 business + re-upserts movement. End state: movement + 4 business.
- *Boot-restore wins the mutex first:* registers movement + 4 business. Refresh then acquires the mutex, sees cached == incoming, skips business, re-upserts movement only. End state: movement + 4 business.

**Tests (commit c94b910):** New `restoreFromCache_givenRefreshInFlight_expectStillRunsViaBootRestoreVariant` launches refresh + restoreFromCache concurrently — refresh holds the path 100ms via a mocked `replaceGeofences` delay, restoreFromCache enters at +20ms — and asserts `manager.replaceGeofencesForBootRestore(any())` was actually called. Under the old gated behavior that call would never have happened.

**Verified end-to-end on emulator:** post-reboot log showed boot-restore firing, both refresh paths writing through `stateMutex` in sequence, and a full Eiffel→Shahkam→Saleem→Thokar journey producing 4 ENTER + 4 EXIT events with no spurious EXIT bursts.

## Test plan

Automated:
- [x] `:location:testDebugUnitTest` passes
- [x] `:location:apiCheck` passes (no public API changes)
- [x] `:samples:java_layout:assembleDebug` and `:samples:kotlin_compose:assembleDebug` build

New test coverage:
- `GeofencePermissionCheckerTest` (new) — FINE/BACKGROUND combinations across SDK 28 and 29
- `GeofenceServicesTest` — `onLocationAcquired` happy path, no-prior-skip no-op, no-userId no-op, no-retrigger-after-successful-sync, and BACKGROUND-missing-warn behavior
- `LocationTrackerTest` — listener invoked with coordinates, null listener no-exception
- `GeofenceCooldownFilterTest` — server-configured cooldown is actually applied (new test), all existing constant-fallback tests preserved
- `GeofenceManagerTest` — FINE-only registration now succeeds (was: expected failure)

Manual (java sample):
- [ ] Grant only FINE (not BACKGROUND) → geofences register, `[Geofence] Geofence sync (...): ACCESS_BACKGROUND_LOCATION not granted` info log appears
- [ ] Tap "Grant background location" → API 29: runtime dialog; API 30+: Settings deep link
- [ ] Fresh install, identify before any GPS fix → confirm refresh fires when the first fix lands (visible in logs via `Geofence sync triggered: user-identified` shortly after `Location update received` for the first fix)
- [ ] Repeated Tier A refresh within the freshness window → confirm `Kept N business geofences unchanged in OS` appears and no spurious EXIT events fire for cached regions
- [ ] Reboot device, do NOT open the app, then cross a business geofence → confirm `sync triggered: boot-restore` fires, `Registered N geofences with OS` appears (N = movement + business count), and subsequent ENTER/EXIT events log for each business region crossed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches geofence registration and refresh logic (OS/GMS interaction and permission gating), which can change when/if transitions fire and when network refreshes occur. Changes are well-scoped and backed by added/updated unit tests, but regressions would impact geofence reliability.
> 
> **Overview**
> Improves geofence reliability and configurability by **allowing registration with only `ACCESS_FINE_LOCATION`** (foreground-only delivery) while separately warning when background delivery is unavailable.
> 
> Adds a one-time **retry path when `identify()` happens before the first GPS fix**, by wiring a `LocationTracker` location-received callback into `GeofenceServices.onLocationAcquired()`.
> 
> Reduces spurious GMS reconciliation transitions by **skipping re-upsert of unchanged business geofences** (`existingBusinessIds` diff) while still re-registering the movement trigger; boot restore bypasses the diff to handle wiped OS state. Also updates duplicate-event suppression to **honor server-configured `duplicateEventsExpiry`**.
> 
> Updates sample apps to declare background location and adds sample UI flow to request it, and expands tests around permissions, cooldown config, diff-based registration, and the new location-acquired retry hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94b9103f7e30ae4db878225a99b7ef7aa684f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




