### PR TITLE
chore(live-notifications): local start API + custom types + app render callback

### DIFF
--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -25,7 +25,7 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig : io/cust
 	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lio/customer/messagingpush/livenotification/LiveNotificationBranding;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoTrackPushEvents ()Z
 	public final fun getLiveNotificationBranding ()Lio/customer/messagingpush/livenotification/LiveNotificationBranding;
-	public final fun getLiveNotificationCustomTypes ()Ljava/util/Set;
+	public final fun getLiveNotificationTypes ()Ljava/util/Set;
 	public final fun getNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;
 	public final fun getPushClickBehavior ()Lio/customer/messagingpush/config/PushClickBehavior;
 	public fun toString ()Ljava/lang/String;
@@ -35,9 +35,9 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder :
 	public fun <init> ()V
 	public fun build ()Lio/customer/messagingpush/MessagingPushModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
-	public final fun registerLiveNotificationTypes ([Ljava/lang/String;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setAutoTrackPushEvents (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setLiveNotificationBranding (Lio/customer/messagingpush/livenotification/LiveNotificationBranding;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
+	public final fun setLiveNotificationTypes ([Ljava/lang/String;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setPushClickBehavior (Lio/customer/messagingpush/config/PushClickBehavior;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 }
@@ -330,6 +330,15 @@ public final class io/customer/messagingpush/livenotification/LiveNotificationDi
 }
 
 public final class io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver$Companion {
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationType {
+	public static final field AUCTION_BID Ljava/lang/String;
+	public static final field COUNTDOWN_TIMER Ljava/lang/String;
+	public static final field DELIVERY_TRACKING Ljava/lang/String;
+	public static final field FLIGHT_STATUS Ljava/lang/String;
+	public static final field INSTANCE Lio/customer/messagingpush/livenotification/LiveNotificationType;
+	public static final field LIVE_SCORE Ljava/lang/String;
 }
 
 public final class io/customer/messagingpush/processor/PushMessageProcessor$Companion {

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -22,9 +22,10 @@ public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
 	public static final field Companion Lio/customer/messagingpush/MessagingPushModuleConfig$Companion;
-	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lio/customer/messagingpush/livenotification/LiveNotificationBranding;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lio/customer/messagingpush/livenotification/LiveNotificationBranding;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoTrackPushEvents ()Z
 	public final fun getLiveNotificationBranding ()Lio/customer/messagingpush/livenotification/LiveNotificationBranding;
+	public final fun getLiveNotificationCustomTypes ()Ljava/util/Set;
 	public final fun getNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;
 	public final fun getPushClickBehavior ()Lio/customer/messagingpush/config/PushClickBehavior;
 	public fun toString ()Ljava/lang/String;
@@ -34,6 +35,7 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder :
 	public fun <init> ()V
 	public fun build ()Lio/customer/messagingpush/MessagingPushModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
+	public final fun registerLiveNotificationTypes ([Ljava/lang/String;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setAutoTrackPushEvents (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setLiveNotificationBranding (Lio/customer/messagingpush/livenotification/LiveNotificationBranding;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
@@ -52,6 +54,8 @@ public final class io/customer/messagingpush/ModuleMessagingPushFCM : io/custome
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun initialize ()V
+	public final fun startLiveNotification (Lio/customer/messagingpush/livenotification/LiveNotificationData;)Ljava/lang/String;
+	public final fun startLiveNotification (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
 }
 
 public final class io/customer/messagingpush/ModuleMessagingPushFCM$Companion {
@@ -77,11 +81,13 @@ public final class io/customer/messagingpush/config/PushClickBehavior : java/lan
 }
 
 public abstract interface class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback {
+	public abstract fun createLiveNotification (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Landroid/app/Notification;
 	public abstract fun onNotificationClicked (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public abstract fun onNotificationComposed (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
 
 public final class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback$DefaultImpls {
+	public static fun createLiveNotification (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Landroid/app/Notification;
 	public static fun onNotificationClicked (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public static fun onNotificationComposed (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
@@ -137,6 +143,181 @@ public final class io/customer/messagingpush/livenotification/LiveNotificationBr
 	public final fun getAccentColor ()I
 	public final fun getCompanyName ()Ljava/lang/String;
 	public final fun getLogoDrawableName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/customer/messagingpush/livenotification/LiveNotificationData {
+	public abstract fun fields ()Ljava/util/Map;
+	public abstract fun getActivityType ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$Airport {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCity ()Ljava/lang/String;
+	public final fun getCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$AuctionBid : io/customer/messagingpush/livenotification/LiveNotificationData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ZLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ZLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ZLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/livenotification/LiveNotificationData$AuctionBid;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$AuctionBid;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ZLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$AuctionBid;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun fields ()Ljava/util/Map;
+	public fun getActivityType ()Ljava/lang/String;
+	public final fun getBidCount ()I
+	public final fun getCurrencySymbol ()Ljava/lang/String;
+	public final fun getCurrentBid ()Ljava/lang/String;
+	public final fun getEndTime ()Ljava/lang/Long;
+	public final fun getItemImageKey ()Ljava/lang/String;
+	public final fun getItemTitle ()Ljava/lang/String;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public final fun getUserBidAmount ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isUserHighBidder ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$CountdownTimer : io/customer/messagingpush/livenotification/LiveNotificationData {
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/livenotification/LiveNotificationData$CountdownTimer;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$CountdownTimer;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$CountdownTimer;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun fields ()Ljava/util/Map;
+	public fun getActivityType ()Ljava/lang/String;
+	public final fun getExpiredMessage ()Ljava/lang/String;
+	public final fun getHeroImageKey ()Ljava/lang/String;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public final fun getTargetDate ()J
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$DeliveryTracking : io/customer/messagingpush/livenotification/LiveNotificationData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;)Lio/customer/messagingpush/livenotification/LiveNotificationData$DeliveryTracking;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$DeliveryTracking;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$DeliveryTracking;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun fields ()Ljava/util/Map;
+	public fun getActivityType ()Ljava/lang/String;
+	public final fun getDriverName ()Ljava/lang/String;
+	public final fun getEstimatedArrival ()Ljava/lang/Long;
+	public final fun getOrderId ()Ljava/lang/String;
+	public final fun getRecipientName ()Ljava/lang/String;
+	public final fun getStatusImageKey ()Ljava/lang/String;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public final fun getStepCurrent ()Ljava/lang/Integer;
+	public final fun getStepTotal ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$FlightStatus : io/customer/messagingpush/livenotification/LiveNotificationData {
+	public fun <init> (Ljava/lang/String;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component2 ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public final fun component3 ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Integer;)Lio/customer/messagingpush/livenotification/LiveNotificationData$FlightStatus;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$FlightStatus;Ljava/lang/String;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/Integer;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$FlightStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun fields ()Ljava/util/Map;
+	public fun getActivityType ()Ljava/lang/String;
+	public final fun getDelayMinutes ()Ljava/lang/Integer;
+	public final fun getDestination ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public final fun getEstimatedArrival ()Ljava/lang/Long;
+	public final fun getFlightNumber ()Ljava/lang/String;
+	public final fun getGate ()Ljava/lang/String;
+	public final fun getOrigin ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Airport;
+	public final fun getProgressFraction ()Ljava/lang/Double;
+	public final fun getScheduledDeparture ()Ljava/lang/Long;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public final fun getTerminal ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$LiveScore : io/customer/messagingpush/livenotification/LiveNotificationData {
+	public fun <init> (Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public final fun component2 ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/livenotification/LiveNotificationData$LiveScore;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$LiveScore;Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$LiveScore;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun fields ()Ljava/util/Map;
+	public fun getActivityType ()Ljava/lang/String;
+	public final fun getAwayScore ()I
+	public final fun getAwayTeam ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public final fun getClock ()Ljava/lang/String;
+	public final fun getHomeScore ()I
+	public final fun getHomeTeam ()Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public final fun getLeagueLogoKey ()Ljava/lang/String;
+	public final fun getPeriod ()Ljava/lang/String;
+	public final fun getSport ()Ljava/lang/String;
+	public final fun getStatusMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messagingpush/livenotification/LiveNotificationData$Team {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public static synthetic fun copy$default (Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messagingpush/livenotification/LiveNotificationData$Team;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLogoKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
@@ -124,7 +124,10 @@ internal object Api36LiveNotificationBuilder {
             builder.style = Notification.BigTextStyle().bigText(params.body)
         }
 
-        params.countdownUntil?.let { until ->
+        // Only start a count-down chronometer to a future instant. A stale/past target
+        // (e.g. an estimatedArrival that has already elapsed) would render as an
+        // already-expired live update and the system may suppress the notification entirely.
+        params.countdownUntil?.takeIf { it > System.currentTimeMillis() }?.let { until ->
             builder.setWhen(until)
             builder.setUsesChronometer(true)
             builder.setChronometerCountDown(true)

--- a/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/BasicNotificationBuilder.kt
@@ -70,7 +70,9 @@ internal object BasicNotificationBuilder {
             builder.setProgress(params.progressMax, safeProgress, false)
         }
 
-        params.countdownUntil?.let { until ->
+        // Only count down to a future instant; a past target renders as an already-expired
+        // chronometer and can suppress the notification (see Api36LiveNotificationBuilder).
+        params.countdownUntil?.takeIf { it > System.currentTimeMillis() }?.let { until ->
             builder.setWhen(until)
             builder.setUsesChronometer(true)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -123,8 +123,8 @@ internal class LiveNotificationHandler(
         // is terminal and bypasses the guard so a stale `end` still cancels the notification.
         val store = SDKComponent.liveNotificationStore
         val timestamp = bundle.getString(TIMESTAMP_KEY)?.toLongOrNull()
+        val lastSeen = store.lastTimestamp(activityId)
         if (!isEnd && timestamp != null) {
-            val lastSeen = store.lastTimestamp(activityId)
             if (lastSeen != null && timestamp <= lastSeen) {
                 SDKComponent.logger.debug(
                     "Dropping out-of-order/duplicate live notification for '$activityId' (timestamp $timestamp <= $lastSeen)."
@@ -137,9 +137,11 @@ internal class LiveNotificationHandler(
         // activity_id reuse where the delayed cancel would otherwise kill the new notification).
         cancelPendingDismissal(activityId)
 
-        // Record the high-water timestamp for ALL events (incl. `end`) so a later stale
-        // update — even one arriving after `end` — is dropped by the guard above.
-        if (timestamp != null) {
+        // Advance the high-water timestamp for ALL events (incl. `end`) so a later stale
+        // update — even one arriving after `end` — is dropped by the guard above. Only ever
+        // move it forward: a stale, out-of-order `end` (which bypasses the guard) must not
+        // lower the mark, or a later stale update could slip through and resurrect the activity.
+        if (timestamp != null && (lastSeen == null || timestamp > lastSeen)) {
             store.setLastTimestamp(activityId, timestamp)
         }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -24,6 +24,7 @@ import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.messagingpush.livenotification.template.TemplateRenderResult
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.core.di.SDKComponent
+import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -72,6 +73,11 @@ internal class LiveNotificationHandler(
             PushTrackingUtil.DELIVERY_ID_KEY,
             PushTrackingUtil.DELIVERY_TOKEN_KEY
         )
+
+        // Pending `end` dismissals, keyed by activity_id, so a new event for the same
+        // activity can cancel a scheduled removal (e.g. when an activity_id is reused).
+        private val dismissalHandler = Handler(Looper.getMainLooper())
+        private val pendingDismissals = ConcurrentHashMap<String, Runnable>()
     }
 
     fun handle(
@@ -102,11 +108,22 @@ internal class LiveNotificationHandler(
             return
         }
 
-        // Out-of-order / duplicate guard. Android renders FCM data directly, so unlike
-        // iOS (where APNs/ActivityKit order updates) the SDK must drop stale pushes itself.
+        // Live notifications are opt-in: only handle activity types the host app enabled.
+        val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
+        if (activityType == null || activityType !in SDKComponent.pushModuleConfig.liveNotificationTypes) {
+            SDKComponent.logger.debug(
+                "Live notification type '$activityType' is not enabled; ignoring activity '$activityId'."
+            )
+            return
+        }
+        val isEnd = event == EVENT_END
+
+        // Out-of-order / duplicate guard. Android renders FCM data directly, so unlike iOS
+        // (where APNs/ActivityKit order updates) the SDK must drop stale pushes itself. `end`
+        // is terminal and bypasses the guard so a stale `end` still cancels the notification.
         val store = SDKComponent.liveNotificationStore
         val timestamp = bundle.getString(TIMESTAMP_KEY)?.toLongOrNull()
-        if (timestamp != null) {
+        if (!isEnd && timestamp != null) {
             val lastSeen = store.lastTimestamp(activityId)
             if (lastSeen != null && timestamp <= lastSeen) {
                 SDKComponent.logger.debug(
@@ -116,25 +133,17 @@ internal class LiveNotificationHandler(
             }
         }
 
-        val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
-        val template = TemplateRegistry.find(activityType)
-        // Customer-defined types have no built-in template; they are rendered by the
-        // host app's createLiveNotification callback (checked below).
-        val isCustomType = activityType != null &&
-            activityType in SDKComponent.pushModuleConfig.liveNotificationCustomTypes
-        if (template == null && !isCustomType) {
-            SDKComponent.logger.error(
-                "Unknown live notification type '$activityType'; dropping push for activity '$activityId'."
-            )
-            return
-        }
+        // A new event for this activity supersedes any scheduled end-dismissal (handles
+        // activity_id reuse where the delayed cancel would otherwise kill the new notification).
+        cancelPendingDismissal(activityId)
 
-        // We have committed to acting on this push: record its timestamp so later,
-        // out-of-order pushes for the same activity are dropped. `end` clears it below.
-        if (event != EVENT_END && timestamp != null) {
+        // Record the high-water timestamp for ALL events (incl. `end`) so a later stale
+        // update — even one arriving after `end` — is dropped by the guard above.
+        if (timestamp != null) {
             store.setLastTimestamp(activityId, timestamp)
         }
 
+        val template = TemplateRegistry.find(activityType)
         val data = extractData(bundle)
         val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
         val effectiveSmallIcon = resolveSmallIcon(context, branding, smallIcon)
@@ -168,24 +177,26 @@ internal class LiveNotificationHandler(
         val deletePendingIntent = createDeleteIntent(context, notifId, activityId)
 
         // The host app may fully render the notification; otherwise fall back to the
-        // SDK template. Custom types have no template, so the callback is required.
+        // SDK template. Custom (template-less) types must be rendered by the callback.
         val appNotification = SDKComponent.pushModuleConfig.notificationCallback
             ?.createLiveNotification(parsedPayload, context)
         val notification = appNotification ?: result?.let {
             buildSdkNotification(context, channelId, effectiveSmallIcon, it, pendingIntent, deletePendingIntent)
         }
-        if (notification == null) {
-            SDKComponent.logger.error(
-                "No renderer for live notification type '$activityType': no built-in template and " +
-                    "createLiveNotification returned null; dropping activity '$activityId'."
-            )
-            return
+
+        when {
+            notification != null -> notificationManager.notify(activityId, notifId, notification)
+            // An `end` with no renderer still falls through to cancel the existing notification.
+            !isEnd -> {
+                SDKComponent.logger.error(
+                    "No renderer for live notification type '$activityType': no built-in template and " +
+                        "createLiveNotification returned null; dropping activity '$activityId'."
+                )
+                return
+            }
         }
 
-        notificationManager.notify(activityId, notifId, notification)
-
-        if (event == EVENT_END) {
-            store.clearTimestamp(activityId)
+        if (isEnd) {
             scheduleEndDismissal(bundle, notificationManager, activityId, notifId)
         }
     }
@@ -264,9 +275,17 @@ internal class LiveNotificationHandler(
             return
         }
         val delayMs = (dismissAtMs - System.currentTimeMillis()).coerceAtLeast(0L)
-        Handler(Looper.getMainLooper()).postDelayed({
+        val task = Runnable {
             notificationManager.cancel(activityId, notifId)
-        }, delayMs)
+            pendingDismissals.remove(activityId)
+        }
+        pendingDismissals[activityId] = task
+        dismissalHandler.postDelayed(task, delayMs)
+    }
+
+    /** Cancels a scheduled end-dismissal for [activityId], if any. */
+    private fun cancelPendingDismissal(activityId: String) {
+        pendingDismissals.remove(activityId)?.let { dismissalHandler.removeCallbacks(it) }
     }
 
     private fun createDeleteIntent(

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -1,5 +1,6 @@
 package io.customer.messagingpush
 
+import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
@@ -20,6 +21,7 @@ import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import io.customer.messagingpush.livenotification.LiveNotificationDismissReceiver
 import io.customer.messagingpush.livenotification.template.TemplateAssets
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.livenotification.template.TemplateRenderResult
 import io.customer.messagingpush.util.PushTrackingUtil
 import io.customer.sdk.core.di.SDKComponent
 import org.json.JSONArray
@@ -116,9 +118,13 @@ internal class LiveNotificationHandler(
 
         val activityType = bundle.getString(ACTIVITY_TYPE_KEY)
         val template = TemplateRegistry.find(activityType)
-        if (template == null) {
+        // Customer-defined types have no built-in template; they are rendered by the
+        // host app's createLiveNotification callback (checked below).
+        val isCustomType = activityType != null &&
+            activityType in SDKComponent.pushModuleConfig.liveNotificationCustomTypes
+        if (template == null && !isCustomType) {
             SDKComponent.logger.error(
-                "Unknown live notification template '$activityType'; dropping push for activity '$activityId'."
+                "Unknown live notification type '$activityType'; dropping push for activity '$activityId'."
             )
             return
         }
@@ -133,7 +139,7 @@ internal class LiveNotificationHandler(
         val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
         val effectiveSmallIcon = resolveSmallIcon(context, branding, smallIcon)
 
-        val result = template.render(
+        val result = template?.render(
             context = context,
             data = data,
             branding = branding,
@@ -143,7 +149,7 @@ internal class LiveNotificationHandler(
 
         val notifId = activityId.hashCode() and 0x7FFFFFFF
 
-        if (result.cancelImmediately) {
+        if (result?.cancelImmediately == true) {
             notificationManager.cancel(activityId, notifId)
             return
         }
@@ -151,19 +157,50 @@ internal class LiveNotificationHandler(
         bundle.putInt(CustomerIOPushNotificationHandler.NOTIFICATION_REQUEST_CODE, notifId)
         val parsedPayload = CustomerIOParsedPushPayload(
             extras = Bundle(bundle),
-            deepLink = result.deepLink ?: bundle.getString(CustomerIOPushNotificationHandler.DEEP_LINK_KEY),
+            deepLink = result?.deepLink ?: bundle.getString(CustomerIOPushNotificationHandler.DEEP_LINK_KEY),
             cioDeliveryId = deliveryId,
             cioDeliveryToken = deliveryToken,
-            title = result.title,
-            body = result.body,
+            title = result?.title ?: bundle.getString(CustomerIOPushNotificationHandler.TITLE_KEY).orEmpty(),
+            body = result?.body ?: bundle.getString(CustomerIOPushNotificationHandler.BODY_KEY).orEmpty(),
             activityId = activityId
         )
         val pendingIntent = createIntentForNotificationClick(context, notifId, parsedPayload)
         val deletePendingIntent = createDeleteIntent(context, notifId, activityId)
 
-        val notification = when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA -> {
-                val params = Api36LiveNotificationParams(
+        // The host app may fully render the notification; otherwise fall back to the
+        // SDK template. Custom types have no template, so the callback is required.
+        val appNotification = SDKComponent.pushModuleConfig.notificationCallback
+            ?.createLiveNotification(parsedPayload, context)
+        val notification = appNotification ?: result?.let {
+            buildSdkNotification(context, channelId, effectiveSmallIcon, it, pendingIntent, deletePendingIntent)
+        }
+        if (notification == null) {
+            SDKComponent.logger.error(
+                "No renderer for live notification type '$activityType': no built-in template and " +
+                    "createLiveNotification returned null; dropping activity '$activityId'."
+            )
+            return
+        }
+
+        notificationManager.notify(activityId, notifId, notification)
+
+        if (event == EVENT_END) {
+            store.clearTimestamp(activityId)
+            scheduleEndDismissal(bundle, notificationManager, activityId, notifId)
+        }
+    }
+
+    private fun buildSdkNotification(
+        context: Context,
+        channelId: String,
+        @DrawableRes effectiveSmallIcon: Int,
+        result: TemplateRenderResult,
+        pendingIntent: PendingIntent,
+        deletePendingIntent: PendingIntent
+    ): Notification = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA -> {
+            Api36LiveNotificationBuilder.build(
+                Api36LiveNotificationParams(
                     context = context,
                     channelId = channelId,
                     title = result.title,
@@ -184,10 +221,11 @@ internal class LiveNotificationHandler(
                     largeIcon = result.largeIcon,
                     showProgress = result.showProgress
                 )
-                Api36LiveNotificationBuilder.build(params)
-            }
-            else -> {
-                val params = BasicNotificationParams(
+            )
+        }
+        else -> {
+            BasicNotificationBuilder.build(
+                BasicNotificationParams(
                     context = context,
                     channelId = channelId,
                     title = result.title,
@@ -204,15 +242,7 @@ internal class LiveNotificationHandler(
                     largeIcon = result.largeIcon,
                     showProgress = result.showProgress
                 )
-                BasicNotificationBuilder.build(params)
-            }
-        }
-
-        notificationManager.notify(activityId, notifId, notification)
-
-        if (event == EVENT_END) {
-            store.clearTimestamp(activityId)
-            scheduleEndDismissal(bundle, notificationManager, activityId, notifId)
+            )
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -20,13 +20,15 @@ class MessagingPushModuleConfig private constructor(
     val autoTrackPushEvents: Boolean,
     val notificationCallback: CustomerIOPushNotificationCallback?,
     val pushClickBehavior: PushClickBehavior,
-    val liveNotificationBranding: LiveNotificationBranding?
+    val liveNotificationBranding: LiveNotificationBranding?,
+    val liveNotificationCustomTypes: Set<String>
 ) : CustomerIOModuleConfig {
     class Builder : CustomerIOModuleConfig.Builder<MessagingPushModuleConfig> {
         private var autoTrackPushEvents: Boolean = true
         private var notificationCallback: CustomerIOPushNotificationCallback? = null
         private var pushClickBehavior: PushClickBehavior = ACTIVITY_PREVENT_RESTART
         private var liveNotificationBranding: LiveNotificationBranding? = null
+        private var liveNotificationCustomTypes: Set<String> = emptySet()
 
         /**
          * Allows to enable/disable automatic tracking of push events. Auto tracking will generate
@@ -71,18 +73,34 @@ class MessagingPushModuleConfig private constructor(
             return this
         }
 
+        /**
+         * Registers customer-defined live-notification activity types (in
+         * addition to the SDK's built-in templates). Registered types are
+         * registered with Customer.io so the backend can push updates for them,
+         * and incoming/locally-started notifications of these types are rendered
+         * by [CustomerIOPushNotificationCallback.createLiveNotification] — there
+         * is no built-in template, so that callback must be provided.
+         *
+         * @param types reverse-DNS activity type identifiers.
+         */
+        fun registerLiveNotificationTypes(vararg types: String): Builder {
+            this.liveNotificationCustomTypes = this.liveNotificationCustomTypes + types
+            return this
+        }
+
         override fun build(): MessagingPushModuleConfig {
             return MessagingPushModuleConfig(
                 autoTrackPushEvents = autoTrackPushEvents,
                 notificationCallback = notificationCallback,
                 pushClickBehavior = pushClickBehavior,
-                liveNotificationBranding = liveNotificationBranding
+                liveNotificationBranding = liveNotificationBranding,
+                liveNotificationCustomTypes = liveNotificationCustomTypes
             )
         }
     }
 
     override fun toString(): String {
-        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding)"
+        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding, liveNotificationCustomTypes=$liveNotificationCustomTypes)"
     }
 
     companion object {

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -21,14 +21,14 @@ class MessagingPushModuleConfig private constructor(
     val notificationCallback: CustomerIOPushNotificationCallback?,
     val pushClickBehavior: PushClickBehavior,
     val liveNotificationBranding: LiveNotificationBranding?,
-    val liveNotificationCustomTypes: Set<String>
+    val liveNotificationTypes: Set<String>
 ) : CustomerIOModuleConfig {
     class Builder : CustomerIOModuleConfig.Builder<MessagingPushModuleConfig> {
         private var autoTrackPushEvents: Boolean = true
         private var notificationCallback: CustomerIOPushNotificationCallback? = null
         private var pushClickBehavior: PushClickBehavior = ACTIVITY_PREVENT_RESTART
         private var liveNotificationBranding: LiveNotificationBranding? = null
-        private var liveNotificationCustomTypes: Set<String> = emptySet()
+        private var liveNotificationTypes: Set<String> = emptySet()
 
         /**
          * Allows to enable/disable automatic tracking of push events. Auto tracking will generate
@@ -74,17 +74,20 @@ class MessagingPushModuleConfig private constructor(
         }
 
         /**
-         * Registers customer-defined live-notification activity types (in
-         * addition to the SDK's built-in templates). Registered types are
-         * registered with Customer.io so the backend can push updates for them,
-         * and incoming/locally-started notifications of these types are rendered
-         * by [CustomerIOPushNotificationCallback.createLiveNotification] — there
-         * is no built-in template, so that callback must be provided.
+         * Enables live notifications for the given activity types. **This is
+         * required to use live notifications** — until at least one type is
+         * enabled the feature is a no-op (nothing is registered with Customer.io
+         * and pushes for non-enabled types are ignored).
          *
-         * @param types reverse-DNS activity type identifiers.
+         * Pass built-in types from [io.customer.messagingpush.livenotification.LiveNotificationType]
+         * (rendered by the SDK's templates) and/or your own custom type strings
+         * (rendered by [CustomerIOPushNotificationCallback.createLiveNotification],
+         * which must be provided for custom types).
+         *
+         * @param types reverse-DNS activity type identifiers to enable.
          */
-        fun registerLiveNotificationTypes(vararg types: String): Builder {
-            this.liveNotificationCustomTypes = this.liveNotificationCustomTypes + types
+        fun setLiveNotificationTypes(vararg types: String): Builder {
+            this.liveNotificationTypes = types.toSet()
             return this
         }
 
@@ -94,13 +97,13 @@ class MessagingPushModuleConfig private constructor(
                 notificationCallback = notificationCallback,
                 pushClickBehavior = pushClickBehavior,
                 liveNotificationBranding = liveNotificationBranding,
-                liveNotificationCustomTypes = liveNotificationCustomTypes
+                liveNotificationTypes = liveNotificationTypes
             )
         }
     }
 
     override fun toString(): String {
-        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding, liveNotificationCustomTypes=$liveNotificationCustomTypes)"
+        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding, liveNotificationTypes=$liveNotificationTypes)"
     }
 
     companion object {

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -27,9 +27,12 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = MODULE_NAME
 
     override fun initialize() {
-        // Start before requesting the token so the registrar observes the resulting
-        // RegisterDeviceTokenEvent and registers the built-in live-notification types.
-        SDKComponent.liveNotificationRegistrar.start()
+        // Live notifications are opt-in: only wire up registration when the host app
+        // enabled at least one activity type. Start before requesting the token so the
+        // registrar observes the resulting RegisterDeviceTokenEvent.
+        if (moduleConfig.liveNotificationTypes.isNotEmpty()) {
+            SDKComponent.liveNotificationRegistrar.start()
+        }
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -2,13 +2,16 @@ package io.customer.messagingpush
 
 import androidx.lifecycle.Lifecycle
 import io.customer.messagingpush.di.fcmTokenProvider
+import io.customer.messagingpush.di.liveNotificationManager
 import io.customer.messagingpush.di.liveNotificationRegistrar
 import io.customer.messagingpush.di.pushTrackingUtil
+import io.customer.messagingpush.livenotification.LiveNotificationData
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 import io.customer.sdk.core.module.CustomerIOModule
+import java.util.UUID
 import kotlinx.coroutines.flow.filter
 
 class ModuleMessagingPushFCM @JvmOverloads constructor(
@@ -29,6 +32,32 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         SDKComponent.liveNotificationRegistrar.start()
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
+    }
+
+    /**
+     * Starts a live notification locally for a built-in template type. The SDK
+     * generates a unique activity id, renders the notification immediately, and
+     * registers the instance with Customer.io so the backend can push updates.
+     *
+     * @return the generated `activity_id`, used to correlate subsequent updates.
+     */
+    fun startLiveNotification(data: LiveNotificationData): String =
+        startLiveNotification(data.activityType, data.fields())
+
+    /**
+     * Starts a live notification locally for a customer-defined [activityType]
+     * (one registered via [MessagingPushModuleConfig.Builder.registerLiveNotificationTypes]).
+     * Custom types have no built-in template, so a
+     * [io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback.createLiveNotification]
+     * must render them.
+     *
+     * @param data flattened fields delivered to the renderer.
+     * @return the generated `activity_id`.
+     */
+    fun startLiveNotification(activityType: String, data: Map<String, Any?>): String {
+        val activityId = UUID.randomUUID().toString()
+        SDKComponent.liveNotificationManager.start(activityId, activityType, data)
+        return activityId
     }
 
     private fun subscribeToLifecycleEvents() {

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
@@ -1,5 +1,6 @@
 package io.customer.messagingpush.data.communication
 
+import android.app.Notification
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
@@ -42,4 +43,28 @@ interface CustomerIOPushNotificationCallback {
         payload: CustomerIOParsedPushPayload,
         builder: NotificationCompat.Builder
     ) = Unit
+
+    /**
+     * Called for live notifications to let the host app render the notification
+     * itself. Return a fully-built [Notification] to take complete control of
+     * its appearance and intents, or null to use the SDK's built-in template.
+     *
+     * Required for customer-defined activity types (registered via
+     * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.registerLiveNotificationTypes]),
+     * which have no built-in template; if this returns null for such a type, the
+     * notification is dropped.
+     *
+     * The SDK still owns the posting lifecycle: it posts the returned
+     * notification keyed by `activity_id` (so later updates replace it) and
+     * cancels it on `end`. It does NOT modify the returned notification, so any
+     * dismissal reporting is the app's responsibility.
+     *
+     * @param payload parsed live-notification payload (activity id + flattened
+     * fields in [CustomerIOParsedPushPayload.extras]).
+     * @param context reference to application context.
+     */
+    fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context
+    ): Notification? = null
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -96,8 +96,7 @@ internal val SDKComponent.liveNotificationManager: LiveNotificationManager
     get() = singleton<LiveNotificationManager> {
         LiveNotificationManager(
             lifecycleClient = liveNotificationLifecycleClient,
-            registrar = liveNotificationRegistrar,
-            fcmTokenProvider = android().fcmTokenProvider
+            registrar = liveNotificationRegistrar
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -12,6 +12,7 @@ import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.PushDeliveryTrackerImpl
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClient
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl
+import io.customer.messagingpush.livenotification.LiveNotificationManager
 import io.customer.messagingpush.livenotification.LiveNotificationRegistrar
 import io.customer.messagingpush.livenotification.LiveNotificationStore
 import io.customer.messagingpush.logger.PushNotificationLogger
@@ -89,6 +90,15 @@ internal val SDKComponent.liveNotificationLifecycleClient: LiveNotificationLifec
 internal val SDKComponent.liveNotificationRegistrar: LiveNotificationRegistrar
     get() = singleton<LiveNotificationRegistrar> {
         LiveNotificationRegistrar(liveNotificationLifecycleClient, liveNotificationStore)
+    }
+
+internal val SDKComponent.liveNotificationManager: LiveNotificationManager
+    get() = singleton<LiveNotificationManager> {
+        LiveNotificationManager(
+            lifecycleClient = liveNotificationLifecycleClient,
+            registrar = liveNotificationRegistrar,
+            fcmTokenProvider = android().fcmTokenProvider
+        )
     }
 
 internal val SDKComponent.pushDeliveryTracker: PushDeliveryTracker

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
@@ -1,0 +1,151 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import org.json.JSONObject
+
+/**
+ * Typed payload for starting a built-in live notification locally via
+ * `ModuleMessagingPushFCM.startLiveNotification`. Each subtype knows its
+ * [activityType] and flattens itself into the envelope fields the templates
+ * read (the same flattened shape the backend delivers).
+ *
+ * For customer-defined activity types, use the `Map` overload of
+ * `startLiveNotification` instead.
+ */
+sealed interface LiveNotificationData {
+    val activityType: String
+
+    /** Flattened template fields; null values are omitted by the caller. */
+    fun fields(): Map<String, Any?>
+
+    data class DeliveryTracking(
+        val orderId: String,
+        val statusMessage: String,
+        val recipientName: String? = null,
+        val driverName: String? = null,
+        val statusImageKey: String? = null,
+        val stepCurrent: Int? = null,
+        val stepTotal: Int? = null,
+        val estimatedArrival: Long? = null
+    ) : LiveNotificationData {
+        override val activityType = TemplateRegistry.DELIVERY_TRACKING
+        override fun fields() = mapOf(
+            "orderId" to orderId,
+            "statusMessage" to statusMessage,
+            "recipientName" to recipientName,
+            "driverName" to driverName,
+            "statusImageKey" to statusImageKey,
+            "stepCurrent" to stepCurrent,
+            "stepTotal" to stepTotal,
+            "estimatedArrival" to estimatedArrival
+        )
+    }
+
+    data class FlightStatus(
+        val flightNumber: String,
+        val origin: Airport,
+        val destination: Airport,
+        val statusMessage: String,
+        val gate: String? = null,
+        val terminal: String? = null,
+        val scheduledDeparture: Long? = null,
+        val estimatedArrival: Long? = null,
+        val progressFraction: Double? = null,
+        val delayMinutes: Int? = null
+    ) : LiveNotificationData {
+        override val activityType = TemplateRegistry.FLIGHT_STATUS
+        override fun fields() = mapOf(
+            "flightNumber" to flightNumber,
+            "origin" to origin.toJson(),
+            "destination" to destination.toJson(),
+            "statusMessage" to statusMessage,
+            "gate" to gate,
+            "terminal" to terminal,
+            "scheduledDeparture" to scheduledDeparture,
+            "estimatedArrival" to estimatedArrival,
+            "progressFraction" to progressFraction,
+            "delayMinutes" to delayMinutes
+        )
+    }
+
+    data class LiveScore(
+        val homeTeam: Team,
+        val awayTeam: Team,
+        val period: String,
+        val homeScore: Int = 0,
+        val awayScore: Int = 0,
+        val clock: String? = null,
+        val statusMessage: String? = null,
+        val sport: String? = null,
+        val leagueLogoKey: String? = null
+    ) : LiveNotificationData {
+        override val activityType = TemplateRegistry.LIVE_SCORE
+        override fun fields() = mapOf(
+            "homeTeam" to homeTeam.toJson(),
+            "awayTeam" to awayTeam.toJson(),
+            "period" to period,
+            "homeScore" to homeScore,
+            "awayScore" to awayScore,
+            "clock" to clock,
+            "statusMessage" to statusMessage,
+            "sport" to sport,
+            "leagueLogoKey" to leagueLogoKey
+        )
+    }
+
+    data class CountdownTimer(
+        val title: String,
+        val targetDate: Long,
+        val statusMessage: String,
+        val expiredMessage: String? = null,
+        val heroImageKey: String? = null
+    ) : LiveNotificationData {
+        override val activityType = TemplateRegistry.COUNTDOWN_TIMER
+        override fun fields() = mapOf(
+            "title" to title,
+            "targetDate" to targetDate,
+            "statusMessage" to statusMessage,
+            "expiredMessage" to expiredMessage,
+            "heroImageKey" to heroImageKey
+        )
+    }
+
+    data class AuctionBid(
+        val itemTitle: String,
+        val currentBid: String,
+        val bidCount: Int,
+        val statusMessage: String,
+        val isUserHighBidder: Boolean,
+        val endTime: Long? = null,
+        val userBidAmount: String? = null,
+        val itemImageKey: String? = null,
+        val currencySymbol: String? = null
+    ) : LiveNotificationData {
+        override val activityType = TemplateRegistry.AUCTION_BID
+        override fun fields() = mapOf(
+            "itemTitle" to itemTitle,
+            "currentBid" to currentBid,
+            "bidCount" to bidCount,
+            "statusMessage" to statusMessage,
+            "isUserHighBidder" to isUserHighBidder,
+            "endTime" to endTime,
+            "userBidAmount" to userBidAmount,
+            "itemImageKey" to itemImageKey,
+            "currencySymbol" to currencySymbol
+        )
+    }
+
+    /** Airport endpoint for [FlightStatus]. */
+    data class Airport(val code: String, val city: String? = null) {
+        internal fun toJson(): JSONObject = JSONObject().put("code", code).apply {
+            city?.let { put("city", it) }
+        }
+    }
+
+    /** Team for [LiveScore]. */
+    data class Team(val name: String, val logoKey: String? = null) {
+        internal fun toJson(): JSONObject = JSONObject().put("name", name).apply {
+            logoKey?.let { put("logoKey", it) }
+        }
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
@@ -1,13 +1,20 @@
 package io.customer.messagingpush.livenotification
 
-import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.livenotification.template.AirportFields
+import io.customer.messagingpush.livenotification.template.AuctionBidFields
+import io.customer.messagingpush.livenotification.template.CountdownTimerFields
+import io.customer.messagingpush.livenotification.template.DeliveryTrackingFields
+import io.customer.messagingpush.livenotification.template.FlightStatusFields
+import io.customer.messagingpush.livenotification.template.LiveScoreFields
+import io.customer.messagingpush.livenotification.template.TeamFields
 import org.json.JSONObject
 
 /**
  * Typed payload for starting a built-in live notification locally via
  * `ModuleMessagingPushFCM.startLiveNotification`. Each subtype knows its
  * [activityType] and flattens itself into the envelope fields the templates
- * read (the same flattened shape the backend delivers).
+ * read (the same flattened shape the backend delivers). Field names come from
+ * the shared `*Fields` constants so local-start and push-render stay in sync.
  *
  * For customer-defined activity types, use the `Map` overload of
  * `startLiveNotification` instead.
@@ -28,16 +35,16 @@ sealed interface LiveNotificationData {
         val stepTotal: Int? = null,
         val estimatedArrival: Long? = null
     ) : LiveNotificationData {
-        override val activityType = TemplateRegistry.DELIVERY_TRACKING
+        override val activityType = LiveNotificationType.DELIVERY_TRACKING
         override fun fields() = mapOf(
-            "orderId" to orderId,
-            "statusMessage" to statusMessage,
-            "recipientName" to recipientName,
-            "driverName" to driverName,
-            "statusImageKey" to statusImageKey,
-            "stepCurrent" to stepCurrent,
-            "stepTotal" to stepTotal,
-            "estimatedArrival" to estimatedArrival
+            DeliveryTrackingFields.ORDER_ID to orderId,
+            DeliveryTrackingFields.STATUS_MESSAGE to statusMessage,
+            DeliveryTrackingFields.RECIPIENT_NAME to recipientName,
+            DeliveryTrackingFields.DRIVER_NAME to driverName,
+            DeliveryTrackingFields.STATUS_IMAGE_KEY to statusImageKey,
+            DeliveryTrackingFields.STEP_CURRENT to stepCurrent,
+            DeliveryTrackingFields.STEP_TOTAL to stepTotal,
+            DeliveryTrackingFields.ESTIMATED_ARRIVAL to estimatedArrival
         )
     }
 
@@ -53,18 +60,18 @@ sealed interface LiveNotificationData {
         val progressFraction: Double? = null,
         val delayMinutes: Int? = null
     ) : LiveNotificationData {
-        override val activityType = TemplateRegistry.FLIGHT_STATUS
+        override val activityType = LiveNotificationType.FLIGHT_STATUS
         override fun fields() = mapOf(
-            "flightNumber" to flightNumber,
-            "origin" to origin.toJson(),
-            "destination" to destination.toJson(),
-            "statusMessage" to statusMessage,
-            "gate" to gate,
-            "terminal" to terminal,
-            "scheduledDeparture" to scheduledDeparture,
-            "estimatedArrival" to estimatedArrival,
-            "progressFraction" to progressFraction,
-            "delayMinutes" to delayMinutes
+            FlightStatusFields.FLIGHT_NUMBER to flightNumber,
+            FlightStatusFields.ORIGIN to origin.toJson(),
+            FlightStatusFields.DESTINATION to destination.toJson(),
+            FlightStatusFields.STATUS_MESSAGE to statusMessage,
+            FlightStatusFields.GATE to gate,
+            FlightStatusFields.TERMINAL to terminal,
+            FlightStatusFields.SCHEDULED_DEPARTURE to scheduledDeparture,
+            FlightStatusFields.ESTIMATED_ARRIVAL to estimatedArrival,
+            FlightStatusFields.PROGRESS_FRACTION to progressFraction,
+            FlightStatusFields.DELAY_MINUTES to delayMinutes
         )
     }
 
@@ -79,17 +86,17 @@ sealed interface LiveNotificationData {
         val sport: String? = null,
         val leagueLogoKey: String? = null
     ) : LiveNotificationData {
-        override val activityType = TemplateRegistry.LIVE_SCORE
+        override val activityType = LiveNotificationType.LIVE_SCORE
         override fun fields() = mapOf(
-            "homeTeam" to homeTeam.toJson(),
-            "awayTeam" to awayTeam.toJson(),
-            "period" to period,
-            "homeScore" to homeScore,
-            "awayScore" to awayScore,
-            "clock" to clock,
-            "statusMessage" to statusMessage,
-            "sport" to sport,
-            "leagueLogoKey" to leagueLogoKey
+            LiveScoreFields.HOME_TEAM to homeTeam.toJson(),
+            LiveScoreFields.AWAY_TEAM to awayTeam.toJson(),
+            LiveScoreFields.PERIOD to period,
+            LiveScoreFields.HOME_SCORE to homeScore,
+            LiveScoreFields.AWAY_SCORE to awayScore,
+            LiveScoreFields.CLOCK to clock,
+            LiveScoreFields.STATUS_MESSAGE to statusMessage,
+            LiveScoreFields.SPORT to sport,
+            LiveScoreFields.LEAGUE_LOGO_KEY to leagueLogoKey
         )
     }
 
@@ -100,13 +107,13 @@ sealed interface LiveNotificationData {
         val expiredMessage: String? = null,
         val heroImageKey: String? = null
     ) : LiveNotificationData {
-        override val activityType = TemplateRegistry.COUNTDOWN_TIMER
+        override val activityType = LiveNotificationType.COUNTDOWN_TIMER
         override fun fields() = mapOf(
-            "title" to title,
-            "targetDate" to targetDate,
-            "statusMessage" to statusMessage,
-            "expiredMessage" to expiredMessage,
-            "heroImageKey" to heroImageKey
+            CountdownTimerFields.TITLE to title,
+            CountdownTimerFields.TARGET_DATE to targetDate,
+            CountdownTimerFields.STATUS_MESSAGE to statusMessage,
+            CountdownTimerFields.EXPIRED_MESSAGE to expiredMessage,
+            CountdownTimerFields.HERO_IMAGE_KEY to heroImageKey
         )
     }
 
@@ -121,31 +128,31 @@ sealed interface LiveNotificationData {
         val itemImageKey: String? = null,
         val currencySymbol: String? = null
     ) : LiveNotificationData {
-        override val activityType = TemplateRegistry.AUCTION_BID
+        override val activityType = LiveNotificationType.AUCTION_BID
         override fun fields() = mapOf(
-            "itemTitle" to itemTitle,
-            "currentBid" to currentBid,
-            "bidCount" to bidCount,
-            "statusMessage" to statusMessage,
-            "isUserHighBidder" to isUserHighBidder,
-            "endTime" to endTime,
-            "userBidAmount" to userBidAmount,
-            "itemImageKey" to itemImageKey,
-            "currencySymbol" to currencySymbol
+            AuctionBidFields.ITEM_TITLE to itemTitle,
+            AuctionBidFields.CURRENT_BID to currentBid,
+            AuctionBidFields.BID_COUNT to bidCount,
+            AuctionBidFields.STATUS_MESSAGE to statusMessage,
+            AuctionBidFields.IS_USER_HIGH_BIDDER to isUserHighBidder,
+            AuctionBidFields.END_TIME to endTime,
+            AuctionBidFields.USER_BID_AMOUNT to userBidAmount,
+            AuctionBidFields.ITEM_IMAGE_KEY to itemImageKey,
+            AuctionBidFields.CURRENCY_SYMBOL to currencySymbol
         )
     }
 
     /** Airport endpoint for [FlightStatus]. */
     data class Airport(val code: String, val city: String? = null) {
-        internal fun toJson(): JSONObject = JSONObject().put("code", code).apply {
-            city?.let { put("city", it) }
+        internal fun toJson(): JSONObject = JSONObject().put(AirportFields.CODE, code).apply {
+            city?.let { put(AirportFields.CITY, it) }
         }
     }
 
     /** Team for [LiveScore]. */
     data class Team(val name: String, val logoKey: String? = null) {
-        internal fun toJson(): JSONObject = JSONObject().put("name", name).apply {
-            logoKey?.let { put("logoKey", it) }
+        internal fun toJson(): JSONObject = JSONObject().put(TeamFields.NAME, name).apply {
+            logoKey?.let { put(TeamFields.LOGO_KEY, it) }
         }
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -21,6 +21,12 @@ import org.json.JSONObject
 internal interface LiveNotificationLifecycleClient {
     suspend fun registerForActivityType(activityType: String, token: String, userId: String): Result<Unit>
 
+    /**
+     * Registers a specific locally-started activity instance so the backend can
+     * push updates to it.
+     */
+    suspend fun registerInstance(activityId: String, activityType: String, token: String, userId: String): Result<Unit>
+
     suspend fun reportDismissed(activityId: String): Result<Unit>
 }
 
@@ -42,6 +48,29 @@ internal class LiveNotificationLifecycleClientImpl(
         return send(
             HttpRequestParams(
                 path = "/v1/live_activities/registration/$activityType",
+                method = HttpMethod.PUT,
+                headers = JSON_HEADERS,
+                body = body.toString()
+            )
+        )
+    }
+
+    override suspend fun registerInstance(
+        activityId: String,
+        activityType: String,
+        token: String,
+        userId: String
+    ): Result<Unit> {
+        val body = JSONObject().apply {
+            put("token", token)
+            put("activity_type", activityType)
+            put("os", OS_ANDROID)
+            put("transport", TRANSPORT_FCM)
+            put("userId", userId)
+        }
+        return send(
+            HttpRequestParams(
+                path = "/v1/live_activities/$activityId/push_token",
                 method = HttpMethod.PUT,
                 headers = JSON_HEADERS,
                 body = body.toString()

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -1,0 +1,96 @@
+package io.customer.messagingpush.livenotification
+
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Bundle
+import androidx.annotation.ColorInt
+import androidx.annotation.DrawableRes
+import io.customer.messagingpush.LiveNotificationHandler
+import io.customer.messagingpush.extensions.getColorOrNull
+import io.customer.messagingpush.extensions.getMetaDataResource
+import io.customer.messagingpush.provider.DeviceTokenProvider
+import io.customer.messagingpush.util.NotificationChannelCreator
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.extensions.applicationMetaData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Starts a live notification locally on behalf of the host app: renders it
+ * immediately through the normal templating path, then registers the instance
+ * with the backend so Customer.io can push subsequent updates to it.
+ *
+ * Rendering goes straight through [LiveNotificationHandler] (not the FCM
+ * delivery path), so no delivered/opened metric is fabricated for a
+ * locally-started notification.
+ */
+internal class LiveNotificationManager(
+    private val lifecycleClient: LiveNotificationLifecycleClient,
+    private val registrar: LiveNotificationRegistrar,
+    private val fcmTokenProvider: DeviceTokenProvider,
+    private val notificationChannelCreator: NotificationChannelCreator = NotificationChannelCreator()
+) {
+    private val context: Context
+        get() = SDKComponent.android().applicationContext
+
+    fun start(activityId: String, activityType: String, fields: Map<String, Any?>) {
+        renderLocally(buildBundle(activityId, activityType, fields))
+        registerInstance(activityId, activityType)
+    }
+
+    private fun buildBundle(activityId: String, activityType: String, fields: Map<String, Any?>): Bundle =
+        Bundle().apply {
+            putString(LiveNotificationHandler.ACTIVITY_ID_KEY, activityId)
+            putString(LiveNotificationHandler.EVENT_KEY, EVENT_START)
+            putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
+            putString(LiveNotificationHandler.TIMESTAMP_KEY, System.currentTimeMillis().toString())
+            for ((key, value) in fields) {
+                if (value != null) putString(key, value.toString())
+            }
+        }
+
+    private fun renderLocally(bundle: Bundle) {
+        val ctx = context
+        val appMetaData = ctx.applicationMetaData()
+        val applicationName = ctx.applicationInfo.loadLabel(ctx.packageManager).toString()
+
+        @DrawableRes
+        val smallIcon = appMetaData?.getMetaDataResource(FCM_DEFAULT_ICON) ?: ctx.applicationInfo.icon
+
+        @ColorInt
+        val tintColor = appMetaData?.getMetaDataResource(FCM_DEFAULT_COLOR)?.let { ctx.getColorOrNull(it) }
+
+        val notificationManager = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = notificationChannelCreator.createLiveNotificationChannelIfNeededAndReturnChannelId(
+            context = ctx,
+            applicationName = applicationName,
+            appMetaData = appMetaData,
+            notificationManager = notificationManager
+        )
+
+        LiveNotificationHandler(bundle).handle(
+            context = ctx,
+            deliveryId = "",
+            deliveryToken = "",
+            smallIcon = smallIcon,
+            tintColor = tintColor,
+            channelId = channelId,
+            notificationManager = notificationManager
+        )
+    }
+
+    private fun registerInstance(activityId: String, activityType: String) {
+        fcmTokenProvider.getCurrentToken { token ->
+            if (token == null) return@getCurrentToken
+            CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
+                lifecycleClient.registerInstance(activityId, activityType, token, registrar.currentUserId())
+            }
+        }
+    }
+
+    companion object {
+        private const val EVENT_START = "start"
+        private const val FCM_DEFAULT_ICON = "com.google.firebase.messaging.default_notification_icon"
+        private const val FCM_DEFAULT_COLOR = "com.google.firebase.messaging.default_notification_color"
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -8,7 +8,6 @@ import androidx.annotation.DrawableRes
 import io.customer.messagingpush.LiveNotificationHandler
 import io.customer.messagingpush.extensions.getColorOrNull
 import io.customer.messagingpush.extensions.getMetaDataResource
-import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
@@ -27,7 +26,6 @@ import kotlinx.coroutines.launch
 internal class LiveNotificationManager(
     private val lifecycleClient: LiveNotificationLifecycleClient,
     private val registrar: LiveNotificationRegistrar,
-    private val fcmTokenProvider: DeviceTokenProvider,
     private val notificationChannelCreator: NotificationChannelCreator = NotificationChannelCreator()
 ) {
     private val context: Context
@@ -80,11 +78,17 @@ internal class LiveNotificationManager(
     }
 
     private fun registerInstance(activityId: String, activityType: String) {
-        fcmTokenProvider.getCurrentToken { token ->
-            if (token == null) return@getCurrentToken
-            CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
-                lifecycleClient.registerInstance(activityId, activityType, token, registrar.currentUserId())
-            }
+        // Reuse the token the registrar already tracks (fetched once in ModuleMessagingPushFCM)
+        // instead of requesting it again.
+        val token = registrar.currentToken()
+        if (token == null) {
+            SDKComponent.logger.debug(
+                "No FCM token available yet; skipping instance registration for live notification '$activityId'."
+            )
+            return
+        }
+        CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
+            lifecycleClient.registerInstance(activityId, activityType, token, registrar.currentUserId())
         }
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -38,13 +38,15 @@ internal class LiveNotificationManager(
 
     private fun buildBundle(activityId: String, activityType: String, fields: Map<String, Any?>): Bundle =
         Bundle().apply {
+            // Write template fields first so the reserved envelope keys below always
+            // win if a field key collides with one (e.g. a field named "timestamp").
+            for ((key, value) in fields) {
+                if (value != null) putString(key, value.toString())
+            }
             putString(LiveNotificationHandler.ACTIVITY_ID_KEY, activityId)
             putString(LiveNotificationHandler.EVENT_KEY, EVENT_START)
             putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
             putString(LiveNotificationHandler.TIMESTAMP_KEY, System.currentTimeMillis().toString())
-            for ((key, value) in fields) {
-                if (value != null) putString(key, value.toString())
-            }
         }
 
     private fun renderLocally(bundle: Bundle) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -1,17 +1,15 @@
 package io.customer.messagingpush.livenotification
 
 import io.customer.messagingpush.di.pushModuleConfig
-import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 
 /**
- * Registers the device's FCM token with the backend for each live-notification
- * activity type the SDK knows about — the built-in templates plus any
- * customer-defined types registered via
- * `MessagingPushModuleConfig.registerLiveNotificationTypes`. This is the
- * Android analogue of iOS push-to-start registration.
+ * Registers the device's FCM token with the backend for the live-notification
+ * activity types the host app enabled via
+ * `MessagingPushModuleConfig.setLiveNotificationTypes` (the Android analogue of
+ * iOS push-to-start registration). No types enabled ⇒ nothing is registered.
  *
  * Registration is (re)attempted whenever the device token rotates
  * ([Event.RegisterDeviceTokenEvent]) or the user changes
@@ -30,11 +28,14 @@ internal class LiveNotificationRegistrar(
     @Volatile
     private var userId: String = ""
 
+    /** The current FCM token, or null if not yet received. */
+    fun currentToken(): String? = token
+
     /** The current resolved user identity (identified userId, else anonymousId). */
     fun currentUserId(): String = userId
 
-    private val registeredTypes: Set<String>
-        get() = TemplateRegistry.builtInTypes.toSet() + SDKComponent.pushModuleConfig.liveNotificationCustomTypes
+    private val enabledTypes: Set<String>
+        get() = SDKComponent.pushModuleConfig.liveNotificationTypes
 
     fun start() {
         // Drop dedup entries for activities that ended long ago without an explicit `end`.
@@ -60,7 +61,7 @@ internal class LiveNotificationRegistrar(
     private suspend fun registerAll() {
         val currentToken = token ?: return
         val signature = "$currentToken|$userId"
-        for (activityType in registeredTypes) {
+        for (activityType in enabledTypes) {
             if (store.registrationSignature(activityType) == signature) continue
             val result = client.registerForActivityType(activityType, currentToken, userId)
             if (result.isSuccess) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -1,14 +1,17 @@
 package io.customer.messagingpush.livenotification
 
+import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 
 /**
- * Registers the device's FCM token with the backend for each built-in
- * live-notification template type — the Android analogue of iOS push-to-start
- * registration — and keeps it current.
+ * Registers the device's FCM token with the backend for each live-notification
+ * activity type the SDK knows about — the built-in templates plus any
+ * customer-defined types registered via
+ * `MessagingPushModuleConfig.registerLiveNotificationTypes`. This is the
+ * Android analogue of iOS push-to-start registration.
  *
  * Registration is (re)attempted whenever the device token rotates
  * ([Event.RegisterDeviceTokenEvent]) or the user changes
@@ -26,6 +29,12 @@ internal class LiveNotificationRegistrar(
 
     @Volatile
     private var userId: String = ""
+
+    /** The current resolved user identity (identified userId, else anonymousId). */
+    fun currentUserId(): String = userId
+
+    private val registeredTypes: Set<String>
+        get() = TemplateRegistry.builtInTypes.toSet() + SDKComponent.pushModuleConfig.liveNotificationCustomTypes
 
     fun start() {
         // Drop dedup entries for activities that ended long ago without an explicit `end`.
@@ -51,7 +60,7 @@ internal class LiveNotificationRegistrar(
     private suspend fun registerAll() {
         val currentToken = token ?: return
         val signature = "$currentToken|$userId"
-        for (activityType in TemplateRegistry.builtInTypes) {
+        for (activityType in registeredTypes) {
             if (store.registrationSignature(activityType) == signature) continue
             val result = client.registerForActivityType(activityType, currentToken, userId)
             if (result.isSuccess) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationType.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationType.kt
@@ -1,0 +1,19 @@
+package io.customer.messagingpush.livenotification
+
+/**
+ * Built-in live-notification activity type identifiers (reverse-DNS, matching
+ * the iOS Live Activity identifiers).
+ *
+ * Pass these — and/or your own custom type strings — to
+ * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.setLiveNotificationTypes]
+ * to enable live notifications. The feature is a no-op until at least one type
+ * is enabled: nothing is registered with the backend and pushes for
+ * non-enabled types are ignored.
+ */
+object LiveNotificationType {
+    const val DELIVERY_TRACKING = "io.customer.liveactivities.deliverytracking"
+    const val FLIGHT_STATUS = "io.customer.liveactivities.flightstatus"
+    const val LIVE_SCORE = "io.customer.liveactivities.livescore"
+    const val COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer"
+    const val AUCTION_BID = "io.customer.liveactivities.auctionbid"
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/AuctionBidTemplate.kt
@@ -29,15 +29,15 @@ internal object AuctionBidTemplate : LiveNotificationTemplate {
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val itemTitle = data.optString("itemTitle")
-        val itemImageKey = data.optStringNonEmpty("itemImageKey")
-        val currencySymbol = data.optStringNonEmpty("currencySymbol") ?: "$"
-        val currentBid = data.optString("currentBid")
-        val bidCount = data.optInt("bidCount", 0)
-        val endTime = data.optLong("endTime").takeIf { it > 0 }
-        val statusMessage = data.optString("statusMessage")
-        val isUserHighBidder = data.optBoolean("isUserHighBidder", false)
-        val userBidAmount = data.optStringNonEmpty("userBidAmount")
+        val itemTitle = data.optString(AuctionBidFields.ITEM_TITLE)
+        val itemImageKey = data.optStringNonEmpty(AuctionBidFields.ITEM_IMAGE_KEY)
+        val currencySymbol = data.optStringNonEmpty(AuctionBidFields.CURRENCY_SYMBOL) ?: "$"
+        val currentBid = data.optString(AuctionBidFields.CURRENT_BID)
+        val bidCount = data.optInt(AuctionBidFields.BID_COUNT, 0)
+        val endTime = data.optLong(AuctionBidFields.END_TIME).takeIf { it > 0 }
+        val statusMessage = data.optString(AuctionBidFields.STATUS_MESSAGE)
+        val isUserHighBidder = data.optBoolean(AuctionBidFields.IS_USER_HIGH_BIDDER, false)
+        val userBidAmount = data.optStringNonEmpty(AuctionBidFields.USER_BID_AMOUNT)
 
         val body = "$statusMessage · $currencySymbol$currentBid"
         val subText = userBidAmount

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/CountdownTimerTemplate.kt
@@ -23,11 +23,11 @@ internal object CountdownTimerTemplate : LiveNotificationTemplate {
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val title = data.optString("title")
-        val heroImageKey = data.optStringNonEmpty("heroImageKey")
-        val targetDate = data.optLong("targetDate").takeIf { it > 0 }
-        val statusMessage = data.optString("statusMessage")
-        val expiredMessage = data.optStringNonEmpty("expiredMessage")
+        val title = data.optString(CountdownTimerFields.TITLE)
+        val heroImageKey = data.optStringNonEmpty(CountdownTimerFields.HERO_IMAGE_KEY)
+        val targetDate = data.optLong(CountdownTimerFields.TARGET_DATE).takeIf { it > 0 }
+        val statusMessage = data.optString(CountdownTimerFields.STATUS_MESSAGE)
+        val expiredMessage = data.optStringNonEmpty(CountdownTimerFields.EXPIRED_MESSAGE)
 
         val now = System.currentTimeMillis()
         val isPostTarget = targetDate != null && now >= targetDate

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/DeliveryTrackingTemplate.kt
@@ -22,14 +22,14 @@ internal object DeliveryTrackingTemplate : LiveNotificationTemplate {
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val orderId = data.optString("orderId")
-        val recipientName = data.optStringNonEmpty("recipientName")
-        val statusMessage = data.optString("statusMessage")
-        val statusImageKey = data.optStringNonEmpty("statusImageKey")
-        val stepCurrent = data.optInt("stepCurrent", 0)
-        val stepTotal = data.optInt("stepTotal", 1).coerceAtLeast(1)
-        val estimatedArrival = data.optLong("estimatedArrival").takeIf { it > 0 }
-        val driverName = data.optStringNonEmpty("driverName")
+        val orderId = data.optString(DeliveryTrackingFields.ORDER_ID)
+        val recipientName = data.optStringNonEmpty(DeliveryTrackingFields.RECIPIENT_NAME)
+        val statusMessage = data.optString(DeliveryTrackingFields.STATUS_MESSAGE)
+        val statusImageKey = data.optStringNonEmpty(DeliveryTrackingFields.STATUS_IMAGE_KEY)
+        val stepCurrent = data.optInt(DeliveryTrackingFields.STEP_CURRENT, 0)
+        val stepTotal = data.optInt(DeliveryTrackingFields.STEP_TOTAL, 1).coerceAtLeast(1)
+        val estimatedArrival = data.optLong(DeliveryTrackingFields.ESTIMATED_ARRIVAL).takeIf { it > 0 }
+        val driverName = data.optStringNonEmpty(DeliveryTrackingFields.DRIVER_NAME)
 
         val title = recipientName?.let { "Delivery for $it" } ?: "Order #$orderId"
         val subText = when {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/FlightStatusTemplate.kt
@@ -25,21 +25,21 @@ internal object FlightStatusTemplate : LiveNotificationTemplate {
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val flightNumber = data.optString("flightNumber")
-        val origin = data.optJSONObject("origin")
-        val destination = data.optJSONObject("destination")
-        val originCode = origin?.optString("code").orEmpty()
-        val destinationCode = destination?.optString("code").orEmpty()
+        val flightNumber = data.optString(FlightStatusFields.FLIGHT_NUMBER)
+        val origin = data.optJSONObject(FlightStatusFields.ORIGIN)
+        val destination = data.optJSONObject(FlightStatusFields.DESTINATION)
+        val originCode = origin?.optString(AirportFields.CODE).orEmpty()
+        val destinationCode = destination?.optString(AirportFields.CODE).orEmpty()
 
-        val statusMessage = data.optString("statusMessage")
-        val gate = data.optStringNonEmpty("gate")
-        val terminal = data.optStringNonEmpty("terminal")
-        val scheduledDeparture = data.optLong("scheduledDeparture").takeIf { it > 0 }
-        val estimatedArrival = data.optLong("estimatedArrival").takeIf { it > 0 }
+        val statusMessage = data.optString(FlightStatusFields.STATUS_MESSAGE)
+        val gate = data.optStringNonEmpty(FlightStatusFields.GATE)
+        val terminal = data.optStringNonEmpty(FlightStatusFields.TERMINAL)
+        val scheduledDeparture = data.optLong(FlightStatusFields.SCHEDULED_DEPARTURE).takeIf { it > 0 }
+        val estimatedArrival = data.optLong(FlightStatusFields.ESTIMATED_ARRIVAL).takeIf { it > 0 }
         val progressFractionRaw =
-            if (data.has("progressFraction")) data.optDouble("progressFraction") else Double.NaN
+            if (data.has(FlightStatusFields.PROGRESS_FRACTION)) data.optDouble(FlightStatusFields.PROGRESS_FRACTION) else Double.NaN
         val progressFraction = progressFractionRaw.takeIf { !it.isNaN() }
-        val delayMinutes = data.optInt("delayMinutes", 0).takeIf { it > 0 }
+        val delayMinutes = data.optInt(FlightStatusFields.DELAY_MINUTES, 0).takeIf { it > 0 }
 
         val title = "$flightNumber · $originCode → $destinationCode"
         val subText = "Gate ${gate ?: "TBA"} · Terminal ${terminal ?: "TBA"}"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationFields.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationFields.kt
@@ -1,0 +1,74 @@
+package io.customer.messagingpush.livenotification.template
+
+/**
+ * Single source of truth for live-notification field names. Referenced by both
+ * the push-render path (each `*Template.render` reading the flattened payload)
+ * and the local-start path (`LiveNotificationData.fields()`), so the two can't
+ * drift apart.
+ */
+internal object DeliveryTrackingFields {
+    const val ORDER_ID = "orderId"
+    const val RECIPIENT_NAME = "recipientName"
+    const val STATUS_MESSAGE = "statusMessage"
+    const val STATUS_IMAGE_KEY = "statusImageKey"
+    const val STEP_CURRENT = "stepCurrent"
+    const val STEP_TOTAL = "stepTotal"
+    const val ESTIMATED_ARRIVAL = "estimatedArrival"
+    const val DRIVER_NAME = "driverName"
+}
+
+internal object FlightStatusFields {
+    const val FLIGHT_NUMBER = "flightNumber"
+    const val ORIGIN = "origin"
+    const val DESTINATION = "destination"
+    const val STATUS_MESSAGE = "statusMessage"
+    const val GATE = "gate"
+    const val TERMINAL = "terminal"
+    const val SCHEDULED_DEPARTURE = "scheduledDeparture"
+    const val ESTIMATED_ARRIVAL = "estimatedArrival"
+    const val PROGRESS_FRACTION = "progressFraction"
+    const val DELAY_MINUTES = "delayMinutes"
+}
+
+internal object LiveScoreFields {
+    const val HOME_TEAM = "homeTeam"
+    const val AWAY_TEAM = "awayTeam"
+    const val HOME_SCORE = "homeScore"
+    const val AWAY_SCORE = "awayScore"
+    const val PERIOD = "period"
+    const val CLOCK = "clock"
+    const val STATUS_MESSAGE = "statusMessage"
+    const val SPORT = "sport"
+    const val LEAGUE_LOGO_KEY = "leagueLogoKey"
+}
+
+internal object CountdownTimerFields {
+    const val TITLE = "title"
+    const val HERO_IMAGE_KEY = "heroImageKey"
+    const val TARGET_DATE = "targetDate"
+    const val STATUS_MESSAGE = "statusMessage"
+    const val EXPIRED_MESSAGE = "expiredMessage"
+}
+
+internal object AuctionBidFields {
+    const val ITEM_TITLE = "itemTitle"
+    const val ITEM_IMAGE_KEY = "itemImageKey"
+    const val CURRENCY_SYMBOL = "currencySymbol"
+    const val CURRENT_BID = "currentBid"
+    const val BID_COUNT = "bidCount"
+    const val END_TIME = "endTime"
+    const val STATUS_MESSAGE = "statusMessage"
+    const val IS_USER_HIGH_BIDDER = "isUserHighBidder"
+    const val USER_BID_AMOUNT = "userBidAmount"
+}
+
+/** Nested object sub-fields shared by templates that embed them. */
+internal object AirportFields {
+    const val CODE = "code"
+    const val CITY = "city"
+}
+
+internal object TeamFields {
+    const val NAME = "name"
+    const val LOGO_KEY = "logoKey"
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveScoreTemplate.kt
@@ -26,16 +26,16 @@ internal object LiveScoreTemplate : LiveNotificationTemplate {
         smallIcon: Int,
         fallbackTintColor: Int?
     ): TemplateRenderResult {
-        val homeTeam = data.optJSONObject("homeTeam")
-        val awayTeam = data.optJSONObject("awayTeam")
-        val homeName = homeTeam?.optString("name").orEmpty()
-        val awayName = awayTeam?.optString("name").orEmpty()
-        val homeScore = data.optInt("homeScore", 0)
-        val awayScore = data.optInt("awayScore", 0)
-        val period = data.optString("period")
-        val clock = data.optStringNonEmpty("clock")
-        val statusMessage = data.optStringNonEmpty("statusMessage")
-        val leagueLogoKey = data.optStringNonEmpty("leagueLogoKey")
+        val homeTeam = data.optJSONObject(LiveScoreFields.HOME_TEAM)
+        val awayTeam = data.optJSONObject(LiveScoreFields.AWAY_TEAM)
+        val homeName = homeTeam?.optString(TeamFields.NAME).orEmpty()
+        val awayName = awayTeam?.optString(TeamFields.NAME).orEmpty()
+        val homeScore = data.optInt(LiveScoreFields.HOME_SCORE, 0)
+        val awayScore = data.optInt(LiveScoreFields.AWAY_SCORE, 0)
+        val period = data.optString(LiveScoreFields.PERIOD)
+        val clock = data.optStringNonEmpty(LiveScoreFields.CLOCK)
+        val statusMessage = data.optStringNonEmpty(LiveScoreFields.STATUS_MESSAGE)
+        val leagueLogoKey = data.optStringNonEmpty(LiveScoreFields.LEAGUE_LOGO_KEY)
 
         val title = "$homeName $homeScore - $awayScore $awayName"
         val body = statusMessage

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/TemplateRegistry.kt
@@ -1,21 +1,15 @@
 package io.customer.messagingpush.livenotification.template
 
+import io.customer.messagingpush.livenotification.LiveNotificationType
+
 internal object TemplateRegistry {
 
-    const val DELIVERY_TRACKING = "io.customer.liveactivities.deliverytracking"
-    const val FLIGHT_STATUS = "io.customer.liveactivities.flightstatus"
-    const val LIVE_SCORE = "io.customer.liveactivities.livescore"
-    const val COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer"
-    const val AUCTION_BID = "io.customer.liveactivities.auctionbid"
-
-    /** The built-in activity types the SDK registers for and can render. */
-    val builtInTypes: List<String> = listOf(
-        DELIVERY_TRACKING,
-        FLIGHT_STATUS,
-        LIVE_SCORE,
-        COUNTDOWN_TIMER,
-        AUCTION_BID
-    )
+    // Aliases to the public identifiers (single source of truth: LiveNotificationType).
+    const val DELIVERY_TRACKING = LiveNotificationType.DELIVERY_TRACKING
+    const val FLIGHT_STATUS = LiveNotificationType.FLIGHT_STATUS
+    const val LIVE_SCORE = LiveNotificationType.LIVE_SCORE
+    const val COUNTDOWN_TIMER = LiveNotificationType.COUNTDOWN_TIMER
+    const val AUCTION_BID = LiveNotificationType.AUCTION_BID
 
     fun find(name: String?): LiveNotificationTemplate? = when (name) {
         DELIVERY_TRACKING -> DeliveryTrackingTemplate

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
@@ -9,7 +9,7 @@ import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.attachToSDKComponent
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
-import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.livenotification.LiveNotificationType
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.mockk.every
 import io.mockk.mockk
@@ -34,7 +34,8 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
         ModuleMessagingPushFCM(
             MessagingPushModuleConfig.Builder().apply {
                 callback?.let { setNotificationCallback(it) }
-                registerLiveNotificationTypes(customType)
+                // Enable a built-in type (for the override test) and the custom type.
+                setLiveNotificationTypes(LiveNotificationType.DELIVERY_TRACKING, customType)
             }.build()
         ).attachToSDKComponent()
     }
@@ -47,9 +48,9 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
     private fun appNotification(title: String): Notification =
         NotificationCompat.Builder(contextMock, "channel").setSmallIcon(0).setContentTitle(title).build()
 
-    private fun bundle(activityType: String): Bundle = Bundle().apply {
+    private fun bundle(activityType: String, event: String = "start"): Bundle = Bundle().apply {
         putString(LiveNotificationHandler.ACTIVITY_ID_KEY, "act-cb")
-        putString(LiveNotificationHandler.EVENT_KEY, "start")
+        putString(LiveNotificationHandler.EVENT_KEY, event)
         putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
     }
 
@@ -70,7 +71,7 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
         val posted = slot<Notification>()
         every { notificationManager.notify(any<String>(), any<Int>(), capture(posted)) } returns Unit
 
-        invoke(bundle(TemplateRegistry.DELIVERY_TRACKING))
+        invoke(bundle(LiveNotificationType.DELIVERY_TRACKING))
 
         posted.captured shouldBeEqualTo custom
     }
@@ -89,12 +90,26 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
 
     @Test
     fun customType_withoutCallback_isDropped() {
-        attach(callback = null) // registered type, but no renderer
+        attach(callback = null) // enabled type, but no renderer
 
         invoke(bundle(customType))
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
+    fun customType_endWithoutRenderer_stillCancels() {
+        // Even with no notification to post (custom type, no callback), an `end` must
+        // still cancel/clean up the existing notification.
+        attach(callback = null)
+        val expectedNotifId = "act-cb".hashCode() and 0x7FFFFFFF
+
+        invoke(bundle(customType, event = "end"))
+
+        verify(exactly = 1) {
+            notificationManager.cancel("act-cb", expectedNotifId)
         }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
@@ -1,0 +1,100 @@
+package io.customer.messagingpush
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.attachToSDKComponent
+import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers the host-app render override (`createLiveNotification`) and
+ * customer-defined activity types.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationCallbackTest : IntegrationTest() {
+
+    private val notificationManager: NotificationManager = mockk(relaxed = true)
+    private val customType = "com.acme.live.ride"
+
+    private fun attach(callback: CustomerIOPushNotificationCallback?) {
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder().apply {
+                callback?.let { setNotificationCallback(it) }
+                registerLiveNotificationTypes(customType)
+            }.build()
+        ).attachToSDKComponent()
+    }
+
+    private fun callbackReturning(notification: Notification) = object : CustomerIOPushNotificationCallback {
+        override fun createLiveNotification(payload: CustomerIOParsedPushPayload, context: Context): Notification =
+            notification
+    }
+
+    private fun appNotification(title: String): Notification =
+        NotificationCompat.Builder(contextMock, "channel").setSmallIcon(0).setContentTitle(title).build()
+
+    private fun bundle(activityType: String): Bundle = Bundle().apply {
+        putString(LiveNotificationHandler.ACTIVITY_ID_KEY, "act-cb")
+        putString(LiveNotificationHandler.EVENT_KEY, "start")
+        putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
+    }
+
+    private fun invoke(b: Bundle) = LiveNotificationHandler(b).handle(
+        context = contextMock,
+        deliveryId = "d",
+        deliveryToken = "t",
+        smallIcon = 0,
+        tintColor = null,
+        channelId = "channel",
+        notificationManager = notificationManager
+    )
+
+    @Test
+    fun builtInType_callbackReturningNotification_isPostedInsteadOfTemplate() {
+        val custom = appNotification("App rendered")
+        attach(callbackReturning(custom))
+        val posted = slot<Notification>()
+        every { notificationManager.notify(any<String>(), any<Int>(), capture(posted)) } returns Unit
+
+        invoke(bundle(TemplateRegistry.DELIVERY_TRACKING))
+
+        posted.captured shouldBeEqualTo custom
+    }
+
+    @Test
+    fun customType_withCallback_isRendered() {
+        val custom = appNotification("Custom render")
+        attach(callbackReturning(custom))
+
+        invoke(bundle(customType))
+
+        verify(exactly = 1) {
+            notificationManager.notify("act-cb", any<Int>(), custom)
+        }
+    }
+
+    @Test
+    fun customType_withoutCallback_isDropped() {
+        attach(callback = null) // registered type, but no renderer
+
+        invoke(bundle(customType))
+
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -3,7 +3,10 @@ package io.customer.messagingpush
 import android.app.Notification
 import android.app.NotificationManager
 import android.os.Bundle
+import io.customer.commontest.config.TestConfig
 import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.attachToSDKComponent
+import io.customer.messagingpush.livenotification.LiveNotificationType
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.mockk.every
@@ -36,6 +39,20 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
     private val notificationManager: NotificationManager = mockk(relaxed = true)
     private val channelId = "live-notifications"
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+        // Live notifications are opt-in; enable all built-in types so the dispatch tests run.
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder().setLiveNotificationTypes(
+                LiveNotificationType.DELIVERY_TRACKING,
+                LiveNotificationType.FLIGHT_STATUS,
+                LiveNotificationType.LIVE_SCORE,
+                LiveNotificationType.COUNTDOWN_TIMER,
+                LiveNotificationType.AUCTION_BID
+            ).build()
+        ).attachToSDKComponent()
+    }
 
     private fun newBundle(
         activityId: String? = "live-act-1",
@@ -298,6 +315,37 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
         verify(exactly = 1) {
             notificationManager.cancel(activityId, expectedNotifId)
+        }
+    }
+
+    @Test
+    fun handle_givenStaleEndTimestamp_stillCancels() {
+        // `end` is terminal and bypasses the out-of-order guard, so it always cancels
+        // even if its timestamp is not newer than the last update.
+        val activityId = "stale-end"
+        val expectedNotifId = activityId.hashCode() and 0x7FFFFFFF
+
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 100L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "end", timestamp = 50L)))
+
+        verify(exactly = 1) {
+            notificationManager.cancel(activityId, expectedNotifId)
+        }
+    }
+
+    @Test
+    fun handle_givenStaleUpdateAfterEnd_isDropped() {
+        // `end` records its timestamp as the high-water mark (not cleared), so a delayed
+        // older update arriving after `end` is dropped rather than resurrecting it.
+        val activityId = "update-after-end"
+
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 100L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "end", timestamp = 200L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 150L)))
+
+        // Only the first update and the end posted; the stale 150 update was dropped.
+        verify(exactly = 2) {
+            notificationManager.notify(activityId, any<Int>(), any<Notification>())
         }
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -348,4 +348,21 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
             notificationManager.notify(activityId, any<Int>(), any<Notification>())
         }
     }
+
+    @Test
+    fun handle_givenStaleEndThenStaleUpdate_doesNotResurrect() {
+        // A stale, out-of-order `end` (lower timestamp) bypasses the guard to cancel, but
+        // must NOT lower the high-water mark; otherwise a later stale update could slip
+        // through and resurrect the cancelled activity.
+        val activityId = "stale-end-then-update"
+
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 100L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "end", timestamp = 50L)))
+        invoke(handlerFor(newBundle(activityId = activityId, event = "update", timestamp = 75L)))
+
+        // Mark stays at 100, so the 75 update is dropped: only the first update and the end posted.
+        verify(exactly = 2) {
+            notificationManager.notify(activityId, any<Int>(), any<Notification>())
+        }
+    }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
@@ -11,6 +11,6 @@ class MessagingPushModuleConfigTest : JUnit5Test() {
         val config = MessagingPushModuleConfig.default()
 
         val actual = config.toString()
-        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null)", actual)
+        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null, liveNotificationCustomTypes=[])", actual)
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
@@ -11,6 +11,6 @@ class MessagingPushModuleConfigTest : JUnit5Test() {
         val config = MessagingPushModuleConfig.default()
 
         val actual = config.toString()
-        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null, liveNotificationCustomTypes=[])", actual)
+        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null, liveNotificationTypes=[])", actual)
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDataTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDataTest.kt
@@ -1,0 +1,55 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationDataTest : IntegrationTest() {
+
+    @Test
+    fun deliveryTracking_mapsActivityTypeAndScalarFields() {
+        val data = LiveNotificationData.DeliveryTracking(
+            orderId = "A-1",
+            statusMessage = "On the way",
+            stepCurrent = 1,
+            stepTotal = 3
+        )
+
+        data.activityType shouldBeEqualTo TemplateRegistry.DELIVERY_TRACKING
+        val fields = data.fields()
+        fields["orderId"] shouldBeEqualTo "A-1"
+        fields["statusMessage"] shouldBeEqualTo "On the way"
+        fields["stepCurrent"] shouldBeEqualTo 1
+        fields["stepTotal"] shouldBeEqualTo 3
+        // Unset optional fields are present as null; the manager omits them from the envelope.
+        fields["recipientName"].shouldBeNull()
+    }
+
+    @Test
+    fun flightStatus_nestedAirportsSerializeToJson() {
+        val data = LiveNotificationData.FlightStatus(
+            flightNumber = "AA1",
+            origin = LiveNotificationData.Airport("JFK", "New York"),
+            destination = LiveNotificationData.Airport("LAX"),
+            statusMessage = "On time"
+        )
+
+        data.activityType shouldBeEqualTo TemplateRegistry.FLIGHT_STATUS
+
+        val origin = data.fields()["origin"] as JSONObject
+        origin.getString("code") shouldBeEqualTo "JFK"
+        origin.getString("city") shouldBeEqualTo "New York"
+
+        val destination = data.fields()["destination"] as JSONObject
+        destination.getString("code") shouldBeEqualTo "LAX"
+        // city omitted when not provided.
+        destination.has("city").shouldBeFalse()
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -46,6 +46,26 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     }
 
     @Test
+    fun registerInstance_buildsPutPushTokenWithActivityType() = runTest {
+        val params = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+
+        client.registerInstance(
+            activityId = "act-9",
+            activityType = "io.customer.liveactivities.deliverytracking",
+            token = "tok",
+            userId = "user"
+        )
+
+        params.captured.method shouldBeEqualTo HttpMethod.PUT
+        params.captured.path shouldBeEqualTo "/v1/live_activities/act-9/push_token"
+        val body = params.captured.body!!
+        body shouldContain "\"activity_type\":\"io.customer.liveactivities.deliverytracking\""
+        body shouldContain "\"os\":\"android\""
+        body shouldContain "\"transport\":\"fcm\""
+    }
+
+    @Test
     fun reportDismissed_buildsDeleteWithEmptyBody() = runTest {
         val params = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(params)) } returns Result.success("")

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -21,6 +21,7 @@ import android.graphics.Color;
 import io.customer.messagingpush.MessagingPushModuleConfig;
 import io.customer.messagingpush.ModuleMessagingPushFCM;
 import io.customer.messagingpush.livenotification.LiveNotificationBranding;
+import io.customer.messagingpush.livenotification.LiveNotificationType;
 import io.customer.sdk.CustomerIO;
 import io.customer.sdk.CustomerIOConfig;
 import io.customer.sdk.CustomerIOConfigBuilder;
@@ -29,6 +30,13 @@ import io.customer.sdk.CustomerIOConfigBuilder;
  * Repository class to hold all Customer.io related operations at single place
  */
 public class CustomerIORepository {
+
+    /**
+     * The push module instance, retained so the live-notification demo screen can call
+     * {@link ModuleMessagingPushFCM#startLiveNotification} (the public local-start API).
+     */
+    public static ModuleMessagingPushFCM messagingPushModule;
+
     public void initializeSdk(SampleApplication application) {
         ApplicationGraph appGraph = application.getApplicationGraph();
         // Get desired SDK config, only required by sample app
@@ -43,15 +51,24 @@ public class CustomerIORepository {
 
         // Enable optional features of the SDK by adding desired modules.
         // Enables push notification with live-notification branding registered once at init.
-        builder.addCustomerIOModule(new ModuleMessagingPushFCM(
+        messagingPushModule = new ModuleMessagingPushFCM(
                 new MessagingPushModuleConfig.Builder()
                         .setLiveNotificationBranding(new LiveNotificationBranding(
                                 "Customer.io Sample",
                                 Color.parseColor("#1B5E20"),
                                 null
                         ))
+                        // Live notifications are opt-in: enable the built-in template types.
+                        .setLiveNotificationTypes(
+                                LiveNotificationType.DELIVERY_TRACKING,
+                                LiveNotificationType.FLIGHT_STATUS,
+                                LiveNotificationType.LIVE_SCORE,
+                                LiveNotificationType.COUNTDOWN_TIMER,
+                                LiveNotificationType.AUCTION_BID
+                        )
                         .build()
-        ));
+        );
+        builder.addCustomerIOModule(messagingPushModule);
 
         // Enables location tracking
         builder.addCustomerIOModule(new ModuleLocation(

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -13,8 +13,11 @@ import java.util.UUID;
 
 import io.customer.android.sample.java_layout.R;
 import io.customer.android.sample.java_layout.databinding.ActivityLiveNotificationDemoBinding;
+import io.customer.android.sample.java_layout.sdk.CustomerIORepository;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService;
+import io.customer.messagingpush.ModuleMessagingPushFCM;
+import io.customer.messagingpush.livenotification.LiveNotificationType;
 
 /**
  * Demo activity that simulates templated live-notification updates by sending
@@ -68,6 +71,7 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         binding.endButton.setOnClickListener(v -> end());
         binding.autoButton.setOnClickListener(v -> autoRun());
         binding.unknownActivityTypeButton.setOnClickListener(v -> sendUnknownActivityType());
+        binding.apiStartButton.setOnClickListener(v -> startViaApi());
 
         binding.typeRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
             if (isActive) {
@@ -301,6 +305,26 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
             if (userBids[step] != null) contentState.put("userBidAmount", userBids[step]);
         } catch (JSONException ignored) { }
         fire(buildBundle("demo-auction-bid", event, ACTIVITY_TYPE_AUCTION_BID, attributes, contentState));
+    }
+
+    /**
+     * Exercises the public local-start API: the SDK generates the activity id, renders
+     * the notification immediately, and registers the instance with the backend.
+     */
+    private void startViaApi() {
+        ModuleMessagingPushFCM module = CustomerIORepository.messagingPushModule;
+        if (module == null) return;
+        java.util.Map<String, Object> data = new java.util.HashMap<>();
+        data.put("orderId", "API-1001");
+        data.put("recipientName", "Mahmoud");
+        data.put("statusMessage", "Out for delivery (started via API)");
+        data.put("statusImageKey", "delivery_truck");
+        data.put("stepCurrent", 3);
+        data.put("stepTotal", 4);
+        data.put("driverName", "Sara");
+        data.put("estimatedArrival", System.currentTimeMillis() + 30L * 60 * 1000);
+        String activityId = module.startLiveNotification(LiveNotificationType.DELIVERY_TRACKING, data);
+        binding.statusTextView.setText(getString(R.string.live_notification_status_format, "API:" + activityId, 1));
     }
 
     private void sendUnknownActivityType() {

--- a/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
+++ b/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
@@ -146,5 +146,13 @@
             android:layout_marginTop="@dimen/margin_default"
             android:text="@string/live_notification_debug_unknown_activity_type" />
 
+        <Button
+            android:id="@+id/api_start_button"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:text="@string/live_notification_debug_start_via_api" />
+
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -177,5 +177,6 @@
     <string name="live_notification_type_auction_bid">Auction Bid</string>
     <string name="live_notification_section_debug">Debug</string>
     <string name="live_notification_debug_unknown_activity_type">Fire unknown activity_type</string>
+    <string name="live_notification_debug_start_via_api">Start via startLiveNotification() API</string>
 
 </resources>


### PR DESCRIPTION
## What

Adds the host-app surface for live notifications. Stacked on #723 (retarget to `feature/live-notifications` as the chain merges down).

### Start a live notification locally
- `ModuleMessagingPushFCM.startLiveNotification(data: LiveNotificationData): String` and `startLiveNotification(activityType: String, data: Map<String, Any?>): String` — the SDK generates the `activity_id` (UUID), renders the notification immediately, and registers the instance with `PUT /v1/live_activities/{activityId}/push_token` so the backend can push updates.
- Rendering goes straight through `LiveNotificationHandler` (not the FCM delivery path), so **no delivered/opened metric is fabricated** for a locally-started notification.
- Sealed **`LiveNotificationData`** with the 5 built-in templates; nested `Airport`/`Team` serialize to JSON. The `Map` overload is for customer-defined types.

### Customer-defined activity types
- `MessagingPushModuleConfig.Builder.registerLiveNotificationTypes(vararg)` (the iOS `register()` analogue). The registrar registers built-ins **+** custom types with the backend so it can push to them.

### App render override
- `CustomerIOPushNotificationCallback.createLiveNotification(payload, context): Notification?` lets the app fully render *any* live notification. A non-null return is posted **as-is** (the SDK doesn't wrap it) while the SDK still owns the posting lifecycle — keyed by `activity_id` so updates replace it, and cancelled on `end`. Returning null falls back to the SDK template. Custom types have no built-in template, so the callback is **required** for them (else the push is dropped + logged).

### Decisions (per earlier plan)
- API surface lives on `ModuleMessagingPushFCM` (no public push facade existed).
- App-rendered notifications are not wrapped, so user-dismissal DELETE reporting is the app's responsibility for those.

## Tests
`LiveNotificationData` field mapping (incl. nested JSON), `registerInstance` request shape, and handler coverage for the callback override (built-in + custom) and custom-type-without-callback drop. Full `:messagingpush` unit suite + ktlint + Android Lint pass locally; binary API dump updated (only the intended public symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API and opt-in behavior change when live notifications run; push handling and lifecycle registration paths are expanded but covered by tests.
> 
> **Overview**
> Makes **live notifications opt-in** via `MessagingPushModuleConfig.Builder.setLiveNotificationTypes`: nothing registers with Customer.io and incoming pushes are ignored until at least one activity type is enabled. Backend registration follows only those types (built-in and custom), not every built-in template by default.
> 
> Adds **`ModuleMessagingPushFCM.startLiveNotification`** (`LiveNotificationData` for the five built-in templates, or `activityType` + `Map` for custom types): the SDK assigns an `activity_id`, renders immediately through `LiveNotificationHandler` (no fabricated push metrics), and registers the instance with `PUT /v1/live_activities/{activityId}/push_token`.
> 
> Introduces **`CustomerIOPushNotificationCallback.createLiveNotification`** so the host app can post a fully custom `Notification` (SDK still owns notify/cancel on `end`); custom enabled types without a callback are dropped. Handler logic is tightened: enabled-type gate, app-vs-template rendering, cancellable scheduled `end` dismissals, and timestamp ordering so stale updates cannot resurrect an activity after `end`.
> 
> Also adds shared **field-name constants**, future-only countdown chronometers in notification builders, and sample/demo wiring for the local-start API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ca0e20f79b719349729094095cae723b4e86c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->