### PR TITLE
chore(sample): expand live-notification demo — custom types, callback, step icons, campaign trigger

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -58,13 +58,18 @@ public class CustomerIORepository {
                                 Color.parseColor("#1B5E20"),
                                 null
                         ))
-                        // Live notifications are opt-in: enable the built-in template types.
+                        // App-rendered custom types go through this callback.
+                        .setNotificationCallback(new LiveNotificationCallback())
+                        // Live notifications are opt-in: enable the built-in template
+                        // types plus our two custom (app-rendered) types.
                         .setLiveNotificationTypes(
                                 LiveNotificationType.DELIVERY_TRACKING,
                                 LiveNotificationType.FLIGHT_STATUS,
                                 LiveNotificationType.LIVE_SCORE,
                                 LiveNotificationType.COUNTDOWN_TIMER,
-                                LiveNotificationType.AUCTION_BID
+                                LiveNotificationType.AUCTION_BID,
+                                LiveNotificationCallback.ACTIVITY_TYPE_RIDESHARE,
+                                LiveNotificationCallback.ACTIVITY_TYPE_WORKOUT
                         )
                         .build()
         );

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/LiveNotificationCallback.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/LiveNotificationCallback.kt
@@ -1,0 +1,174 @@
+package io.customer.android.sample.java_layout.sdk
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.widget.RemoteViews
+import androidx.core.app.NotificationCompat
+import io.customer.android.sample.java_layout.R
+import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+/**
+ * Sample host-app renderer for **custom** live-notification activity types — the
+ * ones the SDK has no built-in template for. The SDK calls
+ * [createLiveNotification] for every live-notification event; we return a fully
+ * app-built [Notification] for the two custom types and `null` for the built-in
+ * ones (so the SDK keeps rendering those from its own templates).
+ *
+ * Two deliberately different rendering strategies are shown:
+ *  - [ACTIVITY_TYPE_RIDESHARE] → a **completely custom RemoteViews layout**
+ *    (collapsed + expanded), with an app-drawn 4-stop progress strip.
+ *  - [ACTIVITY_TYPE_WORKOUT] → the **standard NotificationCompat builder API**
+ *    (determinate progress + BigTextStyle + action), requesting promoted-ongoing
+ *    treatment on Android 16+.
+ *
+ * The SDK still owns posting: it keys the notification by `activity_id` (so
+ * updates replace it) and cancels it on `end`.
+ */
+class LiveNotificationCallback : CustomerIOPushNotificationCallback {
+
+    override fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context
+    ): Notification? {
+        val extras = payload.extras
+        val activityType = extras.getString(KEY_ACTIVITY_TYPE) ?: return null
+        val ended = extras.getString(KEY_EVENT) == EVENT_END
+        ensureChannel(context)
+        return when (activityType) {
+            ACTIVITY_TYPE_RIDESHARE -> buildRideshare(context, extras, ended)
+            ACTIVITY_TYPE_WORKOUT -> buildWorkout(context, extras, ended)
+            // Not one of ours — let the SDK render its built-in template.
+            else -> null
+        }
+    }
+
+    // --- Custom type 1: fully custom RemoteViews layout ---
+
+    private fun buildRideshare(context: Context, extras: Bundle, ended: Boolean): Notification {
+        val driver = extras.getString("driverName") ?: "Your driver"
+        val vehicle = extras.getString("vehicle") ?: ""
+        val plate = extras.getString("plate") ?: ""
+        val eta = extras.getString("etaText") ?: ""
+        val status = extras.getString("statusMessage") ?: ""
+        val step = extras.getString("step")?.toIntOrNull() ?: 0
+        val progress = extras.getString("progress")?.toIntOrNull() ?: 0
+
+        val title = if (ended) "Trip complete" else "$driver is on the way"
+        val subtitle = listOf(vehicle, plate).filter { it.isNotBlank() }.joinToString(" · ")
+        val etaText = if (ended) "Done" else eta
+
+        fun applyHeader(rv: RemoteViews) {
+            rv.setTextViewText(R.id.tv_title, title)
+            rv.setTextViewText(R.id.tv_subtitle, subtitle)
+            rv.setTextViewText(R.id.tv_eta, etaText)
+        }
+
+        val collapsed = RemoteViews(context.packageName, R.layout.notification_rideshare_collapsed)
+        applyHeader(collapsed)
+
+        val expanded = RemoteViews(context.packageName, R.layout.notification_rideshare_expanded)
+        applyHeader(expanded)
+        expanded.setTextViewText(R.id.tv_status, if (ended) "Thanks for riding with us" else status)
+
+        val stepIds = intArrayOf(R.id.iv_step1, R.id.iv_step2, R.id.iv_step3, R.id.iv_step4)
+        for (i in stepIds.indices) {
+            val icon = when {
+                ended || i < step -> R.drawable.ic_step_done
+                i == step -> R.drawable.ic_step_active
+                else -> R.drawable.ic_step_pending
+            }
+            expanded.setImageViewResource(stepIds[i], icon)
+        }
+        expanded.setProgressBar(R.id.progress_bar, 100, if (ended) 100 else progress, false)
+
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_rideshare_car)
+            .setCustomContentView(collapsed)
+            .setCustomBigContentView(expanded)
+            .setOngoing(!ended)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .build()
+    }
+
+    // --- Custom type 2: standard NotificationCompat builder API ---
+
+    private fun buildWorkout(context: Context, extras: Bundle, ended: Boolean): Notification {
+        val title = extras.getString("workoutTitle") ?: "Workout"
+        val distance = extras.getString("distance") ?: ""
+        val duration = extras.getString("duration") ?: ""
+        val pace = extras.getString("pace") ?: ""
+        val progress = extras.getString("progress")?.toIntOrNull() ?: 0
+        val summary = listOf(distance, duration, pace).filter { it.isNotBlank() }.joinToString(" · ")
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_workout_run)
+            .setContentTitle(if (ended) "$title complete" else title)
+            .setContentText(summary)
+            .setProgress(100, if (ended) 100 else progress, false)
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText(if (ended) "$summary\nGreat job — workout saved." else "$summary\nKeep going!")
+            )
+            .setOngoing(!ended)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+
+        if (!ended) {
+            val pauseIntent = PendingIntent.getBroadcast(
+                context,
+                0,
+                Intent(ACTION_WORKOUT_PAUSE),
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            builder.addAction(R.drawable.ic_workout_run, "Pause", pauseIntent)
+        }
+
+        // Request live-update (promoted-ongoing) treatment on Android 16+ (BAKLAVA).
+        // Requires POST_PROMOTED_NOTIFICATIONS (declared in the manifest), an ongoing
+        // notification with a title, an allowed style (BigTextStyle), and no colorize.
+        if (Build.VERSION.SDK_INT >= 36 && !ended) {
+            builder.addExtras(Bundle().apply { putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true) })
+        }
+
+        return builder.build()
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = context.getSystemService(NotificationManager::class.java) ?: return
+            if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+                manager.createNotificationChannel(
+                    NotificationChannel(
+                        CHANNEL_ID,
+                        "Custom Live Updates",
+                        NotificationManager.IMPORTANCE_DEFAULT
+                    )
+                )
+            }
+        }
+    }
+
+    companion object {
+        // Custom activity types (not built-in). Must also be passed to
+        // MessagingPushModuleConfig.Builder.setLiveNotificationTypes(...) to be enabled.
+        const val ACTIVITY_TYPE_RIDESHARE = "io.customer.liveactivities.custom.rideshare"
+        const val ACTIVITY_TYPE_WORKOUT = "io.customer.liveactivities.custom.workout"
+
+        private const val CHANNEL_ID = "cio_custom_live"
+        private const val KEY_ACTIVITY_TYPE = "activity_type"
+        private const val KEY_EVENT = "event"
+        private const val EVENT_END = "end"
+        private const val ACTION_WORKOUT_PAUSE = "io.customer.android.sample.java_layout.WORKOUT_PAUSE"
+
+        // Notification.EXTRA_REQUEST_PROMOTED_ONGOING (extension SDK 36.1) by raw value.
+        private const val EXTRA_REQUEST_PROMOTED_ONGOING = "android.requestPromotedOngoing"
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -3,17 +3,22 @@ package io.customer.android.sample.java_layout.ui.livenotification;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.widget.ArrayAdapter;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.messaging.RemoteMessage;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import io.customer.android.sample.java_layout.R;
 import io.customer.android.sample.java_layout.databinding.ActivityLiveNotificationDemoBinding;
 import io.customer.android.sample.java_layout.sdk.CustomerIORepository;
+import io.customer.android.sample.java_layout.sdk.LiveNotificationCallback;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService;
 import io.customer.messagingpush.ModuleMessagingPushFCM;
@@ -34,7 +39,7 @@ import io.customer.messagingpush.livenotification.LiveNotificationType;
 public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotificationDemoBinding> {
 
     private static final String DEMO_DELIVERY_TOKEN = "demo-token-live";
-    private static final long AUTO_STEP_DELAY_MS = 2000;
+    private static final long AUTO_STEP_DELAY_MS = 5000;
 
     private static final String EVENT_START = "start";
     private static final String EVENT_UPDATE = "update";
@@ -47,19 +52,41 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
     private static final String ACTIVITY_TYPE_COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer";
     private static final String ACTIVITY_TYPE_AUCTION_BID = "io.customer.liveactivities.auctionbid";
     private static final String ACTIVITY_TYPE_UNKNOWN = "io.customer.liveactivities.bogus";
+    // Custom (app-rendered) types — rendered by LiveNotificationCallback, not an SDK template.
+    private static final String ACTIVITY_TYPE_RIDESHARE = LiveNotificationCallback.ACTIVITY_TYPE_RIDESHARE;
+    private static final String ACTIVITY_TYPE_WORKOUT = LiveNotificationCallback.ACTIVITY_TYPE_WORKOUT;
 
     private enum TemplateChoice {
-        DELIVERY_TRACKING, FLIGHT_STATUS, LIVE_SCORE, COUNTDOWN_TIMER, AUCTION_BID
+        DELIVERY_TRACKING, FLIGHT_STATUS, LIVE_SCORE, COUNTDOWN_TIMER, AUCTION_BID,
+        CUSTOM_RIDESHARE, CUSTOM_WORKOUT
     }
+
+    // Event the backend campaign listens for; its `activity_type` property selects the template.
+    private static final String CAMPAIGN_EVENT = "trigger_live";
+    // Dropdown order must match CAMPAIGN_TEMPLATE_LABELS below.
+    private static final String[] CAMPAIGN_ACTIVITY_TYPES = {
+            ACTIVITY_TYPE_DELIVERY_TRACKING,
+            ACTIVITY_TYPE_FLIGHT_STATUS,
+            ACTIVITY_TYPE_LIVE_SCORE,
+            ACTIVITY_TYPE_COUNTDOWN_TIMER,
+            ACTIVITY_TYPE_AUCTION_BID
+    };
 
     private int currentStep = 0;
     private boolean isActive = false;
     private final Handler autoHandler = new Handler(Looper.getMainLooper());
     private boolean isAutoRunning = false;
+    private int selectedCampaignIndex = 0;
+    private CustomerIORepository customerIORepository;
 
     @Override
     protected ActivityLiveNotificationDemoBinding inflateViewBinding() {
         return ActivityLiveNotificationDemoBinding.inflate(getLayoutInflater());
+    }
+
+    @Override
+    protected void injectDependencies() {
+        customerIORepository = applicationGraph.getCustomerIORepository();
     }
 
     @Override
@@ -72,6 +99,9 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         binding.autoButton.setOnClickListener(v -> autoRun());
         binding.unknownActivityTypeButton.setOnClickListener(v -> sendUnknownActivityType());
         binding.apiStartButton.setOnClickListener(v -> startViaApi());
+
+        setupCampaignDropdown();
+        binding.campaignTriggerButton.setOnClickListener(v -> triggerCampaign());
 
         binding.typeRadioGroup.setOnCheckedChangeListener((group, checkedId) -> {
             if (isActive) {
@@ -91,13 +121,15 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         if (checkedId == R.id.radio_live_score) return TemplateChoice.LIVE_SCORE;
         if (checkedId == R.id.radio_countdown_timer) return TemplateChoice.COUNTDOWN_TIMER;
         if (checkedId == R.id.radio_auction_bid) return TemplateChoice.AUCTION_BID;
+        if (checkedId == R.id.radio_custom_rideshare) return TemplateChoice.CUSTOM_RIDESHARE;
+        if (checkedId == R.id.radio_custom_workout) return TemplateChoice.CUSTOM_WORKOUT;
         return TemplateChoice.DELIVERY_TRACKING;
     }
 
     private int getStepCount() {
         switch (getSelectedTemplate()) {
-            // Delivery: ordered → preparing → out-for-delivery → delivered → missing-asset edge case
-            case DELIVERY_TRACKING: return 5;
+            // Delivery: ordered → preparing → out-for-delivery → delivered
+            case DELIVERY_TRACKING: return 4;
             // Flight: pre-departure → boarding → in-flight → arrived → delay-red variant
             case FLIGHT_STATUS: return 5;
             case LIVE_SCORE: return 4;
@@ -105,6 +137,10 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
             case COUNTDOWN_TIMER: return 4;
             // Auction: outbid → winning → outbid again → ended → no-userBidAmount variant
             case AUCTION_BID: return 5;
+            // Rideshare (custom RemoteViews): en route → arriving → in trip → dropoff
+            case CUSTOM_RIDESHARE: return 4;
+            // Workout (builder API): warmup → running → final push → cooldown
+            case CUSTOM_WORKOUT: return 4;
             default: return 1;
         }
     }
@@ -165,6 +201,8 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
             case LIVE_SCORE: sendLiveScore(event, step); break;
             case COUNTDOWN_TIMER: sendCountdownTimer(event, step); break;
             case AUCTION_BID: sendAuctionBid(event, step); break;
+            case CUSTOM_RIDESHARE: sendCustomRideshare(event, step); break;
+            case CUSTOM_WORKOUT: sendCustomWorkout(event, step); break;
         }
     }
 
@@ -173,17 +211,14 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
                 "Your order has been placed",
                 "Your order is being prepared",
                 "Your order is out for delivery",
-                "Your order has been delivered",
-                "Asset key missing — design-for-absence path"
+                "Your order has been delivered"
         };
-        // Step 4 intentionally points to a key the host app has not bundled, exercising
-        // TemplateAssets.resolveDrawable's "did not resolve" branch.
+        // Distinct icon per step: ordered → preparing → out-for-delivery → delivered.
         String[] imageKeys = {
-                "delivery_warehouse",
-                "delivery_warehouse",
+                "delivery_ordered",
+                "delivery_preparing",
                 "delivery_truck",
-                "delivery_door",
-                "unknown_key"
+                "delivery_delivered"
         };
         JSONObject attributes = new JSONObject();
         JSONObject contentState = new JSONObject();
@@ -307,6 +342,60 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         fire(buildBundle("demo-auction-bid", event, ACTIVITY_TYPE_AUCTION_BID, attributes, contentState));
     }
 
