### PR TITLE
chore: improve geofencing reliability for ON_APP_START + sample UX

### DIFF
--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -131,6 +131,14 @@ class ModuleLocation @JvmOverloads constructor(
                     latitude = location?.latitude,
                     longitude = location?.longitude
                 )
+
+                // ON_APP_START's lifecycle one-shot fires per process, but resetContext()
+                // wipes lastLocation on logout — a subsequent identify in the same process
+                // needs a fresh fetch. The onLocationReceivedListener above re-triggers the
+                // geofence refresh once the fix arrives. MANUAL deliberately doesn't auto-fetch.
+                if (location == null && moduleConfig.trackingMode == LocationTrackingMode.ON_APP_START) {
+                    services.requestLocationUpdate()
+                }
             }
         }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -50,7 +50,7 @@ public class CustomerIOSDKConfig {
                 true,
                 false,
                 true,
-                LocationTrackingMode.MANUAL);
+                LocationTrackingMode.ON_APP_START);
     }
 
     @NonNull

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -13,6 +13,7 @@ import io.customer.android.sample.java_layout.support.Optional;
 import io.customer.android.sample.java_layout.utils.StringUtils;
 import io.customer.datapipelines.config.ScreenView;
 import io.customer.datapipelines.extensions.RegionExtKt;
+import io.customer.location.LocationTrackingMode;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
 
@@ -33,6 +34,7 @@ public class CustomerIOSDKConfig {
         static final String TRACK_APPLICATION_LIFECYCLE = "cio_sdk_track_application_lifecycle";
         static final String TEST_MODE_ENABLED = "cio_sdk_test_mode";
         static final String IN_APP_MESSAGING_ENABLED = "cio_sdk_in_app_messaging_enabled";
+        static final String LOCATION_TRACKING_MODE = "cio_sdk_location_tracking_mode";
     }
 
     public static CustomerIOSDKConfig getDefaultConfigurations() {
@@ -47,7 +49,8 @@ public class CustomerIOSDKConfig {
                 ScreenView.All.INSTANCE,
                 true,
                 false,
-                true);
+                true,
+                LocationTrackingMode.MANUAL);
     }
 
     @NonNull
@@ -69,6 +72,7 @@ public class CustomerIOSDKConfig {
         boolean applicationLifecycleTrackingEnabled = StringUtils.parseBoolean(bundle.get(Keys.TRACK_APPLICATION_LIFECYCLE), defaultConfig.applicationLifecycleTrackingEnabled);
         boolean testModeEnabled = StringUtils.parseBoolean(bundle.get(Keys.TEST_MODE_ENABLED), defaultConfig.testModeEnabled);
         boolean inAppMessagingEnabled = StringUtils.parseBoolean(bundle.get(Keys.IN_APP_MESSAGING_ENABLED), defaultConfig.inAppMessagingEnabled);
+        LocationTrackingMode locationTrackingMode = parseLocationTrackingMode(bundle.get(Keys.LOCATION_TRACKING_MODE), defaultConfig.locationTrackingMode);
 
         CustomerIOSDKConfig config = new CustomerIOSDKConfig(cdpApiKey,
                 siteId,
@@ -81,8 +85,21 @@ public class CustomerIOSDKConfig {
                 screenViewUse,
                 applicationLifecycleTrackingEnabled,
                 testModeEnabled,
-                inAppMessagingEnabled);
+                inAppMessagingEnabled,
+                locationTrackingMode);
         return Optional.of(config);
+    }
+
+    @NonNull
+    private static LocationTrackingMode parseLocationTrackingMode(@Nullable String name, @NonNull LocationTrackingMode fallback) {
+        if (TextUtils.isEmpty(name)) {
+            return fallback;
+        }
+        try {
+            return LocationTrackingMode.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return fallback;
+        }
     }
 
     @NonNull
