### PR TITLE
chore: snapshot userId on pending geofence entries to fix cross-user attribution

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -25,16 +25,18 @@ public final class io/customer/sdk/communication/Event$GeofenceTransition : java
 }
 
 public final class io/customer/sdk/communication/Event$GeofenceTransitionEvent : io/customer/sdk/communication/Event {
-	public fun <init> (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;)V
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/customer/sdk/communication/Event$GeofenceTransition;
 	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
-	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;ILjava/lang/Object;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGeofenceId ()Ljava/lang/String;
 	public final fun getProperties ()Ljava/util/Map;
 	public final fun getTransition ()Lio/customer/sdk/communication/Event$GeofenceTransition;
+	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
+++ b/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
@@ -60,10 +60,16 @@ sealed class Event {
     /**
      * Event published by the Location module when a geofence transition is received from the OS.
      * Subscribers (e.g. data pipelines) translate this into a tracked event.
+     *
+     * [userId] is snapshotted at queue time, not the SDK's current identity — non-null means the
+     * subscriber must attribute the resulting track event to this userId (not whoever is identified
+     * at flush time), so a sign-out + sign-in between queue and delivery cannot reattribute. Null
+     * means anonymous at queue time; the subscriber falls back to the pipeline's anonymousId path.
      */
     data class GeofenceTransitionEvent(
         val geofenceId: String,
         val transition: GeofenceTransition,
-        val properties: Map<String, Any>
+        val properties: Map<String, Any>,
+        val userId: String?
     ) : Event()
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -172,12 +172,23 @@ class CustomerIO private constructor(
         eventBus.subscribe<Event.ResetEvent> {
             secureUserStore.clearAll()
         }
-        eventBus.subscribe<Event.GeofenceTransitionEvent> {
-            val eventName = when (it.transition) {
+        eventBus.subscribe<Event.GeofenceTransitionEvent> { geofenceEvent ->
+            val eventName = when (geofenceEvent.transition) {
                 Event.GeofenceTransition.ENTER -> EventNames.GEOFENCE_ENTERED
                 Event.GeofenceTransition.EXIT -> EventNames.GEOFENCE_EXITED
             }
-            track(name = eventName, properties = it.properties)
+            // Snapshotted userId (if any) overrides current SDK identity for this one event so a
+            // sign-out + sign-in between queue and flush cannot reattribute. Null snapshot → no
+            // override → natural anonymousId path.
+            val enrichment: EnrichmentClosure? = geofenceEvent.userId?.takeIf { it.isNotEmpty() }?.let { pinnedUserId ->
+                { event -> event?.apply { userId = pinnedUserId } }
+            }
+            track(
+                name = eventName,
+                properties = geofenceEvent.properties.sanitizeForJson(),
+                serializationStrategy = JsonAnySerializer.serializersModule.serializer(),
+                enrichment = enrichment
+            )
         }
     }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
@@ -56,7 +56,8 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-1",
             transition = Event.GeofenceTransition.ENTER,
-            properties = mapOf("geofence_id" to "biz-1", "transition_type" to "enter")
+            properties = mapOf("geofence_id" to "biz-1", "transition_type" to "enter"),
+            userId = "user-A"
         )
 
         handlerSlot.captured.invoke(event)
@@ -70,12 +71,47 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-2",
             transition = Event.GeofenceTransition.EXIT,
-            properties = mapOf("geofence_id" to "biz-2", "transition_type" to "exit")
+            properties = mapOf("geofence_id" to "biz-2", "transition_type" to "exit"),
+            userId = "user-A"
         )
 
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
         outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "GeoFence Exited"
+    }
+
+    @Test
+    fun handler_givenPinnedUserIdDifferentFromCurrent_expectTrackAttributedToPinnedUserId() = runTest {
+        // Cross-user attribution guard: even though the SDK is currently identified as
+        // user-B (or anonymous), the pinned snapshot is what must land on the event.
+        sdkInstance.identify("user-current-B")
+        val event = Event.GeofenceTransitionEvent(
+            geofenceId = "biz-3",
+            transition = Event.GeofenceTransition.ENTER,
+            properties = mapOf("geofence_id" to "biz-3"),
+            userId = "user-pinned-A"
+        )
+
+        handlerSlot.captured.invoke(event)
+
+        outputReaderPlugin.trackEvents.last().userId shouldBeEqualTo "user-pinned-A"
+    }
+
+    @Test
+    fun handler_givenNullPinnedUserId_expectTrackUsesCurrentIdentity() = runTest {
+        // Anonymous-at-queue-time entry: no override, pipeline attributes via the
+        // current identity (or anonymousId if still anonymous).
+        sdkInstance.identify("user-current")
+        val event = Event.GeofenceTransitionEvent(
+            geofenceId = "biz-4",
+            transition = Event.GeofenceTransition.ENTER,
+            properties = mapOf("geofence_id" to "biz-4"),
+            userId = null
+        )
+
+        handlerSlot.captured.invoke(event)
+
+        outputReaderPlugin.trackEvents.last().userId shouldBeEqualTo "user-current"
     }
 }

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -191,8 +191,8 @@ class ModuleLocation @JvmOverloads constructor(
      * foreground. The shared [PendingDeliveryFlusher] cancels each transition's
      * WorkManager delivery and atomically claims it, so it can't be delivered
      * twice (once here via the pipeline, once by the worker via direct HTTP).
-     * The pipeline attributes via the SDK's current identity; the worker's
-     * snapshotted userId path is what handles cross-user attribution.
+     * The entry's snapshotted userId rides through on [Event.GeofenceTransitionEvent]
+     * so the pipeline subscriber attributes the track event to it.
      */
     private fun flushPendingGeofenceDeliveries() {
         val eventBus = SDKComponent.eventBus
@@ -213,7 +213,8 @@ class ModuleLocation @JvmOverloads constructor(
                 Event.GeofenceTransitionEvent(
                     geofenceId = entry.geofenceId,
                     transition = entry.transition,
-                    properties = entry.toEventProperties()
+                    properties = entry.toEventProperties(),
+                    userId = entry.userId
                 )
             )
         }

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -191,6 +191,8 @@ class ModuleLocation @JvmOverloads constructor(
      * foreground. The shared [PendingDeliveryFlusher] cancels each transition's
      * WorkManager delivery and atomically claims it, so it can't be delivered
      * twice (once here via the pipeline, once by the worker via direct HTTP).
+     * The pipeline attributes via the SDK's current identity; the worker's
+     * snapshotted userId path is what handles cross-user attribution.
      */
     private fun flushPendingGeofenceDeliveries() {
         val eventBus = SDKComponent.eventBus

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceBroadcastReceiver.kt
@@ -140,20 +140,28 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             // death) and the foreground flush (analytics pipeline). Append first
             // so a WorkManager scheduling failure still leaves the entry for the
             // flush; isolate the scheduler so it can't abandon the rest of the batch.
+            // Snapshot userId so a sign-out + sign-in before delivery can't
+            // reattribute this transition. Empty userId is treated as "not
+            // identified" per the SDK's `isUserIdentified` convention.
             val entry = PendingGeofenceDelivery(
                 geofenceId = geofenceId,
                 transition = transition,
                 latitude = latitude,
                 longitude = longitude,
-                timestamp = timestamp
+                timestamp = timestamp,
+                userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
             )
             androidComponent.pendingGeofenceDeliveryStore.append(entry)
-            try {
-                scheduler.schedule(entry)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.logSchedulerFailed(geofenceId, transition.name, e.message)
+            // Anonymous entries can only be delivered via the foreground flush —
+            // skip the WorkManager schedule that would just no-op on null userId.
+            if (entry.userId != null) {
+                try {
+                    scheduler.schedule(entry)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.logSchedulerFailed(geofenceId, transition.name, e.message)
+                }
             }
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/GeofenceLogger.kt
@@ -120,8 +120,8 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Geofence event worker dropped: required field missing (geofenceId='$geofenceId', transition='$transitionName')", tag = TAG)
     }
 
-    fun logEventDeliverySkippedNoUser(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: HTTP delivery skipped — no identified user", tag = TAG)
+    fun logEventDeliveryDeferredAnonymous(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: no identified user at queue time — HTTP path deferred to foreground flush (analytics pipeline)", tag = TAG)
     }
 
     fun logEventDelivered(geofenceId: String, transitionName: String) {

--- a/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/di/DIGraphGeofence.kt
@@ -54,7 +54,7 @@ internal val AndroidSDKComponent.geofenceManager: GeofenceManager
 
 internal val AndroidSDKComponent.geofenceEventTracker: GeofenceEventTracker
     get() = singleton<GeofenceEventTracker> {
-        GeofenceEventTrackerImpl(SDKComponent.httpClient, secureUserStore, SDKComponent.geofenceLogger)
+        GeofenceEventTrackerImpl(SDKComponent.httpClient)
     }
 
 // Shared by the WorkManager worker, the async fallback, and the foreground flush
@@ -83,7 +83,8 @@ internal val AndroidSDKComponent.asyncGeofenceEventTracker: AsyncGeofenceEventTr
         AsyncGeofenceEventTracker(
             tracker = geofenceEventTracker,
             pendingStore = pendingGeofenceDeliveryStore,
-            dispatcher = SDKComponent.dispatchersProvider
+            dispatcher = SDKComponent.dispatchersProvider,
+            logger = SDKComponent.geofenceLogger
         )
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
@@ -20,7 +20,8 @@ internal data class PendingGeofenceDelivery(
     val transition: Event.GeofenceTransition,
     val latitude: Double?,
     val longitude: Double?,
-    val timestamp: Long
+    val timestamp: Long,
+    val userId: String?
 ) : PendingDeliveryStore.PendingDeliveryEntry {
     override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
 

--- a/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt
@@ -7,7 +7,6 @@ import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.data.store.PendingDeliveryStore
-import io.customer.sdk.data.store.SecureUserStore
 import io.customer.sdk.data.store.claimSendRestore
 import io.customer.sdk.util.EventNames
 import kotlinx.coroutines.CoroutineScope
@@ -18,53 +17,35 @@ import org.json.JSONObject
  * Sends a geofence transition event via direct HTTP, bypassing the analytics pipeline.
  * Used by [GeofenceEventWorker] (and the async fallback below) so delivery survives
  * process death and does not depend on full SDK initialization.
+ *
+ * Precondition: [entry] must carry a non-null [PendingGeofenceDelivery.userId]
+ * (the user identified when the transition fired, snapshotted at queue time so
+ * sign-out + sign-in cannot reattribute). Anonymous entries belong on the
+ * foreground-flush path and must not be passed here.
  */
 internal interface GeofenceEventTracker {
-    suspend fun trackEvent(
-        geofenceId: String,
-        transition: Event.GeofenceTransition,
-        latitude: Double?,
-        longitude: Double?,
-        timestamp: Long
-    ): Result<Unit>
+    suspend fun trackEvent(entry: PendingGeofenceDelivery): Result<Unit>
 }
 
 internal class GeofenceEventTrackerImpl(
-    private val httpClient: CustomerIOHttpClient,
-    private val secureUserStore: SecureUserStore,
-    private val logger: GeofenceLogger
+    private val httpClient: CustomerIOHttpClient
 ) : GeofenceEventTracker {
 
-    override suspend fun trackEvent(
-        geofenceId: String,
-        transition: Event.GeofenceTransition,
-        latitude: Double?,
-        longitude: Double?,
-        timestamp: Long
-    ): Result<Unit> {
-        // Cached userId so direct-HTTP delivery works without full SDK init.
-        val userId = secureUserStore.getUserId()
-        // Skip cleanly when there's no identified user — no retry will recover from this,
-        // so we report success to drop the work item without an error-level "delivery failed" log.
+    override suspend fun trackEvent(entry: PendingGeofenceDelivery): Result<Unit> {
+        val userId = entry.userId
         if (userId.isNullOrEmpty()) {
-            logger.logEventDeliverySkippedNoUser(geofenceId, transition.name)
-            return Result.success(Unit)
+            return Result.failure(
+                IllegalArgumentException("trackEvent precondition: entry.userId is null or empty; defer to foreground flush")
+            )
         }
 
-        val eventName = when (transition) {
+        val eventName = when (entry.transition) {
             Event.GeofenceTransition.ENTER -> EventNames.GEOFENCE_ENTERED
             Event.GeofenceTransition.EXIT -> EventNames.GEOFENCE_EXITED
         }
 
-        val propertiesJson = JSONObject().apply {
-            put("geofence_id", geofenceId)
-            put("transition_type", transition.name.lowercase())
-            latitude?.let { put("latitude", it) }
-            longitude?.let { put("longitude", it) }
-            put("timestamp", timestamp)
-        }
         val bodyJson = JSONObject().apply {
-            put("properties", propertiesJson)
+            put("properties", JSONObject(entry.toEventProperties()))
             put("event", eventName)
             put("userId", userId)
         }
@@ -75,7 +56,7 @@ internal class GeofenceEventTrackerImpl(
             body = bodyJson.toString()
         )
 
-        return httpClient.request(params).map { /* success/failure only */ }
+        return httpClient.request(params).map { }
     }
 }
 
@@ -85,22 +66,24 @@ internal class GeofenceEventTrackerImpl(
  * worker — claim before sending — so that if the foreground flush fires while
  * this HTTP call is in flight, only one channel delivers: a lost claim skips
  * the send, and a failed send restores the entry for the flush to retry.
+ *
+ * Entries with a null [PendingGeofenceDelivery.userId] are left untouched here;
+ * the foreground flush handles them via the analytics pipeline's anonymousId.
  */
 internal class AsyncGeofenceEventTracker(
     private val tracker: GeofenceEventTracker,
     private val pendingStore: PendingDeliveryStore<PendingGeofenceDelivery>,
-    private val dispatcher: DispatchersProvider
+    private val dispatcher: DispatchersProvider,
+    private val logger: GeofenceLogger
 ) {
     fun trackEvent(entry: PendingGeofenceDelivery) {
+        if (entry.userId.isNullOrEmpty()) {
+            logger.logEventDeliveryDeferredAnonymous(entry.geofenceId, entry.transition.name)
+            return
+        }
         CoroutineScope(dispatcher.background).launch {
             pendingStore.claimSendRestore(entry) {
-                tracker.trackEvent(
-                    geofenceId = entry.geofenceId,
-                    transition = entry.transition,
-                    latitude = entry.latitude,
-                    longitude = entry.longitude,
-                    timestamp = entry.timestamp
-                )
+                tracker.trackEvent(entry)
             }
         }
     }

--- a/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventWorker.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventWorker.kt
@@ -25,6 +25,7 @@ private const val KEY_TRANSITION = "transition"
 private const val KEY_LATITUDE = "latitude"
 private const val KEY_LONGITUDE = "longitude"
 private const val KEY_TIMESTAMP = "timestamp"
+private const val KEY_USER_ID = "user_id"
 
 /**
  * Schedules a [GeofenceEventWorker] for guaranteed delivery of a geofence transition event.
@@ -42,6 +43,7 @@ internal class GeofenceEventScheduler(
             .apply {
                 entry.latitude?.let { putDouble(KEY_LATITUDE, it) }
                 entry.longitude?.let { putDouble(KEY_LONGITUDE, it) }
+                entry.userId?.let { putString(KEY_USER_ID, it) }
             }
             .build()
 
@@ -106,8 +108,16 @@ internal class GeofenceEventWorker(
             }
         }
 
+        val userId = inputData.getString(KEY_USER_ID)
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
-        val entry = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp)
+        val entry = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
+
+        // No identified user at queue time — direct HTTP needs a userId, so
+        // leave the entry in the store for the foreground flush instead.
+        if (userId.isNullOrEmpty()) {
+            logger.logEventDeliveryDeferredAnonymous(geofenceId, transition.name)
+            return Result.success()
+        }
 
         // Shared exactly-once decision: claim before sending so we don't double
         // deliver against the foreground flush (which also claims before
@@ -115,8 +125,7 @@ internal class GeofenceEventWorker(
         // can deliver it later.
         return when (
             val outcome = store.claimSendRestore(entry) {
-                SDKComponent.android().geofenceEventTracker
-                    .trackEvent(geofenceId, transition, latitude, longitude, timestamp)
+                SDKComponent.android().geofenceEventTracker.trackEvent(entry)
             }
         ) {
             PendingDeliveryResult.AlreadyClaimed -> {

--- a/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/GeofenceBroadcastReceiverTest.kt
@@ -14,6 +14,7 @@ import io.customer.location.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifyOrder
@@ -40,6 +41,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     private val mockCooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
     private val mockStore: GeofenceRegionStore = mockk(relaxed = true)
     private val mockManager: GeofenceManager = mockk(relaxed = true)
+    private val mockSecureUserStore: SecureUserStore = mockk(relaxed = true)
 
     // Real disk-backed store (Robolectric filesDir). The mocked scheduler never
     // claims, so an appended entry stays in the store and we can assert on it.
@@ -59,12 +61,16 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                         overrideDependency<GeofenceCooldownFilter>(mockCooldownFilter)
                         overrideDependency<GeofenceRegionStore>(mockStore)
                         overrideDependency<GeofenceManager>(mockManager)
+                        overrideDependency<SecureUserStore>(mockSecureUserStore)
                     }
                 }
             }
         )
         // Default: cooldown allows emission. Tests override this to test suppression.
         every { mockCooldownFilter.tryAcquire(any(), any()) } returns true
+        // Default: an identified user is the common case; the snapshot lands on the entry.
+        // Tests that need an anonymous-at-queue-time scenario override this to null.
+        every { mockSecureUserStore.getUserId() } returns "user-42"
         // Default: all geofence IDs the tests reference are "registered" so the
         // dispatchTransition store filter is a no-op. Tests for the filter override.
         every { mockStore.getRegisteredIds() } returns setOf(
@@ -170,6 +176,57 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // exactly-once is now arbitrated by the store, not a double-send.
         pendingStore.loadAll() shouldBeEqualTo listOf(scheduled)
         verify(exactly = 0) { mockEventBus.publish(any<Event.GeofenceTransitionEvent>()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenIdentifiedUser_expectUserIdSnapshottedOnEntry() = runTest {
+        // Snapshotting at queue time is what protects A's events from being
+        // reattributed to B if A signs out + B signs in before delivery.
+        every { mockSecureUserStore.getUserId() } returns "user-A"
+        val entrySlot = slot<PendingGeofenceDelivery>()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-1"),
+            latitude = 1.0,
+            longitude = 2.0
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.userId shouldBeEqualTo "user-A"
+    }
+
+    @Test
+    fun dispatchTransition_givenAnonymousSession_expectEntryQueuedAndNoWorkerScheduled() = runTest {
+        // Worker can't HTTP without a userId, so for anonymous entries we skip
+        // WorkManager entirely — the foreground flush is the only delivery path.
+        every { mockSecureUserStore.getUserId() } returns null
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-1"),
+            latitude = 1.0,
+            longitude = 2.0
+        )
+
+        pendingStore.loadAll().single().userId.shouldBeNull()
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenEmptyUserId_expectTreatedAsAnonymous() = runTest {
+        // Matches the SDK's `isUserIdentified` semantics — empty = not identified.
+        every { mockSecureUserStore.getUserId() } returns ""
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-1"),
+            latitude = 1.0,
+            longitude = 2.0
+        )
+
+        pendingStore.loadAll().single().userId.shouldBeNull()
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -11,7 +11,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun key_expectGeofenceIdTransitionTimestampComposite() {
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_234L)
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_234L, "user-A")
 
         // Doubles as the WorkManager unique-work name so the flush can cancel by key.
         entry.key shouldBeEqualTo "biz-1_ENTER_1234"
@@ -19,7 +19,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun serialization_givenRoundTrip_expectEqualEntry() {
-        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 37.7749, -122.4194, 99L)
+        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 37.7749, -122.4194, 99L, "user-A")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -29,7 +29,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun serialization_givenNullLatLng_expectRoundTripPreservesNulls() {
-        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, null, null, 0L)
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, null, null, 0L, "user-A")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -40,8 +40,30 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
+    fun serialization_givenUserIdSnapshot_expectRoundTripPreservesIt() {
+        val entry = PendingGeofenceDelivery("biz-u", Event.GeofenceTransition.ENTER, 1.0, 2.0, 3L, "user-A")
+
+        val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
+        val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
+
+        restored.userId shouldBeEqualTo "user-A"
+    }
+
+    @Test
+    fun serialization_givenNullUserId_expectRoundTripPreservesNull() {
+        // Anonymous entries are queued by the receiver for the foreground flush.
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 1.0, 2.0, 5L, userId = null)
+
+        val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
+        val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
+
+        restored shouldBeEqualTo entry
+        restored.userId shouldBeEqualTo null
+    }
+
+    @Test
     fun toEventProperties_givenLatLng_expectAllPropertiesPresent() {
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.5, 2.5, 50L)
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.5, 2.5, 50L, "user-A")
 
         val props = entry.toEventProperties()
 
@@ -54,7 +76,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun toEventProperties_givenNullLatLng_expectLatLngOmitted() {
-        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.EXIT, null, null, 7L)
+        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.EXIT, null, null, 7L, "user-A")
 
         val props = entry.toEventProperties()
 

--- a/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -3,6 +3,7 @@ package io.customer.location.geofence.worker
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.location.geofence.GeofenceLogger
 import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.DispatchersProvider
@@ -27,6 +28,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
     private val mockTracker: GeofenceEventTracker = mockk(relaxed = true)
     private val mockStore: PendingDeliveryStore<PendingGeofenceDelivery> = mockk(relaxed = true)
+    private val mockLogger: GeofenceLogger = mockk(relaxed = true)
     private val testDispatcher = UnconfinedTestDispatcher()
     private val dispatchersProvider: DispatchersProvider = object : DispatchersProvider {
         override val background: CoroutineDispatcher get() = testDispatcher
@@ -38,72 +40,58 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfigurationDefault { })
-        asyncTracker = AsyncGeofenceEventTracker(mockTracker, mockStore, dispatchersProvider)
+        asyncTracker = AsyncGeofenceEventTracker(mockTracker, mockStore, dispatchersProvider, mockLogger)
     }
 
     @Test
-    fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryFields() = runTest {
+    fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryAndUserId() = runTest {
         every { mockStore.claim(any()) } returns true
-        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 42L)
+        coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 42L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
-        // Claim before send (shared exactly-once contract), then deliver.
+        // Claim before send (shared exactly-once contract), then deliver with the snapshotted entry.
         verify(exactly = 1) { mockStore.claim("biz-1_ENTER_42") }
-        coVerify(exactly = 1) {
-            mockTracker.trackEvent(
-                geofenceId = "biz-1",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = 1.0,
-                longitude = 2.0,
-                timestamp = 42L
-            )
-        }
+        coVerify(exactly = 1) { mockTracker.trackEvent(entry) }
         // claim() already removed it; success must not re-append.
         verify(exactly = 0) { mockStore.append(any()) }
-    }
-
-    @Test
-    fun trackEvent_givenNullLatLng_expectNullPassedThrough() = runTest {
-        every { mockStore.claim(any()) } returns true
-        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
-        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, null, null, 0L)
-
-        asyncTracker.trackEvent(entry)
-
-        coVerify(exactly = 1) {
-            mockTracker.trackEvent(
-                geofenceId = "biz-2",
-                transition = Event.GeofenceTransition.EXIT,
-                latitude = null,
-                longitude = null,
-                timestamp = 0L
-            )
-        }
     }
 
     @Test
     fun trackEvent_givenClaimLost_expectNoSend() = runTest {
         // Foreground flush already claimed + delivered this entry: do not double-send.
         every { mockStore.claim(any()) } returns false
-        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 1.0, 2.0, 7L)
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 1.0, 2.0, 7L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
-        coVerify(exactly = 0) { mockTracker.trackEvent(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
     }
 
     @Test
     fun trackEvent_givenFailure_expectEntryRestoredForFlush() = runTest {
         every { mockStore.claim(any()) } returns true
-        coEvery { mockTracker.trackEvent(any(), any(), any(), any(), any()) } returns
+        coEvery { mockTracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.0, 2.0, 9L)
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.0, 2.0, 9L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
         // Restored so the foreground flush can still deliver it.
         verify(exactly = 1) { mockStore.append(entry) }
+    }
+
+    @Test
+    fun trackEvent_givenNullUserId_expectNoClaimAndNoSend() = runTest {
+        // Anonymous session: HTTP needs a userId, so we leave the entry in
+        // the store for the foreground flush to publish via anonymousId.
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 1.0, 2.0, 11L, userId = null)
+
+        asyncTracker.trackEvent(entry)
+
+        verify(exactly = 0) { mockStore.claim(any()) }
+        coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
+        verify { mockLogger.logEventDeliveryDeferredAnonymous("biz-anon", "ENTER") }
     }
 }

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -57,7 +57,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 transition = Event.GeofenceTransition.ENTER,
                 latitude = 37.7749,
                 longitude = -122.4194,
-                timestamp = 1_234L
+                timestamp = 1_234L,
+                userId = "user-42"
             )
         )
 
@@ -76,6 +77,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         input.getDouble("latitude", -1.0) shouldBeEqualTo 37.7749
         input.getDouble("longitude", -1.0) shouldBeEqualTo -122.4194
         input.getLong("timestamp", -1L) shouldBeEqualTo 1_234L
+        input.getString("user_id") shouldBeEqualTo "user-42"
 
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
@@ -93,7 +95,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 transition = Event.GeofenceTransition.EXIT,
                 latitude = null,
                 longitude = null,
-                timestamp = 99L
+                timestamp = 99L,
+                userId = "user-42"
             )
         )
 
@@ -104,6 +107,28 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
     }
 
     @Test
+    fun schedule_givenNullUserId_expectInputDataWithoutUserIdKey() = runTest {
+        // Worker reads user_id and treats absence as "anonymous-when-queued" → defer to flush.
+        every { workManagerProvider.getWorkManager() } returns workManager
+        val workRequestSlot = slot<OneTimeWorkRequest>()
+
+        scheduler.schedule(
+            PendingGeofenceDelivery(
+                geofenceId = "biz-anon",
+                transition = Event.GeofenceTransition.ENTER,
+                latitude = 1.0,
+                longitude = 2.0,
+                timestamp = 5L,
+                userId = null
+            )
+        )
+
+        verify { workManager.enqueueUniqueWork(any(), any(), capture(workRequestSlot)) }
+        val input = workRequestSlot.captured.workSpec.input
+        input.hasKeyWithValueOfType("user_id", String::class.java) shouldBeEqualTo false
+    }
+
+    @Test
     fun schedule_givenWorkManagerUnavailable_expectFallbackToAsyncTracker() = runTest {
         every { workManagerProvider.getWorkManager() } returns null
         val entry = PendingGeofenceDelivery(
@@ -111,7 +136,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
             transition = Event.GeofenceTransition.ENTER,
             latitude = 1.0,
             longitude = 2.0,
-            timestamp = 42L
+            timestamp = 42L,
+            userId = "user-42"
         )
 
         scheduler.schedule(entry)

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventTrackerTest.kt
@@ -3,14 +3,12 @@ package io.customer.location.geofence.worker
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
-import io.customer.location.geofence.GeofenceLogger
+import io.customer.location.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
-import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
@@ -26,29 +24,29 @@ import org.robolectric.RobolectricTestRunner
 class GeofenceEventTrackerTest : RobolectricTest() {
 
     private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
-    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
-    private val logger: GeofenceLogger = mockk(relaxed = true)
 
     private lateinit var tracker: GeofenceEventTrackerImpl
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfigurationDefault { })
-        tracker = GeofenceEventTrackerImpl(httpClient, secureUserStore, logger)
+        tracker = GeofenceEventTrackerImpl(httpClient)
     }
+
+    private fun entry(
+        geofenceId: String = "biz-geofence-1",
+        transition: Event.GeofenceTransition = Event.GeofenceTransition.ENTER,
+        latitude: Double? = 37.7749,
+        longitude: Double? = -122.4194,
+        timestamp: Long = 1_234_567_890L,
+        userId: String? = "user-42"
+    ) = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
 
     @Test
     fun trackEvent_givenEnterTransition_expectPostToTrackWithCorrectBody() = runTest {
-        every { secureUserStore.getUserId() } returns "user-42"
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
 
-        val result = tracker.trackEvent(
-            geofenceId = "biz-geofence-1",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 37.7749,
-            longitude = -122.4194,
-            timestamp = 1_234_567_890L
-        )
+        val result = tracker.trackEvent(entry())
 
         result.isSuccess shouldBeEqualTo true
         capturedParams.captured.path shouldBeEqualTo "/track"
@@ -65,17 +63,10 @@ class GeofenceEventTrackerTest : RobolectricTest() {
 
     @Test
     fun trackEvent_givenExitTransition_expectExitedEventName() = runTest {
-        every { secureUserStore.getUserId() } returns "user-42"
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
 
-        tracker.trackEvent(
-            geofenceId = "biz-geofence-2",
-            transition = Event.GeofenceTransition.EXIT,
-            latitude = 0.0,
-            longitude = 0.0,
-            timestamp = 0L
-        )
+        tracker.trackEvent(entry(transition = Event.GeofenceTransition.EXIT))
 
         val body = JSONObject(capturedParams.captured.body)
         body.getString("event") shouldBeEqualTo "GeoFence Exited"
@@ -83,72 +74,45 @@ class GeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
-    fun trackEvent_givenAnonymousUser_expectSkippedWithoutHttpCall() = runTest {
-        every { secureUserStore.getUserId() } returns null
-
-        val result = tracker.trackEvent(
-            geofenceId = "biz-geofence-3",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 0.0,
-            longitude = 0.0,
-            timestamp = 0L
-        )
-
-        result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { httpClient.request(any()) }
-    }
-
-    @Test
     fun trackEvent_givenNullLatLng_expectBodyWithoutLatLng() = runTest {
-        every { secureUserStore.getUserId() } returns "user-42"
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
 
-        tracker.trackEvent(
-            geofenceId = "biz-geofence-4",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = null,
-            longitude = null,
-            timestamp = 1L
-        )
+        tracker.trackEvent(entry(latitude = null, longitude = null))
 
-        val body = JSONObject(capturedParams.captured.body)
-        val props = body.getJSONObject("properties")
+        val props = JSONObject(capturedParams.captured.body).getJSONObject("properties")
         props.has("latitude") shouldBeEqualTo false
         props.has("longitude") shouldBeEqualTo false
     }
 
     @Test
     fun trackEvent_givenHttpFailure_expectFailureResult() = runTest {
-        every { secureUserStore.getUserId() } returns "user-42"
         val error = RuntimeException("boom")
         coEvery { httpClient.request(any()) } returns Result.failure(error)
 
-        val result = tracker.trackEvent(
-            geofenceId = "biz-geofence-5",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 0.0,
-            longitude = 0.0,
-            timestamp = 0L
-        )
+        val result = tracker.trackEvent(entry())
 
         result.isFailure shouldBeEqualTo true
         result.exceptionOrNull() shouldBeEqualTo error
     }
 
     @Test
+    fun trackEvent_givenNullUserIdEntry_expectFailureWithoutHttpCall() = runTest {
+        // Precondition guard: anonymous entries belong on the foreground-flush path.
+        // Callers must filter these out; if one slips through, fail loud rather than POST a userId-less event.
+        val result = tracker.trackEvent(entry(userId = null))
+
+        result.isFailure shouldBeEqualTo true
+        (result.exceptionOrNull() is IllegalArgumentException) shouldBeEqualTo true
+        coVerify(exactly = 0) { httpClient.request(any()) }
+    }
+
+    @Test
     fun trackEvent_givenContentTypeHeader_expectJsonHeader() = runTest {
-        every { secureUserStore.getUserId() } returns "user-42"
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
 
-        tracker.trackEvent(
-            geofenceId = "biz-geofence-6",
-            transition = Event.GeofenceTransition.ENTER,
-            latitude = 0.0,
-            longitude = 0.0,
-            timestamp = 0L
-        )
+        tracker.trackEvent(entry())
 
         capturedParams.captured.headers["Content-Type"].shouldNotBeNull() shouldContain "application/json"
         coVerify(exactly = 1) { httpClient.request(any()) }

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventWorkerTest.kt
@@ -48,84 +48,62 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         transition: Event.GeofenceTransition,
         latitude: Double? = 0.0,
         longitude: Double? = 0.0,
-        timestamp: Long = 0L
+        timestamp: Long = 0L,
+        userId: String? = "user-42"
     ): PendingGeofenceDelivery =
-        PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp)
+        PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
             .also { store.append(it) }
 
     @Test
     fun doWork_givenClaimableEntry_expectSuccessTrackerCalledAndEntryRemoved() = runTest {
-        seed("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 99L)
-        val inputData = buildInputData("biz-1", "ENTER", 1.0, 2.0, 99L)
-        coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+        val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 99L)
+        val inputData = buildInputData("biz-1", "ENTER", 1.0, 2.0, 99L, "user-42")
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
 
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.success()
-        coVerify(exactly = 1) {
-            tracker.trackEvent(
-                geofenceId = "biz-1",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = 1.0,
-                longitude = 2.0,
-                timestamp = 99L
-            )
-        }
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
         store.loadAll().isEmpty().shouldBeTrue()
     }
 
     @Test
     fun doWork_givenValidExitInput_expectExitTransitionPassed() = runTest {
-        seed("biz-2", Event.GeofenceTransition.EXIT, timestamp = 0L)
+        val entry = seed("biz-2", Event.GeofenceTransition.EXIT, timestamp = 0L)
         val inputData = buildInputData("biz-2", "EXIT", timestamp = 0L)
-        coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
 
         createWorker(inputData).doWork()
 
-        coVerify(exactly = 1) {
-            tracker.trackEvent(
-                geofenceId = "biz-2",
-                transition = Event.GeofenceTransition.EXIT,
-                latitude = any(),
-                longitude = any(),
-                timestamp = 0L
-            )
-        }
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
     }
 
     @Test
-    fun doWork_givenMissingLatLng_expectNullPassedToTracker() = runTest {
-        seed("biz-3", Event.GeofenceTransition.ENTER, latitude = null, longitude = null, timestamp = 0L)
+    fun doWork_givenMissingLatLng_expectEntryWithNullLatLngPassed() = runTest {
+        val entry = seed("biz-3", Event.GeofenceTransition.ENTER, latitude = null, longitude = null, timestamp = 0L)
         val inputData = Data.Builder()
             .putString("geofence_id", "biz-3")
             .putString("transition", "ENTER")
             .putLong("timestamp", 0L)
+            .putString("user_id", "user-42")
             .build()
-        coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns Result.success(Unit)
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
 
         createWorker(inputData).doWork()
 
-        coVerify(exactly = 1) {
-            tracker.trackEvent(
-                geofenceId = "biz-3",
-                transition = Event.GeofenceTransition.ENTER,
-                latitude = null,
-                longitude = null,
-                timestamp = 0L
-            )
-        }
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
     }
 
     @Test
     fun doWork_givenClaimLost_expectSuccessWithoutTracking() = runTest {
         // No matching entry in the store (the foreground flush already delivered it):
         // the worker's claim fails, so it must not send a duplicate.
-        val inputData = buildInputData("biz-already-delivered", "ENTER", timestamp = 0L)
+        val inputData = buildInputData("biz-already-delivered", "ENTER", timestamp = 0L, userId = "user-42")
 
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.success()
-        coVerify(exactly = 0) { tracker.trackEvent(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
     @Test
@@ -135,7 +113,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.failure()
-        coVerify(exactly = 0) { tracker.trackEvent(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
     @Test
@@ -145,7 +123,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.failure()
-        coVerify(exactly = 0) { tracker.trackEvent(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
     @Test
@@ -155,14 +133,14 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.failure()
-        coVerify(exactly = 0) { tracker.trackEvent(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
     @Test
     fun doWork_givenIOException_expectRetryAndEntryRestored() = runTest {
         seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
-        val inputData = buildInputData("biz", "ENTER", timestamp = 0L)
-        coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns
+        val inputData = buildInputData("biz", "ENTER", timestamp = 0L, userId = "user-42")
+        coEvery { tracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
 
         val result = createWorker(inputData).doWork()
@@ -175,8 +153,8 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     @Test
     fun doWork_givenNonIOException_expectFailureAndEntryRestored() = runTest {
         seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
-        val inputData = buildInputData("biz", "ENTER", timestamp = 0L)
-        coEvery { tracker.trackEvent(any(), any(), any(), any(), any()) } returns
+        val inputData = buildInputData("biz", "ENTER", timestamp = 0L, userId = "user-42")
+        coEvery { tracker.trackEvent(any()) } returns
             Result.failure(IllegalStateException("bad state"))
 
         val result = createWorker(inputData).doWork()
@@ -185,12 +163,28 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0")
     }
 
+    @Test
+    fun doWork_givenNullUserId_expectDeferredWithoutClaimingOrTracking() = runTest {
+        // Anonymous-at-queue-time path: HTTP needs a userId so we leave the
+        // entry intact for the foreground flush (analytics pipeline + anonymousId).
+        seed("biz-anon", Event.GeofenceTransition.ENTER, timestamp = 0L, userId = null)
+        val inputData = buildInputData("biz-anon", "ENTER", timestamp = 0L, userId = null)
+
+        val result = createWorker(inputData).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.success()
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
+        // Entry must NOT be removed — flush still needs it.
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz-anon_ENTER_0")
+    }
+
     private fun buildInputData(
         geofenceId: String?,
         transition: String?,
         latitude: Double = 0.0,
         longitude: Double = 0.0,
-        timestamp: Long = 0L
+        timestamp: Long = 0L,
+        userId: String? = "user-42"
     ): Data {
         val builder = Data.Builder()
             .putDouble("latitude", latitude)
@@ -198,6 +192,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
             .putLong("timestamp", timestamp)
         geofenceId?.let { builder.putString("geofence_id", it) }
         transition?.let { builder.putString("transition", it) }
+        userId?.let { builder.putString("user_id", it) }
         return builder.build()
     }
 


### PR DESCRIPTION
## Stack

```
main
 └── feature/geofence-on-device
      └── mbl-1760-pending-delivery-userid-snapshot  ← this PR
```

Linear: [MBL-1760](https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing)

## Summary

### The bug

A geofence transition queued while User A was identified could be delivered as **User B** if A signed out and B signed in before delivery completed. Both delivery channels resolved the userId at *delivery time*, not at *queue time*:

- The WorkManager worker called `secureUserStore.getUserId()` inside `GeofenceEventTrackerImpl.trackEvent` (always returns the current user).
- The foreground flush published `Event.GeofenceTransitionEvent` to the analytics pipeline, which called `track()` — also resolving to the current identity.

Also: events queued during an anonymous session were silently dropped by the worker (`Result.success()` with no HTTP) instead of being deferred to the pipeline path.

### The fix

Snapshot the userId on [`PendingGeofenceDelivery`](location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt) at queue time, then route per-entry:

| Snapshot userId | Channel | Why |
|---|---|---|
| Non-null | Worker — direct HTTP using the snapshot | The worker can carry an explicit userId; this preserves attribution across sign-out/sign-in. |
| Null (anonymous at queue time) | Flush — analytics pipeline using `anonymousId` | Direct HTTP requires a userId; the pipeline handles anonymous-to-identified merging naturally on later identify. |

To save a no-op WorkManager schedule, the broadcast receiver skips `scheduler.schedule()` for null-userId entries — they can only be delivered via the foreground flush anyway.

### Refactor along the way

[`GeofenceEventTracker.trackEvent`](location/src/main/kotlin/io/customer/location/geofence/worker/GeofenceEventTracker.kt) now takes just the entry — the HTTP body's `properties` come from `entry.toEventProperties()` and the userId is read from the snapshot. The impl guards `entry.userId.isNullOrEmpty()` as an explicit precondition; anonymous entries belong on the foreground-flush path and must not be passed in.

## Test plan

- [x] `dispatchTransition_givenIdentifiedUser_expectUserIdSnapshottedOnEntry` — pins snapshot at queue time
- [x] `dispatchTransition_givenAnonymousSession_expectEntryQueuedAndNoWorkerScheduled` — pins null snapshot + WM skip
- [x] `serialization_givenUserIdSnapshot_expectRoundTripPreservesIt` — pins persistence
- [x] `serialization_givenNullUserId_expectRoundTripPreservesNull` — pins anonymous-entry persistence round-trip
- [x] `schedule_givenWorkManagerAvailable_expectUniqueWorkEnqueued` — pins userId is written into WM input data
- [x] `doWork_givenNullUserId_expectDeferredWithoutClaimingOrTracking` — pins worker defers without claiming
- [x] `trackEvent_givenNullUserId_expectNoClaimAndNoSend` — same for async fallback
- [x] `trackEvent_givenNullUserIdEntry_expectFailureWithoutHttpCall` — pins the precondition guard inside the tracker
- [x] All existing geofence + `:core` + `:messagingpush` tests still green

## Risk

Low — production code diff is ~50 net lines across 7 files in the location module. No `:core` API change.

- **Threading**: no new state — `userId` is `val` on a data class. `secureUserStore.getUserId()` reads from thread-safe storage. The async tracker early-returns *before* launching its coroutine on null userId.
- **Anonymous events**: previously silently dropped by the worker; now correctly deferred to the pipeline flush. Behavior change is intentional and desirable.

## Follow-up (out of scope)

The `if (inputData.hasKeyWithValueOfType(KEY_LATITUDE, Double::class.javaObjectType)) inputData.getDouble(...) else null` dance in `GeofenceEventWorker.doWork` (lines 93-94) is pre-existing and verbose. A small `Data.getDoubleOrNull` extension would tidy it — happy to do that in a separate PR if anyone bites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `GeofenceTransitionEvent` API, analytics user attribution, and geofence delivery routing (HTTP worker vs pipeline flush), including intentional behavior change for anonymous-at-queue-time events.
> 
> **Overview**
> Fixes **cross-user geofence attribution** by snapshotting `userId` when a transition is queued, instead of resolving identity at delivery time.
> 
> **`PendingGeofenceDelivery`** and **`Event.GeofenceTransitionEvent`** now carry an optional **`userId`** from queue time through persistence, WorkManager input, foreground flush, and the datapipelines subscriber. The **broadcast receiver** reads `secureUserStore` when appending an entry; **identified** transitions still schedule WorkManager/direct HTTP using the snapshot, while **anonymous** entries skip scheduling and stay in the pending store for the **foreground flush** (pipeline `anonymousId` path). **`GeofenceEventTracker`** takes the full entry and POSTs the snapshotted `userId`; null/empty `userId` is a hard precondition failure rather than a silent skip.
> 
> On the datapipelines side, the geofence handler **`track()`s** with optional **enrichment** so a non-null snapshot overrides the current SDK user for that event only. Logging is updated for deferred anonymous delivery; tests cover snapshotting, routing, WM payload, worker deferral, and pinned vs current identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6dc4c22e0a8ff5503b808236f483021797a1e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->