### PR TITLE
fix: harden push notification activity and in-app message WebView

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -146,8 +146,11 @@ internal class EngineWebView @JvmOverloads constructor(
         logger.debug("Rendering message with URL: $messageUrl")
         webView?.let {
             it.settings.javaScriptEnabled = true
-            it.settings.allowFileAccess = true
-            it.settings.allowContentAccess = true
+            // File and content access are disabled as defense-in-depth: the renderer only loads our
+            // first-party HTTPS page (navigation is locked to that origin), so it never needs to read
+            // local file:// or content:// resources. These default to false on API 30+ anyway.
+            it.settings.allowFileAccess = false
+            it.settings.allowContentAccess = false
             it.settings.domStorageEnabled = true
             it.settings.textZoom = 100
             it.setBackgroundColor(Color.TRANSPARENT)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewSettingsTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewSettingsTest.kt
@@ -1,0 +1,75 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the security hardening that disables file:// and content:// access in the in-app
+ * message WebView (see EngineWebView.setup).
+ *
+ * The renderer only loads our first-party HTTPS page (navigation is origin-locked), so the
+ * WebView must never be allowed to read local file:// or content:// resources. This test also
+ * pins javaScriptEnabled and domStorageEnabled to true, since the renderer requires them — so a
+ * future change can't silently break rendering while tightening security.
+ *
+ * Fails if any of the four settings drift from their intended values.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewSettingsTest : IntegrationTest() {
+
+    private val inAppMessagingManager: InAppMessagingManager = mockk(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency(inAppMessagingManager)
+                    }
+                }
+            }
+        )
+        // Default state -> GistEnvironment.PROD, so setup() can resolve a real renderer URL.
+        every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
+    }
+
+    @Test
+    fun setup_givenConfiguration_expectFileAndContentAccessDisabledAndRendererSettingsEnabled() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val engineWebView = EngineWebView(context)
+
+        engineWebView.setup(
+            EngineWebConfiguration(
+                siteId = String.random,
+                dataCenter = String.random,
+                messageId = String.random,
+                instanceId = String.random,
+                endpoint = "https://${String.random}"
+            )
+        )
+
+        val settings = (engineWebView.getChildAt(0) as WebView).settings
+        // Security hardening: local resource access must stay disabled.
+        settings.allowFileAccess shouldBeEqualTo false
+        settings.allowContentAccess shouldBeEqualTo false
+        // Required by the renderer: must remain enabled.
+        settings.javaScriptEnabled shouldBeEqualTo true
+        settings.domStorageEnabled shouldBeEqualTo true
+
+        engineWebView.releaseResources()
+    }
+}

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -12,12 +12,15 @@
         was launched recently from earlier notification.
         * launchMode="singleTop" does not work well with ACTIVITY_NO_FLAGS if customer app also has launchMode="singleTop"
         (e.g. Flutter apps) and have multiple instances launched from notifications in one session.
+        * exported="false" because this activity is only ever launched internally via the notification's
+        PendingIntent (an explicit-component intent dispatched with the host app's identity). It has no
+        intent-filter and is never started by other apps, so it does not need to be exported.
 
         -->
         <activity
             android:name=".activity.NotificationClickReceiverActivity"
             android:excludeFromRecents="true"
-            android:exported="true"
+            android:exported="false"
             android:launchMode="singleTask"
             android:noHistory="true"
             android:taskAffinity=""

--- a/messagingpush/src/test/java/io/customer/messagingpush/activity/NotificationClickReceiverActivityManifestTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/activity/NotificationClickReceiverActivityManifestTest.kt
@@ -1,0 +1,35 @@
+package io.customer.messagingpush.activity
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the security hardening that makes [NotificationClickReceiverActivity] non-exported.
+ *
+ * The activity is only ever launched internally via the notification's PendingIntent (an
+ * explicit-component intent dispatched with the host app's identity). It has no intent-filter
+ * and must never be startable by other apps, so it must stay exported="false" in the merged
+ * manifest. This test fails if the flag is ever reverted to exported="true".
+ *
+ * Note: reads the real Robolectric merged manifest via [ApplicationProvider], not the mocked
+ * context/packageManager provided by the base class.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NotificationClickReceiverActivityManifestTest : IntegrationTest() {
+
+    @Test
+    fun activity_givenMergedManifest_expectExportedFalse() {
+        val realContext = ApplicationProvider.getApplicationContext<Context>()
+        val component = ComponentName(realContext, NotificationClickReceiverActivity::class.java)
+
+        val activityInfo = realContext.packageManager.getActivityInfo(component, 0)
+
+        activityInfo.exported shouldBeEqualTo false
+    }
+}


### PR DESCRIPTION
- #725: Make `NotificationClickReceiverActivity` non-exported so other apps can't launch it to spoof notification clicks or trigger deep-link handling.
- #726: Disable `file://` and `content://` access in the in-app message WebView, which only ever loads our first-party HTTPS renderer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes reduce attack surface (non-exported activity, disabled WebView file access) without altering intended notification or HTTPS renderer flows; regression tests guard the new defaults.
> 
> **Overview**
> **Security hardening** for push and in-app messaging on Android.
> 
> `NotificationClickReceiverActivity` is changed from **`exported="true"`** to **`exported="false"`** in the push module manifest. It is only started from the app’s own notification `PendingIntent` (explicit component, no intent-filter), so other apps should not be able to launch it to spoof clicks or trigger deep-link handling. A Robolectric test asserts the merged manifest keeps **`exported` false**.
> 
> In **`EngineWebView.setup`**, **`allowFileAccess`** and **`allowContentAccess`** are set to **`false`** (previously enabled). The in-app renderer only loads the first-party HTTPS page with origin-locked navigation, so `file://` and `content://` access is unnecessary. **`javaScriptEnabled`** and **`domStorageEnabled`** stay enabled for the renderer. **`EngineWebViewSettingsTest`** pins all four WebView settings so security tightening cannot silently break rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38837573583126a7810c9d4227ced930d009dc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->