+    // --- Custom (app-rendered) types: rendered by LiveNotificationCallback, not an SDK template ---
+
+    /**
+     * Custom type rendered by the host app through a completely custom RemoteViews
+     * layout (see {@link LiveNotificationCallback}). The SDK has no template for it.
+     */
+    private void sendCustomRideshare(String event, int step) {
+        String[] statuses = {
+                "Heading to your pickup",
+                "Arriving now — look for the car",
+                "On the way to your destination",
+                "You've arrived"
+        };
+        String[] etas = {"6 min", "1 min", "12 min", "Now"};
+        // progress across the 4 stops
+        int[] progress = {15, 40, 80, 100};
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            attributes.put("driverName", "Alex");
+            attributes.put("vehicle", "Toyota Prius");
+            attributes.put("plate", "7XYZ123");
+
+            contentState.put("statusMessage", statuses[step]);
+            contentState.put("etaText", etas[step]);
+            contentState.put("step", step);
+            contentState.put("progress", progress[step]);
+        } catch (JSONException ignored) { }
+        fire(buildBundle("demo-rideshare", event, ACTIVITY_TYPE_RIDESHARE, attributes, contentState));
+    }
+
+    /**
+     * Custom type rendered by the host app via the standard NotificationCompat builder
+     * API (determinate progress + BigTextStyle + action), requesting promoted-ongoing.
+     */
+    private void sendCustomWorkout(String event, int step) {
+        String[] distances = {"0.4 km", "2.4 km", "4.1 km", "5.0 km"};
+        String[] durations = {"02:10", "14:32", "24:48", "30:15"};
+        String[] paces = {"5'25\"/km", "6'03\"/km", "6'02\"/km", "6'03\"/km"};
+        int[] progress = {8, 48, 82, 100};
+        JSONObject attributes = new JSONObject();
+        JSONObject contentState = new JSONObject();
+        try {
+            attributes.put("workoutTitle", "Morning Run");
+
+            contentState.put("distance", distances[step]);
+            contentState.put("duration", durations[step]);
+            contentState.put("pace", paces[step]);
+            contentState.put("step", step);
+            contentState.put("progress", progress[step]);
+        } catch (JSONException ignored) { }
+        fire(buildBundle("demo-workout", event, ACTIVITY_TYPE_WORKOUT, attributes, contentState));
+    }
+
     /**
      * Exercises the public local-start API: the SDK generates the activity id, renders
      * the notification immediately, and registers the instance with the backend.
@@ -325,6 +414,50 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
         data.put("estimatedArrival", System.currentTimeMillis() + 30L * 60 * 1000);
         String activityId = module.startLiveNotification(LiveNotificationType.DELIVERY_TRACKING, data);
         binding.statusTextView.setText(getString(R.string.live_notification_status_format, "API:" + activityId, 1));
+    }
+
+    // --- Campaign trigger ---
+
+    private void setupCampaignDropdown() {
+        String[] labels = {
+                getString(R.string.live_notification_type_delivery_tracking),
+                getString(R.string.live_notification_type_flight_status),
+                getString(R.string.live_notification_type_live_score),
+                getString(R.string.live_notification_type_countdown_timer),
+                getString(R.string.live_notification_type_auction_bid)
+        };
+        ArrayAdapter<String> adapter =
+                new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, labels);
+        binding.campaignTemplateDropdown.setAdapter(adapter);
+        binding.campaignTemplateDropdown.setText(labels[selectedCampaignIndex], false);
+        binding.campaignTemplateDropdown.setOnItemClickListener(
+                (parent, view, position, id) -> selectedCampaignIndex = position);
+    }
+
+    /**
+     * Tracks the {@code trigger_live} event with the selected {@code activity_type} and a
+     * unique {@code timestamp}. A backend campaign listening for this event then pushes the
+     * real start/update/end lifecycle through the live-notification path — no synthetic local
+     * push here.
+     * <p>
+     * The {@code timestamp} property is meant to be injected into the {@code activity_id} of
+     * every payload via Liquid (e.g. {@code "activity_id": "order-{{ event.timestamp }}"}) so
+     * each campaign run gets a fresh activity id. Reusing an activity id across runs would hit
+     * the SDK's out-of-order guard (a prior {@code end} freezes that id's high-water timestamp),
+     * and the new pushes would be dropped as stale.
+     */
+    private void triggerCampaign() {
+        String activityType = CAMPAIGN_ACTIVITY_TYPES[selectedCampaignIndex];
+        Map<String, String> properties = new HashMap<>();
+        properties.put("activity_type", activityType);
+        // Unique per trigger; used by the campaign to build a fresh activity_id via Liquid.
+        properties.put("timestamp", String.valueOf(System.currentTimeMillis()));
+        customerIORepository.trackEvent(CAMPAIGN_EVENT, properties);
+        Snackbar.make(
+                binding.campaignTriggerButton,
+                getString(R.string.live_notification_campaign_event_sent, activityType),
+                Snackbar.LENGTH_SHORT
+        ).show();
     }
 
     private void sendUnknownActivityType() {

--- a/samples/java_layout/src/main/res/drawable/delivery_delivered.xml
+++ b/samples/java_layout/src/main/res/drawable/delivery_delivered.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1565C0"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/delivery_ordered.xml
+++ b/samples/java_layout/src/main/res/drawable/delivery_ordered.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1565C0"
+        android:pathData="M18,17H6v-2h12v2zM18,13H6v-2h12v2zM18,9H6V7h12v2zM3,22l1.5,-1.5L6,22l1.5,-1.5L9,22l1.5,-1.5L12,22l1.5,-1.5L15,22l1.5,-1.5L18,22l1.5,-1.5L21,22V2l-1.5,1.5L18,2l-1.5,1.5L15,2l-1.5,1.5L12,2l-1.5,1.5L9,2 7.5,3.5 6,2 4.5,3.5 3,2v20z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/delivery_preparing.xml
+++ b/samples/java_layout/src/main/res/drawable/delivery_preparing.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1565C0"
+        android:pathData="M20,2H4C3,2 2,2.9 2,4v3.01C2,7.73 2.43,8.35 3,8.7V20c0,1.1 1.1,2 2,2h14c0.9,0 2,-0.9 2,-2V8.7c0.57,-0.35 1,-0.97 1,-1.69V4c0,-1.1 -1,-2 -2,-2zM15,14H9v-2h6v2zM20,7H4V4h16v3z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/ic_rideshare_car.xml
+++ b/samples/java_layout/src/main/res/drawable/ic_rideshare_car.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1B5E20"
+        android:pathData="M18.92,6.01C18.72,5.42 18.16,5 17.5,5h-11c-0.66,0 -1.21,0.42 -1.42,1.01L3,12v8c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-1h12v1c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1v-8l-2.08,-5.99zM6.5,16c-0.83,0 -1.5,-0.67 -1.5,-1.5S5.67,13 6.5,13s1.5,0.67 1.5,1.5S7.33,16 6.5,16zM17.5,16c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5zM5,11l1.5,-4.5h11L19,11L5,11z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/ic_step_active.xml
+++ b/samples/java_layout/src/main/res/drawable/ic_step_active.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1B5E20"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/ic_step_done.xml
+++ b/samples/java_layout/src/main/res/drawable/ic_step_done.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#2E7D32"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/ic_step_pending.xml
+++ b/samples/java_layout/src/main/res/drawable/ic_step_pending.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#BDBDBD"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z" />
+</vector>

--- a/samples/java_layout/src/main/res/drawable/ic_workout_run.xml
+++ b/samples/java_layout/src/main/res/drawable/ic_workout_run.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1B5E20"
+        android:pathData="M13.49,5.48c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM9.89,19.38l1,-4.4 2.1,2v6h2v-7.5l-2.1,-2 0.6,-3c1.3,1.5 3.3,2.5 5.5,2.5v-2c-1.9,0 -3.5,-1 -4.3,-2.4l-1,-1.6c-0.4,-0.6 -1,-1 -1.7,-1 -0.3,0 -0.5,0.1 -0.8,0.1l-5.2,2.2v4.7h2v-3.4l1.8,-0.7 -1.6,8.1 -4.9,-1 -0.4,2 7,1.4z" />
+</vector>

--- a/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
+++ b/samples/java_layout/src/main/res/layout/activity_live_notification_demo.xml
@@ -17,13 +17,17 @@
             app:title="@string/live_notification_demo" />
     </com.google.android.material.appbar.AppBarLayout>
 
-    <LinearLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:gravity="center_horizontal"
         android:orientation="vertical"
-        android:padding="@dimen/margin_default"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        android:padding="@dimen/margin_default">
 
         <TextView
             android:id="@+id/status_text_view"
@@ -78,6 +82,18 @@
                 android:layout_height="wrap_content"
                 android:text="@string/live_notification_type_auction_bid" />
 
+            <RadioButton
+                android:id="@+id/radio_custom_rideshare"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/live_notification_type_rideshare" />
+
+            <RadioButton
+                android:id="@+id/radio_custom_workout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/live_notification_type_workout" />
+
         </RadioGroup>
 
         <!-- Manual controls -->
@@ -130,6 +146,38 @@
             android:layout_marginTop="@dimen/margin_default"
             android:text="@string/live_notification_auto" />
 
+        <!-- Campaign trigger: tracks a `trigger_activity` event whose `activity_type`
+             property drives a backend campaign that pushes the real start/update/end. -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/live_notification_section_campaign"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/campaign_template_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:hint="@string/live_notification_campaign_hint">
+
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/campaign_template_dropdown"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:id="@+id/campaign_trigger_button"
+            style="?attr/materialButtonStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_default"
+            android:text="@string/live_notification_campaign_trigger" />
+
         <!-- Debug controls -->
         <TextView
             android:layout_width="match_parent"
@@ -155,4 +203,5 @@
             android:text="@string/live_notification_debug_start_via_api" />
 
     </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/java_layout/src/main/res/layout/notification_rideshare_collapsed.xml
+++ b/samples/java_layout/src/main/res/layout/notification_rideshare_collapsed.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Custom RemoteViews layout for the app-rendered "rideshare" live notification
+     (collapsed). Driven entirely by the host app via
+     CustomerIOPushNotificationCallback.createLiveNotification. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            tools:ignore="HardcodedText"
+            android:text="Alex is on the way" />
+
+        <TextView
+            android:id="@+id/tv_subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="13sp"
+            tools:ignore="HardcodedText"
+            android:text="Toyota Prius · 7XYZ123" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:gravity="end"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:letterSpacing="0.08"
+            android:text="@string/live_notification_rideshare_eta"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="10sp" />
+
+        <TextView
+            android:id="@+id/tv_eta"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#2E7D32"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            tools:ignore="HardcodedText"
+            android:text="4 min" />
+    </LinearLayout>
+</LinearLayout>

--- a/samples/java_layout/src/main/res/layout/notification_rideshare_expanded.xml
+++ b/samples/java_layout/src/main/res/layout/notification_rideshare_expanded.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Custom RemoteViews layout for the app-rendered "rideshare" live notification
+     (expanded). The host app sets every field + the 4-stop progress strip from
+     CustomerIOPushNotificationCallback.createLiveNotification. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="14dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tv_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText"
+                android:text="Alex is on the way" />
+
+            <TextView
+                android:id="@+id/tv_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="1dp"
+                android:maxLines="1"
+                android:ellipsize="end"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="13sp"
+                tools:ignore="HardcodedText"
+                android:text="Toyota Prius · 7XYZ123" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:gravity="end"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:letterSpacing="0.08"
+                android:text="@string/live_notification_rideshare_eta"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="10sp" />
+
+            <TextView
+                android:id="@+id/tv_eta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="#2E7D32"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                tools:ignore="HardcodedText"
+                android:text="4 min" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="13sp"
+        tools:ignore="HardcodedText"
+        android:text="Heading to your pickup" />
+
+    <!-- 4-stop progress strip; the app sets each icon (pending/active/done). -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="horizontal"
+        android:weightSum="4">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/iv_step1"
+                android:layout_width="22dp"
+                android:layout_height="22dp"
+                android:contentDescription="@string/live_notification_rideshare_step_pickup"
+                android:src="@drawable/ic_step_active" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="@string/live_notification_rideshare_step_pickup"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="10sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/iv_step2"
+                android:layout_width="22dp"
+                android:layout_height="22dp"
+                android:contentDescription="@string/live_notification_rideshare_step_arriving"
+                android:src="@drawable/ic_step_pending" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="@string/live_notification_rideshare_step_arriving"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="10sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/iv_step3"
+                android:layout_width="22dp"
+                android:layout_height="22dp"
+                android:contentDescription="@string/live_notification_rideshare_step_trip"
+                android:src="@drawable/ic_step_pending" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="@string/live_notification_rideshare_step_trip"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="10sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/iv_step4"
+                android:layout_width="22dp"
+                android:layout_height="22dp"
+                android:contentDescription="@string/live_notification_rideshare_step_dropoff"
+                android:src="@drawable/ic_step_pending" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="3dp"
+                android:text="@string/live_notification_rideshare_step_dropoff"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="10sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="@android:style/Widget.Material.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:max="100"
+        android:progress="25"
+        android:progressTint="#2E7D32" />
+</LinearLayout>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -166,7 +166,7 @@
     <string name="live_notification_status_idle">Status: Idle</string>
     <string name="live_notification_status_format">Status: %1$s (Step %2$d)</string>
     <string name="live_notification_status_ended">Status: Ended</string>
-    <string name="live_notification_auto">Run All Steps (2s each)</string>
+    <string name="live_notification_auto">Run All Steps (5s each)</string>
     <string name="live_notification_section_type">Notification Type</string>
     <string name="live_notification_section_manual">Manual Control</string>
     <string name="live_notification_section_auto">Auto Sequence</string>
@@ -175,6 +175,17 @@
     <string name="live_notification_type_live_score">Live Score</string>
     <string name="live_notification_type_countdown_timer">Countdown Timer</string>
     <string name="live_notification_type_auction_bid">Auction Bid</string>
+    <string name="live_notification_type_rideshare">Rideshare (custom layout)</string>
+    <string name="live_notification_type_workout">Workout (builder API)</string>
+    <string name="live_notification_rideshare_eta">ETA</string>
+    <string name="live_notification_rideshare_step_pickup">Pickup</string>
+    <string name="live_notification_rideshare_step_arriving">Arriving</string>
+    <string name="live_notification_rideshare_step_trip">In trip</string>
+    <string name="live_notification_rideshare_step_dropoff">Drop-off</string>
+    <string name="live_notification_section_campaign">Trigger via Campaign</string>
+    <string name="live_notification_campaign_hint">Template (activity_type)</string>
+    <string name="live_notification_campaign_trigger">Send trigger_live event</string>
+    <string name="live_notification_campaign_event_sent">Tracked trigger_live: %1$s</string>
     <string name="live_notification_section_debug">Debug</string>
     <string name="live_notification_debug_unknown_activity_type">Fire unknown activity_type</string>
     <string name="live_notification_debug_start_via_api">Start via startLiveNotification() API</string>


### PR DESCRIPTION
Follow-up to #724 (stacked on `mbl-live-notification-app-api`). Sample-app only — no SDK changes. Demonstrates the live-notification surface in the `java_layout` sample so it can be QA'd / showcased.

## What's added
- **Two app-rendered custom activity types** via `CustomerIOPushNotificationCallback.createLiveNotification`:
  - `rideshare` — a **fully custom RemoteViews layout** (collapsed + expanded) with a 4-stop progress strip + step captions.
  - `workout` — the **standard `NotificationCompat` builder API** (determinate progress + BigTextStyle + action), requesting promoted-ongoing on Android 16+.
- **"Trigger via Campaign"** control — tracks a `trigger_live` event with `activity_type` + a unique `timestamp` property, so a real backend campaign can drive the start→update→end lifecycle (the `timestamp` is meant to be injected into a fresh `activity_id` via Liquid).
- **Per-step delivery icons** (ordered → preparing → out-for-delivery → delivered) + step-state icons (pending/active/done).
- Delivery demo trimmed to a realistic **4-step lifecycle** (dropped the deliberate missing-asset edge step that looked broken in a demo).

## Testing
Verified end-to-end on a real device (Samsung, Android 16) by driving a real campaign with custom FCM payloads: full delivery lifecycle rendered + updated in place as a single live notification.

## Notes
- Targets `mbl-live-notification-app-api` because it depends on that PR's live-notification public APIs. Rebase/retarget to `feature/live-notifications` once #724 merges.
- The promoted-ongoing status-bar chip needs `POST_PROMOTED_NOTIFICATIONS` granted at runtime (separate follow-up if we want to demo the chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the java_layout sample app (demo UI, assets, and init wiring); no production SDK or auth/data paths are modified.
> 
> **Overview**
> Expands the **java_layout** live-notification demo so QA can exercise app-rendered custom types, richer delivery visuals, and real campaign-driven lifecycles—**sample app only**, no SDK changes.
> 
> **SDK init** wires `LiveNotificationCallback` via `setNotificationCallback` and opts in two custom `activity_type` strings alongside the built-in templates in `setLiveNotificationTypes`.
> 
> **`LiveNotificationCallback`** implements `CustomerIOPushNotificationCallback.createLiveNotification`: **rideshare** uses custom collapsed/expanded `RemoteViews` with a 4-stop progress strip; **workout** uses `NotificationCompat` (progress, BigTextStyle, Pause action, promoted-ongoing on API 36+). Built-in types return `null` so the SDK keeps rendering its templates.
> 
> **`LiveNotificationDemoActivity`** adds radio options and synthetic FCM paths for those custom types; trims delivery to **4 steps** with per-step `statusImageKey` icons (`delivery_ordered` / `preparing` / `truck` / `delivered`); slows auto-run to **5s**; adds **Trigger via Campaign** (`trigger_live` + `activity_type` + unique `timestamp` via `CustomerIORepository.trackEvent`). Layout scrolls and gains campaign dropdown UI plus new drawables/layouts/strings for rideshare and delivery assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4701c4ef4f288cea37430089181278f5268dc246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->