@@ -100,6 +117,7 @@ public class CustomerIOSDKConfig {
         bundle.put(Keys.TRACK_APPLICATION_LIFECYCLE, StringUtils.fromBoolean(config.applicationLifecycleTrackingEnabled));
         bundle.put(Keys.TEST_MODE_ENABLED, StringUtils.fromBoolean(config.testModeEnabled));
         bundle.put(Keys.IN_APP_MESSAGING_ENABLED, StringUtils.fromBoolean(config.inAppMessagingEnabled));
+        bundle.put(Keys.LOCATION_TRACKING_MODE, config.locationTrackingMode.name());
         return bundle;
     }
 
@@ -121,6 +139,8 @@ public class CustomerIOSDKConfig {
     private final boolean applicationLifecycleTrackingEnabled;
     private final boolean testModeEnabled;
     private final boolean inAppMessagingEnabled;
+    @NonNull
+    private final LocationTrackingMode locationTrackingMode;
 
     public CustomerIOSDKConfig(@NonNull String cdpApiKey,
                                @NonNull String siteId,
@@ -133,7 +153,8 @@ public class CustomerIOSDKConfig {
                                @NonNull ScreenView screenViewUse,
                                boolean applicationLifecycleTrackingEnabled,
                                boolean testModeEnabled,
-                               boolean inAppMessagingEnabled) {
+                               boolean inAppMessagingEnabled,
+                               @NonNull LocationTrackingMode locationTrackingMode) {
         this.cdpApiKey = cdpApiKey;
         this.siteId = siteId;
         this.apiHost = apiHost;
@@ -146,6 +167,7 @@ public class CustomerIOSDKConfig {
         this.applicationLifecycleTrackingEnabled = applicationLifecycleTrackingEnabled;
         this.testModeEnabled = testModeEnabled;
         this.inAppMessagingEnabled = inAppMessagingEnabled;
+        this.locationTrackingMode = locationTrackingMode;
     }
 
     @NonNull
@@ -201,5 +223,10 @@ public class CustomerIOSDKConfig {
     @NonNull
     public ScreenView getScreenViewUse() {
         return screenViewUse;
+    }
+
+    @NonNull
+    public LocationTrackingMode getLocationTrackingMode() {
+        return locationTrackingMode;
     }
 }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -14,7 +14,6 @@ import io.customer.android.sample.java_layout.support.Optional;
 import io.customer.messaginginapp.MessagingInAppModuleConfig;
 import io.customer.messaginginapp.ModuleMessagingInApp;
 import io.customer.location.LocationModuleConfig;
-import io.customer.location.LocationTrackingMode;
 import io.customer.location.ModuleLocation;
 import io.customer.messagingpush.ModuleMessagingPushFCM;
 import io.customer.sdk.CustomerIO;
@@ -44,7 +43,7 @@ public class CustomerIORepository {
         // Enables location tracking
         builder.addCustomerIOModule(new ModuleLocation(
                 new LocationModuleConfig.Builder()
-                        .setLocationTrackingMode(LocationTrackingMode.MANUAL)
+                        .setLocationTrackingMode(sdkConfig.getLocationTrackingMode())
                         .build()
         ));
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -61,16 +61,19 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                 }
             });
 
-    // On API 30+, BACKGROUND can't be requested via the standard runtime dialog —
-    // the launcher returns immediately as "denied" and the user must toggle "Allow
-    // all the time" from app settings. This launcher handles the API 29 case where
-    // the runtime dialog still works.
+    // Launcher behavior varies by API:
+    // - API 29: shows the runtime dialog with "Allow all the time".
+    // - API 30+: OS may route directly to the app's location permission page
+    //   (recent Pixel/Samsung) or silently deny (others). Don't trust the
+    //   `granted` flag — re-check actual permission state to cover both paths.
     private final ActivityResultLauncher<String> backgroundLocationLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
-                if (granted) {
+                if (hasBackgroundLocation()) {
                     showSnackbar(getString(R.string.background_location_already_granted));
                 } else {
-                    showBackgroundLocationSettingsAlert();
+                    // Rationale was already shown before launch. If the OS silently
+                    // denied (didn't route to settings), take the user there now.
+                    openAppDetailsSettings();
                 }
             });
 
