### PR TITLE
refactor: deliver geofence transitions exactly-once via shared store

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
@@ -1,0 +1,63 @@
+package io.customer.sdk.data.store
+
+import io.customer.base.internal.InternalCustomerIOApi
+import java.io.IOException
+
+/**
+ * Outcome of a [claimSendRestore] attempt. Delivery channels (the push and
+ * geofence WorkManager workers) map this onto their own result type
+ * (e.g. a `ListenableWorker.Result`).
+ */
+@InternalCustomerIOApi
+sealed interface PendingDeliveryResult {
+    /** The entry was claimed and [send] reported success; the entry is gone. */
+    object Delivered : PendingDeliveryResult
+
+    /**
+     * The entry was already gone when we tried to claim it — another channel
+     * (e.g. the foreground flush) delivered it. Treat as success; do not send.
+     */
+    object AlreadyClaimed : PendingDeliveryResult
+
+    /** [send] failed transiently; the entry was restored so a retry can deliver it later. */
+    data class Retryable(val cause: Throwable?) : PendingDeliveryResult
+
+    /** [send] failed permanently; the entry was restored so the foreground flush can still try. */
+    data class Failed(val cause: Throwable?) : PendingDeliveryResult
+}
+
+/**
+ * Shared "exactly-once" decision for a delivery channel that competes with
+ * other channels over the same [entry] (typically a WorkManager worker racing
+ * the foreground flush).
+ *
+ * Atomically [claims][PendingDeliveryStore.claim] the entry before sending —
+ * a read-only check is not enough, since a slow [send] would let both channels
+ * act on the same still-present entry. If the claim is lost, [send] is never
+ * invoked. On failure the entry is [restored][PendingDeliveryStore.append] so
+ * a retry or the flush can deliver it later; on success it stays removed.
+ *
+ * Both the push and geofence workers share this so the claim/send/restore
+ * logic lives in one place — only the per-channel [send] call differs.
+ */
+@InternalCustomerIOApi
+suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore<T>.claimSendRestore(
+    entry: T,
+    isRetryable: (Throwable?) -> Boolean = { it is IOException },
+    send: suspend () -> Result<Unit>
+): PendingDeliveryResult {
+    if (!claim(entry.key)) return PendingDeliveryResult.AlreadyClaimed
+
+    val result = send()
+    return when {
+        result.isSuccess -> PendingDeliveryResult.Delivered
+        isRetryable(result.exceptionOrNull()) -> {
+            append(entry)
+            PendingDeliveryResult.Retryable(result.exceptionOrNull())
+        }
+        else -> {
+            append(entry)
+            PendingDeliveryResult.Failed(result.exceptionOrNull())
+        }
+    }
+}

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -1,0 +1,99 @@
+package io.customer.sdk.data.store
+
+import androidx.work.await
+import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
+import io.customer.sdk.core.util.DispatchersProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Drains a [PendingDeliveryStore] through an opportunistic in-process channel
+ * (typically an app-foreground handoff), guaranteeing exactly-once delivery
+ * against the durable WorkManager channel that also consumes the same store.
+ *
+ * For each pending entry it: cancels that entry's WorkManager unique work — so
+ * the worker can't also deliver — then atomically
+ * [claims][PendingDeliveryStore.claim] it and hands it to the caller's
+ * [publish] block. Cancel happens before the claim on purpose: an `ENQUEUED`
+ * or running worker flips to `CANCELLED` immediately, narrowing the window in
+ * which both channels could race. The claim is what actually guarantees
+ * exactly-once — cancellation is best-effort and can lose across process death.
+ *
+ * Entries are processed in isolation: one failed cancel/publish does not abort
+ * the batch, and an unclaimed or failed entry survives for the next flush. The
+ * worker's unique-work name must equal [PendingDeliveryStore.PendingDeliveryEntry.key].
+ *
+ * Both push (`handoffPendingPushDeliveryToAnalyticsPipeline`) and geofence
+ * share this so the drain logic lives in one place — only the [publish]
+ * transport and the [Callbacks] logging differ per feature.
+ */
+@InternalCustomerIOApi
+class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
+    private val store: PendingDeliveryStore<T>,
+    private val workManagerProvider: CustomerIOWorkManagerProvider,
+    private val dispatchersProvider: DispatchersProvider
+) {
+
+    /**
+     * Per-feature observation hooks. All default to no-ops so callers only
+     * override the ones they log. Invoked on the background coroutine.
+     */
+    open class Callbacks<T> {
+        /** Number of entries snapshotted at the start of the flush (may be 0). */
+        open fun onSnapshot(count: Int) {}
+
+        /** The entry's WorkManager unique work was cancelled. */
+        open fun onWorkCancelled(entry: T) {}
+
+        /** The entry was claimed and handed to `publish`. */
+        open fun onPublished(entry: T) {}
+
+        /** Processing this entry threw; it stays in the store for the next flush. */
+        open fun onEntryFailed(entry: T, cause: Throwable) {}
+
+        /** The flush finished; [count] entries were published this run. */
+        open fun onComplete(count: Int) {}
+    }
+
+    /**
+     * Launch a background drain of the store. Returns immediately; the work runs
+     * on [DispatchersProvider.background]. Safe to call on every foreground
+     * transition — an empty store is a cheap no-op.
+     */
+    fun flush(callbacks: Callbacks<T> = Callbacks(), publish: (T) -> Unit) {
+        CoroutineScope(dispatchersProvider.background).launch {
+            runCatching {
+                val pending = store.loadAll()
+                callbacks.onSnapshot(pending.size)
+                if (pending.isEmpty()) return@runCatching
+
+                val workManager = workManagerProvider.getWorkManager()
+                var publishedCount = 0
+                pending.forEach { entry ->
+                    try {
+                        if (workManager != null) {
+                            workManager.cancelUniqueWork(entry.key).await()
+                            callbacks.onWorkCancelled(entry)
+                        }
+                        // Atomically claim before publishing so the worker (which
+                        // also claims before sending) cannot deliver the same entry.
+                        // Claiming per-entry here, rather than batching a remove at
+                        // the end, also means a mid-loop CancellationException can't
+                        // strand an already-published entry for re-publish next flush.
+                        if (!store.claim(entry.key)) return@forEach
+                        publish(entry)
+                        callbacks.onPublished(entry)
+                        publishedCount++
+                    } catch (ce: CancellationException) {
+                        throw ce
+                    } catch (ex: Exception) {
+                        callbacks.onEntryFailed(entry, ex)
+                    }
+                }
+                callbacks.onComplete(publishedCount)
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -1,0 +1,101 @@
+package io.customer.sdk.data.store
+
+import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.core.util.Logger
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PendingDeliveryClaimTest : RobolectricTest() {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+
+    @Serializable
+    private data class TestEntry(val id: String) : PendingDeliveryStore.PendingDeliveryEntry {
+        override val key: String get() = id
+    }
+
+    private fun newStore() = PendingDeliveryStore(
+        context = contextMock,
+        fileName = "cio_test_claim_send_restore.json",
+        elementSerializer = TestEntry.serializer(),
+        logger = mockLogger
+    ).also { it.removeAll() }
+
+    @Test
+    fun claimSendRestore_givenEntryNotPresent_expectAlreadyClaimedAndSendNotInvoked() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("absent")
+        var sendInvoked = false
+
+        val result = store.claimSendRestore(entry) {
+            sendInvoked = true
+            Result.success(Unit)
+        }
+
+        result shouldBeEqualTo PendingDeliveryResult.AlreadyClaimed
+        sendInvoked shouldBeEqualTo false
+    }
+
+    @Test
+    fun claimSendRestore_givenSendSucceeds_expectDeliveredAndEntryRemoved() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("ok")
+        store.append(entry)
+
+        val result = store.claimSendRestore(entry) { Result.success(Unit) }
+
+        result shouldBeEqualTo PendingDeliveryResult.Delivered
+        store.loadAll() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun claimSendRestore_givenIOException_expectRetryableAndEntryRestored() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("retry")
+        store.append(entry)
+        val cause = IOException("network down")
+
+        val result = store.claimSendRestore(entry) { Result.failure(cause) }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Retryable::class
+        (result as PendingDeliveryResult.Retryable).cause shouldBeEqualTo cause
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+
+    @Test
+    fun claimSendRestore_givenNonRetryableError_expectFailedAndEntryRestored() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("fail")
+        store.append(entry)
+        val cause = IllegalStateException("400 bad request")
+
+        val result = store.claimSendRestore(entry) { Result.failure(cause) }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Failed::class
+        (result as PendingDeliveryResult.Failed).cause shouldBeEqualTo cause
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+
+    @Test
+    fun claimSendRestore_givenCustomRetryablePredicate_expectRetryableForMatchedError() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("custom")
+        store.append(entry)
+
+        val result = store.claimSendRestore(
+            entry = entry,
+            isRetryable = { it is IllegalStateException }
+        ) { Result.failure(IllegalStateException("transient")) }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Retryable::class
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+}

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -1,11 +1,15 @@
 package io.customer.sdk.data.store
 
+import androidx.work.Operation
+import androidx.work.WorkManager
+import com.google.common.util.concurrent.Futures
 import io.customer.commontest.core.RobolectricTest
 import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.core.util.Logger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verifyOrder
 import kotlinx.serialization.Serializable
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -44,13 +48,19 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
     private class RecordingCallbacks : PendingDeliveryFlusher.Callbacks<TestEntry>() {
         var snapshotCount: Int? = null
         var completeCount: Int? = null
+        val cancelled = mutableListOf<String>()
         val published = mutableListOf<String>()
         val failed = mutableListOf<String>()
 
         override fun onSnapshot(count: Int) { snapshotCount = count }
+        override fun onWorkCancelled(entry: TestEntry) { cancelled += entry.key }
         override fun onPublished(entry: TestEntry) { published += entry.key }
         override fun onEntryFailed(entry: TestEntry, cause: Throwable) { failed += entry.key }
         override fun onComplete(count: Int) { completeCount = count }
+    }
+
+    private fun immediateSuccessfulOperation(): Operation = mockk(relaxed = true) {
+        every { result } returns Futures.immediateFuture(Operation.SUCCESS)
     }
 
     @Test
@@ -80,6 +90,31 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.snapshotCount shouldBeEqualTo 3
         callbacks.published shouldBeEqualTo listOf("a", "b", "c")
         callbacks.completeCount shouldBeEqualTo 3
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun flush_givenWorkManagerAvailable_expectCancelsUniqueWorkByKeyBeforePublishing() {
+        val store = newStore()
+        listOf("a", "b").forEach { store.append(TestEntry(it)) }
+        val workManager: WorkManager = mockk(relaxed = true) {
+            every { cancelUniqueWork(any()) } returns immediateSuccessfulOperation()
+        }
+        every { workManagerProvider.getWorkManager() } returns workManager
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks) { publishedKeys += it.key }
+
+        // Each entry's WorkManager unique work is cancelled before it's published,
+        // so the worker can't also deliver.
+        verifyOrder {
+            workManager.cancelUniqueWork("a")
+            workManager.cancelUniqueWork("b")
+        }
+        callbacks.cancelled shouldBeEqualTo listOf("a", "b")
+        publishedKeys shouldBeEqualTo listOf("a", "b")
+        callbacks.completeCount shouldBeEqualTo 2
         store.loadAll().isEmpty().shouldBeTrue()
     }
 

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -1,0 +1,105 @@
+package io.customer.sdk.data.store
+
+import io.customer.commontest.core.RobolectricTest
+import io.customer.commontest.util.DispatchersProviderStub
+import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
+import io.customer.sdk.core.util.Logger
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.Serializable
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PendingDeliveryFlusherTest : RobolectricTest() {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+
+    // WorkManager unavailable: keeps the flush synchronous (no cancelUniqueWork().await())
+    // and lets us assert the claim/publish/restore logic in isolation. The WorkManager
+    // cancel path is integration-tested in the push and geofence modules.
+    private val workManagerProvider: CustomerIOWorkManagerProvider = mockk {
+        every { getWorkManager() } returns null
+    }
+    private val dispatchers = DispatchersProviderStub()
+
+    @Serializable
+    private data class TestEntry(val id: String) : PendingDeliveryStore.PendingDeliveryEntry {
+        override val key: String get() = id
+    }
+
+    private fun newStore() = PendingDeliveryStore(
+        context = contextMock,
+        fileName = "cio_test_flusher.json",
+        elementSerializer = TestEntry.serializer(),
+        logger = mockLogger
+    ).also { it.removeAll() }
+
+    private fun newFlusher(store: PendingDeliveryStore<TestEntry>) =
+        PendingDeliveryFlusher(store, workManagerProvider, dispatchers)
+
+    private class RecordingCallbacks : PendingDeliveryFlusher.Callbacks<TestEntry>() {
+        var snapshotCount: Int? = null
+        var completeCount: Int? = null
+        val published = mutableListOf<String>()
+        val failed = mutableListOf<String>()
+
+        override fun onSnapshot(count: Int) { snapshotCount = count }
+        override fun onPublished(entry: TestEntry) { published += entry.key }
+        override fun onEntryFailed(entry: TestEntry, cause: Throwable) { failed += entry.key }
+        override fun onComplete(count: Int) { completeCount = count }
+    }
+
+    @Test
+    fun flush_givenEmptyStore_expectSnapshotZeroAndNoPublishNoComplete() {
+        val store = newStore()
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks) { publishedKeys += it.key }
+
+        callbacks.snapshotCount shouldBeEqualTo 0
+        publishedKeys shouldBeEqualTo emptyList()
+        // Mirrors push: an empty store returns before onComplete.
+        callbacks.completeCount shouldBeEqualTo null
+    }
+
+    @Test
+    fun flush_givenEntries_expectEachClaimedPublishedAndStoreEmptied() {
+        val store = newStore()
+        listOf("a", "b", "c").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks) { publishedKeys += it.key }
+
+        publishedKeys shouldBeEqualTo listOf("a", "b", "c")
+        callbacks.snapshotCount shouldBeEqualTo 3
+        callbacks.published shouldBeEqualTo listOf("a", "b", "c")
+        callbacks.completeCount shouldBeEqualTo 3
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun flush_givenPublishThrowsForOneEntry_expectOthersStillProcessed() {
+        val store = newStore()
+        listOf("a", "bad", "c").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks) { entry ->
+            if (entry.key == "bad") throw IllegalStateException("publish failed")
+            publishedKeys += entry.key
+        }
+
+        // "bad" was claimed before publish threw, so it is dropped (not duplicated) —
+        // the deliberate "lose one rather than double-count" trade-off.
+        publishedKeys shouldBeEqualTo listOf("a", "c")
+        callbacks.failed shouldBeEqualTo listOf("bad")
+        callbacks.completeCount shouldBeEqualTo 2
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+}

--- a/docs/manual-tests/geofence-exactly-once.md
+++ b/docs/manual-tests/geofence-exactly-once.md
@@ -1,0 +1,246 @@
+# Manual Test Plan — Geofence Transition Exactly-Once Delivery (Android)
+
+Covers the geofence transition delivery refactor (`geofence-exactly-once-delivery`)
+that reuses the push "exactly-once" pattern: a transition is recorded in a
+disk-backed `PendingDeliveryStore` and delivered by **exactly one** of two
+channels — the **WorkManager worker** (direct HTTP `/track`, survives process
+death) or the **foreground flush** (analytics pipeline) — arbitrated by an
+atomic `claim()`.
+
+> **Core invariant for every case:** each geofence transition (`GeoFence
+> Entered` / `GeoFence Exited`) reaches Customer.io **exactly once** — never
+> zero, never twice. Before the refactor both channels fired in parallel, so a
+> transition observed while the app was alive was sent **twice**; this plan
+> verifies that's now collapsed to one.
+
+---
+
+## Why no synthetic broadcast (read first)
+
+Unlike push (which ships a `SimulatePushDeliveryReceiver`), a geofence
+transition **cannot** be faked with `adb am broadcast`: `GeofencingEvent` has no
+public constructor and is parsed from GMS-internal intent extras. So we drive
+the **real** production path with the emulator's mock location, crossing a
+geofence that the SDK has actually registered with GMS from the workspace's
+`/geofences/nearby` response.
+
+The exactly-once arbitration logic itself is also covered by automated tests:
+- `core` — `PendingDeliveryFlusherTest`, `PendingDeliveryClaimTest`
+- `location` — `GeofenceEventWorkerTest` (claim / skip / restore), `GeofenceBroadcastReceiverTest` (append + schedule, no inline publish), `AsyncGeofenceEventTrackerTest`, `LocationLifecycleObserverTest`, `PendingGeofenceDeliveryTest`
+
+---
+
+## Environment & setup
+
+| Item | Value |
+|---|---|
+| Sample app | `samples/java_layout` (debug build) |
+| Package | `io.customer.android.sample.java_layout` |
+| Emulator | Google **APIs** image (GMS present), location enabled |
+| SDK log level | **DEBUG** (Settings → Log level = Debug) |
+| Precondition | Profile identified; workspace has ≥1 geofence configured; `ModuleLocation` registered with background-location permission granted so transitions fire in the background |
+
+### Helper commands
+
+```bash
+PKG=io.customer.android.sample.java_layout
+
+# 1) Live geofence logs (logcat tag is [CIO], geofence messages are prefixed [Geofence])
+adb logcat | grep -E "\[Geofence\]"
+
+# 2) Inspect the on-disk pending store
+adb shell run-as $PKG cat files/cio_pending_geofence_delivery.json
+
+# 3) Move the device to drive real ENTER/EXIT transitions (lng THEN lat)
+adb emu geo fix <insideLng> <insideLat>     # cross INTO a geofence  -> ENTER
+adb emu geo fix <outsideLng> <outsideLat>   # cross OUT of it        -> EXIT
+
+# 4) Network / lifecycle control
+adb shell cmd connectivity airplane-mode enable             # go offline
+adb shell cmd connectivity airplane-mode disable            # go online
+adb shell input keyevent KEYCODE_HOME                       # background app
+adb shell am start -n $PKG/.ui.dashboard.DashboardActivity  # foreground app
+adb shell am force-stop $PKG                                # kill process
+```
+
+> Tip: confirm geofences are registered first — look for
+> `[Geofence] Geofence sync succeeded: N regions registered`, then note the
+> registered geofence's center/radius to choose inside/outside coordinates.
+
+### Portal check
+
+Workspace → **Data & Integrations → Activity Logs**, filter for the
+`GeoFence Entered` / `GeoFence Exited` event and confirm the **count** for a
+given transition.
+
+### Log hallmarks (message text after the `[Geofence]` prefix)
+
+| Stage | Log line |
+|---|---|
+| Transition recorded | `'<id>' ENTER: queued for exactly-once delivery (WorkManager now, analytics pipeline on next foreground)` |
+| Worker delivered | `'<id>' ENTER: delivered via WorkManager (direct HTTP); removed from pending store` |
+| Worker backed off | `'<id>' ENTER: worker skipped — already delivered via the analytics pipeline (claim lost)` |
+| Flush start | `Geofence foreground flush: N pending transition(s) to hand off to the analytics pipeline` |
+| Flush cancel WM | `'<id>' ENTER: cancelled pending WorkManager delivery before flush` |
+| Flush published | `'<id>' ENTER: published to analytics pipeline via foreground flush` |
+| Flush done | `Geofence foreground flush complete: N transition(s) handed off this run` |
+
+---
+
+## TC1 — Happy path: online, app in foreground
+
+**Objective:** Transition delivered by the WorkManager worker; no double send.
+
+**Preconditions:** Online; app foreground; inside-vs-outside coords known.
+
+**Steps:**
+1. Start log capture.
+2. `adb emu geo fix` to cross **into** a geofence (ENTER).
+
+**Expected logs:**
+```
+[Geofence] '<id>' ENTER: queued for exactly-once delivery ...
+[Geofence] '<id>' ENTER: delivered via WorkManager (direct HTTP); removed from pending store
+```
+_(No `published to analytics pipeline via foreground flush` for this transition — the app was already foregrounded, so no new ON_START fires.)_
+
+**Expected store:** `[]` (worker claimed + delivered).
+
+**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>`.
+
+---
+
+## TC2 — Foreground flush: offline at transition, then online + foreground
+
+**Objective:** When the worker can't confirm (offline), the transition is
+delivered via the analytics-pipeline flush on next foreground, and the worker is
+cancelled so it never also sends.
+
+**Preconditions:** **Offline** (airplane mode on); app **backgrounded**;
+background-location granted (so the transition still fires offline).
+
+**Steps:**
+1. Background the app, go offline.
+2. `adb emu geo fix` to cross into a geofence (ENTER).
+3. Inspect store.
+4. **Go online**, then foreground the app.
+5. Inspect store.
+
+**Expected logs (step 2):**
+```
+[Geofence] '<id>' ENTER: queued for exactly-once delivery ...
+```
+_(no `delivered via WorkManager` — the worker's CONNECTED constraint is unmet while offline.)_
+
+**Expected store after step 3:**
+```
+[{"geofenceId":"<id>","transition":"ENTER","latitude":...,"longitude":...,"timestamp":...}]
+```
+
+**Expected logs (step 4 — on foreground):**
+```
+[Geofence] Geofence foreground flush: 1 pending transition(s) ...
+[Geofence] '<id>' ENTER: cancelled pending WorkManager delivery before flush
+[Geofence] '<id>' ENTER: published to analytics pipeline via foreground flush
+[Geofence] Geofence foreground flush complete: 1 transition(s) handed off this run
+```
+
+**Expected store after step 5:** `[]`
+
+**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>`, via the analytics
+pipeline — **not** the worker.
+
+---
+
+## TC3 — No double delivery (cross-check of TC2)
+
+**Objective:** Confirm the cancelled worker never *also* delivers after the flush.
+
+**Preconditions:** Run TC2; stay online + foreground for ~2–3 min afterward.
+
+**Steps:**
+1. After TC2's flush, keep watching logs.
+2. Re-check the portal.
+
+**Expected logs:** **No** `'<id>' ENTER: delivered via WorkManager ...` for that
+transition at any point after the flush.
+
+**Expected store:** `[]` (stays empty).
+
+**Expected portal:** ✅ `GeoFence Entered` = **exactly 1** for `<id>` — **not 2**.
+(The headline guarantee — pre-refactor this was 2.)
+
+---
+
+## TC4 — Persistence across process death
+
+**Objective:** A pending transition survives a process kill and is delivered on
+relaunch.
+
+**Preconditions:** **Offline**; app backgrounded.
+
+**Steps:**
+1. Cross into a geofence (ENTER) while offline / backgrounded.
+2. Inspect store (expect `<id>` present).
+3. `am force-stop` the app.
+4. Inspect store again (must still contain `<id>`).
+5. **Go online**, relaunch the app.
+6. Inspect store.
+
+**Expected store after steps 2 & 4:** one entry for `<id>` — **survives the kill**.
+
+**Expected logs (step 5 — relaunch foreground):**
+```
+[Geofence] Geofence foreground flush: 1 pending transition(s) ...
+[Geofence] '<id>' ENTER: published to analytics pipeline via foreground flush
+[Geofence] Geofence foreground flush complete: 1 transition(s) handed off this run
+```
+_(Or, if WorkManager runs first on relaunch: `delivered via WorkManager ...` and the flush logs `snapshot ... 0`. Either way — exactly one delivery.)_
+
+**Expected store after step 6:** `[]`
+
+**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>` after relaunch.
+
+---
+
+## TC5 — Empty foreground (nothing pending)
+
+**Objective:** Foregrounding with nothing pending is a clean no-op.
+
+**Preconditions:** Store empty (fresh, or after a completed case); online.
+
+**Steps:**
+1. Background, then foreground the app.
+
+**Expected logs:**
+```
+[Geofence] Geofence foreground flush: 0 pending transition(s) ...
+```
+_(no `cancelled`, no `published`, no `flush complete`.)_
+
+**Expected store:** absent / `[]`.
+
+**Expected portal:** ⛔ no new geofence event.
+
+---
+
+## TC6 — EXIT transition
+
+**Objective:** Same exactly-once guarantee for EXIT.
+
+**Steps:** Repeat TC1 (or TC2) but cross **out** of the geofence.
+
+**Expected:** identical logs/store/portal with `EXIT` / `GeoFence Exited` = **1**.
+
+---
+
+## Summary matrix
+
+| TC | Network @ transition | App state | Delivery channel | Logs hallmark | Portal |
+|----|----------------------|-----------|------------------|---------------|--------|
+| TC1 | Online | Foreground | WorkManager | `delivered via WorkManager` | **1** |
+| TC2 | Offline → Online | Bg → Fg | Pipeline flush | `cancelled ...` + `published to analytics pipeline` | **1** |
+| TC3 | (after TC2) | Foreground | — | **no** late `delivered via WorkManager` | **1, not 2** |
+| TC4 | Offline → Online | killed → Fg | Pipeline flush (or WM) | store survives `force-stop` | **1** |
+| TC5 | Online | Bg → Fg | none | `flush: 0 pending` | **0** |
+| TC6 | any | any | one channel | `EXIT` variants | **1** |

--- a/location/src/main/kotlin/io/customer/location/LocationLifecycleObserver.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationLifecycleObserver.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.LifecycleOwner
  * Manages location lifecycle tied to app foreground/background transitions.
  *
  * Registered with [ProcessLifecycleOwner] during module initialization.
- * - [onStart]: triggers a one-shot location request on the first foreground entry
+ * - [onStart]: hands off any pending geofence transitions to the analytics
+ *   pipeline via [onForeground] (exactly-once against the WorkManager worker),
+ *   then triggers a one-shot location request on the first foreground entry
  *   when [trackingMode] is [LocationTrackingMode.ON_APP_START].
  * - [onStop]: cancels any in-flight GPS request when the app enters background.
  *
@@ -16,12 +18,16 @@ import androidx.lifecycle.LifecycleOwner
  */
 internal class LocationLifecycleObserver(
     private val locationServices: LocationServicesImpl,
-    private val trackingMode: LocationTrackingMode
+    private val trackingMode: LocationTrackingMode,
+    private val onForeground: () -> Unit = {}
 ) : DefaultLifecycleObserver {
 
     private var hasRequestedOnStart = false
 
     override fun onStart(owner: LifecycleOwner) {
+        // Runs on every foreground entry, independent of trackingMode — geofence
+        // deliveries must flush even in MANUAL mode.
+        onForeground()
         if (trackingMode == LocationTrackingMode.ON_APP_START && !hasRequestedOnStart) {
             hasRequestedOnStart = true
             locationServices.requestLocationUpdate()

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -3,7 +3,10 @@ package io.customer.location
 import android.location.Location
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.customer.location.geofence.di.geofenceCooldownFilter
+import io.customer.location.geofence.di.geofenceDeliveryFlusher
+import io.customer.location.geofence.di.geofenceLogger
 import io.customer.location.geofence.di.geofenceServices
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.location.provider.FusedLocationProvider
 import io.customer.location.store.LocationPreferenceStoreImpl
 import io.customer.location.sync.LocationSyncFilter
@@ -17,6 +20,7 @@ import io.customer.sdk.core.pipeline.identifyHookRegistry
 import io.customer.sdk.core.util.HandlerMainThreadPoster
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.core.util.MainThreadPoster
+import io.customer.sdk.data.store.PendingDeliveryFlusher
 
 /**
  * Location module for Customer.io SDK.
@@ -173,7 +177,42 @@ class ModuleLocation @JvmOverloads constructor(
         val mainThreadPoster: MainThreadPoster = HandlerMainThreadPoster()
         mainThreadPoster.post {
             ProcessLifecycleOwner.get().lifecycle.addObserver(
-                LocationLifecycleObserver(services, moduleConfig.trackingMode)
+                LocationLifecycleObserver(
+                    locationServices = services,
+                    trackingMode = moduleConfig.trackingMode,
+                    onForeground = { flushPendingGeofenceDeliveries() }
+                )
+            )
+        }
+    }
+
+    /**
+     * Hand off pending geofence transitions to the analytics pipeline on app
+     * foreground. The shared [PendingDeliveryFlusher] cancels each transition's
+     * WorkManager delivery and atomically claims it, so it can't be delivered
+     * twice (once here via the pipeline, once by the worker via direct HTTP).
+     */
+    private fun flushPendingGeofenceDeliveries() {
+        val eventBus = SDKComponent.eventBus
+        val logger = SDKComponent.geofenceLogger
+        SDKComponent.android().geofenceDeliveryFlusher.flush(
+            callbacks = object : PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>() {
+                override fun onSnapshot(count: Int) = logger.logForegroundFlushSnapshot(count)
+                override fun onWorkCancelled(entry: PendingGeofenceDelivery) =
+                    logger.logForegroundFlushCancelledWorkManager(entry.geofenceId, entry.transition.name)
+                override fun onPublished(entry: PendingGeofenceDelivery) =
+                    logger.logForegroundFlushPublished(entry.geofenceId, entry.transition.name)
+                override fun onEntryFailed(entry: PendingGeofenceDelivery, cause: Throwable) =
+                    logger.logForegroundFlushEntryFailed(entry.geofenceId, entry.transition.name, cause.message)
+                override fun onComplete(count: Int) = logger.logForegroundFlushComplete(count)
+            }
+        ) { entry ->
+            eventBus.publish(
+                Event.GeofenceTransitionEvent(
+                    geofenceId = entry.geofenceId,
+                    transition = entry.transition,
+                    properties = entry.toEventProperties()
+                )
             )
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -12,6 +12,8 @@ import io.customer.location.geofence.di.geofenceLogger
 import io.customer.location.geofence.di.geofenceManager
 import io.customer.location.geofence.di.geofenceRegionStore
 import io.customer.location.geofence.di.geofenceServices
+import io.customer.location.geofence.di.pendingGeofenceDeliveryStore
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
@@ -94,7 +96,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val androidComponent = SDKComponent.android()
         val scheduler = androidComponent.geofenceEventScheduler
         val cooldownFilter = androidComponent.geofenceCooldownFilter
-        val eventBus = SDKComponent.eventBus
         // Defense-in-depth against orphans (failed clearAll, app-data wipe, SDK
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
@@ -133,36 +134,27 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             }
             logger.logTransitionEmitting(geofenceId, transition.name)
 
-            // Parallel delivery: WorkManager (survives process death) + EventBus (analytics pipeline).
-            // Isolate the scheduler so a WorkManager failure doesn't skip EventBus or abandon the batch.
+            // Record the transition durably before scheduling. Two channels then
+            // race to deliver it exactly once, arbitrated by the shared store's
+            // atomic claim: the WorkManager worker (direct HTTP, survives process
+            // death) and the foreground flush (analytics pipeline). Append first
+            // so a WorkManager scheduling failure still leaves the entry for the
+            // flush; isolate the scheduler so it can't abandon the rest of the batch.
+            val entry = PendingGeofenceDelivery(
+                geofenceId = geofenceId,
+                transition = transition,
+                latitude = latitude,
+                longitude = longitude,
+                timestamp = timestamp
+            )
+            androidComponent.pendingGeofenceDeliveryStore.append(entry)
             try {
-                scheduler.schedule(
-                    geofenceId = geofenceId,
-                    transition = transition,
-                    latitude = latitude,
-                    longitude = longitude,
-                    timestamp = timestamp
-                )
+                scheduler.schedule(entry)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 logger.logSchedulerFailed(geofenceId, transition.name, e.message)
             }
-
-            val properties = buildMap<String, Any> {
-                put("geofence_id", geofenceId)
-                put("transition_type", transition.name.lowercase())
-                latitude?.let { put("latitude", it) }
-                longitude?.let { put("longitude", it) }
-                put("timestamp", timestamp)
-            }
-            eventBus.publish(
-                Event.GeofenceTransitionEvent(
-                    geofenceId = geofenceId,
-                    transition = transition,
-                    properties = properties
-                )
-            )
         }
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -37,7 +37,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logTransitionEmitting(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: emitting tracked event via WorkManager + EventBus", tag = TAG)
+        logger.debug("Geofence '$geofenceId' $transitionName: queued for exactly-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
     }
 
     fun logTransitionSuppressed(geofenceId: String, transitionName: String) {
@@ -122,6 +122,34 @@ internal class GeofenceLogger(private val logger: Logger) {
 
     fun logEventDeliverySkippedNoUser(geofenceId: String, transitionName: String) {
         logger.debug("Geofence '$geofenceId' $transitionName: HTTP delivery skipped — no identified user", tag = TAG)
+    }
+
+    fun logEventDelivered(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: delivered via WorkManager (direct HTTP); removed from pending store", tag = TAG)
+    }
+
+    fun logEventDeliverySkippedAlreadyDelivered(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: worker skipped — already delivered via the analytics pipeline (claim lost)", tag = TAG)
+    }
+
+    fun logForegroundFlushSnapshot(count: Int) {
+        logger.debug("Geofence foreground flush: $count pending transition(s) to hand off to the analytics pipeline", tag = TAG)
+    }
+
+    fun logForegroundFlushCancelledWorkManager(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: cancelled pending WorkManager delivery before flush", tag = TAG)
+    }
+
+    fun logForegroundFlushPublished(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: published to analytics pipeline via foreground flush", tag = TAG)
+    }
+
+    fun logForegroundFlushEntryFailed(geofenceId: String, transitionName: String, message: String?) {
+        logger.error("Geofence '$geofenceId' $transitionName: foreground flush failed; left in store for next flush — $message", tag = TAG)
+    }
+
+    fun logForegroundFlushComplete(count: Int) {
+        logger.debug("Geofence foreground flush complete: $count transition(s) handed off this run", tag = TAG)
     }
 
     fun logSchedulerFailed(geofenceId: String, transitionName: String, message: String?) {

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -153,7 +153,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logSchedulerFailed(geofenceId: String, transitionName: String, message: String?) {
-        logger.error("Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; EventBus path still attempted — $message", tag = TAG)
+        logger.error("Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; left in pending store for the foreground flush — $message", tag = TAG)
     }
 
     companion object {

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -19,6 +19,7 @@ import io.customer.location.geofence.store.GeofenceCooldownStore
 import io.customer.location.geofence.store.GeofenceCooldownStoreImpl
 import io.customer.location.geofence.store.GeofenceRegionStore
 import io.customer.location.geofence.store.GeofenceRegionStoreImpl
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.location.geofence.worker.AsyncGeofenceEventTracker
 import io.customer.location.geofence.worker.GeofenceEventScheduler
 import io.customer.location.geofence.worker.GeofenceEventTracker
@@ -28,6 +29,8 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.httpClient
 import io.customer.sdk.core.di.workManagerProvider
+import io.customer.sdk.data.store.PendingDeliveryFlusher
+import io.customer.sdk.data.store.PendingDeliveryStore
 
 internal val SDKComponent.geofenceLogger: GeofenceLogger
     get() = singleton { GeofenceLogger(logger) }
@@ -54,8 +57,35 @@ internal val AndroidSDKComponent.geofenceEventTracker: GeofenceEventTracker
         GeofenceEventTrackerImpl(SDKComponent.httpClient, secureUserStore, SDKComponent.geofenceLogger)
     }
 
+// Shared by the WorkManager worker, the async fallback, and the foreground flush
+// so all three coordinate exactly-once delivery over one lock/file.
+internal val AndroidSDKComponent.pendingGeofenceDeliveryStore: PendingDeliveryStore<PendingGeofenceDelivery>
+    get() = singleton {
+        PendingDeliveryStore(
+            context = applicationContext,
+            fileName = PendingGeofenceDelivery.FILE_NAME,
+            elementSerializer = PendingGeofenceDelivery.serializer(),
+            logger = SDKComponent.logger
+        )
+    }
+
+internal val AndroidSDKComponent.geofenceDeliveryFlusher: PendingDeliveryFlusher<PendingGeofenceDelivery>
+    get() = singleton {
+        PendingDeliveryFlusher(
+            store = pendingGeofenceDeliveryStore,
+            workManagerProvider = SDKComponent.workManagerProvider,
+            dispatchersProvider = SDKComponent.dispatchersProvider
+        )
+    }
+
 internal val AndroidSDKComponent.asyncGeofenceEventTracker: AsyncGeofenceEventTracker
-    get() = singleton { AsyncGeofenceEventTracker(geofenceEventTracker, SDKComponent.dispatchersProvider) }
+    get() = singleton {
+        AsyncGeofenceEventTracker(
+            tracker = geofenceEventTracker,
+            pendingStore = pendingGeofenceDeliveryStore,
+            dispatcher = SDKComponent.dispatchersProvider
+        )
+    }
 
 internal val AndroidSDKComponent.geofenceEventScheduler: GeofenceEventScheduler
     get() = singleton { GeofenceEventScheduler(SDKComponent.workManagerProvider, asyncGeofenceEventTracker) }

--- a/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
@@ -1,0 +1,43 @@
+package io.customer.location.geofence.store
+
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.PendingDeliveryStore
+import kotlinx.serialization.Serializable
+
+/**
+ * A geofence transition observed locally but not yet confirmed as tracked by
+ * the Customer.io backend. Appended when a transition fires, removed when one
+ * of the two delivery channels — the [GeofenceEventWorker] (durable, direct
+ * HTTP) or the foreground flush (analytics pipeline) — delivers it.
+ *
+ * The shared [PendingDeliveryStore] requires a stable `key`; ours doubles as
+ * the WorkManager unique-work name, so the foreground flush can cancel the
+ * pending worker by the same key before publishing.
+ */
+@Serializable
+internal data class PendingGeofenceDelivery(
+    val geofenceId: String,
+    val transition: Event.GeofenceTransition,
+    val latitude: Double?,
+    val longitude: Double?,
+    val timestamp: Long
+) : PendingDeliveryStore.PendingDeliveryEntry {
+    override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
+
+    /**
+     * Properties carried on the tracked "GeoFence Entered/Exited" event. Kept
+     * here so the producer, the worker's direct-HTTP send, and the foreground
+     * flush all build an identical property set.
+     */
+    fun toEventProperties(): Map<String, Any> = buildMap {
+        put("geofence_id", geofenceId)
+        put("transition_type", transition.name.lowercase())
+        latitude?.let { put("latitude", it) }
+        longitude?.let { put("longitude", it) }
+        put("timestamp", timestamp)
+    }
+
+    companion object {
+        internal const val FILE_NAME = "cio_pending_geofence_delivery.json"
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
@@ -8,6 +8,7 @@ import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.data.store.PendingDeliveryStore
 import io.customer.sdk.data.store.SecureUserStore
+import io.customer.sdk.data.store.claimSendRestore
 import io.customer.sdk.util.EventNames
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -80,9 +81,10 @@ internal class GeofenceEventTrackerImpl(
 
 /**
  * Async fallback when WorkManager is unavailable. Fire-and-forget; does not
- * survive process death. Mirrors the worker's success contract: on success the
- * pending entry is removed; on failure it is left in the store so the
- * foreground flush can still deliver it via the analytics pipeline.
+ * survive process death. Uses the same [claimSendRestore] contract as the
+ * worker — claim before sending — so that if the foreground flush fires while
+ * this HTTP call is in flight, only one channel delivers: a lost claim skips
+ * the send, and a failed send restores the entry for the flush to retry.
  */
 internal class AsyncGeofenceEventTracker(
     private val tracker: GeofenceEventTracker,
@@ -91,15 +93,14 @@ internal class AsyncGeofenceEventTracker(
 ) {
     fun trackEvent(entry: PendingGeofenceDelivery) {
         CoroutineScope(dispatcher.background).launch {
-            val result = tracker.trackEvent(
-                geofenceId = entry.geofenceId,
-                transition = entry.transition,
-                latitude = entry.latitude,
-                longitude = entry.longitude,
-                timestamp = entry.timestamp
-            )
-            if (result.isSuccess) {
-                pendingStore.remove(entry.key)
+            pendingStore.claimSendRestore(entry) {
+                tracker.trackEvent(
+                    geofenceId = entry.geofenceId,
+                    transition = entry.transition,
+                    latitude = entry.latitude,
+                    longitude = entry.longitude,
+                    timestamp = entry.timestamp
+                )
             }
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
@@ -1,10 +1,12 @@
 package io.customer.location.geofence.worker
 
 import io.customer.location.geofence.GeofenceLogger
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.data.store.PendingDeliveryStore
 import io.customer.sdk.data.store.SecureUserStore
 import io.customer.sdk.util.EventNames
 import kotlinx.coroutines.CoroutineScope
@@ -76,20 +78,29 @@ internal class GeofenceEventTrackerImpl(
     }
 }
 
-/** Async fallback when WorkManager is unavailable. Fire-and-forget; does not survive process death. */
+/**
+ * Async fallback when WorkManager is unavailable. Fire-and-forget; does not
+ * survive process death. Mirrors the worker's success contract: on success the
+ * pending entry is removed; on failure it is left in the store so the
+ * foreground flush can still deliver it via the analytics pipeline.
+ */
 internal class AsyncGeofenceEventTracker(
     private val tracker: GeofenceEventTracker,
+    private val pendingStore: PendingDeliveryStore<PendingGeofenceDelivery>,
     private val dispatcher: DispatchersProvider
 ) {
-    fun trackEvent(
-        geofenceId: String,
-        transition: Event.GeofenceTransition,
-        latitude: Double?,
-        longitude: Double?,
-        timestamp: Long
-    ) {
+    fun trackEvent(entry: PendingGeofenceDelivery) {
         CoroutineScope(dispatcher.background).launch {
-            tracker.trackEvent(geofenceId, transition, latitude, longitude, timestamp)
+            val result = tracker.trackEvent(
+                geofenceId = entry.geofenceId,
+                transition = entry.transition,
+                latitude = entry.latitude,
+                longitude = entry.longitude,
+                timestamp = entry.timestamp
+            )
+            if (result.isSuccess) {
+                pendingStore.remove(entry.key)
+            }
         }
     }
 }

--- a/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventWorker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventWorker.kt
@@ -11,11 +11,14 @@ import androidx.work.WorkerParameters
 import androidx.work.await
 import io.customer.location.geofence.di.geofenceEventTracker
 import io.customer.location.geofence.di.geofenceLogger
+import io.customer.location.geofence.di.pendingGeofenceDeliveryStore
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
-import java.io.IOException
+import io.customer.sdk.data.store.PendingDeliveryResult
+import io.customer.sdk.data.store.claimSendRestore
 
 private const val KEY_GEOFENCE_ID = "geofence_id"
 private const val KEY_TRANSITION = "transition"
@@ -31,20 +34,14 @@ internal class GeofenceEventScheduler(
     private val workManagerProvider: CustomerIOWorkManagerProvider,
     private val asyncTracker: AsyncGeofenceEventTracker
 ) {
-    suspend fun schedule(
-        geofenceId: String,
-        transition: Event.GeofenceTransition,
-        latitude: Double?,
-        longitude: Double?,
-        timestamp: Long
-    ) {
+    suspend fun schedule(entry: PendingGeofenceDelivery) {
         val input = Data.Builder()
-            .putString(KEY_GEOFENCE_ID, geofenceId)
-            .putString(KEY_TRANSITION, transition.name)
-            .putLong(KEY_TIMESTAMP, timestamp)
+            .putString(KEY_GEOFENCE_ID, entry.geofenceId)
+            .putString(KEY_TRANSITION, entry.transition.name)
+            .putLong(KEY_TIMESTAMP, entry.timestamp)
             .apply {
-                if (latitude != null) putDouble(KEY_LATITUDE, latitude)
-                if (longitude != null) putDouble(KEY_LONGITUDE, longitude)
+                entry.latitude?.let { putDouble(KEY_LATITUDE, it) }
+                entry.longitude?.let { putDouble(KEY_LONGITUDE, it) }
             }
             .build()
 
@@ -59,16 +56,16 @@ internal class GeofenceEventScheduler(
             .addTag(WORK_MANAGER_TAG_GEOFENCE)
             .build()
 
+        // entry.key ("${geofenceId}_${transition}_${timestamp}") doubles as the
+        // unique-work name so the foreground flush can cancel this worker by key.
         // Second-precision timestamp: same-second bursts collide (KEEP dedupes them);
         // later transitions get distinct keys so an offline-queued worker can't block legitimate re-entries.
-        val uniqueKey = "${geofenceId}_${transition.name}_$timestamp"
-
         val workManager = workManagerProvider.getWorkManager()
         if (workManager != null) {
             // Await persistence so the BroadcastReceiver doesn't finish() before WM commits the work spec.
-            workManager.enqueueUniqueWork(uniqueKey, ExistingWorkPolicy.KEEP, workRequest).await()
+            workManager.enqueueUniqueWork(entry.key, ExistingWorkPolicy.KEEP, workRequest).await()
         } else {
-            asyncTracker.trackEvent(geofenceId, transition, latitude, longitude, timestamp)
+            asyncTracker.trackEvent(entry)
         }
     }
 
@@ -109,17 +106,33 @@ internal class GeofenceEventWorker(
             }
         }
 
-        val result = SDKComponent.android().geofenceEventTracker
-            .trackEvent(geofenceId, transition, latitude, longitude, timestamp)
+        val store = SDKComponent.android().pendingGeofenceDeliveryStore
+        val entry = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp)
 
-        return when {
-            result.isSuccess -> Result.success()
-            result.exceptionOrNull() is IOException -> {
-                logger.logEventDeliveryRetryable(geofenceId, transition.name, result.exceptionOrNull()?.message)
+        // Shared exactly-once decision: claim before sending so we don't double
+        // deliver against the foreground flush (which also claims before
+        // publishing), and restore the entry on failure so a retry or the flush
+        // can deliver it later.
+        return when (
+            val outcome = store.claimSendRestore(entry) {
+                SDKComponent.android().geofenceEventTracker
+                    .trackEvent(geofenceId, transition, latitude, longitude, timestamp)
+            }
+        ) {
+            PendingDeliveryResult.AlreadyClaimed -> {
+                logger.logEventDeliverySkippedAlreadyDelivered(geofenceId, transition.name)
+                Result.success()
+            }
+            PendingDeliveryResult.Delivered -> {
+                logger.logEventDelivered(geofenceId, transition.name)
+                Result.success()
+            }
+            is PendingDeliveryResult.Retryable -> {
+                logger.logEventDeliveryRetryable(geofenceId, transition.name, outcome.cause?.message)
                 Result.retry()
             }
-            else -> {
-                logger.logEventDeliveryFailed(geofenceId, transition.name, result.exceptionOrNull()?.message)
+            is PendingDeliveryResult.Failed -> {
+                logger.logEventDeliveryFailed(geofenceId, transition.name, outcome.cause?.message)
                 Result.failure()
             }
         }

--- a/location/src/test/java/io/customer/location/LocationLifecycleObserverTest.kt
+++ b/location/src/test/java/io/customer/location/LocationLifecycleObserverTest.kt
@@ -1,0 +1,66 @@
+package io.customer.location
+
+import androidx.lifecycle.LifecycleOwner
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class LocationLifecycleObserverTest {
+
+    private val services: LocationServicesImpl = mockk(relaxed = true)
+    private val owner: LifecycleOwner = mockk(relaxed = true)
+
+    @Test
+    fun onStart_givenManualMode_expectForegroundFlushInvokedButNoLocationRequest() {
+        var flushCount = 0
+        val observer = LocationLifecycleObserver(
+            locationServices = services,
+            trackingMode = LocationTrackingMode.MANUAL,
+            onForeground = { flushCount++ }
+        )
+
+        observer.onStart(owner)
+
+        // Geofence deliveries must flush even in MANUAL mode, but MANUAL never auto-requests location.
+        flushCount shouldBeEqualTo 1
+        verify(exactly = 0) { services.requestLocationUpdate() }
+    }
+
+    @Test
+    fun onStart_givenOnAppStart_expectForegroundFlushAndLocationRequestedOncePerForeground() {
+        var flushCount = 0
+        val observer = LocationLifecycleObserver(
+            locationServices = services,
+            trackingMode = LocationTrackingMode.ON_APP_START,
+            onForeground = { flushCount++ }
+        )
+
+        observer.onStart(owner)
+        observer.onStart(owner)
+
+        // Flush fires on every foreground entry; the one-shot location request fires once.
+        flushCount shouldBeEqualTo 2
+        verify(exactly = 1) { services.requestLocationUpdate() }
+    }
+
+    @Test
+    fun onStart_givenLocationRequestCancelledOnStop_expectFlushStillFiresOnNextForeground() {
+        var flushCount = 0
+        every { services.cancelInFlightRequest() } returns true
+        val observer = LocationLifecycleObserver(
+            locationServices = services,
+            trackingMode = LocationTrackingMode.ON_APP_START,
+            onForeground = { flushCount++ }
+        )
+
+        observer.onStart(owner)
+        observer.onStop(owner)
+        observer.onStart(owner)
+
+        flushCount shouldBeEqualTo 2
+        // hasRequestedOnStart was reset by the cancelled in-flight request, so it retries.
+        verify(exactly = 2) { services.requestLocationUpdate() }
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
@@ -7,10 +7,13 @@ import io.customer.commontest.config.ApplicationArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.di.pendingGeofenceDeliveryStore
 import io.customer.location.geofence.store.GeofenceRegionStore
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.location.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
+import io.customer.sdk.core.di.SDKComponent
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -20,7 +23,6 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
@@ -38,6 +40,10 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     private val mockCooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
     private val mockStore: GeofenceRegionStore = mockk(relaxed = true)
     private val mockManager: GeofenceManager = mockk(relaxed = true)
+
+    // Real disk-backed store (Robolectric filesDir). The mocked scheduler never
+    // claims, so an appended entry stays in the store and we can assert on it.
+    private val pendingStore get() = SDKComponent.android().pendingGeofenceDeliveryStore
 
     private lateinit var receiver: GeofenceBroadcastReceiver
 
@@ -69,19 +75,20 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             "biz-geofence-1",
             "biz-geofence-2"
         )
+        pendingStore.removeAll()
         receiver = GeofenceBroadcastReceiver()
     }
 
     @Test
-    fun handleGeofencingEvent_givenNullEvent_expectNothingPublished() = runTest {
+    fun handleGeofencingEvent_givenNullEvent_expectNothingScheduled() = runTest {
         receiver.handleGeofencingEvent(null)
 
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun handleGeofencingEvent_givenHasError_expectNothingPublished() = runTest {
+    fun handleGeofencingEvent_givenHasError_expectNothingScheduled() = runTest {
         val event = mockk<GeofencingEvent>(relaxed = true) {
             every { hasError() } returns true
             every { errorCode } returns 1000
@@ -89,12 +96,12 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         receiver.handleGeofencingEvent(event)
 
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun handleGeofencingEvent_givenNullTriggeringGeofences_expectNothingPublished() = runTest {
+    fun handleGeofencingEvent_givenNullTriggeringGeofences_expectNothingScheduled() = runTest {
         val event = mockk<GeofencingEvent>(relaxed = true) {
             every { hasError() } returns false
             every { geofenceTransition } returns Geofence.GEOFENCE_TRANSITION_ENTER
@@ -103,50 +110,45 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         receiver.handleGeofencingEvent(event)
 
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun handleGeofencingEvent_givenNullTriggeringLocation_expectEventPublishedWithoutLatLng() = runTest {
+    fun handleGeofencingEvent_givenNullTriggeringLocation_expectEntryQueuedWithoutLatLng() = runTest {
         val event = buildGeofencingEvent(
             transition = Geofence.GEOFENCE_TRANSITION_ENTER,
             geofenceIds = listOf("biz-1"),
             location = null
         )
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
 
         receiver.handleGeofencingEvent(event)
 
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.geofenceId shouldBeEqualTo "biz-1"
-        published.properties["latitude"].shouldBeNull()
-        published.properties["longitude"].shouldBeNull()
+        val entry = pendingStore.loadAll().single()
+        entry.geofenceId shouldBeEqualTo "biz-1"
+        entry.latitude.shouldBeNull()
+        entry.longitude.shouldBeNull()
     }
 
     @Test
-    fun handleGeofencingEvent_givenValidEnterEvent_expectEventPublishedWithLatLng() = runTest {
+    fun handleGeofencingEvent_givenValidEnterEvent_expectEntryQueuedWithLatLng() = runTest {
         val event = buildGeofencingEvent(
             transition = Geofence.GEOFENCE_TRANSITION_ENTER,
             geofenceIds = listOf("biz-1"),
             location = realLocation(37.7749, -122.4194)
         )
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
 
         receiver.handleGeofencingEvent(event)
 
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
-        published.properties["latitude"] shouldBeEqualTo 37.7749
-        published.properties["longitude"] shouldBeEqualTo -122.4194
+        val entry = pendingStore.loadAll().single()
+        entry.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
+        entry.latitude shouldBeEqualTo 37.7749
+        entry.longitude shouldBeEqualTo -122.4194
     }
 
     @Test
-    fun dispatchTransition_givenEnterTransition_expectScheduledAndPublished() = runTest {
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+    fun dispatchTransition_givenEnterTransition_expectEntryAppendedAndScheduledButNotPublished() = runTest {
+        val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -155,30 +157,24 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = -122.4194
         )
 
-        coVerify(exactly = 1) {
-            mockScheduler.schedule(
-                geofenceId = "biz-geofence-1",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = 37.7749,
-                longitude = -122.4194,
-                timestamp = any()
-            )
-        }
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        val scheduled = entrySlot.captured
+        scheduled.geofenceId shouldBeEqualTo "biz-geofence-1"
+        scheduled.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
+        scheduled.latitude shouldBeEqualTo 37.7749
+        scheduled.longitude shouldBeEqualTo -122.4194
+        scheduled.toEventProperties()["transition_type"] shouldBeEqualTo "enter"
+        scheduled.timestamp.shouldNotBeNull()
 
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.geofenceId shouldBeEqualTo "biz-geofence-1"
-        published.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
-        published.properties["geofence_id"] shouldBeEqualTo "biz-geofence-1"
-        published.properties["transition_type"] shouldBeEqualTo "enter"
-        published.properties["latitude"] shouldBeEqualTo 37.7749
-        published.properties["longitude"] shouldBeEqualTo -122.4194
-        published.properties["timestamp"].shouldNotBeNull()
+        // Durably recorded for the foreground flush, and not published inline:
+        // exactly-once is now arbitrated by the store, not a double-send.
+        pendingStore.loadAll() shouldBeEqualTo listOf(scheduled)
+        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
     }
 
     @Test
-    fun dispatchTransition_givenExitTransition_expectScheduledAndPublished() = runTest {
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+    fun dispatchTransition_givenExitTransition_expectEntryScheduled() = runTest {
+        val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
@@ -187,23 +183,13 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = -0.1278
         )
 
-        coVerify(exactly = 1) {
-            mockScheduler.schedule(
-                geofenceId = "biz-geofence-2",
-                transition = Event.GeofenceTransition.EXIT,
-                latitude = 51.5074,
-                longitude = -0.1278,
-                timestamp = any()
-            )
-        }
-
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.transition shouldBeEqualTo Event.GeofenceTransition.EXIT
-        published.properties["transition_type"] shouldBeEqualTo "exit"
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.transition shouldBeEqualTo Event.GeofenceTransition.EXIT
+        entrySlot.captured.toEventProperties()["transition_type"] shouldBeEqualTo "exit"
     }
 
     @Test
-    fun dispatchTransition_givenMovementTriggerExit_expectServicesNotifiedAndNoEventPublished() = runTest {
+    fun dispatchTransition_givenMovementTriggerExit_expectServicesNotifiedAndNothingScheduled() = runTest {
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
             triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),
@@ -212,8 +198,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         verify { mockServices.onMovementTriggerExit(37.7749, -122.4194) }
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
@@ -228,12 +214,12 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         verify(exactly = 0) { mockServices.onMovementTriggerExit(any(), any()) }
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun dispatchTransition_givenUnknownTransitionType_expectNothingScheduledOrPublished() = runTest {
+    fun dispatchTransition_givenUnknownTransitionType_expectNothingScheduled() = runTest {
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_DWELL,
             triggeringGeofenceIds = listOf("biz-geofence"),
@@ -241,14 +227,13 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun dispatchTransition_givenMissingLatLng_expectBothPathsReceiveNullLatLng() = runTest {
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+    fun dispatchTransition_givenMissingLatLng_expectEntryScheduledWithNullLatLng() = runTest {
+        val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -257,24 +242,14 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = null
         )
 
-        coVerify(exactly = 1) {
-            mockScheduler.schedule(
-                geofenceId = "biz-geofence",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = null,
-                longitude = null,
-                timestamp = any()
-            )
-        }
-
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.properties["latitude"].shouldBeNull()
-        published.properties["longitude"].shouldBeNull()
-        published.properties["geofence_id"] shouldBeEqualTo "biz-geofence"
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.latitude.shouldBeNull()
+        entrySlot.captured.longitude.shouldBeNull()
+        entrySlot.captured.geofenceId shouldBeEqualTo "biz-geofence"
     }
 
     @Test
-    fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduledOrPublished() = runTest {
+    fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduled() = runTest {
         every { mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER) } returns false
 
         receiver.dispatchTransition(
@@ -284,12 +259,12 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
     }
 
     @Test
-    fun dispatchTransition_givenCooldownAllows_expectTryAcquireBeforeScheduleAndPublish() = runTest {
+    fun dispatchTransition_givenCooldownAllows_expectTryAcquireBeforeSchedule() = runTest {
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
             triggeringGeofenceIds = listOf("biz-geofence"),
@@ -299,15 +274,14 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerifyOrder {
             mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER)
-            mockScheduler.schedule(any(), any(), any(), any(), any())
-            mockEventBus.publish(any<Event.GeofenceTransitionEvent>())
+            mockScheduler.schedule(any())
         }
     }
 
     @Test
-    fun dispatchTransition_givenBatchWithMovementTriggerAndBusiness_expectOnlyBusinessPublished() = runTest {
-        val capturedEvents = mutableListOf<Event>()
-        every { mockEventBus.publish(capture(capturedEvents)) } returns Unit
+    fun dispatchTransition_givenBatchWithMovementTriggerAndBusiness_expectOnlyBusinessScheduled() = runTest {
+        val scheduled = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { mockScheduler.schedule(capture(scheduled)) } returns Unit
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -316,16 +290,14 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        capturedEvents.size shouldBeEqualTo 1
-        val published = capturedEvents.first().shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.geofenceId shouldBeEqualTo "biz-geofence"
+        scheduled.map { it.geofenceId } shouldBeEqualTo listOf("biz-geofence")
     }
 
     @Test
-    fun dispatchTransition_givenSchedulerThrows_expectEventBusStillPublished() = runTest {
-        coEvery { mockScheduler.schedule(any(), any(), any(), any(), any()) } throws RuntimeException("WM internal")
-        val capturedEvent = slot<Event>()
-        every { mockEventBus.publish(capture(capturedEvent)) } returns Unit
+    fun dispatchTransition_givenSchedulerThrows_expectEntryStillRecordedForFlush() = runTest {
+        // Append happens before schedule, so a WorkManager scheduling failure
+        // still leaves the entry in the store for the foreground flush to deliver.
+        coEvery { mockScheduler.schedule(any()) } throws RuntimeException("WM internal")
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -334,20 +306,13 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 2.0
         )
 
-        val published = capturedEvent.captured.shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.geofenceId shouldBeEqualTo "biz-geofence-1"
+        pendingStore.loadAll().single().geofenceId shouldBeEqualTo "biz-geofence-1"
     }
 
     @Test
     fun dispatchTransition_givenSchedulerThrowsOnFirstGeofence_expectSecondGeofenceStillProcessed() = runTest {
-        coEvery {
-            mockScheduler.schedule("biz-1", any(), any(), any(), any())
-        } throws RuntimeException("WM internal")
-        coEvery {
-            mockScheduler.schedule("biz-2", any(), any(), any(), any())
-        } returns Unit
-        val capturedEvents = mutableListOf<Event>()
-        every { mockEventBus.publish(capture(capturedEvents)) } returns Unit
+        coEvery { mockScheduler.schedule(match { it.geofenceId == "biz-1" }) } throws RuntimeException("WM internal")
+        coEvery { mockScheduler.schedule(match { it.geofenceId == "biz-2" }) } returns Unit
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -356,13 +321,14 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        capturedEvents.size shouldBeEqualTo 2
-        capturedEvents.map { (it as Event.GeofenceTransitionEvent).geofenceId } shouldBeEqualTo listOf("biz-1", "biz-2")
+        // Both transitions were appended before their schedule attempt.
+        pendingStore.loadAll().map { it.geofenceId } shouldBeEqualTo listOf("biz-1", "biz-2")
+        coVerify { mockScheduler.schedule(match { it.geofenceId == "biz-2" }) }
     }
 
     @Test
     fun dispatchTransition_givenIdNotInStore_expectDroppedAndRemovedFromOs() = runTest {
-        // Orphan ID must not reach scheduler/eventbus/cooldown AND must be removed
+        // Orphan ID must not reach scheduler/cooldown AND must be removed
         // from the OS so it stops firing.
         every { mockStore.getRegisteredIds() } returns setOf("biz-known")
 
@@ -373,8 +339,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        coVerify(exactly = 0) { mockScheduler.schedule(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
         verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any()) }
         coVerify { mockManager.removeGeofencesByIds(listOf("biz-orphan")) }
     }
@@ -401,8 +367,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // A single batch can carry both registered and orphan IDs. Per-ID filter,
         // and orphans removed as a single batched GMS call (not one call per orphan).
         every { mockStore.getRegisteredIds() } returns setOf("biz-known")
-        val capturedEvents = mutableListOf<Event>()
-        every { mockEventBus.publish(capture(capturedEvents)) } returns Unit
+        val scheduled = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { mockScheduler.schedule(capture(scheduled)) } returns Unit
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -411,9 +377,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        capturedEvents.size shouldBeEqualTo 1
-        val published = capturedEvents.first().shouldBeInstanceOf<Event.GeofenceTransitionEvent>()
-        published.geofenceId shouldBeEqualTo "biz-known"
+        scheduled.map { it.geofenceId } shouldBeEqualTo listOf("biz-known")
         // Single batched removal call carrying both orphans.
         coVerify(exactly = 1) {
             mockManager.removeGeofencesByIds(listOf("biz-orphan-1", "biz-orphan-2"))

--- a/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -1,0 +1,66 @@
+package io.customer.location.geofence.store
+
+import io.customer.sdk.communication.Event
+import kotlinx.serialization.json.Json
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotContain
+import org.junit.Test
+
+class PendingGeofenceDeliveryTest {
+
+    @Test
+    fun key_expectGeofenceIdTransitionTimestampComposite() {
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_234L)
+
+        // Doubles as the WorkManager unique-work name so the flush can cancel by key.
+        entry.key shouldBeEqualTo "biz-1_ENTER_1234"
+    }
+
+    @Test
+    fun serialization_givenRoundTrip_expectEqualEntry() {
+        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 37.7749, -122.4194, 99L)
+
+        val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
+        val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
+
+        restored shouldBeEqualTo entry
+    }
+
+    @Test
+    fun serialization_givenNullLatLng_expectRoundTripPreservesNulls() {
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, null, null, 0L)
+
+        val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
+        val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
+
+        restored shouldBeEqualTo entry
+        restored.latitude shouldBeEqualTo null
+        restored.longitude shouldBeEqualTo null
+    }
+
+    @Test
+    fun toEventProperties_givenLatLng_expectAllPropertiesPresent() {
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.5, 2.5, 50L)
+
+        val props = entry.toEventProperties()
+
+        props["geofence_id"] shouldBeEqualTo "biz-4"
+        props["transition_type"] shouldBeEqualTo "enter"
+        props["latitude"] shouldBeEqualTo 1.5
+        props["longitude"] shouldBeEqualTo 2.5
+        props["timestamp"] shouldBeEqualTo 50L
+    }
+
+    @Test
+    fun toEventProperties_givenNullLatLng_expectLatLngOmitted() {
+        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.EXIT, null, null, 7L)
+
+        val props = entry.toEventProperties()
+
+        props.keys shouldNotContain "latitude"
+        props.keys shouldNotContain "longitude"
+        props.keys shouldContain "geofence_id"
+        props["transition_type"] shouldBeEqualTo "exit"
+    }
+}

--- a/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -3,11 +3,15 @@ package io.customer.location.geofence.worker
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.DispatchersProvider
+import io.customer.sdk.data.store.PendingDeliveryStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
+import java.io.IOException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -21,6 +25,7 @@ import org.robolectric.RobolectricTestRunner
 class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
     private val mockTracker: GeofenceEventTracker = mockk(relaxed = true)
+    private val mockStore: PendingDeliveryStore<PendingGeofenceDelivery> = mockk(relaxed = true)
     private val testDispatcher = UnconfinedTestDispatcher()
     private val dispatchersProvider: DispatchersProvider = object : DispatchersProvider {
         override val background: CoroutineDispatcher get() = testDispatcher
@@ -32,22 +37,15 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfigurationDefault { })
-        asyncTracker = AsyncGeofenceEventTracker(mockTracker, dispatchersProvider)
+        asyncTracker = AsyncGeofenceEventTracker(mockTracker, mockStore, dispatchersProvider)
     }
 
     @Test
-    fun trackEvent_expectUnderlyingTrackerInvokedWithSameArgs() = runTest {
-        coEvery {
-            mockTracker.trackEvent(any(), any(), any(), any(), any())
-        } returns Result.success(Unit)
+    fun trackEvent_givenSuccess_expectTrackerCalledWithEntryFieldsAndEntryRemoved() = runTest {
+        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 42L)
 
-        asyncTracker.trackEvent(
-            geofenceId = "biz-1",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 1.0,
-            longitude = 2.0,
-            timestamp = 42L
-        )
+        asyncTracker.trackEvent(entry)
 
         coVerify(exactly = 1) {
             mockTracker.trackEvent(
@@ -58,21 +56,16 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
                 timestamp = 42L
             )
         }
+        // Mirrors the worker's success contract: delivered entry is removed.
+        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42") }
     }
 
     @Test
     fun trackEvent_givenNullLatLng_expectNullPassedThrough() = runTest {
-        coEvery {
-            mockTracker.trackEvent(any(), any(), any(), any(), any())
-        } returns Result.success(Unit)
+        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, null, null, 0L)
 
-        asyncTracker.trackEvent(
-            geofenceId = "biz-2",
-            transition = Event.GeofenceTransition.EXIT,
-            latitude = null,
-            longitude = null,
-            timestamp = 0L
-        )
+        asyncTracker.trackEvent(entry)
 
         coVerify(exactly = 1) {
             mockTracker.trackEvent(
@@ -83,5 +76,17 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
                 timestamp = 0L
             )
         }
+    }
+
+    @Test
+    fun trackEvent_givenFailure_expectEntryLeftInStoreForFlush() = runTest {
+        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns
+            Result.failure(IOException("network down"))
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 1.0, 2.0, 7L)
+
+        asyncTracker.trackEvent(entry)
+
+        // Left in place so the foreground flush can still deliver it.
+        verify(exactly = 0) { mockStore.remove(any()) }
     }
 }

--- a/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -9,6 +9,7 @@ import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.data.store.PendingDeliveryStore
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.io.IOException
@@ -41,12 +42,15 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
-    fun trackEvent_givenSuccess_expectTrackerCalledWithEntryFieldsAndEntryRemoved() = runTest {
+    fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryFields() = runTest {
+        every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
         val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 42L)
 
         asyncTracker.trackEvent(entry)
 
+        // Claim before send (shared exactly-once contract), then deliver.
+        verify(exactly = 1) { mockStore.claim("biz-1_ENTER_42") }
         coVerify(exactly = 1) {
             mockTracker.trackEvent(
                 geofenceId = "biz-1",
@@ -56,12 +60,13 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
                 timestamp = 42L
             )
         }
-        // Mirrors the worker's success contract: delivered entry is removed.
-        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42") }
+        // claim() already removed it; success must not re-append.
+        verify(exactly = 0) { mockStore.append(any()) }
     }
 
     @Test
     fun trackEvent_givenNullLatLng_expectNullPassedThrough() = runTest {
+        every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
         val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, null, null, 0L)
 
@@ -79,14 +84,26 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
-    fun trackEvent_givenFailure_expectEntryLeftInStoreForFlush() = runTest {
-        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns
-            Result.failure(IOException("network down"))
+    fun trackEvent_givenClaimLost_expectNoSend() = runTest {
+        // Foreground flush already claimed + delivered this entry: do not double-send.
+        every { mockStore.claim(any()) } returns false
         val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 1.0, 2.0, 7L)
 
         asyncTracker.trackEvent(entry)
 
-        // Left in place so the foreground flush can still deliver it.
-        verify(exactly = 0) { mockStore.remove(any()) }
+        coVerify(exactly = 0) { mockTracker.trackEvent(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun trackEvent_givenFailure_expectEntryRestoredForFlush() = runTest {
+        every { mockStore.claim(any()) } returns true
+        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns
+            Result.failure(IOException("network down"))
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.0, 2.0, 9L)
+
+        asyncTracker.trackEvent(entry)
+
+        // Restored so the foreground flush can still deliver it.
+        verify(exactly = 1) { mockStore.append(entry) }
     }
 }

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -9,6 +9,7 @@ import com.google.common.util.concurrent.Futures
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.mockk.every
@@ -51,11 +52,13 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val uniqueKeySlot = slot<String>()
 
         scheduler.schedule(
-            geofenceId = "biz-geofence-1",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 37.7749,
-            longitude = -122.4194,
-            timestamp = 1_234L
+            PendingGeofenceDelivery(
+                geofenceId = "biz-geofence-1",
+                transition = Event.GeofenceTransition.ENTER,
+                latitude = 37.7749,
+                longitude = -122.4194,
+                timestamp = 1_234L
+            )
         )
 
         verify(exactly = 1) {
@@ -85,11 +88,13 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val workRequestSlot = slot<OneTimeWorkRequest>()
 
         scheduler.schedule(
-            geofenceId = "biz-geofence-2",
-            transition = Event.GeofenceTransition.EXIT,
-            latitude = null,
-            longitude = null,
-            timestamp = 99L
+            PendingGeofenceDelivery(
+                geofenceId = "biz-geofence-2",
+                transition = Event.GeofenceTransition.EXIT,
+                latitude = null,
+                longitude = null,
+                timestamp = 99L
+            )
         )
 
         verify { workManager.enqueueUniqueWork(any(), any(), capture(workRequestSlot)) }
@@ -101,8 +106,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
     @Test
     fun schedule_givenWorkManagerUnavailable_expectFallbackToAsyncTracker() = runTest {
         every { workManagerProvider.getWorkManager() } returns null
-
-        scheduler.schedule(
+        val entry = PendingGeofenceDelivery(
             geofenceId = "biz-geofence-3",
             transition = Event.GeofenceTransition.ENTER,
             latitude = 1.0,
@@ -110,15 +114,9 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
             timestamp = 42L
         )
 
+        scheduler.schedule(entry)
+
         verify(exactly = 0) { workManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) }
-        verify(exactly = 1) {
-            asyncTracker.trackEvent(
-                geofenceId = "biz-geofence-3",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = 1.0,
-                longitude = 2.0,
-                timestamp = 42L
-            )
-        }
+        verify(exactly = 1) { asyncTracker.trackEvent(entry) }
     }
 }

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventWorkerTest.kt
@@ -7,13 +7,17 @@ import io.customer.commontest.config.ApplicationArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.di.pendingGeofenceDeliveryStore
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
+import io.customer.sdk.core.di.SDKComponent
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,6 +26,8 @@ import org.robolectric.RobolectricTestRunner
 class GeofenceEventWorkerTest : RobolectricTest() {
 
     private val tracker: GeofenceEventTracker = mockk(relaxed = true)
+
+    private val store get() = SDKComponent.android().pendingGeofenceDeliveryStore
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
@@ -32,17 +38,25 @@ class GeofenceEventWorkerTest : RobolectricTest() {
                 }
             }
         )
+        store.removeAll()
     }
 
+    // The worker claims its entry from the shared store before sending, so seed the
+    // store with the matching entry to model "this transition is still pending".
+    private fun seed(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        latitude: Double? = 0.0,
+        longitude: Double? = 0.0,
+        timestamp: Long = 0L
+    ): PendingGeofenceDelivery =
+        PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp)
+            .also { store.append(it) }
+
     @Test
-    fun doWork_givenValidEnterInput_expectSuccessAndTrackerCalled() = runTest {
-        val inputData = buildInputData(
-            geofenceId = "biz-1",
-            transition = "ENTER",
-            latitude = 1.0,
-            longitude = 2.0,
-            timestamp = 99L
-        )
+    fun doWork_givenClaimableEntry_expectSuccessTrackerCalledAndEntryRemoved() = runTest {
+        seed("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 99L)
+        val inputData = buildInputData("biz-1", "ENTER", 1.0, 2.0, 99L)
         coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
 
         val result = createWorker(inputData).doWork()
@@ -57,11 +71,13 @@ class GeofenceEventWorkerTest : RobolectricTest() {
                 timestamp = 99L
             )
         }
+        store.loadAll().isEmpty().shouldBeTrue()
     }
 
     @Test
     fun doWork_givenValidExitInput_expectExitTransitionPassed() = runTest {
-        val inputData = buildInputData(geofenceId = "biz-2", transition = "EXIT", timestamp = 0L)
+        seed("biz-2", Event.GeofenceTransition.EXIT, timestamp = 0L)
+        val inputData = buildInputData("biz-2", "EXIT", timestamp = 0L)
         coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
 
         createWorker(inputData).doWork()
@@ -79,6 +95,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
     @Test
     fun doWork_givenMissingLatLng_expectNullPassedToTracker() = runTest {
+        seed("biz-3", Event.GeofenceTransition.ENTER, latitude = null, longitude = null, timestamp = 0L)
         val inputData = Data.Builder()
             .putString("geofence_id", "biz-3")
             .putString("transition", "ENTER")
@@ -97,6 +114,18 @@ class GeofenceEventWorkerTest : RobolectricTest() {
                 timestamp = 0L
             )
         }
+    }
+
+    @Test
+    fun doWork_givenClaimLost_expectSuccessWithoutTracking() = runTest {
+        // No matching entry in the store (the foreground flush already delivered it):
+        // the worker's claim fails, so it must not send a duplicate.
+        val inputData = buildInputData("biz-already-delivered", "ENTER", timestamp = 0L)
+
+        val result = createWorker(inputData).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.success()
+        coVerify(exactly = 0) { tracker.trackEvent(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -130,25 +159,30 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     }
 
     @Test
-    fun doWork_givenIOException_expectRetry() = runTest {
-        val inputData = buildInputData(geofenceId = "biz", transition = "ENTER")
+    fun doWork_givenIOException_expectRetryAndEntryRestored() = runTest {
+        seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
+        val inputData = buildInputData("biz", "ENTER", timestamp = 0L)
         coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns
             Result.failure(IOException("network down"))
 
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.retry()
+        // Restored so a WorkManager retry — or the foreground flush — can deliver later.
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0")
     }
 
     @Test
-    fun doWork_givenNonIOException_expectFailure() = runTest {
-        val inputData = buildInputData(geofenceId = "biz", transition = "ENTER")
+    fun doWork_givenNonIOException_expectFailureAndEntryRestored() = runTest {
+        seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
+        val inputData = buildInputData("biz", "ENTER", timestamp = 0L)
         coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns
             Result.failure(IllegalStateException("bad state"))
 
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.failure()
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0")
     }
 
     private fun buildInputData(

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -6,10 +6,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.WorkManager
-import androidx.work.await
 import io.customer.messagingpush.di.fcmTokenProvider
-import io.customer.messagingpush.di.pendingPushDeliveryStore
+import io.customer.messagingpush.di.pushDeliveryFlusher
 import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.messagingpush.logger.PushNotificationLogger
@@ -18,14 +16,10 @@ import io.customer.messagingpush.store.PendingPushDeliveryMetric
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
-import io.customer.sdk.core.di.workManagerProvider
 import io.customer.sdk.core.module.CustomerIOModule
-import io.customer.sdk.core.util.DispatchersProvider
-import io.customer.sdk.data.store.PendingDeliveryStore
+import io.customer.sdk.data.store.PendingDeliveryFlusher
 import io.customer.sdk.events.Metric
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.launch
 
 class ModuleMessagingPushFCM @JvmOverloads constructor(
     override val moduleConfig: MessagingPushModuleConfig = MessagingPushModuleConfig.default()
@@ -35,14 +29,10 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = SDKComponent.android().fcmTokenProvider
     private val pushTrackingUtil = SDKComponent.pushTrackingUtil
     private val activityLifecycleCallbacks = SDKComponent.activityLifecycleCallbacks
-    private val pendingPushDeliveryStore: PendingDeliveryStore<PendingPushDeliveryMetric>
-        get() = SDKComponent.pendingPushDeliveryStore
-    private val dispatchers: DispatchersProvider
-        get() = SDKComponent.dispatchersProvider
+    private val pushDeliveryFlusher: PendingDeliveryFlusher<PendingPushDeliveryMetric>
+        get() = SDKComponent.pushDeliveryFlusher
     private val pushLogger: PushNotificationLogger
         get() = SDKComponent.pushLogger
-    private val workManagerForCancel: WorkManager?
-        get() = SDKComponent.workManagerProvider.getWorkManager()
 
     override val moduleName: String
         get() = MODULE_NAME
@@ -112,62 +102,33 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
     }
 
     /**
-     * Snapshot the pending store, cancel each entry's WorkManager unique work
-     * so the worker won't also deliver, then publish each entry through the
-     * analytics pipeline. Removes only the snapshotted keys at the end so
-     * entries appended mid-handoff survive.
-     *
-     * Cancel happens before publish on purpose: a worker that is `ENQUEUED`
-     * or running flips to `CANCELLED` immediately and won't issue its HTTP
-     * call. Reversing the order would widen the window in which both
-     * channels can race to deliver the same metric.
+     * Drain the pending push-delivery store through the analytics pipeline,
+     * cancelling each entry's WorkManager unique work so the two channels can't
+     * both deliver. The exactly-once drain logic (cancel → claim → publish, with
+     * per-entry isolation) lives in the shared [PendingDeliveryFlusher]; here we
+     * only supply the analytics-pipeline transport and the push-specific logs.
      */
     @androidx.annotation.VisibleForTesting
     internal fun handoffPendingPushDeliveryToAnalyticsPipeline() {
-        CoroutineScope(dispatchers.background).launch {
-            runCatching {
-                val pending = pendingPushDeliveryStore.loadAll()
-                if (pending.isEmpty()) {
-                    pushLogger.logForegroundSnapshot(count = 0)
-                    return@runCatching
-                }
-                pushLogger.logForegroundSnapshot(count = pending.size)
-
-                val wm = workManagerForCancel
-                // Process each entry in isolation. WorkManager's cancelUniqueWork().await()
-                // can throw — if one entry's cancel fails we don't want to short-circuit
-                // the rest of the batch. Failed entries stay in the store so the next
-                // foreground transition retries them.
-                var flushedCount = 0
-                pending.forEach { entry ->
-                    try {
-                        if (wm != null) {
-                            wm.cancelUniqueWork(entry.deliveryId).await()
-                            pushLogger.logHandoffCancelledWorkManager(entry.deliveryId)
-                        }
-                        // Atomically claim before publishing so the WorkManager worker
-                        // (which also claims before sending) cannot deliver the same
-                        // metric. Removing per-entry here, rather than batching at the
-                        // end, also means a mid-loop CancellationException can't strand
-                        // an already-published entry for re-publish next foreground.
-                        if (!pendingPushDeliveryStore.claim(entry.deliveryId)) return@forEach
-                        eventBus.publish(
-                            Event.TrackPushMetricEvent(
-                                event = Metric.Delivered,
-                                deliveryId = entry.deliveryId,
-                                deviceToken = entry.token
-                            )
-                        )
-                        pushLogger.logHandoffPublishedToEventBus(entry.deliveryId)
-                        flushedCount++
-                    } catch (ce: kotlinx.coroutines.CancellationException) {
-                        throw ce
-                    } catch (ex: Exception) {
-                        pushLogger.logHandoffEntryFailed(entry.deliveryId, ex)
-                    }
-                }
-                pushLogger.logHandoffComplete(count = flushedCount)
+        pushDeliveryFlusher.flush(
+            callbacks = object : PendingDeliveryFlusher.Callbacks<PendingPushDeliveryMetric>() {
+                override fun onSnapshot(count: Int) = pushLogger.logForegroundSnapshot(count)
+                override fun onWorkCancelled(entry: PendingPushDeliveryMetric) =
+                    pushLogger.logHandoffCancelledWorkManager(entry.deliveryId)
+                override fun onPublished(entry: PendingPushDeliveryMetric) =
+                    pushLogger.logHandoffPublishedToEventBus(entry.deliveryId)
+                override fun onEntryFailed(entry: PendingPushDeliveryMetric, cause: Throwable) =
+                    pushLogger.logHandoffEntryFailed(entry.deliveryId, cause)
+                override fun onComplete(count: Int) = pushLogger.logHandoffComplete(count)
             }
+        ) { entry ->
+            eventBus.publish(
+                Event.TrackPushMetricEvent(
+                    event = Metric.Delivered,
+                    deliveryId = entry.deliveryId,
+                    deviceToken = entry.token
+                )
+            )
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -24,6 +24,7 @@ import io.customer.messagingpush.util.PushTrackingUtilImpl
 import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.workManagerProvider
+import io.customer.sdk.data.store.PendingDeliveryFlusher
 import io.customer.sdk.data.store.PendingDeliveryStore
 
 /*
@@ -61,6 +62,15 @@ internal val SDKComponent.pendingPushDeliveryStore: PendingDeliveryStore<Pending
             fileName = PendingPushDeliveryMetric.FILE_NAME,
             elementSerializer = PendingPushDeliveryMetric.serializer(),
             logger = logger
+        )
+    }
+
+internal val SDKComponent.pushDeliveryFlusher: PendingDeliveryFlusher<PendingPushDeliveryMetric>
+    get() = singleton {
+        PendingDeliveryFlusher(
+            store = pendingPushDeliveryStore,
+            workManagerProvider = workManagerProvider,
+            dispatchersProvider = dispatchersProvider
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -14,8 +14,9 @@ import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.store.PendingPushDeliveryMetric
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
+import io.customer.sdk.data.store.PendingDeliveryResult
+import io.customer.sdk.data.store.claimSendRestore
 import io.customer.sdk.events.Metric
-import java.io.IOException
 
 private const val DELIVERY_ID = "delivery-id"
 private const val DELIVERY_TOKEN = "delivery-token"
@@ -81,39 +82,35 @@ internal class PushDeliveryMetricsWorker(
 
         val logger = SDKComponent.pushLogger
         val store = SDKComponent.pendingPushDeliveryStore
+        val entry = PendingPushDeliveryMetric(deliveryId = deliveryId, token = deliveryToken)
 
-        // Atomically claim the entry before sending. If it's already gone, the
-        // foreground handoff (which also claims before publishing) already
-        // delivered this metric via the analytics pipeline, so sending here
-        // would double-count it. This guards the race when WorkManager restores
-        // a persisted job after process death and runs it alongside the handoff.
-        if (!store.claim(deliveryId)) {
-            logger.logWorkerSkippedAlreadyDelivered(deliveryId)
-            return Result.success()
-        }
-
-        val result = SDKComponent.pushDeliveryTracker.trackMetric(
-            event = Metric.Delivered.name,
-            deliveryId = deliveryId,
-            token = deliveryToken
-        )
-
-        return when {
-            result.isSuccess -> {
-                // Entry was already removed by claim() above; just log success.
+        // Shared exactly-once decision: atomically claim before sending (a lost
+        // claim means the foreground handoff already delivered this metric via
+        // the analytics pipeline, so sending here would double-count it), and
+        // restore the entry on failure so a retry or the handoff can deliver it.
+        return when (
+            val outcome = store.claimSendRestore(entry) {
+                SDKComponent.pushDeliveryTracker.trackMetric(
+                    event = Metric.Delivered.name,
+                    deliveryId = deliveryId,
+                    token = deliveryToken
+                )
+            }
+        ) {
+            PendingDeliveryResult.AlreadyClaimed -> {
+                logger.logWorkerSkippedAlreadyDelivered(deliveryId)
+                Result.success()
+            }
+            PendingDeliveryResult.Delivered -> {
                 logger.logWorkerSuccessRemoved(deliveryId)
                 Result.success()
             }
-            result.exceptionOrNull() is IOException -> {
-                // Transient failure: restore the claim so a WorkManager retry —
-                // or the foreground handoff — can deliver it later.
-                store.append(PendingPushDeliveryMetric(deliveryId = deliveryId, token = deliveryToken))
-                logger.logWorkerRetry(deliveryId, result.exceptionOrNull())
+            is PendingDeliveryResult.Retryable -> {
+                logger.logWorkerRetry(deliveryId, outcome.cause)
                 Result.retry()
             }
-            else -> {
-                store.append(PendingPushDeliveryMetric(deliveryId = deliveryId, token = deliveryToken))
-                logger.logWorkerFailure(deliveryId, result.exceptionOrNull())
+            is PendingDeliveryResult.Failed -> {
+                logger.logWorkerFailure(deliveryId, outcome.cause)
                 Result.failure()
             }
         }


### PR DESCRIPTION
## What

Geofence transitions were delivered by **two channels in parallel** — the WorkManager worker (direct HTTP `/track`) and an inline `EventBus` publish to the analytics pipeline — so a transition observed while the app was alive was sent **twice**.

This reuses the push **exactly-once** pattern: each transition is recorded in the disk-backed `PendingDeliveryStore` and delivered by **exactly one** channel, arbitrated by an atomic `claim()`. The worker claims before sending; the foreground flush claims before publishing (and cancels the worker first).

## De-duplication between push & geofence

The two shared pieces move into `core` and are now used by **both** modules:
- `claimSendRestore()` + `PendingDeliveryResult` — the worker decision (claim → send → restore-on-failure).
- `PendingDeliveryFlusher<T>` — the foreground drain (loadAll → cancel WM by `key` → claim → `publish`, per-entry isolation).

`messagingpush` is refactored onto these with **no behavior change** (existing handoff/worker tests stay green; net ~−146 lines across the two push files).

## Geofence wiring
- New `PendingGeofenceDelivery` entry + shared `pendingGeofenceDeliveryStore` & `geofenceDeliveryFlusher` in DI.
- Producer (`dispatchTransition`): `append` + `schedule(entry)` — **inline `eventBus.publish` removed**.
- Worker → `claimSendRestore`; async fallback → claim/remove-on-success.
- Flush wired into the existing `LocationLifecycleObserver.onStart`.

**Net effect:** a transition is delivered once (worker via direct HTTP in the background, or the pipeline flush on foreground) instead of the previous double-send.

## Tests & verification
- New core tests: `PendingDeliveryClaimTest`, `PendingDeliveryFlusherTest`.
- New/updated location tests: worker (claim/skip/restore), async, broadcast receiver (append-not-publish), `LocationLifecycleObserverTest`, `PendingGeofenceDeliveryTest`.
- `:core`, `:messagingpush` full suites + touched `:location` classes pass; `:core`/`:location`/`:messagingpush` `lintDebug` clean.
- Added claim/flush debug logs (`[CIO] [Geofence] …`) and `docs/manual-tests/geofence-exactly-once.md` (emulator mock-location runbook).

## Notes
- Base is `feature/geofence-on-device` (builds on geofence work not yet in `main`).
- Like push, the flush fires on `ProcessLifecycleOwner.ON_START`, so a transition observed while *already* foregrounded is delivered by the worker; the pipeline path kicks in on the next background→foreground.
- Unrelated pre-existing flake observed: `GeofenceRepositoryTest.refresh_givenRecentSuccessfulSyncAndNotForced_expectSkipApiCall` (order-dependent; reproduced on the base branch — not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Geofence event delivery path and timing change (eliminates duplicate tracks); push refactor should be behavior-neutral but touches shared delivery coordination used by both features.
> 
> **Overview**
> **Geofence transitions are no longer sent twice.** The receiver used to fire WorkManager (direct HTTP) and an inline `EventBus` publish in parallel; it now **appends** a `PendingGeofenceDelivery` to a disk store and schedules WorkManager only. Delivery is **exactly once**, via atomic `claim()` between the worker and a **foreground flush** that publishes `GeofenceTransitionEvent` to the analytics pipeline (wired on every `ProcessLifecycleOwner` `onStart`, including `MANUAL` tracking mode).
> 
> **Shared core helpers** (`claimSendRestore`, `PendingDeliveryResult`, `PendingDeliveryFlusher`) centralize claim → send/publish → restore-on-failure and cancel-WM-then-claim flush logic. **Push** is refactored onto these helpers with **no intended behavior change** (~146 lines removed from handoff/worker code).
> 
> New/updated tests cover claim, flush, broadcast (queue-not-publish), worker, lifecycle, and serialization; a manual emulator runbook documents verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c3fefa6161ffc69152c310877406cd7fce55e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->