### PR TITLE
chore(live-notifications): backend lifecycle reporting + out-of-order/dismissal handling

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -141,6 +141,16 @@ public final class io/customer/messagingpush/livenotification/LiveNotificationBr
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver : android/content/BroadcastReceiver {
+	public static final field Companion Lio/customer/messagingpush/livenotification/LiveNotificationDismissReceiver$Companion;
+	public static final field EXTRA_ACTIVITY_ID Ljava/lang/String;
+	public fun <init> ()V
+	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver$Companion {
+}
+
 public final class io/customer/messagingpush/processor/PushMessageProcessor$Companion {
 	public static final field RECENT_MESSAGES_MAX_SIZE I
 	public final fun getRecentMessagesQueue ()Ljava/util/concurrent/LinkedBlockingDeque;

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -44,6 +44,15 @@
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
         </receiver>
+
+        <!--
+        Receives the delete intent fired when a user dismisses a live notification,
+        so the SDK can report the dismissal to Customer.io. Triggered via an explicit
+        PendingIntent only, so it does not need to be exported.
+        -->
+        <receiver
+            android:name=".livenotification.LiveNotificationDismissReceiver"
+            android:exported="false" />
     </application>
 
     <queries>

--- a/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
@@ -41,6 +41,7 @@ internal data class Api36LiveNotificationParams(
     @DrawableRes val endIconRes: Int?,
     @DrawableRes val trackerIconRes: Int?,
     val pendingIntent: PendingIntent?,
+    val deleteIntent: PendingIntent?,
     val countdownUntil: Long?,
     val largeIcon: Bitmap?,
     val showProgress: Boolean
@@ -137,6 +138,7 @@ internal object Api36LiveNotificationBuilder {
         params.subText?.let { builder.setSubText(it) }
         params.accentColor?.let { builder.setColor(it) }
         params.pendingIntent?.let { builder.setContentIntent(it) }
+        params.deleteIntent?.let { builder.setDeleteIntent(it) }
 
         return builder.build()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
@@ -37,6 +37,7 @@ internal data class BasicNotificationParams(
     val progress: Int,
     val progressMax: Int,
     val pendingIntent: PendingIntent?,
+    val deleteIntent: PendingIntent?,
     val countdownUntil: Long?,
     val largeIcon: Bitmap?,
     val showProgress: Boolean
@@ -86,6 +87,7 @@ internal object BasicNotificationBuilder {
             builder.setColorized(true)
         }
         params.pendingIntent?.let { builder.setContentIntent(it) }
+        params.deleteIntent?.let { builder.setDeleteIntent(it) }
 
         return builder.build()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -7,13 +7,17 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationDismissReceiver
 import io.customer.messagingpush.livenotification.template.TemplateAssets
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.messagingpush.util.PushTrackingUtil
@@ -95,6 +99,21 @@ internal class LiveNotificationHandler(
             )
             return
         }
+
+        // Out-of-order / duplicate guard. Android renders FCM data directly, so unlike
+        // iOS (where APNs/ActivityKit order updates) the SDK must drop stale pushes itself.
+        val store = SDKComponent.liveNotificationStore
+        val timestamp = bundle.getString(TIMESTAMP_KEY)?.toLongOrNull()
+        if (timestamp != null) {
+            val lastSeen = store.lastTimestamp(activityId)
+            if (lastSeen != null && timestamp <= lastSeen) {
+                SDKComponent.logger.debug(
+                    "Dropping out-of-order/duplicate live notification for '$activityId' (timestamp $timestamp <= $lastSeen)."
+                )
+                return
+            }
+        }
+
         val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
         val template = TemplateRegistry.find(activityType)
         if (template == null) {
@@ -102,6 +121,12 @@ internal class LiveNotificationHandler(
                 "Unknown live notification template '$activityType'; dropping push for activity '$activityId'."
             )
             return
+        }
+
+        // We have committed to acting on this push: record its timestamp so later,
+        // out-of-order pushes for the same activity are dropped. `end` clears it below.
+        if (event != EVENT_END && timestamp != null) {
+            store.setLastTimestamp(activityId, timestamp)
         }
 
         val data = extractData(bundle)
@@ -134,6 +159,7 @@ internal class LiveNotificationHandler(
             activityId = activityId
         )
         val pendingIntent = createIntentForNotificationClick(context, notifId, parsedPayload)
+        val deletePendingIntent = createDeleteIntent(context, notifId, activityId)
 
         val notification = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA -> {
@@ -153,6 +179,7 @@ internal class LiveNotificationHandler(
                     endIconRes = result.endIconRes,
                     trackerIconRes = result.trackerIconRes,
                     pendingIntent = pendingIntent,
+                    deleteIntent = deletePendingIntent,
                     countdownUntil = result.countdownUntil,
                     largeIcon = result.largeIcon,
                     showProgress = result.showProgress
@@ -172,6 +199,7 @@ internal class LiveNotificationHandler(
                     progress = result.progress,
                     progressMax = result.progressMax,
                     pendingIntent = pendingIntent,
+                    deleteIntent = deletePendingIntent,
                     countdownUntil = result.countdownUntil,
                     largeIcon = result.largeIcon,
                     showProgress = result.showProgress
@@ -183,10 +211,48 @@ internal class LiveNotificationHandler(
         notificationManager.notify(activityId, notifId, notification)
 
         if (event == EVENT_END) {
-            // Without a dismissal_date the activity is removed immediately.
-            // Scheduled dismissal via dismissal_date is added with lifecycle reporting.
-            notificationManager.cancel(activityId, notifId)
+            store.clearTimestamp(activityId)
+            scheduleEndDismissal(bundle, notificationManager, activityId, notifId)
         }
+    }
+
+    /**
+     * On `end`, removes the notification at the server-provided `dismissal_date`
+     * (epoch ms). When absent, the activity is removed immediately — there is no
+     * invented default delay. (Best-effort: a long delay does not survive
+     * process death.)
+     */
+    private fun scheduleEndDismissal(
+        bundle: Bundle,
+        notificationManager: NotificationManager,
+        activityId: String,
+        notifId: Int
+    ) {
+        val dismissAtMs = bundle.getString(DISMISSAL_DATE_KEY)?.toLongOrNull()
+        if (dismissAtMs == null) {
+            notificationManager.cancel(activityId, notifId)
+            return
+        }
+        val delayMs = (dismissAtMs - System.currentTimeMillis()).coerceAtLeast(0L)
+        Handler(Looper.getMainLooper()).postDelayed({
+            notificationManager.cancel(activityId, notifId)
+        }, delayMs)
+    }
+
+    private fun createDeleteIntent(
+        context: Context,
+        requestCode: Int,
+        activityId: String
+    ): PendingIntent {
+        val intent = Intent(context, LiveNotificationDismissReceiver::class.java).apply {
+            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_ID, activityId)
+        }
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getBroadcast(context, requestCode, intent, flags)
     }
 
     /**

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -2,6 +2,7 @@ package io.customer.messagingpush
 
 import androidx.lifecycle.Lifecycle
 import io.customer.messagingpush.di.fcmTokenProvider
+import io.customer.messagingpush.di.liveNotificationRegistrar
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.sdk.communication.Event
@@ -23,6 +24,9 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = MODULE_NAME
 
     override fun initialize() {
+        // Start before requesting the token so the registrar observes the resulting
+        // RegisterDeviceTokenEvent and registers the built-in live-notification types.
+        SDKComponent.liveNotificationRegistrar.start()
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -10,6 +10,10 @@ import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.PushDeliveryTrackerImpl
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClient
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl
+import io.customer.messagingpush.livenotification.LiveNotificationRegistrar
+import io.customer.messagingpush.livenotification.LiveNotificationStore
 import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.network.HttpClient
 import io.customer.messagingpush.network.HttpClientImpl
@@ -75,6 +79,17 @@ internal val SDKComponent.pushMessageProcessor: PushMessageProcessor
 
 internal val SDKComponent.httpClient: HttpClient
     get() = singleton<HttpClient> { HttpClientImpl() }
+
+internal val SDKComponent.liveNotificationStore: LiveNotificationStore
+    get() = singleton<LiveNotificationStore> { LiveNotificationStore(android().applicationContext) }
+
+internal val SDKComponent.liveNotificationLifecycleClient: LiveNotificationLifecycleClient
+    get() = singleton<LiveNotificationLifecycleClient> { LiveNotificationLifecycleClientImpl() }
+
+internal val SDKComponent.liveNotificationRegistrar: LiveNotificationRegistrar
+    get() = singleton<LiveNotificationRegistrar> {
+        LiveNotificationRegistrar(liveNotificationLifecycleClient, liveNotificationStore)
+    }
 
 internal val SDKComponent.pushDeliveryTracker: PushDeliveryTracker
     get() = singleton<PushDeliveryTracker> { PushDeliveryTrackerImpl() }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
@@ -1,0 +1,39 @@
+package io.customer.messagingpush.livenotification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.customer.messagingpush.di.liveNotificationLifecycleClient
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.setupAndroidComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Receives the delete intent the system fires when the user dismisses a live
+ * notification, and reports the dismissal to the backend.
+ *
+ * Programmatic [android.app.NotificationManager.cancel] does NOT trigger a
+ * delete intent, so server-driven `end` events (which cancel the notification)
+ * do not produce a false user-dismissal report.
+ */
+class LiveNotificationDismissReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val activityId = intent.getStringExtra(EXTRA_ACTIVITY_ID) ?: return
+        SDKComponent.setupAndroidComponent(context = context)
+        // Keep the receiver alive for the short-lived network call.
+        val pendingResult = goAsync()
+        CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
+            try {
+                SDKComponent.liveNotificationLifecycleClient.reportDismissed(activityId)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_ACTIVITY_ID = "io.customer.messagingpush.EXTRA_LIVE_ACTIVITY_ID"
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -1,0 +1,92 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.di.httpClient
+import io.customer.messagingpush.network.HttpClient
+import io.customer.messagingpush.network.HttpMethod
+import io.customer.messagingpush.network.HttpRequestException
+import io.customer.messagingpush.network.HttpRequestParams
+import io.customer.sdk.core.di.SDKComponent
+import kotlinx.coroutines.delay
+import org.json.JSONObject
+
+/**
+ * Reports live-notification lifecycle to the Customer.io backend.
+ *
+ * Android has no push-to-start token like iOS; [registerForActivityType]
+ * instead registers the device's FCM token per activity type so the backend
+ * can push updates for it (`os = android`, `transport = fcm`).
+ * [reportDismissed] mirrors iOS's terminal-state DELETE, fired when the user
+ * dismisses the notification.
+ */
+internal interface LiveNotificationLifecycleClient {
+    suspend fun registerForActivityType(activityType: String, token: String, userId: String): Result<Unit>
+
+    suspend fun reportDismissed(activityId: String): Result<Unit>
+}
+
+internal class LiveNotificationLifecycleClientImpl(
+    private val httpClient: HttpClient = SDKComponent.httpClient
+) : LiveNotificationLifecycleClient {
+
+    override suspend fun registerForActivityType(
+        activityType: String,
+        token: String,
+        userId: String
+    ): Result<Unit> {
+        val body = JSONObject().apply {
+            put("token", token)
+            put("os", OS_ANDROID)
+            put("transport", TRANSPORT_FCM)
+            put("userId", userId)
+        }
+        return send(
+            HttpRequestParams(
+                path = "/v1/live_activities/registration/$activityType",
+                method = HttpMethod.PUT,
+                headers = JSON_HEADERS,
+                body = body.toString()
+            )
+        )
+    }
+
+    override suspend fun reportDismissed(activityId: String): Result<Unit> {
+        return send(
+            HttpRequestParams(
+                path = "/v1/live_activities/$activityId",
+                method = HttpMethod.DELETE,
+                headers = JSON_HEADERS,
+                body = "{}"
+            )
+        )
+    }
+
+    /**
+     * Sends [params], retrying transport failures and 5xx responses up to
+     * [MAX_ATTEMPTS] with linear backoff. 4xx responses are not retried
+     * (mirrors the iOS lifecycle client policy).
+     */
+    private suspend fun send(params: HttpRequestParams): Result<Unit> {
+        var attempt = 0
+        while (true) {
+            attempt++
+            val result = httpClient.request(params)
+            if (result.isSuccess) return Result.success(Unit)
+
+            val error = result.exceptionOrNull()
+            val statusCode = (error as? HttpRequestException)?.statusCode
+            val isClientError = statusCode != null && statusCode in 400..499
+            if (isClientError || attempt >= MAX_ATTEMPTS) {
+                return Result.failure(error ?: IllegalStateException("Live notification request failed"))
+            }
+            delay(BASE_BACKOFF_MS * attempt)
+        }
+    }
+
+    companion object {
+        private const val OS_ANDROID = "android"
+        private const val TRANSPORT_FCM = "fcm"
+        private const val MAX_ATTEMPTS = 3
+        private const val BASE_BACKOFF_MS = 500L
+        private val JSON_HEADERS = mapOf("Content-Type" to "application/json; charset=utf-8")
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -1,0 +1,66 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.sdk.communication.Event
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.di.SDKComponent.eventBus
+
+/**
+ * Registers the device's FCM token with the backend for each built-in
+ * live-notification template type — the Android analogue of iOS push-to-start
+ * registration — and keeps it current.
+ *
+ * Registration is (re)attempted whenever the device token rotates
+ * ([Event.RegisterDeviceTokenEvent]) or the user changes
+ * ([Event.UserChangedEvent]), and is deduped per activity type via
+ * [LiveNotificationStore] (signature = `token|userId`). Token deletion / reset
+ * clears the stored signatures so the next token re-registers.
+ */
+internal class LiveNotificationRegistrar(
+    private val client: LiveNotificationLifecycleClient,
+    private val store: LiveNotificationStore
+) {
+
+    @Volatile
+    private var token: String? = null
+
+    @Volatile
+    private var userId: String = ""
+
+    fun start() {
+        // Drop dedup entries for activities that ended long ago without an explicit `end`.
+        store.trimStaleTimestamps()
+
+        eventBus.subscribe(Event.RegisterDeviceTokenEvent::class) { event ->
+            token = event.token
+            registerAll()
+        }
+        eventBus.subscribe(Event.UserChangedEvent::class) { event ->
+            userId = event.userId ?: event.anonymousId
+            registerAll()
+        }
+        eventBus.subscribe(Event.DeleteDeviceTokenEvent::class) {
+            token = null
+            store.clearRegistrations()
+        }
+        eventBus.subscribe(Event.ResetEvent::class) {
+            store.clearRegistrations()
+        }
+    }
+
+    private suspend fun registerAll() {
+        val currentToken = token ?: return
+        val signature = "$currentToken|$userId"
+        for (activityType in TemplateRegistry.builtInTypes) {
+            if (store.registrationSignature(activityType) == signature) continue
+            val result = client.registerForActivityType(activityType, currentToken, userId)
+            if (result.isSuccess) {
+                store.setRegistrationSignature(activityType, signature)
+            } else {
+                SDKComponent.logger.debug(
+                    "Live notification registration failed for '$activityType'; will retry on next token/user change."
+                )
+            }
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
@@ -1,0 +1,74 @@
+package io.customer.messagingpush.livenotification
+
+import android.content.Context
+import androidx.core.content.edit
+import java.util.concurrent.TimeUnit
+
+/**
+ * Persistent state for live notifications, backed by a dedicated
+ * SharedPreferences file:
+ *
+ * - **Registration dedup** (per `activity_type`): the last signature
+ *   (`token|userId`) registered with the backend, so repeated app launches /
+ *   unchanged tokens don't re-POST the registration.
+ * - **Out-of-order / dedup guard** (per `activity_id`): the last `timestamp`
+ *   seen, so a delayed or duplicate push that is older than one already
+ *   rendered is dropped. Unlike iOS (where APNs/ActivityKit order updates), the
+ *   Android SDK renders FCM data directly and must guard ordering itself.
+ *
+ * Timestamp entries are stored with their record time so stale ones (for
+ * activities that ended long ago without an explicit `end`) can be trimmed on
+ * app launch.
+ */
+internal class LiveNotificationStore(context: Context) {
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    // --- Registration dedup (per activity_type) ---
+
+    fun registrationSignature(activityType: String): String? =
+        prefs.getString(REG_PREFIX + activityType, null)
+
+    fun setRegistrationSignature(activityType: String, signature: String) {
+        prefs.edit { putString(REG_PREFIX + activityType, signature) }
+    }
+
+    /** Clears all registration signatures, forcing re-registration (e.g. on reset / token deletion). */
+    fun clearRegistrations() {
+        prefs.edit {
+            prefs.all.keys.filter { it.startsWith(REG_PREFIX) }.forEach { remove(it) }
+        }
+    }
+
+    // --- Out-of-order / dedup guard (per activity_id) ---
+
+    /** The last `timestamp` seen for [activityId], or null if none recorded. */
+    fun lastTimestamp(activityId: String): Long? =
+        prefs.getString(TS_PREFIX + activityId, null)?.substringBefore('|')?.toLongOrNull()
+
+    fun setLastTimestamp(activityId: String, timestamp: Long, now: Long = System.currentTimeMillis()) {
+        prefs.edit { putString(TS_PREFIX + activityId, "$timestamp|$now") }
+    }
+
+    fun clearTimestamp(activityId: String) {
+        prefs.edit { remove(TS_PREFIX + activityId) }
+    }
+
+    /** Removes timestamp entries recorded longer than [ttlMs] ago. Intended to run on app launch. */
+    fun trimStaleTimestamps(ttlMs: Long = DEFAULT_TS_TTL_MS, now: Long = System.currentTimeMillis()) {
+        val staleKeys = prefs.all.entries.filter { (key, value) ->
+            key.startsWith(TS_PREFIX) &&
+                ((value as? String)?.substringAfter('|', "")?.toLongOrNull()?.let { now - it > ttlMs } ?: true)
+        }.map { it.key }
+        if (staleKeys.isNotEmpty()) {
+            prefs.edit { staleKeys.forEach { remove(it) } }
+        }
+    }
+
+    companion object {
+        private const val PREFS_NAME = "io.customer.messagingpush.live_notifications"
+        private const val REG_PREFIX = "reg:"
+        private const val TS_PREFIX = "ts:"
+        private val DEFAULT_TS_TTL_MS = TimeUnit.DAYS.toMillis(7)
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
@@ -8,6 +8,15 @@ internal object TemplateRegistry {
     const val COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer"
     const val AUCTION_BID = "io.customer.liveactivities.auctionbid"
 
+    /** The built-in activity types the SDK registers for and can render. */
+    val builtInTypes: List<String> = listOf(
+        DELIVERY_TRACKING,
+        FLIGHT_STATUS,
+        LIVE_SCORE,
+        COUNTDOWN_TIMER,
+        AUCTION_BID
+    )
+
     fun find(name: String?): LiveNotificationTemplate? = when (name) {
         DELIVERY_TRACKING -> DeliveryTrackingTemplate
         FLIGHT_STATUS -> FlightStatusTemplate

--- a/messagingpush/src/main/java/io/customer/messagingpush/network/HTTPClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/network/HTTPClient.kt
@@ -9,20 +9,36 @@ import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
 
+internal enum class HttpMethod { GET, POST, PUT, DELETE }
+
 internal data class HttpRequestParams(
     val path: String,
+    val method: HttpMethod = HttpMethod.POST,
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null
 )
 
+/**
+ * IOException carrying the HTTP [statusCode] for non-2xx responses ([statusCode]
+ * is null for transport-level failures). Lets callers apply status-aware retry
+ * (e.g. retry 5xx, skip 4xx) without parsing the message.
+ */
+internal class HttpRequestException(
+    val statusCode: Int?,
+    message: String,
+    cause: Throwable? = null
+) : IOException(message, cause)
+
 internal interface HttpClient {
     /**
-     * Performs a POST request to [params.path] with [params.headers] and [params.body].
+     * Performs an HTTP request to [params.path] using [params.method], with
+     * [params.headers] and [params.body].
      *
-     * @param params The request parameters (path, headers, body).
+     * @param params The request parameters (path, method, headers, body).
      * @return A `Result<String>`:
      *   - `Result.success(responseBody)` for 2xx response codes
      *   - `Result.failure(exception)` for network errors or non-2xx codes
+     *     (an [HttpRequestException] for non-2xx, carrying the status code)
      */
     suspend fun request(params: HttpRequestParams): Result<String>
 }
@@ -62,7 +78,7 @@ internal class HttpClientImpl : HttpClient {
             // Configure the connection
             connection.connectTimeout = connectTimeoutMs
             connection.readTimeout = readTimeoutMs
-            connection.requestMethod = "POST"
+            connection.requestMethod = params.method.name
             connection.setRequestProperty("User-Agent", client.toString())
 
             // Authorization: Basic <base64("writeKey:")>
@@ -97,7 +113,7 @@ internal class HttpClientImpl : HttpClient {
             if (responseCode in 200..299) {
                 Result.success(responseBody)
             } else {
-                Result.failure(IOException("HTTP $responseCode: $responseBody"))
+                Result.failure(HttpRequestException(responseCode, "HTTP $responseCode: $responseBody"))
             }
         } catch (e: IOException) {
             Result.failure(e)

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -15,6 +15,7 @@ import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
 
 /**
  * Tests for [LiveNotificationHandler] focused on envelope parsing and dispatch:
@@ -40,12 +41,16 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
         activityId: String? = "live-act-1",
         event: String? = "start",
         activityType: String? = TemplateRegistry.DELIVERY_TRACKING,
-        data: JSONObject = JSONObject()
+        data: JSONObject = JSONObject(),
+        timestamp: Long? = null,
+        dismissalDate: Long? = null
     ): Bundle {
         val bundle = Bundle()
         if (activityId != null) bundle.putString(LiveNotificationHandler.ACTIVITY_ID_KEY, activityId)
         if (event != null) bundle.putString(LiveNotificationHandler.EVENT_KEY, event)
         if (activityType != null) bundle.putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
+        if (timestamp != null) bundle.putString(LiveNotificationHandler.TIMESTAMP_KEY, timestamp.toString())
+        if (dismissalDate != null) bundle.putString(LiveNotificationHandler.DISMISSAL_DATE_KEY, dismissalDate.toString())
         // Template fields ride flattened at the top level, as the backend delivers them.
         for (key in data.keys()) bundle.putString(key, data.get(key).toString())
         return bundle
@@ -236,6 +241,62 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
             notificationManager.notify(activityId, expectedNotifId, any<Notification>())
         }
         assertCalledNever {
+            notificationManager.cancel(activityId, expectedNotifId)
+        }
+    }
+
+    // --- Out-of-order / duplicate guard ---
+
+    @Test
+    fun handle_givenOlderTimestamp_dropsTheStalePush() {
+        val activityId = "ooo-activity"
+
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 100L)))
+        // Arrives late and is older than what was already rendered: must be dropped.
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 50L)))
+
+        verify(exactly = 1) {
+            notificationManager.notify(activityId, any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
+    fun handle_givenNewerTimestamp_rendersBoth() {
+        val activityId = "in-order-activity"
+
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 100L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 200L)))
+
+        verify(exactly = 2) {
+            notificationManager.notify(activityId, any<Int>(), any<Notification>())
+        }
+    }
+
+    // --- dismissal_date scheduling on end ---
+
+    @Test
+    fun handle_givenEndWithFutureDismissalDate_cancelsOnlyAfterDelay() {
+        val activityId = "scheduled-end"
+        val expectedNotifId = activityId.hashCode() and 0x7FFFFFFF
+        val bundle = newBundle(
+            activityId = activityId,
+            event = "end",
+            dismissalDate = System.currentTimeMillis() + 60_000L
+        )
+
+        invoke(handlerFor(bundle))
+
+        // Posted now, but not cancelled until the dismissal_date is reached.
+        verify(exactly = 1) {
+            notificationManager.notify(activityId, expectedNotifId, any<Notification>())
+        }
+        assertCalledNever {
+            notificationManager.cancel(activityId, expectedNotifId)
+        }
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        verify(exactly = 1) {
             notificationManager.cancel(activityId, expectedNotifId)
         }
     }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -1,0 +1,92 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.network.HttpClient
+import io.customer.messagingpush.network.HttpMethod
+import io.customer.messagingpush.network.HttpRequestException
+import io.customer.messagingpush.network.HttpRequestParams
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
+
+    private val httpClient: HttpClient = mockk()
+    private val client = LiveNotificationLifecycleClientImpl(httpClient)
+
+    @Test
+    fun register_buildsPutWithAndroidFcmBody() = runTest {
+        val params = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+
+        val result = client.registerForActivityType(
+            activityType = "io.customer.liveactivities.deliverytracking",
+            token = "tok-1",
+            userId = "user-1"
+        )
+
+        result.isSuccess.shouldBeTrue()
+        params.captured.method shouldBeEqualTo HttpMethod.PUT
+        params.captured.path shouldBeEqualTo
+            "/v1/live_activities/registration/io.customer.liveactivities.deliverytracking"
+        val body = params.captured.body!!
+        body shouldContain "tok-1"
+        body shouldContain "\"os\":\"android\""
+        body shouldContain "\"transport\":\"fcm\""
+        body shouldContain "user-1"
+    }
+
+    @Test
+    fun reportDismissed_buildsDeleteWithEmptyBody() = runTest {
+        val params = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+
+        client.reportDismissed("act-123")
+
+        params.captured.method shouldBeEqualTo HttpMethod.DELETE
+        params.captured.path shouldBeEqualTo "/v1/live_activities/act-123"
+        params.captured.body shouldBeEqualTo "{}"
+    }
+
+    @Test
+    fun send_retriesOn5xxUpToThreeAttempts() = runTest {
+        coEvery { httpClient.request(any()) } returns Result.failure(HttpRequestException(503, "boom"))
+
+        val result = client.reportDismissed("act-1")
+
+        result.isFailure.shouldBeTrue()
+        coVerify(exactly = 3) { httpClient.request(any()) }
+    }
+
+    @Test
+    fun send_doesNotRetryOn4xx() = runTest {
+        coEvery { httpClient.request(any()) } returns Result.failure(HttpRequestException(400, "bad request"))
+
+        val result = client.reportDismissed("act-1")
+
+        result.isFailure.shouldBeTrue()
+        coVerify(exactly = 1) { httpClient.request(any()) }
+    }
+
+    @Test
+    fun send_succeedsAfterTransientFailure() = runTest {
+        coEvery { httpClient.request(any()) } returnsMany listOf(
+            Result.failure(HttpRequestException(500, "x")),
+            Result.success("")
+        )
+
+        val result = client.reportDismissed("act-1")
+
+        result.isSuccess.shouldBeTrue()
+        coVerify(exactly = 2) { httpClient.request(any()) }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
@@ -1,0 +1,56 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationStoreTest : IntegrationTest() {
+
+    private val store by lazy { LiveNotificationStore(contextMock) }
+
+    @Test
+    fun registrationSignature_setGetClear() {
+        store.registrationSignature("type-a").shouldBeNull()
+
+        store.setRegistrationSignature("type-a", "tok|user")
+        store.setRegistrationSignature("type-b", "tok|user")
+
+        store.registrationSignature("type-a") shouldBeEqualTo "tok|user"
+
+        store.clearRegistrations()
+
+        store.registrationSignature("type-a").shouldBeNull()
+        store.registrationSignature("type-b").shouldBeNull()
+    }
+
+    @Test
+    fun lastTimestamp_setGetClear() {
+        store.lastTimestamp("act-1").shouldBeNull()
+
+        store.setLastTimestamp("act-1", 1_000L)
+        store.lastTimestamp("act-1") shouldBeEqualTo 1_000L
+
+        store.clearTimestamp("act-1")
+        store.lastTimestamp("act-1").shouldBeNull()
+    }
+
+    @Test
+    fun trimStaleTimestamps_removesEntriesOlderThanTtl() {
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        // Recorded before the cutoff -> stale.
+        store.setLastTimestamp("old", 1L, now = now - ttl - 1)
+        // Recorded within the ttl -> kept.
+        store.setLastTimestamp("fresh", 2L, now = now - 1)
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.lastTimestamp("old").shouldBeNull()
+        store.lastTimestamp("fresh") shouldBeEqualTo 2L
+    }
+}


### PR DESCRIPTION
## What

Adds the Android analogue of the iOS Live Activity **backend lifecycle**, plus the **`timestamp` / `dismissal_date`** envelope handling Android needs because it renders FCM data directly (there's no APNs/ActivityKit ordering layer to lean on).

Stacked on #722 (set base to `feature/live-notifications` once #722 merges).

### Backend lifecycle
- `HttpClient` gains a per-request `HttpMethod` (PUT/DELETE) and a status-aware `HttpRequestException`, so callers can retry 5xx but not 4xx.
- **`LiveNotificationLifecycleClient`**
  - per-template registration: `PUT /v1/live_activities/registration/{activityType}` with `{token, os:"android", transport:"fcm", userId}` (Android's equivalent of iOS push-to-start — no special token, registers the FCM token per type)
  - user dismissal: `DELETE /v1/live_activities/{activityId}`
  - retries 5xx up to 3×, skips 4xx (mirrors the iOS client)
- **`LiveNotificationRegistrar`** registers all built-in types on device-token rotation and on user change, deduped per type via `LiveNotificationStore`; clears registrations on reset / token deletion.
- **User dismissal** is detected via the notification's delete intent (`LiveNotificationDismissReceiver`). Programmatic `NotificationManager.cancel()` does **not** fire a delete intent, so a server-driven `end` is never mis-reported as a user dismissal.

### Envelope metadata
- **`timestamp`** — out-of-order / duplicate guard: a push whose timestamp is `<= ` the last one rendered for that `activity_id` is dropped; the guard is skipped when `timestamp` is absent (arrival order), and the entry is cleared on `end`. Persisted in `LiveNotificationStore` with a launch-time trim of stale entries.
- **`dismissal_date`** — honored on `event:"end"` only; schedules removal at that time (epoch ms), or removes immediately when absent (no invented delay; replaces the old hardcoded 3s).

### Decisions baked in (per earlier alignment discussion)
- Token-based device identity (no `installationId`), even though it is now available on the base — can revisit.
- No per-instance content-state echo (`update` PUT) — not applicable on Android.

## Tests
`LiveNotificationStore` (dedup get/set/clear + stale trim), `LiveNotificationLifecycleClient` (request shape + 5xx-retry / 4xx-no-retry policy), and handler `timestamp` dedup + `dismissal_date` scheduling. Full `:messagingpush` unit suite, ktlint, and Android Lint pass locally.

## Notes for reviewers (cross-team)
- `timestamp` / `dismissal_date` are treated as **epoch milliseconds** (consistent with the other Android template time fields), unlike iOS APNs seconds — backend must send Android-flavored values.
- Backend must emit the per-type registration / accept the DELETE with token-only identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated backend calls and push-handling logic affect live notification delivery and teardown; mis-timed timestamps or dismissal_date could drop updates or remove UI early, but scope is limited to the live-notification path.
> 
> **Overview**
> Adds **Android live-notification backend lifecycle** (FCM token registration per built-in activity type, user-dismissal reporting) and **envelope handling** for out-of-order FCM updates and scheduled teardown on `end`.
> 
> **Lifecycle:** `HttpClient` now supports configurable methods and surfaces `HttpRequestException` with status codes for retry policy. `LiveNotificationLifecycleClient` performs `PUT /v1/live_activities/registration/{activityType}` and `DELETE /v1/live_activities/{activityId}` with 5xx retries. `LiveNotificationRegistrar` starts during push module init, re-registers on token/user changes with SharedPreferences dedup, and clears on reset/token deletion. User swipes are reported via notification **delete intents** and `LiveNotificationDismissReceiver` (programmatic `cancel` does not fire delete, avoiding false dismissals on server `end`).
> 
> **Handler:** Drops pushes when `timestamp` ≤ last rendered for the same `activity_id` (persisted in `LiveNotificationStore`); on `end`, honors `dismissal_date` (epoch ms) or cancels immediately. Both notification builders wire `setDeleteIntent`.
> 
> **API surface:** Public `LiveNotificationDismissReceiver` is declared in the API dump and manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252fc3ea91bdf6aeed043e7bc5c10348e6be5ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->