### PR TITLE
chore: make NotificationClickReceiverActivity non-exported

### DIFF
--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -12,12 +12,15 @@
         was launched recently from earlier notification.
         * launchMode="singleTop" does not work well with ACTIVITY_NO_FLAGS if customer app also has launchMode="singleTop"
         (e.g. Flutter apps) and have multiple instances launched from notifications in one session.
+        * exported="false" because this activity is only ever launched internally via the notification's
+        PendingIntent (an explicit-component intent dispatched with the host app's identity). It has no
+        intent-filter and is never started by other apps, so it does not need to be exported.
 
         -->
         <activity
             android:name=".activity.NotificationClickReceiverActivity"
             android:excludeFromRecents="true"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTask"
             android:noHistory="true"
             android:taskAffinity=""

--- a/messagingpush/src/test/java/io/customer/messagingpush/activity/NotificationClickReceiverActivityManifestTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/activity/NotificationClickReceiverActivityManifestTest.kt
@@ -1,0 +1,35 @@
+package io.customer.messagingpush.activity
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the security hardening that makes [NotificationClickReceiverActivity] non-exported.
+ *
+ * The activity is only ever launched internally via the notification's PendingIntent (an
+ * explicit-component intent dispatched with the host app's identity). It has no intent-filter
+ * and must never be startable by other apps, so it must stay exported="false" in the merged
+ * manifest. This test fails if the flag is ever reverted to exported="true".
+ *
+ * Note: reads the real Robolectric merged manifest via [ApplicationProvider], not the mocked
+ * context/packageManager provided by the base class.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NotificationClickReceiverActivityManifestTest : IntegrationTest() {
+
+    @Test
+    fun activity_givenMergedManifest_expectExportedFalse() {
+        val realContext = ApplicationProvider.getApplicationContext<Context>()
+        val component = ComponentName(realContext, NotificationClickReceiverActivity::class.java)
+
+        val activityInfo = realContext.packageManager.getActivityInfo(component, 0)
+
+        activityInfo.exported shouldBeEqualTo false
+    }
+}


### PR DESCRIPTION
## Summary

Hardening for a reported finding that `NotificationClickReceiverActivity` is `android:exported="true"` and therefore directly startable by other apps (allowing them to simulate notification clicks, trigger deep-link handling, or spoof open metrics).

This PR sets `android:exported="false"`.

## Why this is safe

The activity is **only ever launched internally** via the notification's `PendingIntent` (`CustomerIOPushNotificationHandler` → `PendingIntent.getActivity` with an explicit-component `Intent`). A `PendingIntent` is dispatched with the **identity of the app that created it** (the host app), and the intent targets the component explicitly — neither requires the target to be exported. The activity has **no `<intent-filter>`**, so it was never reachable via implicit intents/deep links; `exported="true"` only ever permitted explicit external launches, which is exactly the attack surface being removed.

Verified that nothing in the SDK, the RN/Flutter/Expo wrappers, or the test suite launches this activity from outside the app.

## Impact

- ✅ Notification tap → app opens + deep link resolves: **unchanged**
- ✅ `Opened` metric tracking: **unchanged**
- ✅ Instrumented test (`NotificationClickReceiverActivityTest`, launches via explicit intent + `ActivityScenario` from the same UID): **unaffected**
- 🚫 External apps starting the activity directly: **now blocked** (the fix)

## Testing

- [ ] `messagingpush` unit tests (`CustomerIOPushNotificationHandlerTest`)
- [ ] `messagingpush` instrumented test (`NotificationClickReceiverActivityTest`)
- [ ] Manual notification-tap verification across cold/killed/backgrounded states and API 23/30/34
- [ ] Sample apps: native + RN + Flutter + Expo
- [ ] Negative check: external `am start` / explicit intent from a second app is now rejected

_E2E (mobile-e2e) changes are out of scope for this PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow manifest-only security fix; in-app notification PendingIntent launches should behave the same, with only cross-app explicit starts blocked.
> 
> **Overview**
> Closes a security gap where **`NotificationClickReceiverActivity`** was **`android:exported="true"`**, so other apps could start it explicitly and mimic notification taps (deep links, open metrics). The manifest now sets **`exported="false"`**, with comments that the activity is only started from the notification **`PendingIntent`** (explicit component, no intent-filter).
> 
> Adds **`NotificationClickReceiverActivityManifestTest`**, which reads the Robolectric merged manifest and fails if **`exported`** is ever turned back on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddf958e8e0c69079279dae9e71cdf9b47c98461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->