### PR TITLE
chore: rename geofence events + stamp transition timestamp on CDP event

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -25,16 +25,18 @@ public final class io/customer/sdk/communication/Event$GeofenceTransition : java
 }
 
 public final class io/customer/sdk/communication/Event$GeofenceTransitionEvent : io/customer/sdk/communication/Event {
-	public fun <init> (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/customer/sdk/communication/Event$GeofenceTransition;
 	public final fun component3 ()Ljava/util/Map;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
-	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
+	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;Ljava/lang/String;Lio/customer/sdk/communication/Event$GeofenceTransition;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/customer/sdk/communication/Event$GeofenceTransitionEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGeofenceId ()Ljava/lang/String;
 	public final fun getProperties ()Ljava/util/Map;
+	public fun getTimestamp ()Ljava/util/Date;
 	public final fun getTransition ()Lio/customer/sdk/communication/Event$GeofenceTransition;
 	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
+++ b/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
@@ -65,11 +65,16 @@ sealed class Event {
      * subscriber must attribute the resulting track event to this userId (not whoever is identified
      * at flush time), so a sign-out + sign-in between queue and delivery cannot reattribute. Null
      * means anonymous at queue time; the subscriber falls back to the pipeline's anonymousId path.
+     *
+     * [timestamp] is the moment the transition fired (captured at receiver time), not the publish
+     * time. Subscribers stamp this onto the outgoing CDP event so a delayed flush still attributes
+     * the transition to when it happened, not when it was sent.
      */
     data class GeofenceTransitionEvent(
         val geofenceId: String,
         val transition: GeofenceTransition,
         val properties: Map<String, Any>,
-        val userId: String?
+        val userId: String?,
+        override val timestamp: Date
     ) : Event()
 }

--- a/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
+++ b/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
@@ -16,6 +16,6 @@ object EventNames {
     const val LOCATION_UPDATE = "CIO Location Update"
 
     // Event names for geofence transitions tracked by the Location module
-    const val GEOFENCE_ENTERED = "GeoFence Entered"
-    const val GEOFENCE_EXITED = "GeoFence Exited"
+    const val GEOFENCE_ENTERED = "CIO Geofence Entered"
+    const val GEOFENCE_EXITED = "CIO Geofence Exited"
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/util/SegmentInstantFormatter.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/util/SegmentInstantFormatter.kt
@@ -38,5 +38,13 @@ internal class SegmentInstantFormatter {
             date.time = TimeUnit.SECONDS.toMillis(unixTimestamp)
             return formatter.format(date).replace("UTC", "Z")
         }.getOrNull()
+
+        /**
+         * Same as [from(Long)] but for a [Date] input — preserves millisecond precision.
+         */
+        fun from(date: Date): String? = runCatching {
+            val formatter = formatters.get() ?: return null
+            return formatter.format(date).replace("UTC", "Z")
+        }.getOrNull()
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -27,6 +27,7 @@ import io.customer.datapipelines.plugins.ContextPlugin
 import io.customer.datapipelines.plugins.CustomerIODestination
 import io.customer.datapipelines.plugins.IdentifyContextPlugin
 import io.customer.datapipelines.plugins.ScreenFilterPlugin
+import io.customer.datapipelines.util.SegmentInstantFormatter
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
 import io.customer.sdk.core.di.AndroidSDKComponent
@@ -180,8 +181,15 @@ class CustomerIO private constructor(
             // Snapshotted userId (if any) overrides current SDK identity for this one event so a
             // sign-out + sign-in between queue and flush cannot reattribute. Null snapshot → no
             // override → natural anonymousId path.
-            val enrichment: EnrichmentClosure? = geofenceEvent.userId?.takeIf { it.isNotEmpty() }?.let { pinnedUserId ->
-                { event -> event?.apply { userId = pinnedUserId } }
+            val pinnedUserId = geofenceEvent.userId?.takeIf { it.isNotEmpty() }
+            // Transition time, not flush time — a delayed flush still attributes the event to
+            // when the transition fired.
+            val transitionTimestamp = SegmentInstantFormatter.from(geofenceEvent.timestamp)
+            val enrichment: EnrichmentClosure = { event ->
+                event?.apply {
+                    pinnedUserId?.let { userId = it }
+                    transitionTimestamp?.let { timestamp = it }
+                }
             }
             track(
                 name = eventName,

--- a/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
@@ -5,19 +5,21 @@ import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.trackEvents
+import io.customer.datapipelines.util.SegmentInstantFormatter
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import java.util.Date
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 
 /**
  * Verifies the EventBus subscription wired up in CustomerIO.subscribeToJourneyEvents
- * correctly maps Event.GeofenceTransitionEvent → analytics track event with the right
- * EventNames constant ("GeoFence Entered" / "GeoFence Exited") and forwards the properties.
+ * correctly maps Event.GeofenceTransitionEvent → "Geofence Entered/Exited" track event
+ * and forwards the properties.
  *
  * Captures the subscription handler with a mock EventBus at SDK init time, then invokes
  * the captured handler directly so we exercise the mapping logic without depending on
@@ -52,33 +54,35 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
     }
 
     @Test
-    fun handler_givenEnterTransition_expectTrackWithGeoFenceEnteredEventName() = runTest {
+    fun handler_givenEnterTransition_expectTrackWithGeofenceEnteredEventName() = runTest {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-1",
             transition = Event.GeofenceTransition.ENTER,
             properties = mapOf("geofence_id" to "biz-1", "transition_type" to "enter"),
-            userId = "user-A"
+            userId = "user-A",
+            timestamp = Date()
         )
 
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "GeoFence Entered"
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "CIO Geofence Entered"
     }
 
     @Test
-    fun handler_givenExitTransition_expectTrackWithGeoFenceExitedEventName() = runTest {
+    fun handler_givenExitTransition_expectTrackWithGeofenceExitedEventName() = runTest {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-2",
             transition = Event.GeofenceTransition.EXIT,
             properties = mapOf("geofence_id" to "biz-2", "transition_type" to "exit"),
-            userId = "user-A"
+            userId = "user-A",
+            timestamp = Date()
         )
 
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "GeoFence Exited"
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "CIO Geofence Exited"
     }
 
     @Test
@@ -90,7 +94,8 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
             geofenceId = "biz-3",
             transition = Event.GeofenceTransition.ENTER,
             properties = mapOf("geofence_id" to "biz-3"),
-            userId = "user-pinned-A"
+            userId = "user-pinned-A",
+            timestamp = Date()
         )
 
         handlerSlot.captured.invoke(event)
@@ -107,11 +112,30 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
             geofenceId = "biz-4",
             transition = Event.GeofenceTransition.ENTER,
             properties = mapOf("geofence_id" to "biz-4"),
-            userId = null
+            userId = null,
+            timestamp = Date()
         )
 
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.last().userId shouldBeEqualTo "user-current"
+    }
+
+    @Test
+    fun handler_givenPastTransitionTimestamp_expectTrackStampedWithTransitionTime() = runTest {
+        // A delayed flush must attribute the event to when the transition fired, not when
+        // the flush ran — the subscriber stamps BaseEvent.timestamp from the transition time.
+        val transitionTime = Date(1_700_000_000_000L) // 2023-11-14T22:13:20.000Z
+        val event = Event.GeofenceTransitionEvent(
+            geofenceId = "biz-5",
+            transition = Event.GeofenceTransition.ENTER,
+            properties = mapOf("geofence_id" to "biz-5"),
+            userId = "user-A",
+            timestamp = transitionTime
+        )
+
+        handlerSlot.captured.invoke(event)
+
+        outputReaderPlugin.trackEvents.last().timestamp shouldBeEqualTo SegmentInstantFormatter.from(transitionTime)
     }
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/util/SegmentInstantFormatterTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/util/SegmentInstantFormatterTest.kt
@@ -50,6 +50,33 @@ class SegmentInstantFormatterTest : JUnitTest() {
         SegmentInstantFormatter.from(mockedTimestamp).shouldNotBeNull() shouldBeEqualTo event.timestamp
     }
 
+    @Test
+    fun parse_givenInvalidDate_expectReturnNull() {
+        every { anyConstructed<Date>().time } throws IllegalArgumentException("Forced exception")
+
+        SegmentInstantFormatter.from(Date()).shouldBeNull()
+    }
+
+    @Test
+    fun parse_givenValidDate_expectMatchAnalyticsFormat() {
+        every { anyConstructed<Date>().time } returns mockedTime
+
+        val event = TrackEvent(emptyJsonObject, String.random)
+        analytics.process(event)
+
+        SegmentInstantFormatter.from(Date()).shouldNotBeNull() shouldBeEqualTo event.timestamp
+    }
+
+    @Test
+    fun parse_givenDateWithSubSecondMillis_expectMillisPreservedInOutput() {
+        // Date-overload exists specifically to preserve ms precision (the Long
+        // overload is seconds-quantized). Pin .time to a non-zero ms fraction
+        // and assert the formatter renders it in the .SSS slot.
+        every { anyConstructed<Date>().time } returns FIXED_TIME_MILLIS + 123L
+
+        SegmentInstantFormatter.from(Date()).shouldNotBeNull() shouldBeEqualTo "2023-11-14T22:13:20.123Z"
+    }
+
     private companion object {
         // Arbitrary fixed instant (2023-11-14T22:13:20Z). Stable across runs;
         // the exact value doesn't matter — only that it's deterministic.

--- a/docs/manual-tests/geofence-exactly-once.md
+++ b/docs/manual-tests/geofence-exactly-once.md
@@ -7,8 +7,8 @@ channels — the **WorkManager worker** (direct HTTP `/track`, survives process
 death) or the **foreground flush** (analytics pipeline) — arbitrated by an
 atomic `claim()`.
 
-> **Core invariant for every case:** each geofence transition (`GeoFence
-> Entered` / `GeoFence Exited`) reaches Customer.io **exactly once** — never
+> **Core invariant for every case:** each geofence transition (`CIO Geofence
+> Entered` / `CIO Geofence Exited`) reaches Customer.io **exactly once** — never
 > zero, never twice. Before the refactor both channels fired in parallel, so a
 > transition observed while the app was alive was sent **twice**; this plan
 > verifies that's now collapsed to one.
@@ -70,7 +70,7 @@ adb shell am force-stop $PKG                                # kill process
 ### Portal check
 
 Workspace → **Data & Integrations → Activity Logs**, filter for the
-`GeoFence Entered` / `GeoFence Exited` event and confirm the **count** for a
+`CIO Geofence Entered` / `CIO Geofence Exited` event and confirm the **count** for a
 given transition.
 
 ### Log hallmarks (message text after the `[Geofence]` prefix)
@@ -106,7 +106,7 @@ _(No `published to analytics pipeline via foreground flush` for this transition 
 
 **Expected store:** `[]` (worker claimed + delivered).
 
-**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>`.
+**Expected portal:** ✅ `CIO Geofence Entered` = **1** for `<id>`.
 
 ---
 
@@ -147,7 +147,7 @@ _(no `delivered via WorkManager` — the worker's CONNECTED constraint is unmet 
 
 **Expected store after step 5:** `[]`
 
-**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>`, via the analytics
+**Expected portal:** ✅ `CIO Geofence Entered` = **1** for `<id>`, via the analytics
 pipeline — **not** the worker.
 
 ---
@@ -167,7 +167,7 @@ transition at any point after the flush.
 
 **Expected store:** `[]` (stays empty).
 
-**Expected portal:** ✅ `GeoFence Entered` = **exactly 1** for `<id>` — **not 2**.
+**Expected portal:** ✅ `CIO Geofence Entered` = **exactly 1** for `<id>` — **not 2**.
 (The headline guarantee — pre-refactor this was 2.)
 
 ---
@@ -199,7 +199,7 @@ _(Or, if WorkManager runs first on relaunch: `delivered via WorkManager ...` and
 
 **Expected store after step 6:** `[]`
 
-**Expected portal:** ✅ `GeoFence Entered` = **1** for `<id>` after relaunch.
+**Expected portal:** ✅ `CIO Geofence Entered` = **1** for `<id>` after relaunch.
 
 ---
 
@@ -230,7 +230,7 @@ _(no `cancelled`, no `published`, no `flush complete`.)_
 
 **Steps:** Repeat TC1 (or TC2) but cross **out** of the geofence.
 
-**Expected:** identical logs/store/portal with `EXIT` / `GeoFence Exited` = **1**.
+**Expected:** identical logs/store/portal with `EXIT` / `CIO Geofence Exited` = **1**.
 
 ---
 

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -209,14 +209,7 @@ class ModuleLocation @JvmOverloads constructor(
                 override fun onComplete(count: Int) = logger.logForegroundFlushComplete(count)
             }
         ) { entry ->
-            eventBus.publish(
-                Event.GeofenceTransitionEvent(
-                    geofenceId = entry.geofenceId,
-                    transition = entry.transition,
-                    properties = entry.toEventProperties(),
-                    userId = entry.userId
-                )
-            )
+            eventBus.publish(entry.toGeofenceTransitionEvent())
         }
     }
 

--- a/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
+++ b/location/src/main/kotlin/io/customer/location/geofence/store/PendingGeofenceDelivery.kt
@@ -2,6 +2,8 @@ package io.customer.location.geofence.store
 
 import io.customer.sdk.communication.Event
 import io.customer.sdk.data.store.PendingDeliveryStore
+import java.util.Date
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.Serializable
 
 /**
@@ -20,13 +22,14 @@ internal data class PendingGeofenceDelivery(
     val transition: Event.GeofenceTransition,
     val latitude: Double?,
     val longitude: Double?,
+    /** Unix epoch **seconds** at receiver time. Use [toGeofenceTransitionEvent] when a [Date] is needed. */
     val timestamp: Long,
     val userId: String?
 ) : PendingDeliveryStore.PendingDeliveryEntry {
     override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
 
     /**
-     * Properties carried on the tracked "GeoFence Entered/Exited" event. Kept
+     * Properties carried on the tracked "Geofence Entered/Exited" event. Kept
      * here so the producer, the worker's direct-HTTP send, and the foreground
      * flush all build an identical property set.
      */
@@ -37,6 +40,21 @@ internal data class PendingGeofenceDelivery(
         longitude?.let { put("longitude", it) }
         put("timestamp", timestamp)
     }
+
+    /**
+     * Builds the EventBus event the foreground flush publishes for this row.
+     * Owns the seconds→milliseconds conversion on [timestamp] so no caller has
+     * to construct a [Date] from the raw [Long] (which would silently produce
+     * a date in January 1970 if passed seconds).
+     */
+    fun toGeofenceTransitionEvent(): Event.GeofenceTransitionEvent =
+        Event.GeofenceTransitionEvent(
+            geofenceId = geofenceId,
+            transition = transition,
+            properties = toEventProperties(),
+            userId = userId,
+            timestamp = Date(TimeUnit.SECONDS.toMillis(timestamp))
+        )
 
     companion object {
         internal const val FILE_NAME = "cio_pending_geofence_delivery.json"

--- a/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -1,6 +1,7 @@
 package io.customer.location.geofence.store
 
 import io.customer.sdk.communication.Event
+import java.util.Date
 import kotlinx.serialization.json.Json
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContain
@@ -72,6 +73,21 @@ class PendingGeofenceDeliveryTest {
         props["latitude"] shouldBeEqualTo 1.5
         props["longitude"] shouldBeEqualTo 2.5
         props["timestamp"] shouldBeEqualTo 50L
+    }
+
+    @Test
+    fun toGeofenceTransitionEvent_givenSecondsTimestamp_expectEventTimestampInMillis() {
+        // `timestamp` is unix seconds; `Event.timestamp` is a `Date` (millis).
+        // The conversion lives on the data class so no caller can hand-roll
+        // `Date(entry.timestamp)` and silently produce a January 1970 instant.
+        val entry = PendingGeofenceDelivery("biz-t", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_700_000_000L, "user-A")
+
+        val event = entry.toGeofenceTransitionEvent()
+
+        event.timestamp shouldBeEqualTo Date(1_700_000_000_000L)
+        event.geofenceId shouldBeEqualTo "biz-t"
+        event.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
+        event.userId shouldBeEqualTo "user-A"
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/geofence/worker/GeofenceEventTrackerTest.kt
@@ -51,7 +51,7 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         capturedParams.captured.path shouldBeEqualTo "/track"
         val body = JSONObject(capturedParams.captured.body)
-        body.getString("event") shouldBeEqualTo "GeoFence Entered"
+        body.getString("event") shouldBeEqualTo "CIO Geofence Entered"
         body.getString("userId") shouldBeEqualTo "user-42"
         val props = body.getJSONObject("properties")
         props.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
@@ -69,7 +69,7 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         tracker.trackEvent(entry(transition = Event.GeofenceTransition.EXIT))
 
         val body = JSONObject(capturedParams.captured.body)
-        body.getString("event") shouldBeEqualTo "GeoFence Exited"
+        body.getString("event") shouldBeEqualTo "CIO Geofence Exited"
         body.getJSONObject("properties").getString("transition_type") shouldBeEqualTo "exit"
     }
 


### PR DESCRIPTION
## Summary

Two related geofence-attribution fixes for the EventBus delivery path:

1. **Rename the wire event names**
   - `"GeoFence Entered"` → `"CIO Geofence Entered"`
   - `"GeoFence Exited"` → `"CIO Geofence Exited"`

2. **Stamp the CDP event's canonical timestamp from the captured transition time, not the flush time.** Without this, a transition queued at T0 and delivered by the foreground flush at T0+1h lands on the backend with T0+1h as the event timestamp. The worker direct-HTTP path already carries transition time via `properties.timestamp`, matching the iOS port-back from `mbl-1770-d`.

   Mechanism: `Event.GeofenceTransitionEvent` adds `override val timestamp: Date` (reusing the existing `Event.timestamp` slot). The Module Location flush populates it from `entry.timestamp`. The subscriber's enrichment closure formats it via a new `SegmentInstantFormatter.from(Date)` overload and assigns it to `BaseEvent.timestamp`.

## Stack

```
main
 └── feature/geofence-on-device
      └── mbl-1780-rename-geofence-events  ← this PR
```

## Linear

[MBL-1780](https://linear.app/customerio/issue/MBL-1780/rename-geofence-events-in-mobile-sdks)

## Test plan

- [x] Unit: `GeofenceEventSubscriptionTest` — new `handler_givenPastTransitionTimestamp_expectTrackStampedWithTransitionTime` asserts the subscriber stamps `BaseEvent.timestamp` from the transition time, not flush time. Existing tests updated for the new constructor.
- [x] Unit: `SegmentInstantFormatterTest` — new `parse_givenDateWithSubSecondMillis_expectMillisPreservedInOutput` pins the ms-precision invariant (would fail if anyone "simplifies" the `Date` overload to delegate through the seconds-quantized `Long` overload).
- [x] API check: `core.api` regenerated for the new ctor signature and `getTimestamp()`.
- [x] Manual (post-merge): verify `CIO Geofence Entered`/`CIO Geofence Exited` events land on the backend with the original transition timestamp when delivered via foreground flush after a delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API on GeofenceTransitionEvent plus renamed analytics event strings may affect existing Journeys; timestamp enrichment changes when delayed foreground-flush events appear in Activity Logs.
> 
> **Overview**
> Renames geofence track events to **`CIO Geofence Entered`** / **`CIO Geofence Exited`** (constants, direct HTTP worker, tests, manual docs) so wire names align with other CIO-prefixed location events.
> 
> **`Event.GeofenceTransitionEvent`** now requires a **`timestamp: Date`** (transition time at receiver, not publish). The location foreground flush builds events via **`PendingGeofenceDelivery.toGeofenceTransitionEvent()`**, which converts stored unix **seconds** to millis so callers cannot mis-build a `Date` from seconds. The Data Pipelines **`CustomerIO`** geofence subscriber always applies an enrichment closure that pins the snapshotted **userId** (unchanged) and sets **`BaseEvent.timestamp`** from that transition instant using a new **`SegmentInstantFormatter.from(Date)`** overload (millisecond precision).
> 
> Public **`core.api`** is regenerated for the new constructor. Unit tests cover renamed event names, transition-time stamping on delayed flush, and formatter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cf5a0b336c5a9b379f565bbfcc209482f6f867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->