### PR TITLE
chore(location): publish location updates via EventBus

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -43,6 +43,19 @@ public final class io/customer/sdk/communication/Event$GeofenceTransitionEvent :
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/customer/sdk/communication/Event$LocationAcquired : io/customer/sdk/communication/Event {
+	public fun <init> (DD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun copy (DD)Lio/customer/sdk/communication/Event$LocationAcquired;
+	public static synthetic fun copy$default (Lio/customer/sdk/communication/Event$LocationAcquired;DDILjava/lang/Object;)Lio/customer/sdk/communication/Event$LocationAcquired;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLatitude ()D
+	public final fun getLongitude ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/customer/sdk/communication/Event$RegisterDeviceTokenEvent : io/customer/sdk/communication/Event {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
+++ b/core/src/main/kotlin/io/customer/sdk/communication/Event.kt
@@ -50,6 +50,15 @@ sealed class Event {
         val token: String
     ) : Event()
 
+    /**
+     * Published by the location module on every fresh location fix. Other modules
+     * subscribe to react to location updates without depending on its internals.
+     */
+    data class LocationAcquired(
+        val latitude: Double,
+        val longitude: Double
+    ) : Event()
+
     class DeleteDeviceTokenEvent : Event()
 
     enum class GeofenceTransition {

--- a/location/src/main/kotlin/io/customer/location/LocationTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationTracker.kt
@@ -2,6 +2,8 @@ package io.customer.location
 
 import io.customer.location.store.LocationPreferenceStore
 import io.customer.location.sync.LocationSyncFilter
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.pipeline.DataPipeline
 import io.customer.sdk.core.pipeline.IdentifyHook
 import io.customer.sdk.core.util.Logger
@@ -34,6 +36,7 @@ internal class LocationTracker(
     dataPipeline: DataPipeline?,
     private val locationPreferenceStore: LocationPreferenceStore,
     private val locationSyncFilter: LocationSyncFilter,
+    private val eventBus: EventBus,
     private val logger: Logger
 ) : IdentifyHook {
 
@@ -46,12 +49,6 @@ internal class LocationTracker(
     @Volatile
     internal var lastLocation: LocationCoordinates? = null
         private set
-
-    // Single-listener hook fired after every successful location update.
-    // Promote to a list-backed API or EventBus if multiple consumers or
-    // modularity needs emerge.
-    @Volatile
-    internal var onLocationReceivedListener: ((Double, Double) -> Unit)? = null
 
     override fun getIdentifyContext(): Map<String, Any> {
         val location = lastLocation ?: return emptyMap()
@@ -98,7 +95,7 @@ internal class LocationTracker(
         locationPreferenceStore.saveCachedLocation(latitude, longitude)
 
         trySendLocationTrack(latitude, longitude)
-        onLocationReceivedListener?.invoke(latitude, longitude)
+        eventBus.publish(Event.LocationAcquired(latitude = latitude, longitude = longitude))
     }
 
     /**

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -84,7 +84,7 @@ class ModuleLocation @JvmOverloads constructor(
         val locationSyncFilter = LocationSyncFilter(
             LocationSyncStoreImpl(context, logger)
         )
-        val locationTracker = LocationTracker(dataPipeline, store, locationSyncFilter, logger)
+        val locationTracker = LocationTracker(dataPipeline, store, locationSyncFilter, eventBus, logger)
 
         val locationProvider = FusedLocationProvider(context)
         val orchestrator = LocationOrchestrator(
@@ -114,8 +114,8 @@ class ModuleLocation @JvmOverloads constructor(
         // Recover from a first-run race where identify lands before the first
         // GPS fix: GeofenceServices holds a "last skipped for no-location" flag
         // and re-triggers a refresh when a fresh fix arrives.
-        locationTracker.onLocationReceivedListener = { lat, lng ->
-            SDKComponent.android().geofenceServices.onLocationAcquired(lat, lng)
+        eventBus.subscribe<Event.LocationAcquired> {
+            SDKComponent.android().geofenceServices.onLocationAcquired(it.latitude, it.longitude)
         }
 
         // Register as IdentifyHook so location is added to identify event context
@@ -138,7 +138,7 @@ class ModuleLocation @JvmOverloads constructor(
 
                 // ON_APP_START's lifecycle one-shot fires per process, but resetContext()
                 // wipes lastLocation on logout — a subsequent identify in the same process
-                // needs a fresh fetch. The onLocationReceivedListener above re-triggers the
+                // needs a fresh fetch. The LocationAcquired subscriber above re-triggers the
                 // geofence refresh once the fix arrives. MANUAL deliberately doesn't auto-fetch.
                 if (location == null && moduleConfig.trackingMode == LocationTrackingMode.ON_APP_START) {
                     services.requestLocationUpdate()

--- a/location/src/test/java/io/customer/location/LocationTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/LocationTrackerTest.kt
@@ -2,11 +2,14 @@ package io.customer.location
 
 import io.customer.location.store.LocationPreferenceStore
 import io.customer.location.sync.LocationSyncFilter
+import io.customer.sdk.communication.Event
+import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.pipeline.DataPipeline
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.util.EventNames
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
@@ -19,6 +22,7 @@ class LocationTrackerTest {
     private val dataPipeline: DataPipeline = mockk(relaxUnitFun = true)
     private val store: LocationPreferenceStore = mockk(relaxUnitFun = true)
     private val syncFilter: LocationSyncFilter = mockk(relaxUnitFun = true)
+    private val mockEventBus: EventBus = mockk(relaxUnitFun = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
 
     private lateinit var tracker: LocationTracker
@@ -27,7 +31,7 @@ class LocationTrackerTest {
     fun setup() {
         every { dataPipeline.isUserIdentified } returns true
         every { syncFilter.filterAndRecord(any(), any()) } returns true
-        tracker = LocationTracker(dataPipeline, store, syncFilter, logger)
+        tracker = LocationTracker(dataPipeline, store, syncFilter, mockEventBus, logger)
     }
 
     // -- onLocationReceived --
@@ -71,7 +75,7 @@ class LocationTrackerTest {
 
     @Test
     fun givenNullDataPipeline_expectNoException() {
-        val trackerWithNullPipeline = LocationTracker(null, store, syncFilter, logger)
+        val trackerWithNullPipeline = LocationTracker(null, store, syncFilter, mockEventBus, logger)
 
         trackerWithNullPipeline.onLocationReceived(37.7749, -122.4194)
 
@@ -80,22 +84,13 @@ class LocationTrackerTest {
     }
 
     @Test
-    fun givenLocationReceived_listenerRegistered_expectListenerInvokedWithCoordinates() {
-        var captured: Pair<Double, Double>? = null
-        tracker.onLocationReceivedListener = { lat, lng -> captured = lat to lng }
+    fun givenLocationReceived_expectLocationAcquiredPublishedOnEventBus() {
+        val captured = slot<Event.LocationAcquired>()
 
         tracker.onLocationReceived(37.7749, -122.4194)
 
-        captured shouldBeEqualTo (37.7749 to -122.4194)
-    }
-
-    @Test
-    fun givenLocationReceived_noListener_expectNoException() {
-        tracker.onLocationReceivedListener = null
-
-        tracker.onLocationReceived(37.7749, -122.4194)
-
-        verify { store.saveCachedLocation(37.7749, -122.4194) }
+        verify { mockEventBus.publish(capture(captured)) }
+        captured.captured shouldBeEqualTo Event.LocationAcquired(latitude = 37.7749, longitude = -122.4194)
     }
 
     // -- syncCachedLocationIfNeeded --


### PR DESCRIPTION
**Linear:** [MBL-1781](https://linear.app/customerio/issue/MBL-1781/android-extract-geofencing-into-a-dedicated-module)

**Stack** (merge bottom-up into `feature/geofence-on-device`):
- PR 1 — scaffold `:geofence` module (#730)
- **PR 2 — publish location updates via EventBus 👈 this PR**
- PR 3 — move geofence implementation into `:geofence` (#732)

Replaces `LocationTracker.onLocationReceivedListener` (single-callback hook) with `Event.LocationAcquired` on the SDK-wide EventBus. `ModuleLocation` subscribes and forwards to `geofenceServices.onLocationAcquired` exactly as before. The decoupling is what lets the next PR move geofence code out of `:location` — the consumer subscribes to a core event instead of reaching into a `LocationTracker` field.

Behavior unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only wiring change with the same geofence forward path; no changes to location tracking, identify enrichment, or sync filter behavior.
> 
> **Overview**
> Fresh GPS fixes are now broadcast as **`Event.LocationAcquired`** on the SDK **`EventBus`** instead of invoking a single **`LocationTracker.onLocationReceivedListener`** callback.
> 
> **`LocationTracker`** takes **`EventBus`** and **`publish`es** lat/lng after the existing cache, persist, and track logic. **`ModuleLocation`** **subscribes** and still calls **`geofenceServices.onLocationAcquired`** with the same coordinates, so geofence refresh behavior is unchanged.
> 
> The new core event is exposed in the public API surface (`core.api`). Unit tests assert **`EventBus.publish`** rather than a listener hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d58fb877fc1fab2c8e0ec89331e2fdf4befd86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->