### PR TITLE
chore: unit-aware SDK binary-size report + de-flake NotificationInboxTest

### DIFF
--- a/messaginginapp/src/test/java/io/customer/messaginginapp/inbox/NotificationInboxTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/inbox/NotificationInboxTest.kt
@@ -246,10 +246,14 @@ class NotificationInboxTest : IntegrationTest() {
     fun addChangeListener_givenNoTopicFilter_expectListenerReceivesAllMessages() = runTest {
         initializeAndSetUser()
 
-        // Create test messages with different topics
-        val message1 = createInboxMessage(deliveryId = "msg1", topics = listOf("promotions"))
-        val message2 = createInboxMessage(deliveryId = "msg2", topics = listOf("updates"))
-        val message3 = createInboxMessage(deliveryId = "msg3", topics = listOf("promotions", "special"))
+        // Create test messages with different topics and distinct, decreasing sentAt values.
+        // The inbox delivers messages sorted newest-first (sentAt descending), so explicit
+        // timestamps make the expected order deterministic. With the default sentAt = Date(),
+        // the three messages can straddle a millisecond boundary and reorder, flaking the
+        // order-sensitive assertion below.
+        val message1 = createInboxMessage(deliveryId = "msg1", topics = listOf("promotions"), sentAt = dateNow())
+        val message2 = createInboxMessage(deliveryId = "msg2", topics = listOf("updates"), sentAt = dateHoursAgo(1))
+        val message3 = createInboxMessage(deliveryId = "msg3", topics = listOf("promotions", "special"), sentAt = dateHoursAgo(2))
         val allMessages = listOf(message1, message2, message3)
 
         // Use a real recording listener instead of a mockk + verify pair. MockK's

--- a/scripts/sdk-binary-size.gradle
+++ b/scripts/sdk-binary-size.gradle
@@ -116,9 +116,24 @@ tasks.register('compareSdkSizeReports') {
         output << '| Module | Last Recorded Size | Current Size | Change in Size |\n'
         output << '| ------ | ------------------ | ------------ | -------------- |\n'
 
-        // Closure to parse size string and extract the number
+        // Closure to parse a size string (e.g. "628 B", "16.11 KB", "1.3 MB") into a number of KB,
+        // so values that apkscale reports in different units still compare correctly. apkscale emits
+        // bytes for very small artifacts (e.g. an empty/placeholder module), which the previous
+        // KB-only parser could not handle and crashed on (`For input string: "628 B"`).
         Closure<Float> parseSize = { sizeStr ->
-            sizeStr.replace(sdkSizeUnit, '').trim() as float
+            def matcher = (sizeStr =~ /([0-9.]+)\s*([KMGT]?B)/)
+            if (!matcher.find()) {
+                return 0f
+            }
+            float value = matcher.group(1) as float
+            switch (matcher.group(2)) {
+                case 'B': return value / 1024f
+                case 'KB': return value
+                case 'MB': return value * 1024f
+                case 'GB': return value * 1024f * 1024f
+                case 'TB': return value * 1024f * 1024f * 1024f
+                default: return value
+            }
         }
 
         // Closure to compare the sizes of a module and variant


### PR DESCRIPTION
Two small, independent CI-reliability fixes (surfaced while working on the overlay inbox branches):

- **`scripts/sdk-binary-size.gradle`** — make `parseSize` unit-aware (B/KB/MB/GB → KB). apkscale reports very small artifacts in bytes, which the KB-only parser crashed on (`For input string: "628 B"`), failing the *Generate Comparison Report* check.
- **`NotificationInboxTest`** — de-flake the order-sensitive listener assertion by giving the test messages distinct, decreasing `sentAt` values (the inbox delivers newest-first; default `Date()` timestamps occasionally reordered across a millisecond boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a Gradle report parser and test fixtures; no runtime SDK or inbox logic is modified.
> 
> **Overview**
> **CI reliability fixes** with no production behavior changes.
> 
> The SDK binary size comparison script now **parses apkscale size strings in any unit** (B through TB) and normalizes them to KB before diffing. That stops the *Generate Comparison Report* step from failing when apkscale emits byte-sized values like `628 B`, which the old KB-only parser could not parse.
> 
> **`NotificationInboxTest`** sets explicit, decreasing `sentAt` values on the three fixture messages in `addChangeListener_givenNoTopicFilter_expectListenerReceivesAllMessages`, so listener callbacks match the inbox’s newest-first sort deterministically instead of occasionally reordering when defaults share the same millisecond.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e535148ce221afa51a0ad1b2b9f1ade5ef181e29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->