### PR TITLE
chore(geofence): remove precise location from geofence events

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -146,8 +146,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             val entry = PendingGeofenceDelivery(
                 geofenceId = geofenceId,
                 transition = transition,
-                latitude = latitude,
-                longitude = longitude,
                 timestamp = timestamp,
                 userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
             )

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -57,7 +57,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logTransitionWithoutLocation() {
-        logger.debug("Geofence transition fired but OS provided no location; emitting event with lat/lng omitted from properties", tag = TAG)
+        logger.debug("Geofence transition fired but OS provided no triggering location; a movement-trigger refresh cannot run without it", tag = TAG)
     }
 
     fun logMovementTriggerIgnoredNonExit(transitionName: String) {

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -20,8 +20,6 @@ import kotlinx.serialization.Serializable
 internal data class PendingGeofenceDelivery(
     val geofenceId: String,
     val transition: Event.GeofenceTransition,
-    val latitude: Double?,
-    val longitude: Double?,
     /** Unix epoch **seconds** at receiver time. Use [toGeofenceTransitionEvent] when a [Date] is needed. */
     val timestamp: Long,
     val userId: String?
@@ -36,8 +34,6 @@ internal data class PendingGeofenceDelivery(
     fun toEventProperties(): Map<String, Any> = buildMap {
         put("geofence_id", geofenceId)
         put("transition_type", transition.name.lowercase())
-        latitude?.let { put("latitude", it) }
-        longitude?.let { put("longitude", it) }
         put("timestamp", timestamp)
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -22,8 +22,6 @@ import io.customer.sdk.data.store.claimSendRestore
 
 private const val KEY_GEOFENCE_ID = "geofence_id"
 private const val KEY_TRANSITION = "transition"
-private const val KEY_LATITUDE = "latitude"
-private const val KEY_LONGITUDE = "longitude"
 private const val KEY_TIMESTAMP = "timestamp"
 private const val KEY_USER_ID = "user_id"
 
@@ -41,8 +39,6 @@ internal class GeofenceEventScheduler(
             .putString(KEY_TRANSITION, entry.transition.name)
             .putLong(KEY_TIMESTAMP, entry.timestamp)
             .apply {
-                entry.latitude?.let { putDouble(KEY_LATITUDE, it) }
-                entry.longitude?.let { putDouble(KEY_LONGITUDE, it) }
                 entry.userId?.let { putString(KEY_USER_ID, it) }
             }
             .build()
@@ -90,8 +86,6 @@ internal class GeofenceEventWorker(
         val logger = SDKComponent.geofenceLogger
         val geofenceId = inputData.getString(KEY_GEOFENCE_ID)
         val transitionName = inputData.getString(KEY_TRANSITION)
-        val latitude = if (inputData.hasKeyWithValueOfType(KEY_LATITUDE, Double::class.javaObjectType)) inputData.getDouble(KEY_LATITUDE, 0.0) else null
-        val longitude = if (inputData.hasKeyWithValueOfType(KEY_LONGITUDE, Double::class.javaObjectType)) inputData.getDouble(KEY_LONGITUDE, 0.0) else null
         val timestamp = inputData.getLong(KEY_TIMESTAMP, 0L)
 
         if (geofenceId.isNullOrEmpty() || transitionName.isNullOrEmpty()) {
@@ -110,7 +104,7 @@ internal class GeofenceEventWorker(
 
         val userId = inputData.getString(KEY_USER_ID)
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
-        val entry = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
+        val entry = PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
 
         // No identified user at queue time — direct HTTP needs a userId, so
         // leave the entry in the store for the foreground flush instead.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -121,7 +121,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
-    fun handleGeofencingEvent_givenNullTriggeringLocation_expectEntryQueuedWithoutLatLng() = runTest {
+    fun handleGeofencingEvent_givenNullTriggeringLocation_expectEntryStillQueued() = runTest {
+        // Business-geofence delivery doesn't depend on a triggering location, so
+        // a null location must still queue the transition.
         val event = buildGeofencingEvent(
             transition = Geofence.GEOFENCE_TRANSITION_ENTER,
             geofenceIds = listOf("biz-1"),
@@ -132,12 +134,10 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         val entry = pendingStore.loadAll().single()
         entry.geofenceId shouldBeEqualTo "biz-1"
-        entry.latitude.shouldBeNull()
-        entry.longitude.shouldBeNull()
     }
 
     @Test
-    fun handleGeofencingEvent_givenValidEnterEvent_expectEntryQueuedWithLatLng() = runTest {
+    fun handleGeofencingEvent_givenValidEnterEvent_expectEntryQueued() = runTest {
         val event = buildGeofencingEvent(
             transition = Geofence.GEOFENCE_TRANSITION_ENTER,
             geofenceIds = listOf("biz-1"),
@@ -147,9 +147,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         receiver.handleGeofencingEvent(event)
 
         val entry = pendingStore.loadAll().single()
+        entry.geofenceId shouldBeEqualTo "biz-1"
         entry.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
-        entry.latitude shouldBeEqualTo 37.7749
-        entry.longitude shouldBeEqualTo -122.4194
     }
 
     @Test
@@ -167,8 +166,6 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         val scheduled = entrySlot.captured
         scheduled.geofenceId shouldBeEqualTo "biz-geofence-1"
         scheduled.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
-        scheduled.latitude shouldBeEqualTo 37.7749
-        scheduled.longitude shouldBeEqualTo -122.4194
         scheduled.toEventProperties()["transition_type"] shouldBeEqualTo "enter"
         scheduled.timestamp.shouldNotBeNull()
 
@@ -290,7 +287,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
-    fun dispatchTransition_givenMissingLatLng_expectEntryScheduledWithNullLatLng() = runTest {
+    fun dispatchTransition_givenMissingLocation_expectEntryStillScheduled() = runTest {
+        // A missing triggering location can't block a business-geofence
+        // transition from being scheduled for delivery.
         val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
@@ -301,8 +300,6 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
-        entrySlot.captured.latitude.shouldBeNull()
-        entrySlot.captured.longitude.shouldBeNull()
         entrySlot.captured.geofenceId shouldBeEqualTo "biz-geofence"
     }
 

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -4,7 +4,6 @@ import io.customer.sdk.communication.Event
 import java.util.Date
 import kotlinx.serialization.json.Json
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotContain
 import org.junit.Test
 
@@ -12,7 +11,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun key_expectGeofenceIdTransitionTimestampComposite() {
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_234L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A")
 
         // Doubles as the WorkManager unique-work name so the flush can cancel by key.
         entry.key shouldBeEqualTo "biz-1_ENTER_1234"
@@ -20,29 +19,17 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun serialization_givenRoundTrip_expectEqualEntry() {
-        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 37.7749, -122.4194, 99L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 99L, "user-A")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
 
         restored shouldBeEqualTo entry
-    }
-
-    @Test
-    fun serialization_givenNullLatLng_expectRoundTripPreservesNulls() {
-        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, null, null, 0L, "user-A")
-
-        val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
-        val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
-
-        restored shouldBeEqualTo entry
-        restored.latitude shouldBeEqualTo null
-        restored.longitude shouldBeEqualTo null
     }
 
     @Test
     fun serialization_givenUserIdSnapshot_expectRoundTripPreservesIt() {
-        val entry = PendingGeofenceDelivery("biz-u", Event.GeofenceTransition.ENTER, 1.0, 2.0, 3L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-u", Event.GeofenceTransition.ENTER, 3L, "user-A")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -53,7 +40,7 @@ class PendingGeofenceDeliveryTest {
     @Test
     fun serialization_givenNullUserId_expectRoundTripPreservesNull() {
         // Anonymous entries are queued by the receiver for the foreground flush.
-        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 1.0, 2.0, 5L, userId = null)
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 5L, userId = null)
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -63,16 +50,16 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
-    fun toEventProperties_givenLatLng_expectAllPropertiesPresent() {
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.5, 2.5, 50L, "user-A")
+    fun toEventProperties_expectOnlyGeofenceTransitionAndTimestamp() {
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 50L, "user-A")
 
         val props = entry.toEventProperties()
 
         props["geofence_id"] shouldBeEqualTo "biz-4"
         props["transition_type"] shouldBeEqualTo "enter"
-        props["latitude"] shouldBeEqualTo 1.5
-        props["longitude"] shouldBeEqualTo 2.5
         props["timestamp"] shouldBeEqualTo 50L
+        props.keys shouldNotContain "latitude"
+        props.keys shouldNotContain "longitude"
     }
 
     @Test
@@ -80,7 +67,7 @@ class PendingGeofenceDeliveryTest {
         // `timestamp` is unix seconds; `Event.timestamp` is a `Date` (millis).
         // The conversion lives on the data class so no caller can hand-roll
         // `Date(entry.timestamp)` and silently produce a January 1970 instant.
-        val entry = PendingGeofenceDelivery("biz-t", Event.GeofenceTransition.ENTER, 1.0, 2.0, 1_700_000_000L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-t", Event.GeofenceTransition.ENTER, 1_700_000_000L, "user-A")
 
         val event = entry.toGeofenceTransitionEvent()
 
@@ -88,17 +75,5 @@ class PendingGeofenceDeliveryTest {
         event.geofenceId shouldBeEqualTo "biz-t"
         event.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
         event.userId shouldBeEqualTo "user-A"
-    }
-
-    @Test
-    fun toEventProperties_givenNullLatLng_expectLatLngOmitted() {
-        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.EXIT, null, null, 7L, "user-A")
-
-        val props = entry.toEventProperties()
-
-        props.keys shouldNotContain "latitude"
-        props.keys shouldNotContain "longitude"
-        props.keys shouldContain "geofence_id"
-        props["transition_type"] shouldBeEqualTo "exit"
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -47,7 +47,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryAndUserId() = runTest {
         every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 42L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 42L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
@@ -62,7 +62,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenClaimLost_expectNoSend() = runTest {
         // Foreground flush already claimed + delivered this entry: do not double-send.
         every { mockStore.claim(any()) } returns false
-        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 1.0, 2.0, 7L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 7L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
@@ -74,7 +74,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
         every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 1.0, 2.0, 9L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42")
 
         asyncTracker.trackEvent(entry)
 
@@ -86,7 +86,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenNullUserId_expectNoClaimAndNoSend() = runTest {
         // Anonymous session: HTTP needs a userId, so we leave the entry in
         // the store for the foreground flush to publish via anonymousId.
-        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 1.0, 2.0, 11L, userId = null)
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 11L, userId = null)
 
         asyncTracker.trackEvent(entry)
 

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -55,8 +55,6 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
             PendingGeofenceDelivery(
                 geofenceId = "biz-geofence-1",
                 transition = Event.GeofenceTransition.ENTER,
-                latitude = 37.7749,
-                longitude = -122.4194,
                 timestamp = 1_234L,
                 userId = "user-42"
             )
@@ -74,36 +72,14 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val input = workRequestSlot.captured.workSpec.input
         input.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
         input.getString("transition") shouldBeEqualTo "ENTER"
-        input.getDouble("latitude", -1.0) shouldBeEqualTo 37.7749
-        input.getDouble("longitude", -1.0) shouldBeEqualTo -122.4194
         input.getLong("timestamp", -1L) shouldBeEqualTo 1_234L
         input.getString("user_id") shouldBeEqualTo "user-42"
+        input.hasKeyWithValueOfType("latitude", Double::class.javaObjectType) shouldBeEqualTo false
+        input.hasKeyWithValueOfType("longitude", Double::class.javaObjectType) shouldBeEqualTo false
 
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
         constraints.requiredNetworkType shouldBeEqualTo NetworkType.CONNECTED
-    }
-
-    @Test
-    fun schedule_givenNullLatLng_expectInputDataWithoutLatLngKeys() = runTest {
-        every { workManagerProvider.getWorkManager() } returns workManager
-        val workRequestSlot = slot<OneTimeWorkRequest>()
-
-        scheduler.schedule(
-            PendingGeofenceDelivery(
-                geofenceId = "biz-geofence-2",
-                transition = Event.GeofenceTransition.EXIT,
-                latitude = null,
-                longitude = null,
-                timestamp = 99L,
-                userId = "user-42"
-            )
-        )
-
-        verify { workManager.enqueueUniqueWork(any(), any(), capture(workRequestSlot)) }
-        val input = workRequestSlot.captured.workSpec.input
-        input.hasKeyWithValueOfType("latitude", Double::class.javaObjectType) shouldBeEqualTo false
-        input.hasKeyWithValueOfType("longitude", Double::class.javaObjectType) shouldBeEqualTo false
     }
 
     @Test
@@ -116,8 +92,6 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
             PendingGeofenceDelivery(
                 geofenceId = "biz-anon",
                 transition = Event.GeofenceTransition.ENTER,
-                latitude = 1.0,
-                longitude = 2.0,
                 timestamp = 5L,
                 userId = null
             )
@@ -134,8 +108,6 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val entry = PendingGeofenceDelivery(
             geofenceId = "biz-geofence-3",
             transition = Event.GeofenceTransition.ENTER,
-            latitude = 1.0,
-            longitude = 2.0,
             timestamp = 42L,
             userId = "user-42"
         )

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
@@ -35,11 +35,9 @@ class GeofenceEventTrackerTest : RobolectricTest() {
     private fun entry(
         geofenceId: String = "biz-geofence-1",
         transition: Event.GeofenceTransition = Event.GeofenceTransition.ENTER,
-        latitude: Double? = 37.7749,
-        longitude: Double? = -122.4194,
         timestamp: Long = 1_234_567_890L,
         userId: String? = "user-42"
-    ) = PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
+    ) = PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
 
     @Test
     fun trackEvent_givenEnterTransition_expectPostToTrackWithCorrectBody() = runTest {
@@ -50,15 +48,15 @@ class GeofenceEventTrackerTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         capturedParams.captured.path shouldBeEqualTo "/track"
-        val body = JSONObject(capturedParams.captured.body)
+        val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
         body.getString("event") shouldBeEqualTo "CIO Geofence Entered"
         body.getString("userId") shouldBeEqualTo "user-42"
         val props = body.getJSONObject("properties")
         props.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
         props.getString("transition_type") shouldBeEqualTo "enter"
-        props.getDouble("latitude") shouldBeEqualTo 37.7749
-        props.getDouble("longitude") shouldBeEqualTo -122.4194
         props.getLong("timestamp") shouldBeEqualTo 1_234_567_890L
+        props.has("latitude") shouldBeEqualTo false
+        props.has("longitude") shouldBeEqualTo false
     }
 
     @Test
@@ -68,21 +66,9 @@ class GeofenceEventTrackerTest : RobolectricTest() {
 
         tracker.trackEvent(entry(transition = Event.GeofenceTransition.EXIT))
 
-        val body = JSONObject(capturedParams.captured.body)
+        val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
         body.getString("event") shouldBeEqualTo "CIO Geofence Exited"
         body.getJSONObject("properties").getString("transition_type") shouldBeEqualTo "exit"
-    }
-
-    @Test
-    fun trackEvent_givenNullLatLng_expectBodyWithoutLatLng() = runTest {
-        val capturedParams = slot<HttpRequestParams>()
-        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
-
-        tracker.trackEvent(entry(latitude = null, longitude = null))
-
-        val props = JSONObject(capturedParams.captured.body).getJSONObject("properties")
-        props.has("latitude") shouldBeEqualTo false
-        props.has("longitude") shouldBeEqualTo false
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -46,18 +46,16 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     private fun seed(
         geofenceId: String,
         transition: Event.GeofenceTransition,
-        latitude: Double? = 0.0,
-        longitude: Double? = 0.0,
         timestamp: Long = 0L,
         userId: String? = "user-42"
     ): PendingGeofenceDelivery =
-        PendingGeofenceDelivery(geofenceId, transition, latitude, longitude, timestamp, userId)
+        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
             .also { store.append(it) }
 
     @Test
     fun doWork_givenClaimableEntry_expectSuccessTrackerCalledAndEntryRemoved() = runTest {
-        val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 1.0, 2.0, 99L)
-        val inputData = buildInputData("biz-1", "ENTER", 1.0, 2.0, 99L, "user-42")
+        val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 99L)
+        val inputData = buildInputData("biz-1", "ENTER", 99L, "user-42")
         coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
 
         val result = createWorker(inputData).doWork()
@@ -71,22 +69,6 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     fun doWork_givenValidExitInput_expectExitTransitionPassed() = runTest {
         val entry = seed("biz-2", Event.GeofenceTransition.EXIT, timestamp = 0L)
         val inputData = buildInputData("biz-2", "EXIT", timestamp = 0L)
-        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
-
-        createWorker(inputData).doWork()
-
-        coVerify(exactly = 1) { tracker.trackEvent(entry) }
-    }
-
-    @Test
-    fun doWork_givenMissingLatLng_expectEntryWithNullLatLngPassed() = runTest {
-        val entry = seed("biz-3", Event.GeofenceTransition.ENTER, latitude = null, longitude = null, timestamp = 0L)
-        val inputData = Data.Builder()
-            .putString("geofence_id", "biz-3")
-            .putString("transition", "ENTER")
-            .putLong("timestamp", 0L)
-            .putString("user_id", "user-42")
-            .build()
         coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
 
         createWorker(inputData).doWork()
@@ -181,14 +163,10 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     private fun buildInputData(
         geofenceId: String?,
         transition: String?,
-        latitude: Double = 0.0,
-        longitude: Double = 0.0,
         timestamp: Long = 0L,
         userId: String? = "user-42"
     ): Data {
         val builder = Data.Builder()
-            .putDouble("latitude", latitude)
-            .putDouble("longitude", longitude)
             .putLong("timestamp", timestamp)
         geofenceId?.let { builder.putString("geofence_id", it) }
         transition?.let { builder.putString("transition", it) }


### PR DESCRIPTION
**Linear:** [MBL-1831](https://linear.app/customerio/issue/MBL-1831/remove-precise-location-data-from-geofence-events)

Geofence **Entered/Exited** events no longer carry the device's precise latitude/longitude — avoiding the privacy/compliance burden of emitting exact user location. The geofence id + transition type are all a consumer needs.

### What changed
- `PendingGeofenceDelivery` drops the `latitude`/`longitude` fields (no longer persisted) and `toEventProperties()` drops the keys. Both delivery channels — the WorkManager worker (direct HTTP) and the foreground flush (analytics pipeline) build their payload from this single method, so each now emits `geofence_id` + `transition_type` + `timestamp` only.
- Removed the lat/lng WorkManager `Data` plumbing in `GeofenceEventScheduler` / `GeofenceEventWorker`.
- `GeofenceBroadcastReceiver` still reads the triggering location, but only to drive the movement-trigger re-sync (`onMovementTriggerExit`) — it's no longer attached to the event. A transition with no location still delivers.

### Acceptance criteria
- ✅ Entered/Exited events no longer include precise lat/lng.
- ✅ Geofencing still works — movement-trigger re-sync uses the triggering location directly; business transitions deliver without location.
- ✅ Consumers still get `geofence_id` + `transition_type` (+ `timestamp`).

### Scope notes
- The `/geofences/nearby` fetch still uses device location (functionally required to fetch nearby geofences); out of scope per the ticket.
- Feature is unreleased, so removing the persisted fields has no migration risk; the pending-delivery store also drops any unparseable stale entry gracefully.

### Tests
Payload/`Data`/event assertions updated to verify coords are **absent** at every boundary that emitted them (`PendingGeofenceDeliveryTest`, `GeofenceEventTrackerTest`, `GeofenceEventSchedulerTest`); receiver tests verify a transition with no location still queues/schedules; obsolete null-coord tests removed. `:geofence` unit tests, lint, and apiCheck pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-focused payload shrink on an unreleased feature; delivery and movement-trigger behavior are preserved and covered by updated tests.
> 
> **Overview**
> **Geofence Entered/Exited** analytics and HTTP payloads no longer include device **latitude/longitude** — only `geofence_id`, `transition_type`, and `timestamp`.
> 
> `PendingGeofenceDelivery` drops the coord fields from persistence and from `toEventProperties()`, so both the WorkManager direct-HTTP path and the foreground analytics flush share the same reduced property set. Lat/lng are also removed from WorkManager `Data` in `GeofenceEventScheduler` / `GeofenceEventWorker`.
> 
> The broadcast receiver still reads the OS triggering location for **movement-trigger** EXIT re-sync (`onMovementTriggerExit`); business transitions queue and deliver even when location is null. The no-location log message now reflects that missing coords block movement refresh, not event emission.
> 
> Unit tests were updated to assert coords are absent at each boundary; obsolete null-coord cases were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ecfd285202c039cdf542437fa3ef4e5451f4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

