### PR TITLE
chore(geofence): fetch all geofences without sending location

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -8,11 +8,11 @@ internal object GeofenceConstants {
 
     // Fallback for the movement trigger's OS geofence radius (meters). API field:
     // `local_refresh_trigger_radius`.
-    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 1_000f
+    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 3_000f
 
     // Fallback for the distance from the last API anchor at which an EXIT escalates
     // to a fresh API fetch (meters). API field: `remote_fetch_refresh_trigger_radius`.
-    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 5_000f
+    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 20_000f
 
     // Fallback for `maxBusinessGeofences` from the API config. Matches the
     // historical cap so customers aren't punished by a misconfigured backend.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -6,6 +6,7 @@ import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.api.toDomainConfig
 import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.location.LocationCoordinates
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
@@ -15,11 +16,10 @@ import kotlinx.coroutines.sync.withLock
 /**
  * Geofence sync pipeline. Two public entry points:
  *
- * - [refresh] — for identify / app-launch. A recent successful sync within the
- *   freshness window short-circuits the API call.
- * - [handleMovement] — for movement-trigger EXIT. Two-tier dispatch: re-rank cached regions
- *   when within `remoteFetchRefreshTriggerRadius` of the last API anchor, otherwise hit
- *   the API for fresh data.
+ * - [refresh] — for identify / app-launch. Reuses the cached set within the freshness window
+ *   (re-registering locally or skipping); otherwise fetches fresh from the API.
+ * - [handleMovement] — for movement-trigger EXIT. Re-ranks the cached regions for the new
+ *   location; in NEARBY mode a large enough move instead triggers a fresh API fetch.
  */
 internal interface GeofenceRepository {
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
@@ -58,7 +58,8 @@ internal class GeofenceRepositoryImpl(
     private val manager: GeofenceManager,
     private val secureUserStore: SecureUserStore,
     private val clock: Clock,
-    private val logger: GeofenceLogger
+    private val logger: GeofenceLogger,
+    private val syncMode: GeofenceSyncMode = GeofenceSyncMode.active
 ) : GeofenceRepository {
 
     // Dedup gate shared by refresh() and handleMovement(). If either is already running,
@@ -82,35 +83,55 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("no identified user")
                 return Result.success(Unit)
             }
-            val lastSync = store.getLastSyncTimestamp()
-            if (lastSync != null) {
-                // Time-fresh alone isn't enough: if the app was killed while the
-                // user travelled far, no movement EXIT fired to update the cache.
-                // Null anchor (never fetched) treats distance as 0 → time-only check.
-                val effectiveConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-                val timeSinceLastSync = clock.currentTimeMillis() - lastSync
-                val distanceFromAnchor = store.getLastApiFetchLocation()
-                    ?.distanceTo(latitude, longitude) ?: 0f
-                val withinFreshness = timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry &&
-                    distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius
-                if (withinFreshness) {
-                    // Cache fresh — if OS regs were wiped on sign-out, re-
-                    // register from cache instead of skipping; otherwise the
-                    // new user has no geofences until stale-window expiry.
-                    val cachedRegions = store.getCachedRegions()
-                    val registered = store.getRegisteredIds()
-                    if (cachedRegions.isNotEmpty() && registered.isEmpty()) {
-                        return performLocalRefresh(userId, latitude, longitude, effectiveConfig)
-                    }
+
+            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            return when (refreshAction(LocationCoordinates(latitude, longitude), config)) {
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
+                RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
-                    return Result.success(Unit)
+                    Result.success(Unit)
                 }
             }
-            return performRemoteRefresh(userId, latitude, longitude)
         } finally {
             refreshInProgress.set(false)
         }
     }
+
+    // Decision table for identify/launch refresh. Only the re-fetch question depends on the sync
+    // mode; staleness in time, staleness of the ranking, and OS-registration gaps are mode-agnostic.
+    private fun refreshAction(location: LocationCoordinates, config: GeofenceConfig): RefreshAction {
+        // Each distance is measured from its own reference: re-fetch from the last API fetch, re-rank
+        // from the last registration (the movement-trigger center). Null (never set) → 0 → within radius.
+        val distanceFromLastFetch = store.getLastApiFetchLocation()
+            ?.distanceTo(location.latitude, location.longitude) ?: 0f
+        val distanceFromLastRegistration = store.getLastMovementTriggerLocation()
+            ?.distanceTo(location.latitude, location.longitude) ?: 0f
+
+        return when {
+            isStaleInTime(config) -> RefreshAction.REMOTE
+            syncMode.movementRequiresRemoteFetch(distanceFromLastFetch, config) -> RefreshAction.REMOTE
+            isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
+            hasUnregisteredCache() -> RefreshAction.LOCAL
+            else -> RefreshAction.SKIP
+        }
+    }
+
+    // Cache aged out of its freshness window (or was never fetched).
+    private fun isStaleInTime(config: GeofenceConfig): Boolean {
+        val lastSync = store.getLastSyncTimestamp() ?: return true
+        return clock.currentTimeMillis() - lastSync >= config.remoteFetchRefreshExpiry
+    }
+
+    // The device has left the trigger radius since the nearest-N was last ranked, so the registered
+    // set no longer reflects the closest geofences — re-rank locally (no network). This is exactly the
+    // condition the live movement trigger fires on; refresh() catches an EXIT missed while app was dead.
+    private fun isRankingStale(distanceFromLastRegistration: Float, config: GeofenceConfig): Boolean =
+        distanceFromLastRegistration >= config.localRefreshTriggerRadius
+
+    /** Cache holds regions but none are registered with the OS (e.g. regs lost on sign-out) → re-register. */
+    private fun hasUnregisteredCache(): Boolean =
+        store.getCachedRegions().isNotEmpty() && store.getRegisteredIds().isEmpty()
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
@@ -124,18 +145,18 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("no identified user")
                 return Result.success(Unit)
             }
