### PR TITLE
chore: bump codecov-action to v7.0.0 (Keybase key migration)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run unit tests (${{ matrix.module }})
         run: ./gradlew :${{ matrix.module }}:runJacocoTestReport
       - name: Upload code coverage report
-        uses: codecov/codecov-action@e96185f4044c2f0cedf0f022454acf9811cf8057 # v5.4.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- Bumps `codecov/codecov-action` from v5.4.0 → v7.0.0 (SHA-pinned).
- Unblocks the `Upload code coverage report` step, which has been failing on every PR since 2026-06-08 with `gpg: Can't check signature: No public key`.

## Root cause
Codecov deleted the `codecovsecurity` Keybase account around 2026-06-07 (per the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)). The v5.4.0 script still fetches the signing key from `https://keybase.io/codecovsecurity/pgp_keys.asc`, which now returns non-OpenPGP data — `gpg --import` reports `Total number processed: 0`, and the subsequent signature verify fails. v7.0.0 re-points the fetch at the new `codecovsecops` Keybase account with the original GPG key.

v6.0.2 and v7.0.0 share the same commit SHA (`fb8b358…`) — v7.0.0 is a release-tag-only bump on top of v6.0.2 — so this is the same runtime change as the v6 line, pinned at the latest tag.

## Test plan
- [x] CI: `Upload code coverage report` step succeeds across all `Unit tests (<module>)` jobs
- [x] Codecov upload visible in the run summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency bump with no application or secret-handling changes beyond restoring a failing upload step.
> 
> **Overview**
> Updates the **Unit tests** workflow so JaCoCo coverage uploads use **`codecov/codecov-action` v7.0.0** (SHA-pinned) instead of v5.4.0. Upload step settings (`CODECOV_TOKEN`, `fail_ci_if_error`, `verbose`, Jacoco XML paths) are unchanged.
> 
> This targets CI failures where v5.4.0 could not verify the uploader signature after Codecov’s old Keybase signing key was removed; v7.0.0 fetches the key from the replacement account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0caf205040fda9d52bf981b5e88f75056fd61b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->