@@ -110,13 +113,19 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
             showSnackbar(getString(R.string.background_location_already_granted));
             return;
         }
-        // API 30+ requires the user to grant from Settings; the runtime dialog
-        // is not shown. Route them directly there.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            showBackgroundLocationSettingsAlert();
-            return;
-        }
-        backgroundLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION);
+        // Show the rationale first — "Allow all the time" is not obvious in
+        // either the API 29 runtime dialog or the API 30+ settings page.
+        showBackgroundLocationRationale();
+    }
+
+    private void showBackgroundLocationRationale() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.geofence_permissions_section)
+                .setMessage(R.string.background_location_rationale_message)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.background_location_continue, (dialog, which) ->
+                        backgroundLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+                .show();
     }
 
     private boolean hasFineLocation() {
@@ -130,16 +139,10 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                 Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_GRANTED;
     }
 
-    private void showBackgroundLocationSettingsAlert() {
-        new MaterialAlertDialogBuilder(this)
-                .setTitle(R.string.geofence_permissions_section)
-                .setMessage(R.string.background_location_open_settings)
-                .setNeutralButton(R.string.open_settings, (dialog, which) -> {
-                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                    intent.setData(Uri.parse("package:" + getPackageName()));
-                    startActivity(intent);
-                })
-                .show();
+    private void openAppDetailsSettings() {
+        Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        intent.setData(Uri.parse("package:" + getPackageName()));
+        startActivity(intent);
     }
 
     private void setupPresetButtons() {
@@ -270,11 +273,7 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
         new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.location_permission_required)
                 .setMessage(R.string.location_permission_failure)
-                .setNeutralButton(R.string.open_settings, (dialog, which) -> {
-                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                    intent.setData(Uri.parse("package:" + getPackageName()));
-                    startActivity(intent);
-                })
+                .setNeutralButton(R.string.open_settings, (dialog, which) -> openAppDetailsSettings())
                 .show();
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/InternalSettingsActivity.java
@@ -128,7 +128,8 @@ public class InternalSettingsActivity extends BaseActivity<ActivityInternalSetti
                 currentSettings.getScreenViewUse(),
                 currentSettings.isApplicationLifecycleTrackingEnabled(),
                 currentSettings.isTestModeEnabled(),
-                currentSettings.isInAppMessagingEnabled()
+                currentSettings.isInAppMessagingEnabled(),
+                currentSettings.getLocationTrackingMode()
         );
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/settings/SettingsActivity.java
@@ -18,6 +18,7 @@ import io.customer.android.sample.java_layout.ui.dashboard.DashboardActivity;
 import io.customer.android.sample.java_layout.utils.OSUtils;
 import io.customer.android.sample.java_layout.utils.ViewUtils;
 import io.customer.datapipelines.config.ScreenView;
+import io.customer.location.LocationTrackingMode;
 import io.customer.sdk.core.util.CioLogLevel;
 import io.customer.sdk.data.model.Region;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
@@ -139,6 +140,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         binding.settingsLogLevelValuesGroup.check(getCheckedLogLevelButtonId(config.getLogLevel()));
         binding.settingsTestModeValuesGroup.check(getCheckedTestModeButtonId(config.isTestModeEnabled()));
         binding.settingsInAppMessagingValuesGroup.check(getCheckedInAppMessagingButtonId(config.isInAppMessagingEnabled()));
