### PR TITLE
chore: align live notifications with iOS + address #676/#690 review feedback

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -48,8 +48,14 @@ internal class LiveNotificationHandler(
         private const val EVENT_END = "end"
 
         /**
-         * Envelope keys that are not template fields. Everything else in the
-         * bundle is flattened into the template `data` object.
+         * Live-notification envelope keys that are never template fields.
+         * Everything else in the bundle is flattened into the template `data`
+         * object.
+         *
+         * Note: standard-push keys (`title`, `body`, `image`, `link`, …) are
+         * intentionally NOT reserved here — they are not part of the live
+         * envelope, and reserving them would shadow legitimate template fields
+         * of the same name (e.g. CountdownTimer's `title`).
          */
         private val RESERVED_KEYS = setOf(
             ACTIVITY_ID_KEY,
@@ -58,12 +64,7 @@ internal class LiveNotificationHandler(
             TIMESTAMP_KEY,
             DISMISSAL_DATE_KEY,
             PushTrackingUtil.DELIVERY_ID_KEY,
-            PushTrackingUtil.DELIVERY_TOKEN_KEY,
-            CustomerIOPushNotificationHandler.DEEP_LINK_KEY,
-            CustomerIOPushNotificationHandler.IMAGE_KEY,
-            CustomerIOPushNotificationHandler.TITLE_KEY,
-            CustomerIOPushNotificationHandler.BODY_KEY,
-            CustomerIOPushNotificationHandler.NOTIFICATION_REQUEST_CODE
+            PushTrackingUtil.DELIVERY_TOKEN_KEY
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -7,18 +7,18 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.pushModuleConfig
-import io.customer.messagingpush.extensions.getDrawableByName
 import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.template.TemplateAssets
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.core.di.SDKComponent
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -28,10 +28,11 @@ import org.json.JSONObject
  * Live notifications are ongoing notifications that can be updated in-place
  * (the Android counterpart of iOS Live Activities). Each push declares an
  * `activity_type` (one of the closed set in [TemplateRegistry], prefixed with
- * `io.customer.live.`) plus two JSON objects: `attributes` for static fields
- * and `content_state` for dynamic fields. Pushes share a stable
- * [ACTIVITY_ID_KEY] so successive updates replace the previous notification
- * rather than creating new ones.
+ * `io.customer.liveactivities.`). Unlike iOS, Android does not split static
+ * `attributes` from dynamic `content-state`: all template fields arrive
+ * flattened at the envelope top level. Pushes share a stable [ACTIVITY_ID_KEY]
+ * so successive updates replace the previous notification rather than creating
+ * new ones.
  */
 internal class LiveNotificationHandler(
     private val bundle: Bundle
@@ -41,12 +42,29 @@ internal class LiveNotificationHandler(
         const val ACTIVITY_ID_KEY = "activity_id"
         const val EVENT_KEY = "event"
         const val ACTIVITY_TYPE_KEY = "activity_type"
-        const val ATTRIBUTES_KEY = "attributes"
-        const val CONTENT_STATE_KEY = "content_state"
+        const val TIMESTAMP_KEY = "timestamp"
+        const val DISMISSAL_DATE_KEY = "dismissal_date"
 
         private const val EVENT_END = "end"
 
-        private const val DEFAULT_DISMISS_DELAY_MS = 3000L
+        /**
+         * Envelope keys that are not template fields. Everything else in the
+         * bundle is flattened into the template `data` object.
+         */
+        private val RESERVED_KEYS = setOf(
+            ACTIVITY_ID_KEY,
+            EVENT_KEY,
+            ACTIVITY_TYPE_KEY,
+            TIMESTAMP_KEY,
+            DISMISSAL_DATE_KEY,
+            PushTrackingUtil.DELIVERY_ID_KEY,
+            PushTrackingUtil.DELIVERY_TOKEN_KEY,
+            CustomerIOPushNotificationHandler.DEEP_LINK_KEY,
+            CustomerIOPushNotificationHandler.IMAGE_KEY,
+            CustomerIOPushNotificationHandler.TITLE_KEY,
+            CustomerIOPushNotificationHandler.BODY_KEY,
+            CustomerIOPushNotificationHandler.NOTIFICATION_REQUEST_CODE
+        )
     }
 
     fun handle(
@@ -69,6 +87,13 @@ internal class LiveNotificationHandler(
         }
 
         val activityId = bundle.getString(ACTIVITY_ID_KEY) ?: return
+        val event = bundle.getString(EVENT_KEY)
+        if (event == null) {
+            SDKComponent.logger.error(
+                "Live notification push for activity '$activityId' is missing '$EVENT_KEY'; dropping."
+            )
+            return
+        }
         val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
         val template = TemplateRegistry.find(activityType)
         if (template == null) {
@@ -78,22 +103,19 @@ internal class LiveNotificationHandler(
             return
         }
 
-        val attributes = parseJson(bundle.getString(ATTRIBUTES_KEY))
-        val contentState = parseJson(bundle.getString(CONTENT_STATE_KEY))
+        val data = extractData(bundle)
         val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
         val effectiveSmallIcon = resolveSmallIcon(context, branding, smallIcon)
 
         val result = template.render(
             context = context,
-            attributes = attributes,
-            contentState = contentState,
+            data = data,
             branding = branding,
             smallIcon = effectiveSmallIcon,
             fallbackTintColor = tintColor
         )
 
         val notifId = activityId.hashCode() and 0x7FFFFFFF
-        val event = bundle.getString(EVENT_KEY) ?: "update"
 
         if (result.cancelImmediately) {
             notificationManager.cancel(activityId, notifId)
@@ -160,19 +182,39 @@ internal class LiveNotificationHandler(
         notificationManager.notify(activityId, notifId, notification)
 
         if (event == EVENT_END) {
-            Handler(Looper.getMainLooper()).postDelayed({
-                notificationManager.cancel(activityId, notifId)
-            }, DEFAULT_DISMISS_DELAY_MS)
+            // Without a dismissal_date the activity is removed immediately.
+            // Scheduled dismissal via dismissal_date is added with lifecycle reporting.
+            notificationManager.cancel(activityId, notifId)
         }
     }
 
-    private fun parseJson(raw: String?): JSONObject {
-        if (raw.isNullOrEmpty()) return JSONObject()
+    /**
+     * Collects the flattened template fields from the FCM envelope: every
+     * top-level bundle key that is not a [RESERVED_KEYS] envelope key. String
+     * values that look like JSON objects/arrays (e.g. `origin`, `homeTeam`) are
+     * parsed so templates can read them as nested structures; scalar strings
+     * are kept verbatim and coerced on read by `JSONObject.optInt`/`optLong`/etc.
+     */
+    private fun extractData(bundle: Bundle): JSONObject {
+        val data = JSONObject()
+        for (key in bundle.keySet()) {
+            if (key in RESERVED_KEYS) continue
+            val raw = bundle.getString(key) ?: continue
+            data.put(key, coerceJsonValue(raw))
+        }
+        return data
+    }
+
+    private fun coerceJsonValue(raw: String): Any {
+        val trimmed = raw.trim()
         return try {
-            JSONObject(raw)
+            when {
+                trimmed.startsWith("{") -> JSONObject(trimmed)
+                trimmed.startsWith("[") -> JSONArray(trimmed)
+                else -> raw
+            }
         } catch (e: JSONException) {
-            SDKComponent.logger.error("Failed to parse live notification JSON: ${e.message}")
-            JSONObject()
+            raw
         }
     }
 
@@ -182,9 +224,8 @@ internal class LiveNotificationHandler(
         branding: LiveNotificationBranding?,
         fallback: Int
     ): Int {
-        val key = branding?.logoDrawableName?.takeIf { it.isNotEmpty() } ?: return fallback
-        val normalized = key.replace('-', '_')
-        return context.getDrawableByName(normalized) ?: fallback
+        // Reuses TemplateAssets' kebab→snake normalization + drawable lookup.
+        return TemplateAssets.resolveDrawable(context, branding?.logoDrawableName) ?: fallback
     }
 
     private fun createIntentForNotificationClick(

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
@@ -5,10 +5,10 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import org.json.JSONObject
 
 /**
- * `auction_bid` template — current bid + winning/outbid state.
+ * `auctionbid` template — current bid + winning/outbid state.
  *
- * Static: itemTitle (req), itemImageKey (opt), currencySymbol (default `$`).
- * Dynamic: currentBid (req, preformatted string), bidCount (req, int),
+ * Fields: itemTitle (req), itemImageKey (opt), currencySymbol (default `$`),
+ * currentBid (req, preformatted string), bidCount (req, int),
  * endTime (req, epoch ms), statusMessage (req), isUserHighBidder (req, bool),
  * userBidAmount (opt, preformatted string).
  *
@@ -24,21 +24,20 @@ internal object AuctionBidTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val itemTitle = attributes.optString("itemTitle")
-        val itemImageKey = attributes.optString("itemImageKey").takeIf { it.isNotEmpty() }
-        val currencySymbol = attributes.optString("currencySymbol").takeIf { it.isNotEmpty() } ?: "$"
-        val currentBid = contentState.optString("currentBid")
-        val bidCount = contentState.optInt("bidCount", 0)
-        val endTime = contentState.optLong("endTime").takeIf { it > 0 }
-        val statusMessage = contentState.optString("statusMessage")
-        val isUserHighBidder = contentState.optBoolean("isUserHighBidder", false)
-        val userBidAmount = contentState.optString("userBidAmount").takeIf { it.isNotEmpty() }
+        val itemTitle = data.optString("itemTitle")
+        val itemImageKey = data.optStringNonEmpty("itemImageKey")
+        val currencySymbol = data.optStringNonEmpty("currencySymbol") ?: "$"
+        val currentBid = data.optString("currentBid")
+        val bidCount = data.optInt("bidCount", 0)
+        val endTime = data.optLong("endTime").takeIf { it > 0 }
+        val statusMessage = data.optString("statusMessage")
+        val isUserHighBidder = data.optBoolean("isUserHighBidder", false)
+        val userBidAmount = data.optStringNonEmpty("userBidAmount")
 
         val body = "$statusMessage · $currencySymbol$currentBid"
         val subText = userBidAmount

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
@@ -5,13 +5,12 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import org.json.JSONObject
 
 /**
- * `countdown_timer` template — chronometer ticking toward [targetDate].
+ * `countdowntimer` template — chronometer ticking toward [targetDate].
  *
- * Static: title (req), heroImageKey (opt).
- * Dynamic: targetDate (req, epoch ms — extendable across pushes), statusMessage
- * (req, label above timer), expiredMessage (opt). Post-target with no
- * expiredMessage means the activity should hide; SDK signals this via
- * [TemplateRenderResult.cancelImmediately].
+ * Fields: title (req), heroImageKey (opt), targetDate (req, epoch ms —
+ * extendable across pushes), statusMessage (req, label above timer),
+ * expiredMessage (opt). Post-target with no expiredMessage means the activity
+ * should hide; SDK signals this via [TemplateRenderResult.cancelImmediately].
  */
 internal object CountdownTimerTemplate : LiveNotificationTemplate {
 
@@ -19,53 +18,28 @@ internal object CountdownTimerTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val title = attributes.optString("title")
-        val heroImageKey = attributes.optString("heroImageKey").takeIf { it.isNotEmpty() }
-        val targetDate = contentState.optLong("targetDate").takeIf { it > 0 }
-        val statusMessage = contentState.optString("statusMessage")
-        val expiredMessage = contentState.optString("expiredMessage").takeIf { it.isNotEmpty() }
+        val title = data.optString("title")
+        val heroImageKey = data.optStringNonEmpty("heroImageKey")
+        val targetDate = data.optLong("targetDate").takeIf { it > 0 }
+        val statusMessage = data.optString("statusMessage")
+        val expiredMessage = data.optStringNonEmpty("expiredMessage")
 
         val now = System.currentTimeMillis()
         val isPostTarget = targetDate != null && now >= targetDate
-
-        if (isPostTarget && expiredMessage == null) {
-            // Server pushed a post-target state with no message: hide the activity.
-            return TemplateRenderResult(
-                title = title,
-                body = "",
-                subText = null,
-                largeIcon = null,
-                accentColor = null,
-                colorized = false,
-                showProgress = false,
-                progress = 0,
-                progressMax = 0,
-                segments = emptyList(),
-                points = emptyList(),
-                startIconRes = null,
-                endIconRes = null,
-                trackerIconRes = null,
-                countdownUntil = null,
-                deepLink = null,
-                cancelImmediately = true
-            )
-        }
-
-        val body = if (isPostTarget) expiredMessage.orEmpty() else statusMessage
-        val countdownUntil = if (isPostTarget) null else targetDate
+        // Server pushed a post-target state with no message: hide the activity.
+        val cancelImmediately = isPostTarget && expiredMessage == null
 
         return TemplateRenderResult(
             title = title,
-            body = body,
+            body = if (isPostTarget) expiredMessage.orEmpty() else statusMessage,
             subText = null,
-            largeIcon = TemplateAssets.resolveBitmap(context, heroImageKey),
-            accentColor = branding?.accentColor ?: fallbackTintColor,
+            largeIcon = if (cancelImmediately) null else TemplateAssets.resolveBitmap(context, heroImageKey),
+            accentColor = if (cancelImmediately) null else (branding?.accentColor ?: fallbackTintColor),
             colorized = false,
             showProgress = false,
             progress = 0,
@@ -75,8 +49,9 @@ internal object CountdownTimerTemplate : LiveNotificationTemplate {
             startIconRes = null,
             endIconRes = null,
             trackerIconRes = null,
-            countdownUntil = countdownUntil,
-            deepLink = null
+            countdownUntil = if (isPostTarget) null else targetDate,
+            deepLink = null,
+            cancelImmediately = cancelImmediately
         )
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
@@ -5,11 +5,11 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import org.json.JSONObject
 
 /**
- * `delivery_tracking` template — segmented progress bar over delivery stages.
+ * `deliverytracking` template — segmented progress bar over delivery stages.
  *
- * Static: orderId (req), recipientName (opt).
- * Dynamic: statusMessage (req), statusImageKey (opt), stepCurrent/stepTotal (req),
- * estimatedArrival (opt, epoch ms), driverName (opt).
+ * Fields: orderId (req), recipientName (opt), statusMessage (req),
+ * statusImageKey (opt), stepCurrent/stepTotal (req), estimatedArrival (opt,
+ * epoch ms), driverName (opt).
  */
 internal object DeliveryTrackingTemplate : LiveNotificationTemplate {
 
@@ -17,20 +17,19 @@ internal object DeliveryTrackingTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val orderId = attributes.optString("orderId")
-        val recipientName = attributes.optString("recipientName").takeIf { it.isNotEmpty() }
-        val statusMessage = contentState.optString("statusMessage")
-        val statusImageKey = contentState.optString("statusImageKey").takeIf { it.isNotEmpty() }
-        val stepCurrent = contentState.optInt("stepCurrent", 0)
-        val stepTotal = contentState.optInt("stepTotal", 1).coerceAtLeast(1)
-        val estimatedArrival = contentState.optLong("estimatedArrival").takeIf { it > 0 }
-        val driverName = contentState.optString("driverName").takeIf { it.isNotEmpty() }
+        val orderId = data.optString("orderId")
+        val recipientName = data.optStringNonEmpty("recipientName")
+        val statusMessage = data.optString("statusMessage")
+        val statusImageKey = data.optStringNonEmpty("statusImageKey")
+        val stepCurrent = data.optInt("stepCurrent", 0)
+        val stepTotal = data.optInt("stepTotal", 1).coerceAtLeast(1)
+        val estimatedArrival = data.optLong("estimatedArrival").takeIf { it > 0 }
+        val driverName = data.optStringNonEmpty("driverName")
 
         val title = recipientName?.let { "Delivery for $it" } ?: "Order #$orderId"
         val subText = when {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
@@ -5,10 +5,10 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import org.json.JSONObject
 
 /**
- * `flight_status` template — flight progress with optional in-flight progress bar.
+ * `flightstatus` template — flight progress with optional in-flight progress bar.
  *
- * Static: flightNumber, origin{code, city}, destination{code, city}.
- * Dynamic: statusMessage (req), gate (opt), terminal (opt),
+ * Fields: flightNumber, origin{code, city}, destination{code, city},
+ * statusMessage (req), gate (opt), terminal (opt),
  * scheduledDeparture/estimatedArrival (req, epoch ms), progressFraction (opt, 0–1),
  * delayMinutes (opt).
  */
@@ -20,27 +20,26 @@ internal object FlightStatusTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val flightNumber = attributes.optString("flightNumber")
-        val origin = attributes.optJSONObject("origin")
-        val destination = attributes.optJSONObject("destination")
+        val flightNumber = data.optString("flightNumber")
+        val origin = data.optJSONObject("origin")
+        val destination = data.optJSONObject("destination")
         val originCode = origin?.optString("code").orEmpty()
         val destinationCode = destination?.optString("code").orEmpty()
 
-        val statusMessage = contentState.optString("statusMessage")
-        val gate = contentState.optString("gate").takeIf { it.isNotEmpty() }
-        val terminal = contentState.optString("terminal").takeIf { it.isNotEmpty() }
-        val scheduledDeparture = contentState.optLong("scheduledDeparture").takeIf { it > 0 }
-        val estimatedArrival = contentState.optLong("estimatedArrival").takeIf { it > 0 }
+        val statusMessage = data.optString("statusMessage")
+        val gate = data.optStringNonEmpty("gate")
+        val terminal = data.optStringNonEmpty("terminal")
+        val scheduledDeparture = data.optLong("scheduledDeparture").takeIf { it > 0 }
+        val estimatedArrival = data.optLong("estimatedArrival").takeIf { it > 0 }
         val progressFractionRaw =
-            if (contentState.has("progressFraction")) contentState.optDouble("progressFraction") else Double.NaN
+            if (data.has("progressFraction")) data.optDouble("progressFraction") else Double.NaN
         val progressFraction = progressFractionRaw.takeIf { !it.isNaN() }
-        val delayMinutes = contentState.optInt("delayMinutes", 0).takeIf { it > 0 }
+        val delayMinutes = data.optInt("delayMinutes", 0).takeIf { it > 0 }
 
         val title = "$flightNumber · $originCode → $destinationCode"
         val subText = "Gate ${gate ?: "TBA"} · Terminal ${terminal ?: "TBA"}"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/JsonExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/JsonExtensions.kt
@@ -1,0 +1,16 @@
+package io.customer.messagingpush.livenotification.template
+
+import org.json.JSONObject
+
+/**
+ * Returns the string value for [key], or null when the key is absent, holds an
+ * explicit JSON null, or is empty.
+ *
+ * Prefer this over `optString(key).takeIf { it.isNotEmpty() }`: `optString`
+ * returns the literal string `"null"` for an explicit JSON null, which would
+ * otherwise slip past an `isNotEmpty()` guard and render as visible text.
+ */
+internal fun JSONObject.optStringNonEmpty(key: String): String? {
+    if (isNull(key)) return null
+    return optString(key).takeIf { it.isNotEmpty() }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationTemplate.kt
@@ -9,14 +9,14 @@ import org.json.JSONObject
 /**
  * Renders a single live-notification template.
  *
- * Each template owns its typed schema (e.g. `delivery_tracking` knows about
+ * Each template owns its typed schema (e.g. `deliverytracking` knows about
  * `orderId`, `stepCurrent`, `statusImageKey`). The handler dispatches to a
  * concrete subtype via [TemplateRegistry.find] using the `activity_type` key
  * from the FCM envelope.
  *
- * Static fields arrive in the `attributes` JSON object; dynamic fields arrive
- * in the `content_state` JSON object. Strict slotting is enforced — each
- * template reads each documented field only from its designated slot.
+ * All template fields arrive flattened in a single [data] object alongside the
+ * envelope keys (unlike iOS, Android does not split static `attributes` from
+ * dynamic `content-state`). Each template reads the fields it documents.
  *
  * Sealed and `internal` — the v1 closed set of templates is the only path.
  * Adding a template means adding a subtype to this hierarchy and an entry to
@@ -27,8 +27,7 @@ internal sealed interface LiveNotificationTemplate {
 
     fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         @DrawableRes smallIcon: Int,
         @ColorInt fallbackTintColor: Int?

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
@@ -5,11 +5,11 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import org.json.JSONObject
 
 /**
- * `live_score` template — text-only live update for sports scores.
+ * `livescore` template — text-only live update for sports scores.
  *
- * Static: homeTeam{name, logoKey?}, awayTeam{name, logoKey?}, sport (ignored —
- * Android can't change layout per sport without custom views), leagueLogoKey (opt).
- * Dynamic: homeScore/awayScore (int), period (req), clock (opt),
+ * Fields: homeTeam{name, logoKey?}, awayTeam{name, logoKey?}, sport (ignored —
+ * Android can't change layout per sport without custom views), leagueLogoKey (opt),
+ * homeScore/awayScore (int), period (req), clock (opt),
  * statusMessage (opt — overrides body for special situations).
  *
  * Limitation: Android exposes a single large-icon slot; we use [leagueLogoKey].
@@ -21,22 +21,21 @@ internal object LiveScoreTemplate : LiveNotificationTemplate {
 
     override fun render(
         context: Context,
-        attributes: JSONObject,
-        contentState: JSONObject,
+        data: JSONObject,
         branding: LiveNotificationBranding?,
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val homeTeam = attributes.optJSONObject("homeTeam")
-        val awayTeam = attributes.optJSONObject("awayTeam")
+        val homeTeam = data.optJSONObject("homeTeam")
+        val awayTeam = data.optJSONObject("awayTeam")
         val homeName = homeTeam?.optString("name").orEmpty()
         val awayName = awayTeam?.optString("name").orEmpty()
-        val homeScore = contentState.optInt("homeScore", 0)
-        val awayScore = contentState.optInt("awayScore", 0)
-        val period = contentState.optString("period")
-        val clock = contentState.optString("clock").takeIf { it.isNotEmpty() }
-        val statusMessage = contentState.optString("statusMessage").takeIf { it.isNotEmpty() }
-        val leagueLogoKey = attributes.optString("leagueLogoKey").takeIf { it.isNotEmpty() }
+        val homeScore = data.optInt("homeScore", 0)
+        val awayScore = data.optInt("awayScore", 0)
+        val period = data.optString("period")
+        val clock = data.optStringNonEmpty("clock")
+        val statusMessage = data.optStringNonEmpty("statusMessage")
+        val leagueLogoKey = data.optStringNonEmpty("leagueLogoKey")
 
         val title = "$homeName $homeScore - $awayScore $awayName"
         val body = statusMessage

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateAssets.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateAssets.kt
@@ -6,6 +6,7 @@ import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
 import io.customer.messagingpush.extensions.getDrawableByName
 import io.customer.sdk.core.di.SDKComponent
 
@@ -49,7 +50,7 @@ internal object TemplateAssets {
         val width = drawable.intrinsicWidth.takeIf { it > 0 } ?: 1
         val height = drawable.intrinsicHeight.takeIf { it > 0 } ?: 1
         return try {
-            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            val bitmap = createBitmap(width, height)
             val canvas = Canvas(bitmap)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
@@ -2,11 +2,11 @@ package io.customer.messagingpush.livenotification.template
 
 internal object TemplateRegistry {
 
-    const val DELIVERY_TRACKING = "io.customer.live.delivery_tracking"
-    const val FLIGHT_STATUS = "io.customer.live.flight_status"
-    const val LIVE_SCORE = "io.customer.live.live_score"
-    const val COUNTDOWN_TIMER = "io.customer.live.countdown_timer"
-    const val AUCTION_BID = "io.customer.live.auction_bid"
+    const val DELIVERY_TRACKING = "io.customer.liveactivities.deliverytracking"
+    const val FLIGHT_STATUS = "io.customer.liveactivities.flightstatus"
+    const val LIVE_SCORE = "io.customer.liveactivities.livescore"
+    const val COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer"
+    const val AUCTION_BID = "io.customer.liveactivities.auctionbid"
 
     fun find(name: String?): LiveNotificationTemplate? = when (name) {
         DELIVERY_TRACKING -> DeliveryTrackingTemplate

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -6,7 +6,9 @@ import android.os.Bundle
 import io.customer.commontest.extensions.assertCalledNever
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.json.JSONObject
@@ -114,6 +116,23 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
         verify(exactly = 1) {
             notificationManager.notify(activityId, expectedNotifId, any<Notification>())
         }
+    }
+
+    @Test
+    fun handle_givenTemplateFieldNamedTitle_isNotStrippedAsReservedKey() {
+        // Regression: "title" is a CountdownTimer template field and must reach the
+        // template, not be treated as the standard-push reserved key and dropped.
+        val posted = slot<Notification>()
+        every { notificationManager.notify(any<String>(), any<Int>(), capture(posted)) } returns Unit
+
+        val data = JSONObject().apply {
+            put("title", "Flash Sale")
+            put("targetDate", System.currentTimeMillis() + 60_000L)
+            put("statusMessage", "Sale starts in")
+        }
+        invoke(handlerFor(newBundle(activityType = TemplateRegistry.COUNTDOWN_TIMER, data = data)))
+
+        posted.captured.extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() shouldBeEqualTo "Flash Sale"
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -8,21 +8,22 @@ import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.mockk.mockk
 import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows
-import org.robolectric.shadows.ShadowLooper
 
 /**
  * Tests for [LiveNotificationHandler] focused on envelope parsing and dispatch:
  *
- * - top-level wire keys (`activity_id`, `event`, `activity_type`, `attributes`,
- *   `content_state`) are read from the [Bundle];
- * - `attributes` and `content_state` are decoded into independent JSONObjects;
- * - unknown / missing `activity_type` and `activity_id` are dropped without
- *   posting a notification;
- * - `event = "end"` schedules a delayed cancel.
+ * - top-level wire keys (`activity_id`, `event`, `activity_type`, `timestamp`,
+ *   `dismissal_date`) are read from the [Bundle];
+ * - template fields arrive flattened at the envelope top level (no
+ *   `attributes` / `content_state` split);
+ * - missing `activity_id`, `event`, or unknown `activity_type` are dropped
+ *   without posting a notification;
+ * - `event = "end"` cancels the notification immediately.
  *
  * The actual rendered notification is opaque to these tests — that's covered by
  * the per-template render tests. Here we only assert the dispatch contract.
@@ -37,15 +38,14 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
         activityId: String? = "live-act-1",
         event: String? = "start",
         activityType: String? = TemplateRegistry.DELIVERY_TRACKING,
-        attributesJson: String? = "{}",
-        contentStateJson: String? = "{}"
+        data: JSONObject = JSONObject()
     ): Bundle {
         val bundle = Bundle()
         if (activityId != null) bundle.putString(LiveNotificationHandler.ACTIVITY_ID_KEY, activityId)
         if (event != null) bundle.putString(LiveNotificationHandler.EVENT_KEY, event)
         if (activityType != null) bundle.putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
-        if (attributesJson != null) bundle.putString(LiveNotificationHandler.ATTRIBUTES_KEY, attributesJson)
-        if (contentStateJson != null) bundle.putString(LiveNotificationHandler.CONTENT_STATE_KEY, contentStateJson)
+        // Template fields ride flattened at the top level, as the backend delivers them.
+        for (key in data.keys()) bundle.putString(key, data.get(key).toString())
         return bundle
     }
 
@@ -69,11 +69,11 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
     fun envelopeKeys_areTheCrossPlatformSpecKeys() {
         // Lock the wire-format constants so any future rename surfaces here.
         // Failure to update both the SDK and CIO backend would silently break live notifications.
-        assert(LiveNotificationHandler.ACTIVITY_ID_KEY == "activity_id")
-        assert(LiveNotificationHandler.EVENT_KEY == "event")
-        assert(LiveNotificationHandler.ACTIVITY_TYPE_KEY == "activity_type")
-        assert(LiveNotificationHandler.ATTRIBUTES_KEY == "attributes")
-        assert(LiveNotificationHandler.CONTENT_STATE_KEY == "content_state")
+        LiveNotificationHandler.ACTIVITY_ID_KEY shouldBeEqualTo "activity_id"
+        LiveNotificationHandler.EVENT_KEY shouldBeEqualTo "event"
+        LiveNotificationHandler.ACTIVITY_TYPE_KEY shouldBeEqualTo "activity_type"
+        LiveNotificationHandler.TIMESTAMP_KEY shouldBeEqualTo "timestamp"
+        LiveNotificationHandler.DISMISSAL_DATE_KEY shouldBeEqualTo "dismissal_date"
     }
 
     // --- Happy-path dispatch ---
@@ -88,12 +88,7 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
             TemplateRegistry.AUCTION_BID
         )
         for (activityType in templates) {
-            val bundle = newBundle(
-                activityType = activityType,
-                attributesJson = "{}",
-                contentStateJson = "{}"
-            )
-            invoke(handlerFor(bundle))
+            invoke(handlerFor(newBundle(activityType = activityType)))
         }
 
         verify(exactly = templates.size) {
@@ -105,11 +100,14 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
     fun handle_postsNotificationKeyedByActivityIdHash() {
         val activityId = "live-activity-id-xyz"
         val expectedNotifId = activityId.hashCode() and 0x7FFFFFFF
-        val bundle = newBundle(
-            activityId = activityId,
-            attributesJson = """{"orderId":"A-1","recipientName":"User"}""",
-            contentStateJson = """{"statusMessage":"Out for delivery","stepCurrent":2,"stepTotal":4}"""
-        )
+        val data = JSONObject().apply {
+            put("orderId", "A-1")
+            put("recipientName", "User")
+            put("statusMessage", "Out for delivery")
+            put("stepCurrent", 2)
+            put("stepTotal", 4)
+        }
+        val bundle = newBundle(activityId = activityId, data = data)
 
         invoke(handlerFor(bundle))
 
@@ -118,13 +116,40 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
         }
     }
 
+    @Test
+    fun handle_givenNestedJsonFieldAsString_parsesAndPosts() {
+        // Nested objects (origin, homeTeam, …) arrive as JSON strings in FCM data;
+        // the handler parses them so templates can read the nested values.
+        val data = JSONObject().apply {
+            put("flightNumber", "AA1")
+            put("origin", JSONObject().put("code", "JFK"))
+            put("destination", JSONObject().put("code", "LAX"))
+            put("statusMessage", "On time")
+        }
+        val bundle = newBundle(activityType = TemplateRegistry.FLIGHT_STATUS, data = data)
+
+        invoke(handlerFor(bundle))
+
+        verify(exactly = 1) {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
     // --- Missing required fields short-circuit ---
 
     @Test
     fun handle_givenMissingActivityId_returnsEarlyWithoutNotifying() {
-        val bundle = newBundle(activityId = null)
+        invoke(handlerFor(newBundle(activityId = null)))
 
-        invoke(handlerFor(bundle))
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
+    fun handle_givenMissingEvent_dropsAndDoesNotNotify() {
+        // event is required — there is no implicit "update" default.
+        invoke(handlerFor(newBundle(event = null)))
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
@@ -133,9 +158,7 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
     @Test
     fun handle_givenMissingActivityType_dropsAndDoesNotNotify() {
-        val bundle = newBundle(activityType = null)
-
-        invoke(handlerFor(bundle))
+        invoke(handlerFor(newBundle(activityType = null)))
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
@@ -144,9 +167,7 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
     @Test
     fun handle_givenUnknownActivityType_dropsAndDoesNotNotify() {
-        val bundle = newBundle(activityType = "io.customer.live.bogus")
-
-        invoke(handlerFor(bundle))
+        invoke(handlerFor(newBundle(activityType = "io.customer.liveactivities.bogus")))
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
@@ -155,101 +176,42 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
     @Test
     fun handle_givenBareTemplateNameWithoutSpecPrefix_dropsAndDoesNotNotify() {
-        // The cross-platform spec requires the `io.customer.live.` prefix.
-        // Bare names like "delivery_tracking" must be rejected to stay aligned with iOS.
-        val bundle = newBundle(activityType = "delivery_tracking")
-
-        invoke(handlerFor(bundle))
+        // The cross-platform spec requires the `io.customer.liveactivities.` prefix.
+        // Bare names like "deliverytracking" must be rejected to stay aligned with iOS.
+        invoke(handlerFor(newBundle(activityType = "deliverytracking")))
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
         }
     }
 
-    // --- Malformed JSON tolerated ---
+    // --- End event dismisses immediately ---
 
     @Test
-    fun handle_givenMalformedAttributesJson_stillPostsNotification() {
-        // Lenient parsing — malformed JSON in one slot becomes an empty JSONObject so
-        // the template still attempts to render with defaults rather than dropping the push.
-        val bundle = newBundle(
-            attributesJson = "{this is not json",
-            contentStateJson = "{}"
-        )
-
-        invoke(handlerFor(bundle))
-
-        verify(exactly = 1) {
-            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
-        }
-    }
-
-    @Test
-    fun handle_givenMalformedContentStateJson_stillPostsNotification() {
-        val bundle = newBundle(
-            attributesJson = "{}",
-            contentStateJson = "}not json{"
-        )
-
-        invoke(handlerFor(bundle))
-
-        verify(exactly = 1) {
-            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
-        }
-    }
-
-    @Test
-    fun handle_givenNullAttributesAndContentState_stillPostsNotification() {
-        val bundle = newBundle(
-            attributesJson = null,
-            contentStateJson = null
-        )
-
-        invoke(handlerFor(bundle))
-
-        verify(exactly = 1) {
-            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
-        }
-    }
-
-    // --- End event dismisses after the documented delay ---
-
-    @Test
-    fun handle_givenEventEnd_schedulesDelayedCancel() {
+    fun handle_givenEventEnd_cancelsImmediately() {
         val activityId = "ending-activity"
         val expectedNotifId = activityId.hashCode() and 0x7FFFFFFF
-        val bundle = newBundle(
-            activityId = activityId,
-            event = "end"
-        )
+        val bundle = newBundle(activityId = activityId, event = "end")
 
         invoke(handlerFor(bundle))
 
-        // Notification was posted immediately and a cancel was queued on the main looper.
+        // Final state is posted, then removed immediately (dismissal_date scheduling
+        // arrives with the lifecycle-reporting work).
         verify(exactly = 1) {
             notificationManager.notify(activityId, expectedNotifId, any<Notification>())
         }
-        assertCalledNever {
-            notificationManager.cancel(activityId, expectedNotifId)
-        }
-
-        // Drain the main looper to execute the postDelayed dismiss task.
-        Shadows.shadowOf(android.os.Looper.getMainLooper()).runToEndOfTasks()
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
-
         verify(exactly = 1) {
             notificationManager.cancel(activityId, expectedNotifId)
         }
     }
 
     @Test
-    fun handle_givenEventStart_doesNotScheduleCancel() {
+    fun handle_givenEventStart_doesNotCancel() {
         val activityId = "starting-activity"
         val expectedNotifId = activityId.hashCode() and 0x7FFFFFFF
         val bundle = newBundle(activityId = activityId, event = "start")
 
         invoke(handlerFor(bundle))
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         verify(exactly = 1) {
             notificationManager.notify(activityId, expectedNotifId, any<Notification>())

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplateTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplateTest.kt
@@ -26,8 +26,7 @@ internal class AuctionBidTemplateTest : IntegrationTest() {
         contentState: JSONObject = JSONObject()
     ): TemplateRenderResult = AuctionBidTemplate.render(
         context = contextMock,
-        attributes = attributes,
-        contentState = contentState,
+        data = flatten(attributes, contentState),
         branding = null,
         smallIcon = 0,
         fallbackTintColor = null
@@ -156,42 +155,5 @@ internal class AuctionBidTemplateTest : IntegrationTest() {
         val result = render(baseAttributes(), contentState)
 
         (result.countdownUntil == null).shouldBeTrue()
-    }
-
-    // --- Strict-slotting regression guards ---
-
-    @Test
-    fun render_isUserHighBidderInAttributes_isIgnored() {
-        val attributes = baseAttributes().apply {
-            put("isUserHighBidder", true) // wrong slot
-        }
-        val contentState = JSONObject().apply {
-            put("currentBid", "1,000")
-            put("bidCount", 1)
-            put("statusMessage", "x")
-            // Note: no isUserHighBidder here, so it defaults to false → red.
-        }
-
-        val result = render(attributes, contentState)
-
-        result.accentColor shouldBeEqualTo outbidRed
-    }
-
-    @Test
-    fun render_currencySymbolInContentState_isIgnoredAndDefaultsApply() {
-        val attributes = JSONObject().apply {
-            put("itemTitle", "x") // no currencySymbol in attributes
-        }
-        val contentState = JSONObject().apply {
-            put("currencySymbol", "€") // wrong slot
-            put("currentBid", "1")
-            put("bidCount", 1)
-            put("statusMessage", "x")
-        }
-
-        val result = render(attributes, contentState)
-
-        // The misplaced currency symbol must be ignored; default `$` is applied.
-        result.body shouldBeEqualTo "x · $1"
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplateTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplateTest.kt
@@ -27,8 +27,7 @@ internal class CountdownTimerTemplateTest : IntegrationTest() {
         contentState: JSONObject = JSONObject()
     ): TemplateRenderResult = CountdownTimerTemplate.render(
         context = contextMock,
-        attributes = attributes,
-        contentState = contentState,
+        data = flatten(attributes, contentState),
         branding = null,
         smallIcon = 0,
         fallbackTintColor = null
@@ -113,38 +112,5 @@ internal class CountdownTimerTemplateTest : IntegrationTest() {
         val result = render(attributes, contentState)
 
         result.largeIcon.shouldBeNull()
-    }
-
-    // --- Strict-slotting regression guards ---
-
-    @Test
-    fun render_titleInContentState_isIgnored() {
-        val attributes = JSONObject() // intentionally empty: no title
-        val contentState = JSONObject().apply {
-            put("title", "MISPLACED")
-            put("targetDate", System.currentTimeMillis() + 60_000L)
-            put("statusMessage", "msg")
-        }
-
-        val result = render(attributes, contentState)
-
-        result.title shouldBeEqualTo "" // empty, because the misplaced value is ignored
-    }
-
-    @Test
-    fun render_targetDateInAttributes_isIgnored() {
-        val past = System.currentTimeMillis() - 60_000L
-        val attributes = titleAttributes().apply {
-            put("targetDate", past) // wrong slot
-        }
-        val contentState = JSONObject().apply {
-            put("statusMessage", "Pre-sale")
-        }
-
-        val result = render(attributes, contentState)
-
-        // No targetDate seen by the template ⇒ treated as pre-target with statusMessage.
-        result.body shouldBeEqualTo "Pre-sale"
-        result.cancelImmediately.shouldBeFalse()
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplateTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplateTest.kt
@@ -2,22 +2,19 @@ package io.customer.messagingpush.livenotification.template
 
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
-import org.amshove.kluent.shouldContain
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Tests [DeliveryTrackingTemplate] rendering against the documented per-slot schema.
+ * Tests [DeliveryTrackingTemplate] rendering against the documented field schema.
  *
- * The template lives behind the strict-slotting decision: `orderId` and
- * `recipientName` arrive only in `attributes`; everything dynamic arrives in
- * `content_state`. Mis-slotted fields must be silently ignored so the rendering
- * stays predictable as the cross-platform spec evolves.
+ * All fields arrive flattened in a single `data` object; the legacy
+ * `attributes` / `content_state` grouping in these tests is purely for
+ * readability and is merged via [flatten] before rendering.
  */
 @RunWith(RobolectricTestRunner::class)
 internal class DeliveryTrackingTemplateTest : IntegrationTest() {
@@ -27,8 +24,7 @@ internal class DeliveryTrackingTemplateTest : IntegrationTest() {
         contentState: JSONObject = JSONObject()
     ): TemplateRenderResult = DeliveryTrackingTemplate.render(
         context = contextMock,
-        attributes = attributes,
-        contentState = contentState,
+        data = flatten(attributes, contentState),
         branding = null,
         smallIcon = 0,
         fallbackTintColor = null
@@ -167,43 +163,5 @@ internal class DeliveryTrackingTemplateTest : IntegrationTest() {
         val result = render(contentState = contentState)
 
         result.countdownUntil.shouldBeNull()
-    }
-
-    // --- Strict-slotting regression guards ---
-
-    @Test
-    fun render_orderIdInContentState_isIgnored() {
-        // Mis-slotted `orderId` must NOT be picked up from content_state.
-        // This is what locks the strict-slotting decision against future regressions.
-        val attributes = JSONObject()
-        val contentState = JSONObject().apply {
-            put("orderId", "MISPLACED")
-            put("statusMessage", "no order")
-            put("stepTotal", 2)
-        }
-
-        val result = render(attributes, contentState)
-
-        result.title shouldBeEqualTo "Order #"
-        // SubText should not contain the misplaced order id.
-        (result.subText ?: "").shouldContain("").also {
-            (result.subText?.contains("MISPLACED") == true).shouldBeFalse()
-        }
-    }
-
-    @Test
-    fun render_statusMessageInAttributes_isIgnored() {
-        // statusMessage belongs in content_state — putting it in attributes leaves body empty.
-        val attributes = JSONObject().apply {
-            put("orderId", "X")
-            put("statusMessage", "MISPLACED MESSAGE")
-        }
-        val contentState = JSONObject().apply {
-            put("stepTotal", 2)
-        }
-
-        val result = render(attributes, contentState)
-
-        result.body shouldBeEqualTo ""
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplateTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplateTest.kt
@@ -16,8 +16,9 @@ import org.robolectric.RobolectricTestRunner
  * - basic title/body/subText composition with origin / destination codes;
  * - the delay-red branch — `delayMinutes > 0` flips the accent and suffixes the body;
  * - countdown target switching: `progressFraction` present ⇒ estimatedArrival,
- *   absent ⇒ scheduledDeparture;
- * - strict slotting — `flightNumber` in `content_state` is ignored.
+ *   absent ⇒ scheduledDeparture.
+ *
+ * All fields arrive flattened; the legacy grouping is merged via [flatten].
  */
 @RunWith(RobolectricTestRunner::class)
 internal class FlightStatusTemplateTest : IntegrationTest() {
@@ -29,8 +30,7 @@ internal class FlightStatusTemplateTest : IntegrationTest() {
         contentState: JSONObject = JSONObject()
     ): TemplateRenderResult = FlightStatusTemplate.render(
         context = contextMock,
-        attributes = attributes,
-        contentState = contentState,
+        data = flatten(attributes, contentState),
         branding = null,
         smallIcon = 0,
         fallbackTintColor = null
@@ -143,38 +143,5 @@ internal class FlightStatusTemplateTest : IntegrationTest() {
         val result = render(baseAttributes(), contentState)
 
         result.progress shouldBeEqualTo 100
-    }
-
-    // --- Strict-slotting regression guard ---
-
-    @Test
-    fun render_flightNumberInContentState_isIgnored() {
-        val attributes = JSONObject().apply {
-            put("origin", JSONObject().put("code", "JFK"))
-            put("destination", JSONObject().put("code", "LAX"))
-        }
-        val contentState = JSONObject().apply {
-            put("flightNumber", "MISPLACED")
-            put("statusMessage", "x")
-        }
-
-        val result = render(attributes, contentState)
-
-        result.title shouldBeEqualTo " · JFK → LAX" // flightNumber empty, prefix space remains
-    }
-
-    @Test
-    fun render_delayMinutesInAttributes_isIgnored() {
-        val attributes = baseAttributes().apply {
-            put("delayMinutes", 25) // wrong slot
-        }
-        val contentState = JSONObject().apply {
-            put("statusMessage", "x")
-        }
-
-        val result = render(attributes, contentState)
-
-        (result.accentColor == delayRed).shouldBeFalse()
-        result.body shouldBeEqualTo "x"
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplateTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplateTest.kt
@@ -13,7 +13,7 @@ import org.robolectric.RobolectricTestRunner
  * Exercises the body composition fallback chain:
  * `statusMessage` overrides ⇒ `period · clock` ⇒ bare `period`.
  *
- * Also locks the strict-slotting decision — `homeScore` in `attributes` is ignored.
+ * All fields arrive flattened; the legacy grouping is merged via [flatten].
  */
 @RunWith(RobolectricTestRunner::class)
 internal class LiveScoreTemplateTest : IntegrationTest() {
@@ -23,8 +23,7 @@ internal class LiveScoreTemplateTest : IntegrationTest() {
         contentState: JSONObject = JSONObject()
     ): TemplateRenderResult = LiveScoreTemplate.render(
         context = contextMock,
-        attributes = attributes,
-        contentState = contentState,
+        data = flatten(attributes, contentState),
         branding = null,
         smallIcon = 0,
         fallbackTintColor = null
@@ -109,43 +108,5 @@ internal class LiveScoreTemplateTest : IntegrationTest() {
         val result = render(attributes, contentState)
 
         result.title shouldBeEqualTo " 3 - 0 "
-    }
-
-    // --- Strict-slotting regression guards ---
-
-    @Test
-    fun render_homeScoreInAttributes_isIgnored() {
-        val attributes = teamsAttributes().apply {
-            put("homeScore", 99) // wrong slot
-        }
-        val contentState = JSONObject().apply {
-            put("awayScore", 7)
-            put("period", "1st")
-        }
-
-        val result = render(attributes, contentState)
-
-        // homeScore defaults to 0 in content_state, because the misplaced value must be ignored.
-        result.title shouldBeEqualTo "Lakers 0 - 7 Celtics"
-    }
-
-    @Test
-    fun render_leagueLogoKeyInContentState_isIgnored() {
-        // leagueLogoKey belongs in `attributes` per the spec. Misplaced should not resolve.
-        val attributes = teamsAttributes()
-        val contentState = JSONObject().apply {
-            put("homeScore", 0)
-            put("awayScore", 0)
-            put("period", "1st")
-            put("leagueLogoKey", "league_nba")
-        }
-
-        val result = render(attributes, contentState)
-
-        // largeIcon should be null because the misplaced key was not consulted.
-        // (No host-app drawable was registered for "league_nba" anyway, but the contract
-        // we lock here is "don't even attempt to resolve from content_state".)
-        // We can't observe `attempted` directly; we can observe the slot still produces null.
-        result.largeIcon shouldBeEqualTo null
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/TemplateTestData.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/template/TemplateTestData.kt
@@ -1,0 +1,20 @@
+package io.customer.messagingpush.livenotification.template
+
+import org.json.JSONObject
+
+/**
+ * Merges JSON objects into a single flattened [JSONObject], mirroring how the
+ * backend now delivers all live-notification template fields at the envelope
+ * top level (no `attributes` / `content_state` split). Lets per-template tests
+ * keep expressing inputs as two logical groups while exercising the flattened
+ * `render(data = …)` contract.
+ */
+internal fun flatten(vararg objects: JSONObject): JSONObject {
+    val data = JSONObject()
+    for (obj in objects) {
+        for (key in obj.keys()) {
+            data.put(key, obj.get(key))
+        }
+    }
+    return data
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -22,10 +22,11 @@ import io.customer.messagingpush.CustomerIOFirebaseMessagingService;
  * <p>
  * Each scenario builds a templated FCM data bundle that matches the
  * cross-platform live-activity envelope: top-level lifecycle keys
- * ({@code activity_id}, {@code event}, {@code activity_type}) plus two JSON
- * strings, {@code attributes} (static fields) and {@code content_state}
- * (dynamic fields). The static branding bundle lives in
- * {@code MessagingPushModuleConfig} and is registered once at SDK init.
+ * ({@code activity_id}, {@code event}, {@code activity_type}) plus the
+ * template fields flattened alongside them (Android does not split static
+ * {@code attributes} from dynamic {@code content_state}). The static branding
+ * bundle lives in {@code MessagingPushModuleConfig} and is registered once at
+ * SDK init.
  */
 public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotificationDemoBinding> {
 
@@ -36,13 +37,13 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
     private static final String EVENT_UPDATE = "update";
     private static final String EVENT_END = "end";
 
-    // activity_type values are prefixed per the cross-platform spec.
-    private static final String ACTIVITY_TYPE_DELIVERY_TRACKING = "io.customer.live.delivery_tracking";
-    private static final String ACTIVITY_TYPE_FLIGHT_STATUS = "io.customer.live.flight_status";
-    private static final String ACTIVITY_TYPE_LIVE_SCORE = "io.customer.live.live_score";
-    private static final String ACTIVITY_TYPE_COUNTDOWN_TIMER = "io.customer.live.countdown_timer";
-    private static final String ACTIVITY_TYPE_AUCTION_BID = "io.customer.live.auction_bid";
-    private static final String ACTIVITY_TYPE_UNKNOWN = "io.customer.live.bogus";
+    // activity_type values match the iOS Live Activity identifiers per the cross-platform spec.
+    private static final String ACTIVITY_TYPE_DELIVERY_TRACKING = "io.customer.liveactivities.deliverytracking";
+    private static final String ACTIVITY_TYPE_FLIGHT_STATUS = "io.customer.liveactivities.flightstatus";
+    private static final String ACTIVITY_TYPE_LIVE_SCORE = "io.customer.liveactivities.livescore";
+    private static final String ACTIVITY_TYPE_COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer";
+    private static final String ACTIVITY_TYPE_AUCTION_BID = "io.customer.liveactivities.auctionbid";
+    private static final String ACTIVITY_TYPE_UNKNOWN = "io.customer.liveactivities.bogus";
 
     private enum TemplateChoice {
         DELIVERY_TRACKING, FLIGHT_STATUS, LIVE_SCORE, COUNTDOWN_TIMER, AUCTION_BID
@@ -329,9 +330,22 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         bundle.putString("activity_id", activityId);
         bundle.putString("event", event);
         bundle.putString("activity_type", activityType);
-        bundle.putString("attributes", attributes.toString());
-        bundle.putString("content_state", contentState.toString());
+        // The backend sends template fields flattened at the envelope top level.
+        putFlattened(bundle, attributes);
+        putFlattened(bundle, contentState);
         return bundle;
+    }
+
+    private void putFlattened(Bundle bundle, JSONObject obj) {
+        java.util.Iterator<String> keys = obj.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value = obj.opt(key);
+            if (value == null || value == JSONObject.NULL) continue;
+            // Nested objects (origin, homeTeam, …) ride along as JSON strings,
+            // matching how FCM delivers non-scalar data values.
+            bundle.putString(key, value.toString());
+        }
     }
 
     private void fire(Bundle bundle) {


### PR DESCRIPTION
## What

Aligns the Android live-notification envelope and templates with the iOS Live Activity contract, and folds in the review feedback left on the now-merged **#676** (templates) and **#690** (tests) — as promised in those PR threads.

### iOS alignment
- **activity_type** values now match iOS verbatim: `io.customer.liveactivities.{deliverytracking,flightstatus,livescore,countdowntimer,auctionbid}` (was `io.customer.live.*`).
- **Flattened envelope** — dropped the `attributes` / `content_state` split; all template fields arrive flattened at the envelope top level (the backend delivers them flattened). Reserved envelope keys (`activity_id`, `activity_type`, `event`, `timestamp`, `dismissal_date`, plus standard CIO/FCM keys) are excluded; nested JSON values (`origin`, `homeTeam`, …) are parsed so templates still read them.
- **`event` is required** — removed the implicit `"update"` default; a push without `event` is dropped + logged.
- **Removed the hardcoded 3s dismiss delay** — `end` cancels immediately. (Server-driven `dismissal_date` scheduling arrives with the lifecycle-reporting PR.)
- Kept render-layer presentation defaults (currency `$`, step/progress fallbacks, semantic colors, composed labels) — these match iOS's example widgets.

### Review feedback addressed
| Comment | Resolution |
|---|---|
| Bugbot: `optString(..).takeIf{isNotEmpty()}` renders literal `"null"` for explicit JSON null | New `JSONObject.optStringNonEmpty` treats JSON null/empty as absent; applied across templates |
| @mrehan27: repeated `optString..takeIf` → extension | Same `optStringNonEmpty` extension |
| @mrehan27: CountdownTimer single exit point | Builds `TemplateRenderResult` once |
| @mrehan27: `resolveSmallIcon` duplicates `TemplateAssets.resolveDrawable` | Now reuses it |
| @mrehan27: `Bitmap.createBitmap` lint | Uses KTX `createBitmap` |
| Bugbot/@mrehan27: `assert()` is a no-op in tests | Envelope test uses real `shouldBeEqualTo` assertions |
| @mrehan27: are composed label texts SDK-hardcoded? | Yes — intentionally kept to match iOS's render layer |

### Tests
Updated `LiveNotificationHandlerTest` + all per-template tests for the flattened envelope; added `event`-required and end-cancels-immediately coverage. Strict-slotting regression tests removed (no longer applicable after flatten).

## Notes for reviewers (cross-team)
- The flattened wire format and the `io.customer.liveactivities.*` namespace need the backend/partner-API to emit matching payloads for Android.

## Verification
- `:messagingpush:testDebugUnitTest` (live-notification + template tests) ✅
- ktlint ✅ · `:messagingpush` + `:samples:java_layout` compile ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking push wire-format and `activity_type` namespace changes will drop or mis-handle live notifications until the backend sends matching flattened payloads; lifecycle behavior (`event` required, immediate `end` cancel) also changes what users see on device.
> 
> **Overview**
> Aligns Android **live notification** push handling with the iOS Live Activity wire contract and folds in prior review fixes.
> 
> **Envelope & dispatch (`LiveNotificationHandler`)** — Drops the `attributes` / `content_state` JSON blobs; template fields are read from **flattened** FCM bundle keys (envelope keys like `activity_id`, `event`, `activity_type`, `timestamp`, `dismissal_date`, and CIO delivery keys are reserved). Nested values sent as JSON strings are parsed into objects/arrays. **`event` is required** (no implicit `"update"`); missing `event` drops the push. **`activity_type`** identifiers move to `io.customer.liveactivities.{deliverytracking,…}` (replacing `io.customer.live.*`). **`event = "end"`** cancels the notification **immediately** (removed the fixed 3s delayed dismiss; `dismissal_date` scheduling is deferred). Branding small icon resolution reuses `TemplateAssets.resolveDrawable`.
> 
> **Templates** — `LiveNotificationTemplate.render` now takes a single `data` object; all five templates read flattened fields. Adds `JSONObject.optStringNonEmpty` so explicit JSON null does not render as the literal `"null"`. Minor refactors (e.g. CountdownTimer single return path).
> 
> **Tests & sample** — Handler and template tests updated for the new envelope; added coverage for required `event`, flattened `title`, nested JSON parsing, and immediate end cancel. Removed strict attributes vs content_state slotting tests. Java sample demo builds flattened bundles and uses the new `activity_type` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fa8964d98c790e5b158ed2f89781716cd23540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->