### PR TITLE
chore: geofence reliability fixes + logger tag dispatch

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/util/LoggerImpl.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/LoggerImpl.kt
@@ -45,13 +45,13 @@ internal open class LoggerImpl(
     private fun logIfMatchesCriteria(levelForMessage: CioLogLevel, message: String, tag: String?, throwable: Throwable?) {
         if (!shouldLog(levelForMessage)) return
 
-        // Dispatch log event to log dispatcher only if the log level is met and the dispatcher is set
-        // Otherwise, log to Logcat
-        logDispatcher?.invoke(levelForMessage, message) ?: when (levelForMessage) {
+        // Tag prepended once so dispatcher and Logcat see the same final message.
+        val taggedMessage = prependTagToMessage(tag, message)
+        logDispatcher?.invoke(levelForMessage, taggedMessage) ?: when (levelForMessage) {
             CioLogLevel.NONE -> {}
-            CioLogLevel.ERROR -> actualLogger.error(TAG, prependTagToMessage(tag, message), throwable)
-            CioLogLevel.INFO -> actualLogger.info(TAG, prependTagToMessage(tag, message))
-            CioLogLevel.DEBUG -> actualLogger.debug(TAG, prependTagToMessage(tag, message))
+            CioLogLevel.ERROR -> actualLogger.error(TAG, taggedMessage, throwable)
+            CioLogLevel.INFO -> actualLogger.info(TAG, taggedMessage)
+            CioLogLevel.DEBUG -> actualLogger.debug(TAG, taggedMessage)
         }
     }
 

--- a/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/LoggerTest.kt
@@ -200,4 +200,19 @@ class LoggerTest : JUnit5Test() {
         assertCalledOnce { mockLogger.info(LoggerImpl.TAG, "[Tag?] Test info message") }
         assertCalledOnce { mockLogger.debug(LoggerImpl.TAG, "[Tag?] Test debug message") }
     }
+
+    @Test
+    fun givenTagAndDispatcher_shouldDeliverTaggedMessageToDispatcher() {
+        logger.logLevel = CioLogLevel.DEBUG
+        val logEventListenerMock = mockk<(CioLogLevel, String) -> Unit>(relaxed = true)
+        logger.setLogDispatcher(logEventListenerMock)
+
+        logger.error("error msg", "Subsystem")
+        logger.info("info msg", "Subsystem")
+        logger.debug("debug msg", "Subsystem")
+
+        assertCalledOnce { logEventListenerMock(CioLogLevel.ERROR, "[Subsystem] error msg") }
+        assertCalledOnce { logEventListenerMock(CioLogLevel.INFO, "[Subsystem] info msg") }
+        assertCalledOnce { logEventListenerMock(CioLogLevel.DEBUG, "[Subsystem] debug msg") }
+    }
 }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -108,8 +108,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
         knownIds.forEach { geofenceId ->
             if (geofenceId == GeofenceConstants.MOVEMENT_TRIGGER_ID) {
-                // Movement-trigger geofence is registered with NO_INITIAL_TRIGGER so it
-                // should only ever fire EXIT; defensive guard in case the OS surprises us.
+                // ENTER fires on every re-registration and boot-restore can fire
+                // EXIT. Only EXIT drives a refresh.
                 if (gmsTransitionType == Geofence.GEOFENCE_TRANSITION_EXIT) {
                     androidComponent.geofenceServices.onMovementTriggerExit(latitude, longitude)
                 } else {

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceConstants.kt
@@ -30,11 +30,6 @@ internal object GeofenceConstants {
     // when the field is missing or non-positive.
     const val DEDUPE_COOLDOWN_MS = 60 * 60 * 1_000L
 
-    // GMS `GeofencingRequest.Builder().setInitialTrigger()` flag for "no initial
-    // events on registration". Used for the movement trigger so re-registration
-    // doesn't spuriously fire EXIT.
-    const val NO_INITIAL_TRIGGER = 0
-
     // GMS `Geofence.Builder().setExpirationDuration()` flag for "never expires".
     // Our geofences are managed at the application level (we remove explicitly)
     // so OS-side expiration is disabled.

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceManager.kt
@@ -51,7 +51,7 @@ internal class GeofenceManager(
         existingBusinessIds: Set<String> = emptySet()
     ): Result<Unit> = replaceGeofencesInternal(
         regions = regions,
-        movementInitialTrigger = GeofenceConstants.NO_INITIAL_TRIGGER,
+        movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_ENTER,
         existingBusinessIds = existingBusinessIds
     )
 
@@ -94,6 +94,10 @@ internal class GeofenceManager(
             .partition { it.id !in existingBusinessIds }
 
         if (movementTrigger.isNotEmpty()) {
+            // GMS retains per-ID transition state across same-ID re-registers, so
+            // a just-fired EXIT keeps the ID stuck OUTSIDE and blocks future EXITs
+            // at the new center. Removing first forces a fresh state machine.
+            removeGeofencesByIds(listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID))
             val result = registerBatch(movementTrigger, initialTrigger = movementInitialTrigger)
             if (result.isFailure) return result
         }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt
@@ -84,20 +84,23 @@ internal class GeofenceRepositoryImpl(
             }
             val lastSync = store.getLastSyncTimestamp()
             if (lastSync != null) {
-                // Freshness window from the cached server config; falls back to
-                // STALE_THRESHOLD_MS when no cache exists. Non-positive values
-                // are sanitized at parse time in GeofenceApiConfig.toDomain.
-                val threshold = store.getCachedConfig()?.remoteFetchRefreshExpiry
-                    ?: GeofenceConstants.STALE_THRESHOLD_MS
-                if (clock.currentTimeMillis() - lastSync < threshold) {
+                // Time-fresh alone isn't enough: if the app was killed while the
+                // user travelled far, no movement EXIT fired to update the cache.
+                // Null anchor (never fetched) treats distance as 0 → time-only check.
+                val effectiveConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
+                val timeSinceLastSync = clock.currentTimeMillis() - lastSync
+                val distanceFromAnchor = store.getLastApiFetchLocation()
+                    ?.distanceTo(latitude, longitude) ?: 0f
+                val withinFreshness = timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry &&
+                    distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius
+                if (withinFreshness) {
                     // Cache fresh — if OS regs were wiped on sign-out, re-
                     // register from cache instead of skipping; otherwise the
                     // new user has no geofences until stale-window expiry.
                     val cachedRegions = store.getCachedRegions()
                     val registered = store.getRegisteredIds()
                     if (cachedRegions.isNotEmpty() && registered.isEmpty()) {
-                        val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-                        return performLocalRefresh(userId, latitude, longitude, cachedConfig)
+                        return performLocalRefresh(userId, latitude, longitude, effectiveConfig)
                     }
                     logger.logSyncSkippedFresh()
                     return Result.success(Unit)

--- a/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
@@ -218,8 +218,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
     @Test
     fun dispatchTransition_givenMovementTriggerNonExit_expectServicesNotNotified() = runTest {
-        // Movement trigger is registered NO_INITIAL_TRIGGER so it should never fire ENTER;
-        // defensive guard ensures we ignore stray non-EXIT transitions if the OS surprises us.
+        // Movement trigger fires ENTER expectedly (INITIAL_TRIGGER_ENTER on re-registration)
+        // and may also fire DWELL/ENTER on boot. Only EXIT drives a refresh — verify the
+        // receiver ignores non-EXIT cases.
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
             triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),

--- a/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceManagerTest.kt
@@ -21,7 +21,6 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -114,17 +113,37 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun replaceGeofences_givenMovementTrigger_expectNoInitialTrigger() = runTest {
+    fun replaceGeofences_givenMovementTrigger_expectInitialTriggerEnter() = runTest {
+        // Movement trigger registered with INITIAL_TRIGGER_ENTER so GMS records
+        // state as INSIDE at the new center — without this, prior OUTSIDE state
+        // from the previous EXIT would block future EXITs from firing.
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
+        stubClientRemoveByIdsSuccess()
 
         manager.replaceGeofences(
             listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
         )
 
-        requestSlot.captured.initialTrigger shouldNotContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requestSlot.captured.initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+    }
+
+    @Test
+    fun replaceGeofences_givenMovementTrigger_expectPriorRegistrationRemovedFirst() = runTest {
+        // GMS caches per-ID transition state across same-ID addGeofences. Removing
+        // the prior registration first forces a truly fresh state machine so the
+        // next EXIT will fire.
+        grantAllPermissions()
+        stubClientAddSuccess()
+        stubClientRemoveByIdsSuccess()
+
+        manager.replaceGeofences(
+            listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
+        )
+
+        verify { client.removeGeofences(listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)) }
     }
 
     @Test
@@ -133,6 +152,7 @@ class GeofenceManagerTest : RobolectricTest() {
 
         val requestSlot = slot<GeofencingRequest>()
         stubClientAddSuccess(requestSlot)
+        stubClientRemoveByIdsSuccess()
 
         manager.replaceGeofencesForBootRestore(
             listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
@@ -162,6 +182,7 @@ class GeofenceManagerTest : RobolectricTest() {
         val requests = mutableListOf<GeofencingRequest>()
         val task = immediateSuccessTask<Void>()
         every { client.addGeofences(capture(requests), any()) } returns task
+        stubClientRemoveByIdsSuccess()
 
         manager.replaceGeofences(
             listOf(
@@ -171,10 +192,8 @@ class GeofenceManagerTest : RobolectricTest() {
         )
 
         requests.size shouldBeEqualTo 2
-        // First request: movement trigger with no initial trigger
-        requests[0].initialTrigger shouldNotContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requests[0].initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
         requests[0].geofences.first().requestId shouldBeEqualTo GeofenceConstants.MOVEMENT_TRIGGER_ID
-        // Second request: business geofence with INITIAL_TRIGGER_ENTER
         requests[1].initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
         requests[1].geofences.first().requestId shouldBeEqualTo "business-1"
     }
@@ -403,10 +422,6 @@ class GeofenceManagerTest : RobolectricTest() {
 
     private infix fun Int.shouldContainFlag(flag: Int) {
         (this and flag == flag).shouldBeTrue()
-    }
-
-    private infix fun Int.shouldNotContainFlag(flag: Int) {
-        (this and flag == flag).shouldBeFalse()
     }
 
     private infix fun <T> List<T>.shouldContainAll(expected: List<T>) {

--- a/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceRepositoryTest.kt
@@ -63,6 +63,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Repeated identify within the freshness window must not hit the API.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // 1 min ago
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -110,6 +112,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenFreshButMovedFarFromAnchor_expectApiCalled() = runTest {
+        // App killed → user travels far → reopens within freshness window.
+        // Time-based check alone would skip and leave geofences stale at the
+        // old location; the distance check forces a fresh fetch.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // 1° latitude ≈ 111 km, way beyond the 5 km remoteFetchRefreshTriggerRadius.
+        repository.refresh(latitude = 1.0, longitude = 0.0)
+
+        coVerify { apiService.fetchGeofences(1.0, 0.0) }
+        verify(exactly = 0) { logger.logSyncSkippedFresh() }
     }
 
     @Test


### PR DESCRIPTION
## Stack

```
main
 └── feature/geofence-on-device
      └── mbl-1760-geofence-reliability-fixes  ← this PR
```

Linear: [MBL-1760](https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing)

## Summary

Three related fixes surfaced during MBL-1760 validation (long-distance journey testing + log inspection):

### 1. Movement-trigger geofence stuck after first EXIT

**Symptom.** A 20km drive produced exactly one movement EXIT — the second and subsequent ones never fired. After re-registration the trigger geofence appeared centered on the user, but GMS would not emit EXIT until the user physically returned to the OLD circle.

**Root cause.** `GeofencingClient` caches per-ID INSIDE/OUTSIDE state across same-ID `addGeofences` calls. A just-fired EXIT leaves the ID stuck OUTSIDE; re-registering the same ID at a new center inherits that OUTSIDE state, so the next EXIT can only fire when the user re-enters the OLD circle.

**Fix.** Remove the prior movement-trigger registration before adding the new one — forces GMS to allocate a fresh state machine. Register with `INITIAL_TRIGGER_ENTER` so GMS evaluates state at register time (user is at the new center → INSIDE). The receiver gracefully ignores the resulting ENTER ([`GeofenceBroadcastReceiver.kt`](location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt#L111)).

`NO_INITIAL_TRIGGER` is removed; it's no longer used anywhere.

Verified end-to-end on emulator: a long-distance journey now produces one EXIT per ~radius traveled instead of stalling after the first.

### 2. App-launch refresh ignored anchor distance

**Symptom.** A user who travels far while the app is killed (e.g. flies to a new city) reopens the app and sees stale geofences from the old location — until the time-based freshness window expires (default 24h).

**Root cause.** [`GeofenceRepository.refresh()`](location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt#L86) only checked the time-based freshness window. Movement-trigger EXITs can't fire while the app process is dead, so the cache stays stale until the time-based threshold trips.

**Fix.** Mirror [`handleMovement()`](location/src/main/kotlin/io/customer/location/geofence/GeofenceRepository.kt#L131) — skip the API call only if **both** are true: time-fresh **and** user near the last fetch anchor (`distance < remoteFetchRefreshTriggerRadius`). Null anchor (never fetched) preserves existing behavior via a `0f` distance fallback so the time-only check still applies.

### 3. `setLogDispatcher` silently dropped the subsystem tag

**Symptom.** Custom dispatchers (used for downstream telemetry / observability) received messages without the `[Subsystem]` prefix that Logcat saw — e.g. `Geofence sync succeeded: 4 regions registered` instead of `[Geofence] Geofence sync succeeded: 4 regions registered`.

**Root cause.** [`LoggerImpl.logIfMatchesCriteria`](core/src/main/kotlin/io/customer/sdk/core/util/LoggerImpl.kt#L45) passed the raw `message` to the dispatcher, but the tagged form (via `prependTagToMessage(tag, message)`) to `actualLogger`. The two paths diverged.

**Fix.** Prepend the tag once and pass the same tagged string to both paths. No public API change.

## Test plan

- [x] `LoggerTest.givenTagAndDispatcher_shouldDeliverTaggedMessageToDispatcher` — pins ERROR/INFO/DEBUG with tag through dispatcher
- [x] `GeofenceManagerTest.replaceGeofences_givenMovementTrigger_expectInitialTriggerEnter` — pins the new flag
- [x] `GeofenceManagerTest.replaceGeofences_givenMovementTrigger_expectPriorRegistrationRemovedFirst` — pins the remove-first behavior
- [x] `GeofenceRepositoryTest.refresh_givenFreshButMovedFarFromAnchor_expectApiCalled` — pins the distance-check force-fetch
- [x] All existing geofence + Logger tests still green
- [x] Verified end-to-end on emulator: long journey now produces multiple movement EXITs

## Risk

Low — production code diff is ~46 LOC across 5 files. The movement-trigger remove-first runs inside the existing `stateMutex`-protected path; no new threading surface. The distance check has a `null` anchor fallback that preserves the pre-fix behavior for users without an established anchor.

## Follow-ups (separate tickets, intentionally not in this PR)

- Freshness self-extension catch-22: when the cached config has a 24h `remoteFetchRefreshExpiry`, you can't shorten it without `pm clear` or natural expiry. Edge case; bites testing more than production.
- Duplicate emit per transition: WorkManager + EventBus both call `track()` for each transition. Plan to mirror PR #695's `PendingPushDeliveryStore` pattern once that merges.
- Real-device verification of the movement-trigger fix (emulator-only so far).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted changes to geofence registration/refresh and logging formatting; movement remove-first stays on the existing mutex-protected path, and null anchor preserves prior time-only skip behavior.
> 
> **Overview**
> Fixes **geofence movement-trigger reliability**, **app-launch refresh when the user has moved**, and **logger tag parity** for custom dispatchers.
> 
> **Movement trigger:** Re-registers the movement geofence with `INITIAL_TRIGGER_ENTER` and **removes the prior OS registration first** so GMS does not keep a stale OUTSIDE state that blocks later EXIT events. `GeofenceBroadcastReceiver` still treats non-EXIT movement events as no-ops; `NO_INITIAL_TRIGGER` is dropped.
> 
> **`GeofenceRepository.refresh`:** Skips the API only when sync is **time-fresh and** the current location is within `remoteFetchRefreshTriggerRadius` of the last fetch anchor (aligned with `handleMovement`), so a long trip while the app was killed can still force a remote fetch inside the time window.
> 
> **`LoggerImpl`:** Builds the tagged message once and sends the same string to `setLogDispatcher` and Logcat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43a846531c23120d8edd424661f608d7a517ca54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->