+        binding.settingsLocationTrackingModeValuesGroup.check(getCheckedLocationTrackingModeButtonId(config.getLocationTrackingMode()));
     }
 
     private void saveSettings() {
@@ -182,6 +184,7 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
         CioLogLevel logLevel = getSelectedLogLevel();
         Region region = getSelectedRegion();
         ScreenView screenViewUse = getSelectedScreenViewUse();
+        LocationTrackingMode locationTrackingMode = getSelectedLocationTrackingMode();
 
         return new CustomerIOSDKConfig(cdpApiKey,
                 siteId,
@@ -194,7 +197,34 @@ public class SettingsActivity extends BaseActivity<ActivitySettingsBinding> {
                 screenViewUse,
                 featTrackApplicationLifecycle,
                 featTestModeEnabled,
-                featInAppMessagingEnabled);
+                featInAppMessagingEnabled,
+                locationTrackingMode);
+    }
+
+    @NonNull
+    private LocationTrackingMode getSelectedLocationTrackingMode() {
+        int checkedButton = binding.settingsLocationTrackingModeValuesGroup.getCheckedButtonId();
+        if (checkedButton == R.id.settings_location_tracking_mode_off_button) {
+            return LocationTrackingMode.OFF;
+        } else if (checkedButton == R.id.settings_location_tracking_mode_manual_button) {
+            return LocationTrackingMode.MANUAL;
+        } else if (checkedButton == R.id.settings_location_tracking_mode_on_app_start_button) {
+            return LocationTrackingMode.ON_APP_START;
+        }
+        throw new IllegalStateException();
+    }
+
+    private int getCheckedLocationTrackingModeButtonId(@NonNull LocationTrackingMode mode) {
+        switch (mode) {
+            case OFF:
+                return R.id.settings_location_tracking_mode_off_button;
+            case MANUAL:
+                return R.id.settings_location_tracking_mode_manual_button;
+            case ON_APP_START:
+                return R.id.settings_location_tracking_mode_on_app_start_button;
+            default:
+                throw new IllegalStateException();
+        }
     }
 
     @NonNull

--- a/samples/java_layout/src/main/res/layout/activity_settings.xml
+++ b/samples/java_layout/src/main/res/layout/activity_settings.xml
@@ -321,6 +321,58 @@
                 </com.google.android.material.button.MaterialButtonToggleGroup>
 
                 <TextView
+                    android:id="@+id/settings_location_tracking_mode_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_default"
+                    android:text="@string/location_tracking_mode"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/settings_in_app_messaging_values_group" />
+
+                <TextView
+                    android:id="@+id/settings_location_tracking_mode_desc_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/location_tracking_mode_desc"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/settings_location_tracking_mode_label" />
+
+                <com.google.android.material.button.MaterialButtonToggleGroup
+                    android:id="@+id/settings_location_tracking_mode_values_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/settings_location_tracking_mode_desc_label"
+                    app:singleSelection="true">
+
+                    <Button
+                        android:id="@+id/settings_location_tracking_mode_off_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/location_tracking_mode_off" />
+
+                    <Button
+                        android:id="@+id/settings_location_tracking_mode_manual_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/location_tracking_mode_manual" />
+
+                    <Button
+                        android:id="@+id/settings_location_tracking_mode_on_app_start_button"
+                        style="?attr/materialButtonOutlinedStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/location_tracking_mode_on_app_start" />
+                </com.google.android.material.button.MaterialButtonToggleGroup>
+
+                <TextView
                     android:id="@+id/settings_development_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -328,7 +380,7 @@
                     android:text="@string/development"
                     android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/settings_in_app_messaging_values_group" />
+                    app:layout_constraintTop_toBottomOf="@+id/settings_location_tracking_mode_values_group" />
 
                 <TextView
                     android:id="@+id/settings_log_level_label"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -37,6 +37,11 @@
     <string name="settings_yes">Yes</string>
     <string name="settings_no">No</string>
     <string name="enable_in_app_messages">Enable in-app messages</string>
