### PR TITLE
chore(geofence): coarsen sync location and widen refresh radii

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -8,11 +8,11 @@ internal object GeofenceConstants {
 
     // Fallback for the movement trigger's OS geofence radius (meters). API field:
     // `local_refresh_trigger_radius`.
-    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 1_000f
+    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 3_000f
 
     // Fallback for the distance from the last API anchor at which an EXIT escalates
     // to a fresh API fetch (meters). API field: `remote_fetch_refresh_trigger_radius`.
-    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 5_000f
+    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 20_000f
 
     // Fallback for `maxBusinessGeofences` from the API config. Matches the
     // historical cap so customers aren't punished by a misconfigured backend.

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
@@ -25,8 +25,8 @@ internal class GeofenceApiServiceImpl(
             path = ENDPOINT_PATH,
             method = HttpMethod.GET,
             queryParams = mapOf(
-                "latitude" to latitude.toString(),
-                "longitude" to longitude.toString()
+                "latitude" to GeofenceCoordinateCoarsener.coarsen(latitude).toString(),
+                "longitude" to GeofenceCoordinateCoarsener.coarsen(longitude).toString()
             )
         )
 

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceCoordinateCoarsener.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceCoordinateCoarsener.kt
@@ -1,0 +1,19 @@
+package io.customer.geofence.api
+
+import java.math.RoundingMode
+
+/**
+ * Snaps the coordinates sent to `/geofences/nearby` to a ~1km grid (rounding to [GRID_DECIMALS]
+ * decimal places; 0.01° ≈ 1.1km latitude) so the SDK never transmits the device's exact position.
+ * Precise location stays on-device for proximity and movement-trigger logic.
+ *
+ * Snapping is deterministic, not jittered: repeated syncs from the same area send the same value, so
+ * averaging many requests can't recover the true position. The server fetch radius must cover the
+ * re-sync displacement plus this cell, or a geofence near a cell boundary can be missed.
+ */
+internal object GeofenceCoordinateCoarsener {
+    private const val GRID_DECIMALS = 2
+
+    fun coarsen(coordinate: Double): Double =
+        coordinate.toBigDecimal().setScale(GRID_DECIMALS, RoundingMode.HALF_EVEN).toDouble()
+}

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
@@ -1,0 +1,28 @@
+package io.customer.geofence.api
+
+import io.customer.geofence.GeofenceJsonSerializer
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpRequestParams
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceApiServiceTest {
+
+    private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
+    private val service = GeofenceApiServiceImpl(httpClient, GeofenceJsonSerializer())
+
+    @Test
+    fun fetchGeofences_givenPreciseLocation_expectCoarseCoordinatesOnTheWire() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
+
+        service.fetchGeofences(latitude = 37.774929, longitude = -122.419416)
+
+        capturedParams.captured.queryParams["latitude"] shouldBeEqualTo "37.77"
+        capturedParams.captured.queryParams["longitude"] shouldBeEqualTo "-122.42"
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceCoordinateCoarsenerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceCoordinateCoarsenerTest.kt
@@ -1,0 +1,26 @@
+package io.customer.geofence.api
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceCoordinateCoarsenerTest {
+
+    @Test
+    fun coarsen_givenPreciseCoordinate_expectRoundedToGrid() {
+        GeofenceCoordinateCoarsener.coarsen(37.774929) shouldBeEqualTo 37.77
+        GeofenceCoordinateCoarsener.coarsen(-122.419416) shouldBeEqualTo -122.42
+    }
+
+    @Test
+    fun coarsen_givenTwoPointsInSameCell_expectIdenticalOutput() {
+        // ~500m apart but snap to the same grid value, so repeated syncs from the area
+        // can't be averaged back to the true position.
+        GeofenceCoordinateCoarsener.coarsen(37.7701) shouldBeEqualTo GeofenceCoordinateCoarsener.coarsen(37.7749)
+    }
+
+    @Test
+    fun coarsen_givenAlreadyCoarseValue_expectUnchanged() {
+        GeofenceCoordinateCoarsener.coarsen(37.77) shouldBeEqualTo 37.77
+        GeofenceCoordinateCoarsener.coarsen(0.0) shouldBeEqualTo 0.0
+    }
+}


### PR DESCRIPTION
**Linear:** [MBL-1843](https://linear.app/customerio/issue/MBL-1843/use-coarse-location-for-nearby-geofence-fetch-requests)

### Why
The `/geofences/nearby` sync call sent the device's **precise** lat/lng as GET query params, so exact location landed in access logs/proxies on every fetch. This blurs the outbound coordinates so the SDK never transmits an exact position to fetch geofences — precise location stays on-device for proximity and movement-trigger logic.

### What changed
- **`GeofenceCoordinateCoarsener`** snaps the outbound coordinates to a **~1km grid** (round to 2 decimals; 0.01° ≈ 1.1km). Applied at the `GeofenceApiServiceImpl.fetchGeofences` boundary — a single chokepoint, so no caller can send precise coords. The repository still uses precise location for its own anchor/distance math; only the wire value is coarsened.
- Snapping is **deterministic, not jittered** — repeated syncs from the same area send the same value, so the true position can't be recovered by averaging many requests.
- **Widened fallback refresh radii** to minimize server calls: `localRefreshTriggerRadius` 1km→**3km**, `remoteFetchRefreshTriggerRadius` 5km→**20km**. These are fallbacks only — server-shipped config still overrides both.

### Cross-team dependencies
- **Server fetch radius must be ≥ ~21km** (20km re-sync + 1km coarsening cell), or a geofence near a cell/anchor boundary can be missed.
- The 20km re-sync stays accurate only if the **100-geofence cap** realistically spans ~20km for a deployment; in dense areas the cap truncates to the nearest 100 around the anchor, leaving a coverage gap. Accepted trade-off (fewer server calls vs coarser coverage).
- Server should ship config matching 3/20 or the new fallbacks won't be what runs in production.

### Tests
- `GeofenceCoordinateCoarsenerTest` — rounding to grid, same-cell collapse (the anti-averaging property), negatives/zero.
- `GeofenceApiServiceTest` — wire-level: precise in → coarse out (`fetchGeofences` had no test before).
- Full `:geofence` unit tests + lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence fetch location and refresh thresholds; server fetch radius and config must stay aligned or boundary geofences can be missed.
> 
> **Overview**
> **`/geofences/nearby` no longer sends precise device coordinates.** A new `GeofenceCoordinateCoarsener` snaps lat/lng to a ~1km grid (2 decimal places, half-even rounding) at the `GeofenceApiServiceImpl` boundary only; on-device proximity and movement-trigger logic still use full precision.
> 
> **Fallback refresh radii are larger** when server config is missing: local movement trigger **1km → 3km**, remote re-fetch trigger **5km → 20km**, to reduce sync frequency and align with coarser outbound location.
> 
> Unit tests cover grid rounding, same-cell collapse, and wire-level query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a366569d861d408f701917cfb3ad346ebe2bdfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->