+
             val anchor = store.getLastApiFetchLocation()
-            val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-            // Tier B (remote fetch) when:
-            // - no anchor yet (first EXIT after install / clearAll / sign-out), OR
-            // - we've moved beyond the API threshold from the last fetch.
-            // Otherwise Tier A: re-rank the cached regions for the new location.
+            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
+            // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
+            // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
             val needsRemoteFetch = anchor == null ||
-                anchor.distanceTo(latitude, longitude) >= cachedConfig.remoteFetchRefreshTriggerRadius
+                syncMode.movementRequiresRemoteFetch(distanceFromAnchor, config)
             return if (needsRemoteFetch) {
                 performRemoteRefresh(userId, latitude, longitude)
             } else {
-                performLocalRefresh(userId, latitude, longitude, cachedConfig)
+                performLocalRefresh(userId, latitude, longitude, config)
             }
         } finally {
             refreshInProgress.set(false)
@@ -181,36 +202,44 @@ internal class GeofenceRepositoryImpl(
         userId: String,
         latitude: Double,
         longitude: Double
-    ): Result<Unit> = apiService.fetchGeofences(latitude, longitude).fold(
-        onSuccess = { response ->
-            val regions = response.toDomainRegions()
-            // Config preference: server-shipped > last cached > constants.
-            val parsedConfig = response.toDomainConfig()
-            val config = parsedConfig
-                ?: store.getCachedConfig()
-                ?: GeofenceConfig.fallback()
-            registerNearestAndPersist(
-                userId = userId,
-                latitude = latitude,
-                longitude = longitude,
-                regions = regions,
-                config = config,
-                // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
-                // Skip the config save when backend didn't ship one this response —
-                // a null parse must not clobber a previously cached value.
-                onRegistered = {
-                    store.saveCachedRegions(regions)
-                    parsedConfig?.let { store.saveCachedConfig(it) }
-                    store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
-                    store.setLastSyncTimestamp(clock.currentTimeMillis())
-                }
-            )
-        },
-        onFailure = { error ->
-            logger.logSyncFailed(error.message)
-            Result.failure(error)
+    ): Result<Unit> {
+        // FETCH_ALL sends no location; NEARBY sends it (coarsened at the API boundary). Either way
+        // the precise lat/lng below drive on-device ranking and the anchor — they never leave here.
+        val fetchResult = when (syncMode) {
+            GeofenceSyncMode.FETCH_ALL -> apiService.fetchGeofences()
+            GeofenceSyncMode.NEARBY -> apiService.fetchGeofences(latitude, longitude)
         }
-    )
+        return fetchResult.fold(
+            onSuccess = { response ->
+                val regions = response.toDomainRegions()
+                // Config preference: server-shipped > last cached > constants.
+                val parsedConfig = response.toDomainConfig()
+                val config = parsedConfig
+                    ?: store.getCachedConfig()
+                    ?: GeofenceConfig.fallback()
+                registerNearestAndPersist(
+                    userId = userId,
+                    latitude = latitude,
+                    longitude = longitude,
+                    regions = regions,
+                    config = config,
+                    // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
+                    // Skip the config save when backend didn't ship one this response —
+                    // a null parse must not clobber a previously cached value.
+                    onRegistered = {
+                        store.saveCachedRegions(regions)
+                        parsedConfig?.let { store.saveCachedConfig(it) }
+                        store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
+                        store.setLastSyncTimestamp(clock.currentTimeMillis())
+                    }
+                )
+            },
+            onFailure = { error ->
+                logger.logSyncFailed(error.message)
+                Result.failure(error)
+            }
+        )
+    }
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     private suspend fun performLocalRefresh(

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceSyncMode.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceSyncMode.kt
@@ -1,0 +1,39 @@
+package io.customer.geofence
+
+/**
+ * The kind of refresh a signal calls for, decided independently of what triggered it.
+ *
+ * - [REMOTE] — fetch a fresh set from the API.
+ * - [LOCAL]  — re-rank / re-register the cached set on-device, no network.
+ * - [SKIP]   — cache is current; do nothing.
+ */
+internal enum class RefreshAction { REMOTE, LOCAL, SKIP }
+
+/**
+ * How the SDK fetches a user's geofences.
+ *
+ * [FETCH_ALL] is the active default: the backend returns the full (capped) set and the SDK never
+ * sends device location to fetch.
+ *
+ * [NEARBY] sends coarse location and lets the backend return only nearby geofences. It is retained
+ * and tested so location-based fetch can be re-enabled in a later phase by changing [active] — that
+ * also needs backend support and is a deliberate SDK release, never a runtime or server-pushed
+ * toggle (which would re-introduce the ability to silently start sending location).
+ */
+internal enum class GeofenceSyncMode {
+    FETCH_ALL,
+    NEARBY;
+
+    /**
+     * NEARBY's set is location-bound, so it re-fetches once the device outruns it; FETCH_ALL holds
+     * the full set, so movement never re-fetches.
+     */
+    fun movementRequiresRemoteFetch(distanceFromAnchor: Float, config: GeofenceConfig): Boolean = when (this) {
+        NEARBY -> distanceFromAnchor >= config.remoteFetchRefreshTriggerRadius
+        FETCH_ALL -> false
+    }
+
+    companion object {
+        val active: GeofenceSyncMode = FETCH_ALL
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
@@ -6,10 +6,12 @@ import io.customer.sdk.core.network.HttpMethod
 import io.customer.sdk.core.network.HttpRequestParams
 
 internal interface GeofenceApiService {
-    suspend fun fetchGeofences(
-        latitude: Double,
-        longitude: Double
-    ): Result<GeofenceApiResponse>
+    /** Fetch-all: returns the full set with no location sent. */
+    suspend fun fetchGeofences(): Result<GeofenceApiResponse>
+
+    /** Nearby: sends the location (coarsened before it leaves the device) so the backend returns
+     *  only nearby geofences. */
+    suspend fun fetchGeofences(latitude: Double, longitude: Double): Result<GeofenceApiResponse>
 }
 
 internal class GeofenceApiServiceImpl(
@@ -17,19 +19,22 @@ internal class GeofenceApiServiceImpl(
     private val jsonSerializer: GeofenceJsonSerializer
 ) : GeofenceApiService {
 
-    override suspend fun fetchGeofences(
-        latitude: Double,
-        longitude: Double
-    ): Result<GeofenceApiResponse> {
-        val params = HttpRequestParams(
-            path = ENDPOINT_PATH,
-            method = HttpMethod.GET,
-            queryParams = mapOf(
-                "latitude" to latitude.toString(),
-                "longitude" to longitude.toString()
+    override suspend fun fetchGeofences(): Result<GeofenceApiResponse> = request(emptyMap())
+
+    override suspend fun fetchGeofences(latitude: Double, longitude: Double): Result<GeofenceApiResponse> =
+        request(
+            mapOf(
+                "latitude" to GeofenceCoordinateCoarsener.coarsen(latitude).toString(),
+                "longitude" to GeofenceCoordinateCoarsener.coarsen(longitude).toString()
             )
         )
 
+    private suspend fun request(queryParams: Map<String, String>): Result<GeofenceApiResponse> {
+        val params = HttpRequestParams(
+            path = ENDPOINT_PATH,
+            method = HttpMethod.GET,
+            queryParams = queryParams
+        )
         return httpClient.request(params).mapCatching { responseBody ->
             // Lenient at the wire boundary so the SDK doesn't pin a specific
             // type for `id` — accepts either numeric or quoted-string form.

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceCoordinateCoarsener.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceCoordinateCoarsener.kt
@@ -1,0 +1,17 @@
+package io.customer.geofence.api
+
+import java.math.RoundingMode
+
+/**
+ * Snaps coordinates sent to `/geofences/nearby` to a ~1km grid (0.01° ≈ 1.1km) so the SDK never
+ * transmits the device's exact position — precise location stays on-device for proximity logic.
+ *
+ * Deterministic, not jittered: the same area always sends the same value, so averaging repeated
+ * requests can't recover the true point.
+ */
+internal object GeofenceCoordinateCoarsener {
+    private const val GRID_DECIMALS = 2
+
+    fun coarsen(coordinate: Double): Double =
+        coordinate.toBigDecimal().setScale(GRID_DECIMALS, RoundingMode.HALF_EVEN).toDouble()
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -54,7 +54,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager = manager,
             secureUserStore = secureUserStore,
             clock = clock,
-            logger = logger
+            logger = logger,
+            // This suite covers the NEARBY (location-based) path; FETCH_ALL is covered separately.
+            syncMode = GeofenceSyncMode.NEARBY
         )
     }
 
@@ -65,6 +67,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // 1 min ago
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
@@ -135,6 +138,158 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify { apiService.fetchGeofences(1.0, 0.0) }
         verify(exactly = 0) { logger.logSyncSkippedFresh() }
     }
+
+    @Test
+    fun refresh_givenMovedBeyondTriggerSinceLastRegistration_expectLocalRerank() = runTest {
+        // refresh() catches a movement EXIT missed while the app was dead: the device is beyond the
+        // trigger radius from where the nearest-N was last ranked, so re-rank locally — and not
+        // remotely, since it's still within the remote radius and time-fresh. Mode-independent;
+        // repository here is NEARBY.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // time-fresh
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // ~2.2 km from the last registration: beyond the 1 km trigger, within the 5 km remote radius.
+        repository.refresh(latitude = 0.02, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) } // no remote fetch
+        coVerify { manager.replaceGeofences(any(), any()) } // local re-rank
+        verify(exactly = 0) { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenWithinTriggerSinceLastRegistration_expectSkip() = runTest {
+        // The complement: a move smaller than the trigger radius leaves the ranking valid, so a
+        // time-fresh refresh with regs intact skips — the live movement trigger hasn't fired yet.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+
+        // ~550 m from the last registration: within the 1 km trigger radius.
+        repository.refresh(latitude = 0.005, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFetchAllMode_expectFetchWithoutLocation() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null // never synced -> remote fetch
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        fetchAllRepository().refresh(latitude = 37.7749, longitude = -122.4194)
+
+        // Fetch-all uses the no-location overload; precise lat/lng stay on-device.
+        coVerify { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+    }
+
+    @Test
+    fun handleMovement_givenFetchAllModeAndMovedFar_expectLocalRefreshNotRemote() = runTest {
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // 1° latitude ≈ 111 km — far beyond any radius — but fetch-all never re-fetches on movement.
+        fetchAllRepository().handleMovement(latitude = 1.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify { manager.replaceGeofences(any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenFetchAllModeFreshButMovedFar_expectLocalReRankNotRemote() = runTest {
+        // App killed while the user travelled far, reopened within the freshness window: the cached
+        // set is still valid (location-independent) but the registered nearest-N must be re-ranked
+        // for the new location — locally, without a server call.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // 1° latitude ≈ 111 km — far beyond localRefreshTriggerRadius — but within time freshness.
+        fetchAllRepository().refresh(latitude = 1.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify { manager.replaceGeofences(any(), any()) }
+        verify(exactly = 0) { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFetchAllModeFreshAndNotMoved_expectSkip() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact -> nothing to do
+
+        fetchAllRepository().refresh(latitude = 0.0, longitude = 0.0) // same as anchor
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFarFromLastFetchButAtLastRegistration_expectSkip() = runTest {
+        // Ranking staleness is measured from the last registration (movement-trigger center), NOT the
+        // last API fetch. The device sits far from a stale fetch anchor but exactly where it was last
+        // re-ranked, so the ranking is current → SKIP. Guards against measuring from the fetch anchor.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // time-fresh
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0) // stale fetch anchor
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(1.0, 0.0) // last re-rank
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 1.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+
+        // At the last-registration point (0 m from it), but ~111 km from the fetch anchor.
+        fetchAllRepository().refresh(latitude = 1.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    private fun fetchAllRepository() = GeofenceRepositoryImpl(
+        apiService = apiService,
+        store = store,
+        distanceFilter = distanceFilter,
+        manager = manager,
+        secureUserStore = secureUserStore,
+        clock = clock,
+        logger = logger,
+        syncMode = GeofenceSyncMode.FETCH_ALL
+    )
 
     @Test
     fun refresh_givenStaleLastSync_expectApiCalled() = runTest {

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
@@ -1,0 +1,39 @@
+package io.customer.geofence.api
+
+import io.customer.geofence.GeofenceJsonSerializer
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpRequestParams
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceApiServiceTest {
+
+    private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
+    private val service = GeofenceApiServiceImpl(httpClient, GeofenceJsonSerializer())
+
+    @Test
+    fun fetchGeofences_givenPreciseLocation_expectCoarseCoordinatesOnTheWire() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
+
+        service.fetchGeofences(latitude = 37.774929, longitude = -122.419416)
+
+        capturedParams.captured.queryParams["latitude"] shouldBeEqualTo "37.77"
+        capturedParams.captured.queryParams["longitude"] shouldBeEqualTo "-122.42"
+    }
+
+    @Test
+    fun fetchGeofences_givenNoLocation_expectNoCoordinatesOnTheWire() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
+
+        service.fetchGeofences()
+
+        capturedParams.captured.queryParams.shouldBeEmpty()
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceCoordinateCoarsenerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceCoordinateCoarsenerTest.kt
@@ -1,0 +1,26 @@
+package io.customer.geofence.api
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceCoordinateCoarsenerTest {
+
+    @Test
+    fun coarsen_givenPreciseCoordinate_expectRoundedToGrid() {
+        GeofenceCoordinateCoarsener.coarsen(37.774929) shouldBeEqualTo 37.77
+        GeofenceCoordinateCoarsener.coarsen(-122.419416) shouldBeEqualTo -122.42
+    }
+
+    @Test
+    fun coarsen_givenTwoPointsInSameCell_expectIdenticalOutput() {
+        // ~500m apart but snap to the same grid value, so repeated syncs from the area
+        // can't be averaged back to the true position.
+        GeofenceCoordinateCoarsener.coarsen(37.7701) shouldBeEqualTo GeofenceCoordinateCoarsener.coarsen(37.7749)
+    }
+
+    @Test
+    fun coarsen_givenAlreadyCoarseValue_expectUnchanged() {
+        GeofenceCoordinateCoarsener.coarsen(37.77) shouldBeEqualTo 37.77
+        GeofenceCoordinateCoarsener.coarsen(0.0) shouldBeEqualTo 0.0
+    }
+}


### PR DESCRIPTION
**Linear:** [MBL-1843](https://linear.app/customerio/issue/MBL-1843/use-coarse-location-for-nearby-geofence-fetch-requests)

> Supersedes #741 (coarse-location-only). Backend agreed to accept no location and return the full set, so we default to fetch-all and **retain** the coarse-nearby path behind a switch for a later phase.
>
> **Base:** `feature/geofence-on-device` (after #739 + #740, both merged).

### Why
The `/geofences/nearby` sync call sent the device's location to fetch geofences. The backend now returns the full set (capped at 100) without location, so the SDK can fetch everything and filter on-device — sending **zero** location to the backend.

### What changed
- **`GeofenceSyncMode`** (`FETCH_ALL` default, `NEARBY` retained). The active mode is an **SDK-internal** decision — not a runtime or server-pushed toggle — so the shipped SDK never sends location, and re-enabling nearby is a deliberate SDK release.
- **`FETCH_ALL`**: no location sent; remote fetch is time/staleness-based; movement only **re-ranks the cached set on-device** (movement can't change a location-independent set).
- **`refresh()` decision table** — only the re-fetch question depends on the mode; everything else is mode-agnostic:
  - re-fetch when stale in time, or (NEARBY) the device outran the remote radius **from the last API fetch**;
  - re-rank locally when the device left the trigger radius **since the last registration**, or the cached set isn't registered with the OS;
  - otherwise skip.
- **Two reference points** (a bug fix): re-fetch distance is measured from the last API fetch; re-rank distance from the last registration (the movement-trigger center). The re-rank condition is exactly "a movement EXIT missed while the app was dead," so it applies to **both** modes.
- **`NEARBY`** (retained, still tested): sends coarse (~1km grid) location via `GeofenceCoordinateCoarsener`, re-fetches on movement beyond the API anchor. Widened fallback radii (local 3km, remote 20km).
- **`GeofenceApiService`** split into two overloads: `fetchGeofences()` (fetch-all, no query params) and `fetchGeofences(lat, lng)` (nearby, coarsened at the boundary).

### Tests
- `GeofenceRepositoryTest` — decision-table coverage incl. the NEARBY re-rank-on-moved-device case, its within-trigger SKIP complement, and a **regression guard** that the re-rank is measured from the last registration, not the last API fetch.
- `GeofenceApiServiceTest` — coarse coords for the location overload, none for the no-arg overload.
- `GeofenceCoordinateCoarsenerTest` — grid rounding, same-cell collapse (anti-averaging), negatives/zero.
- Full `:geofence` unit tests, ktlint, and apiCheck pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence sync behavior and location transmission (privacy-sensitive), but FETCH_ALL is the shipped default with broad test coverage; wrong staleness logic could leave stale OS registrations.
> 
> **Overview**
> **Default geofence sync no longer sends device location** to `/geofences/nearby`. The SDK fetches the full capped set with `fetchGeofences()` (no query params), ranks nearest regions on-device, and only re-fetches on **time staleness**—not on travel distance.
> 
> Introduces **`GeofenceSyncMode`**: **`FETCH_ALL`** is the active default (SDK-internal, not runtime-togglable); **`NEARBY`** remains for a future release and still sends **coarse** lat/lng via `GeofenceCoordinateCoarsener` (~1 km grid).
> 
> **`refresh()`** is refactored into a **`RefreshAction`** decision table: remote when time-stale or (NEARBY only) beyond the remote radius from the **last API fetch**; local re-rank when beyond the local trigger from the **last registration** (movement-trigger center) or when cache exists but OS regs are empty; otherwise skip. That split fixes conflating fetch-anchor distance with ranking staleness.
> 
> **`handleMovement()`** uses the same mode rules: FETCH_ALL never remote-fetches on movement; NEARBY still escalates to API past the remote radius. Fallback radii widen to **3 km** local and **20 km** remote.
> 
> Tests cover FETCH_ALL vs NEARBY, coarsening, and the registration-vs-fetch-anchor regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7387ae1ae682f2d8efb7c546b360084f2ae5cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

