### PR TITLE
chore: disable WebView file & content access in in-app renderer

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -146,8 +146,11 @@ internal class EngineWebView @JvmOverloads constructor(
         logger.debug("Rendering message with URL: $messageUrl")
         webView?.let {
             it.settings.javaScriptEnabled = true
-            it.settings.allowFileAccess = true
-            it.settings.allowContentAccess = true
+            // File and content access are disabled as defense-in-depth: the renderer only loads our
+            // first-party HTTPS page (navigation is locked to that origin), so it never needs to read
+            // local file:// or content:// resources. These default to false on API 30+ anyway.
+            it.settings.allowFileAccess = false
+            it.settings.allowContentAccess = false
             it.settings.domStorageEnabled = true
             it.settings.textZoom = 100
             it.setBackgroundColor(Color.TRANSPARENT)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewSettingsTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewSettingsTest.kt
@@ -1,0 +1,75 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the security hardening that disables file:// and content:// access in the in-app
+ * message WebView (see EngineWebView.setup).
+ *
+ * The renderer only loads our first-party HTTPS page (navigation is origin-locked), so the
+ * WebView must never be allowed to read local file:// or content:// resources. This test also
+ * pins javaScriptEnabled and domStorageEnabled to true, since the renderer requires them — so a
+ * future change can't silently break rendering while tightening security.
+ *
+ * Fails if any of the four settings drift from their intended values.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewSettingsTest : IntegrationTest() {
+
+    private val inAppMessagingManager: InAppMessagingManager = mockk(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency(inAppMessagingManager)
+                    }
+                }
+            }
+        )
+        // Default state -> GistEnvironment.PROD, so setup() can resolve a real renderer URL.
+        every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
+    }
+
+    @Test
+    fun setup_givenConfiguration_expectFileAndContentAccessDisabledAndRendererSettingsEnabled() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val engineWebView = EngineWebView(context)
+
+        engineWebView.setup(
+            EngineWebConfiguration(
+                siteId = String.random,
+                dataCenter = String.random,
+                messageId = String.random,
+                instanceId = String.random,
+                endpoint = "https://${String.random}"
+            )
+        )
+
+        val settings = (engineWebView.getChildAt(0) as WebView).settings
+        // Security hardening: local resource access must stay disabled.
+        settings.allowFileAccess shouldBeEqualTo false
+        settings.allowContentAccess shouldBeEqualTo false
+        // Required by the renderer: must remain enabled.
+        settings.javaScriptEnabled shouldBeEqualTo true
+        settings.domStorageEnabled shouldBeEqualTo true
+
+        engineWebView.releaseResources()
+    }
+}


### PR DESCRIPTION
## Summary

Hardening for a reported finding flagging the in-app message WebView's combination of `javaScriptEnabled` + `allowFileAccess` + `allowContentAccess` + a JS bridge.

This PR sets `allowFileAccess = false` and `allowContentAccess = false` in `EngineWebView.setup()`. JavaScript and DOM storage remain enabled (required by the renderer).

> ⚠️ **Blocked pending in-app rendering team confirmation** — see checklist. Do not merge until we've confirmed no message assets are loaded via `file://` or `content://`.

## Why this is safe

The WebView only ever loads our first-party HTTPS renderer page (`getGistRendererUrl()/index.html`), and navigation is locked to that origin (`shouldOverrideUrlLoading` rejects anything else), with TLS errors failing closed. It never loads arbitrary or local content. `allowFileAccess` governs only `file://` URLs and `allowContentAccess` only `content://` URLs — **remote HTTPS images are unaffected** by disabling them.

Per [Android's guidance](https://developer.android.com/privacy-and-security/risks/webview-unsafe-file-inclusion), these should be disabled when not needed; they already default to `false` on API 30+, so this PR mainly makes behavior consistent on API ≤ 29.

## Open question (rendering team)

Confirm the Gist renderer / in-app templates load all assets over remote HTTPS and do **not** rely on `file://` or `content://`. If `content://` is used (e.g. local image attachments), we'd keep `allowContentAccess` and disable only file access, or migrate local assets to `WebViewAssetLoader`.

## Testing

- [ ] **Rendering team sign-off on asset loading** (gating)
- [ ] In-app messages render correctly: modal / banner / full-screen
- [ ] **Messages containing images render correctly** (before/after comparison)
- [ ] Bridge interactions still fire: tap/click, deep-link buttons, close, route changes, resize
- [ ] API 29 (defaults were `true`) and API 30+ (already `false`) render identically
- [ ] Sample apps: native + RN + Flutter + Expo

_E2E (mobile-e2e) changes are out of scope for this PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebView security settings for a JS-enabled in-app renderer; low blast radius if assets are HTTPS-only, but incorrect assumptions about `file://`/`content://` assets could break message rendering on older API levels.
> 
> **Overview**
> Hardens the in-app message **WebView** in `EngineWebView.setup()` by explicitly setting **`allowFileAccess`** and **`allowContentAccess`** to **`false`** (previously **`true`**), with comments that the Gist renderer only loads the first-party HTTPS page and does not need `file://` or `content://` access.
> 
> Adds **`EngineWebViewSettingsTest`** (Robolectric) to assert those two flags stay off and that **`javaScriptEnabled`** / **`domStorageEnabled`** remain on so rendering cannot break silently during future security tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832e3528ffd46ca1d55dbb3b8de411ae5b7c8524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->