+    <string name="location_tracking_mode">Location tracking mode</string>
+    <string name="location_tracking_mode_desc">(Controls whether the SDK captures location automatically — required for geofencing without a manual fetch)</string>
+    <string name="location_tracking_mode_off">Off</string>
+    <string name="location_tracking_mode_manual">Manual</string>
+    <string name="location_tracking_mode_on_app_start">On app start</string>
     <string name="development">Development</string>
     <string name="log_level">Log level</string>
     <string name="log_level_none">None</string>
@@ -145,7 +150,8 @@
     <string name="background_location_already_granted">Background location is already granted</string>
     <string name="background_location_not_required_pre_q">Background location permission is not required on this Android version</string>
     <string name="background_location_needs_fine_first">Grant fine location first, then re-tap this button</string>
-    <string name="background_location_open_settings">Open Settings and choose \"Allow all the time\"</string>
+    <string name="background_location_rationale_message">Background location is required so geofence transitions can fire while the app isn\'t running. On the next screen, choose \"Allow all the time\" for location.</string>
+    <string name="background_location_continue">Continue</string>
 
     <!-- Inbox Messages -->
     <string name="inbox_messages">Inbox Messages</string>


### PR DESCRIPTION
## Summary

Three reliability/UX changes under the MBL-1735 bucket:

1. **SDK** — bootstrap location on identify when `ON_APP_START` is configured and `lastLocation` is null. The lifecycle one-shot fires per process, but `resetContext()` wipes `lastLocation` on logout — so a subsequent identify in the same process needs a fresh fetch. The existing `onLocationReceivedListener` re-triggers the geofence refresh once the fix arrives. `MANUAL` stays strict per its "host controls" contract; `OFF` is unaffected.
2. **Sample (Java)** — expose `LocationTrackingMode` (`OFF` / `MANUAL` / `ON_APP_START`) as a Settings toggle so QA can exercise each path without a rebuild.
3. **Sample (Java)** — show a rationale dialog before requesting background location so the user knows to choose **Allow all the time** on the next screen. Drive the launcher on all supported APIs and re-check actual permission state in the callback instead of the unreliable `granted` flag.

Linear: [MBL-1735](https://linear.app/customerio/issue/MBL-1735/android-fix-geofencing-reliability-and-lifecycle-issues-identified)

## Stack

```
main
 └── feature/geofence-on-device
      └── MBL-1735-fix-geofencing-reliability  ← this PR
```

## Test plan

- [x] Emulator (Android 16): cold start with `ON_APP_START`, identify, geofences register cleanly once location arrives.
- [x] Emulator (Android 16): logout → re-login while app stays foregrounded → fresh location is fetched and geofences re-register (previously stuck on "no location available").
- [x] Real device: confirmed geofences register on cold start with `ON_APP_START`.
- [x] Background location rationale dialog shows before the OS settings page on Android 16; instruction stays fresh in the user's mind when picking "Allow all the time".
- [x] API 29 emulator: sanity check that the runtime dialog path still works (low risk; deferred).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDK change affects identify-time location requests and geofence registration for ON_APP_START; scope is narrow and gated on null cache, but touches identity/location lifecycle.
> 
> **Overview**
> Fixes **geofencing after logout → re-identify** when `LocationTrackingMode` is **`ON_APP_START`**: if `lastLocation` was cleared by `resetContext()` but the process stayed alive, the SDK now calls **`requestLocationUpdate()`** on identify so geofences can refresh once a fix arrives (existing listener still drives `onLocationAcquired`). **`MANUAL`** / **`OFF`** behavior is unchanged.
> 
> The **Java sample** wires **`LocationTrackingMode`** through persisted config (default **`ON_APP_START`**), **Settings** toggles (**Off / Manual / On app start**), and **`ModuleLocation`** init from saved settings. **Location test** background-permission flow adds a **rationale dialog**, uses the permission launcher on all supported APIs, and **re-checks actual permission** in the callback instead of trusting `granted`, opening app details when still denied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce747c7b8fa7184e85822d5c9f482d9fea49339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->