### PR TITLE
docs: fix broken CoC link, duplicated "the", and grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![min Android SDK version is 21](https://img.shields.io/badge/min%20Android%20SDK-21-green)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.customer.android/datapipelines/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.customer.android/datapipelines)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md) 
 [![codecov](https://codecov.io/gh/customerio/customerio-android/branch/develop/graph/badge.svg?token=PYV1XQTKGO)](https://codecov.io/gh/customerio/customerio-android)
 
 # Customer.io Android SDK
@@ -60,7 +60,7 @@ implementation 'io.customer.android:datapipelines:<version-here>'
 implementation 'io.customer.android:messaging-push-fcm:<version-here>'
 ```
 
-Replace `version-here` with the the latest version: ![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.customer.android/datapipelines/badge.svg)
+Replace `version-here` with the latest version: ![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.customer.android/datapipelines/badge.svg)
 
 
 ## Initialize the SDK
@@ -79,7 +79,7 @@ class App : Application() {
 }
 ```
 
-The `Builder` for CustomerIO exposes configuration options for features such `region`,`timeout`.
+The `Builder` for CustomerIO exposes configuration options for features such as `region`, `timeout`.
 
 ```kotlin
         val builder = CustomerIOBuilder(


### PR DESCRIPTION
Three small README cleanups:

1. **Contributor Covenant badge link** — the badge links to `code_of_conduct.md` (lowercase) but the file is `CODE_OF_CONDUCT.md` (uppercase), causing a 404. The same README uses the correct case on line 105.
2. **Duplicated word** — "with the the latest version" → "with the latest version".
3. **Grammar / spacing** — "features such `region`,`timeout`" → "features such as `region`, `timeout`" (missing "as", added space after comma).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, SDK, or security impact.
> 
> **Overview**
> README-only fixes: the Contributor Covenant badge now points to **`CODE_OF_CONDUCT.md`** instead of **`code_of_conduct.md`**, matching the real filename and the link used in the Contributing section.
> 
> Also removes the duplicated **"the"** in the Maven version sentence and tightens the builder docs line to **"such as `region`, `timeout`"** (adds "as" and spacing after the comma).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997d54724c0d5c12cebdef69a0f4e61d66c7a5db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->