### PR TITLE
chore(geofence): remove on-device location-send and add monitoring-distance cap

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
@@ -9,16 +9,24 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 internal data class GeofenceConfig(
+    // Radius (m) of the movement-trigger geofence; its EXIT re-ranks nearby business geofences.
     @SerialName("localRefreshTriggerRadius")
     val localRefreshTriggerRadius: Float,
+    // Distance (m) from the last API anchor at which an EXIT escalates to a fresh server fetch.
     @SerialName("remoteFetchRefreshTriggerRadius")
     val remoteFetchRefreshTriggerRadius: Float,
+    // Min interval (ms) between server fetches; a successful sync within this window is reused.
     @SerialName("remoteFetchRefreshExpiry")
     val remoteFetchRefreshExpiry: Long,
+    // Window (ms) for suppressing duplicate transition events for the same geofence.
     @SerialName("duplicateEventsExpiry")
     val duplicateEventsExpiry: Long,
+    // Max business geofences registered at once (the movement trigger is extra).
     @SerialName("maxBusinessGeofences")
-    val maxBusinessGeofences: Int
+    val maxBusinessGeofences: Int,
+    // Cap (m) on how far a business geofence can be from the device to be registered.
+    @SerialName("maxMonitoringDistance")
+    val maxMonitoringDistance: Float
 ) {
     internal companion object {
         // Used when the cached server config is missing. Today that's the
@@ -29,7 +37,8 @@ internal data class GeofenceConfig(
             remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
             remoteFetchRefreshExpiry = GeofenceConstants.STALE_THRESHOLD_MS,
             duplicateEventsExpiry = GeofenceConstants.DEDUPE_COOLDOWN_MS,
-            maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+            maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES,
+            maxMonitoringDistance = GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
         )
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -6,17 +6,30 @@ internal object GeofenceConstants {
     // business geofences when applying separate INITIAL_TRIGGER strategies.
     const val MOVEMENT_TRIGGER_ID = "cio_movement_trigger"
 
-    // Fallback for the movement trigger's OS geofence radius (meters). API field:
-    // `local_refresh_trigger_radius`.
-    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 1_000f
+    // Fallback for `localRefreshTriggerRadius` when the API config omits it.
+    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 3_000f
 
-    // Fallback for the distance from the last API anchor at which an EXIT escalates
-    // to a fresh API fetch (meters). API field: `remote_fetch_refresh_trigger_radius`.
-    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 5_000f
+    // Fallback for `remoteFetchRefreshTriggerRadius` when the API config omits it.
+    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 20_000f
 
-    // Fallback for `maxBusinessGeofences` from the API config. Matches the
-    // historical cap so customers aren't punished by a misconfigured backend.
+    // Fallback for `maxBusinessGeofences`. Matches the historical cap so customers
+    // aren't punished by a misconfigured backend.
     const val FALLBACK_MAX_BUSINESS_GEOFENCES = 19
+
+    // Fallback for `maxMonitoringDistance`. Finite so a far-away geofence (e.g. another
+    // continent) isn't registered for a local user; local re-rank adds it once the device
+    // approaches. The server sends 0 to disable the cap.
+    const val FALLBACK_MAX_MONITORING_DISTANCE_METERS = 1_000_000f // 1000 km
+    const val NO_MONITORING_DISTANCE_CAP_METERS = Float.MAX_VALUE
+
+    // Sane bounds the SDK clamps server config into: a positive out-of-range value clamps to the
+    // bound; a non-positive value falls back.
+    const val MIN_LOCAL_REFRESH_RADIUS_METERS = 100f
+    const val MAX_LOCAL_REFRESH_RADIUS_METERS = 5_000f
+    const val MIN_REMOTE_FETCH_REFRESH_EXPIRY_MS = 60_000L // 1 minute
+    const val MAX_REMOTE_FETCH_REFRESH_EXPIRY_MS = 7L * 24 * 60 * 60 * 1_000L // 7 days
+    const val MIN_DUPLICATE_EVENTS_EXPIRY_MS = 60_000L // 1 minute
+    const val MAX_DUPLICATE_EVENTS_EXPIRY_MS = 24L * 60 * 60 * 1_000L // 24 hours
 
     // Minimum interval between server fetches. Non-forced refresh calls (identify,
     // app launch) skip the API call when a successful sync happened within this

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
@@ -19,8 +19,10 @@ internal class GeofenceDistanceFilter {
     ): List<GeofenceRegion> {
         if (max <= 0 || regions.isEmpty()) return emptyList()
         return regions
-            .filter { it.distanceTo(latitude, longitude) <= maxDistanceMeters }
-            .sortedBy { it.distanceTo(latitude, longitude) }
+            .map { it to it.distanceTo(latitude, longitude) }
+            .filter { (_, distance) -> distance <= maxDistanceMeters }
+            .sortedBy { (_, distance) -> distance }
             .take(max)
+            .map { (region, _) -> region }
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
@@ -1,21 +1,25 @@
 package io.customer.geofence
 
 /**
- * Selects the geofence regions closest to a reference location, capped at a maximum count.
+ * Selects the geofence regions closest to a reference location, capped at a maximum count and
+ * (optionally) a maximum distance.
  *
  * The OS limits the number of geofences an app can register simultaneously; this filter
  * picks the most relevant subset based on straight-line distance from the device's
- * current location.
+ * current location. Regions beyond [maxDistanceMeters] are excluded entirely; local re-ranking
+ * re-includes them as the device approaches.
  */
 internal class GeofenceDistanceFilter {
     fun nearest(
         regions: List<GeofenceRegion>,
         latitude: Double,
         longitude: Double,
-        max: Int
+        max: Int,
+        maxDistanceMeters: Float
     ): List<GeofenceRegion> {
         if (max <= 0 || regions.isEmpty()) return emptyList()
         return regions
+            .filter { it.distanceTo(latitude, longitude) <= maxDistanceMeters }
             .sortedBy { it.distanceTo(latitude, longitude) }
             .take(max)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -6,6 +6,7 @@ import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.api.toDomainConfig
 import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.location.LocationCoordinates
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
@@ -15,11 +16,10 @@ import kotlinx.coroutines.sync.withLock
 /**
  * Geofence sync pipeline. Two public entry points:
  *
- * - [refresh] — for identify / app-launch. A recent successful sync within the
- *   freshness window short-circuits the API call.
- * - [handleMovement] — for movement-trigger EXIT. Two-tier dispatch: re-rank cached regions
- *   when within `remoteFetchRefreshTriggerRadius` of the last API anchor, otherwise hit
- *   the API for fresh data.
+ * - [refresh] — for identify / app-launch. Reuses the cached set within the freshness window
+ *   (re-registering locally or skipping); otherwise fetches fresh from the API.
+ * - [handleMovement] — for movement-trigger EXIT. Re-ranks the cached regions for the new
+ *   location.
  */
 internal interface GeofenceRepository {
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
@@ -58,7 +58,8 @@ internal class GeofenceRepositoryImpl(
     private val manager: GeofenceManager,
     private val secureUserStore: SecureUserStore,
     private val clock: Clock,
-    private val logger: GeofenceLogger
+    private val logger: GeofenceLogger,
+    private val syncMode: GeofenceSyncMode
 ) : GeofenceRepository {
 
     // Dedup gate shared by refresh() and handleMovement(). If either is already running,
@@ -82,35 +83,55 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("no identified user")
                 return Result.success(Unit)
             }
-            val lastSync = store.getLastSyncTimestamp()
-            if (lastSync != null) {
-                // Time-fresh alone isn't enough: if the app was killed while the
-                // user travelled far, no movement EXIT fired to update the cache.
-                // Null anchor (never fetched) treats distance as 0 → time-only check.
-                val effectiveConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-                val timeSinceLastSync = clock.currentTimeMillis() - lastSync
-                val distanceFromAnchor = store.getLastApiFetchLocation()
-                    ?.distanceTo(latitude, longitude) ?: 0f
-                val withinFreshness = timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry &&
-                    distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius
-                if (withinFreshness) {
-                    // Cache fresh — if OS regs were wiped on sign-out, re-
-                    // register from cache instead of skipping; otherwise the
-                    // new user has no geofences until stale-window expiry.
-                    val cachedRegions = store.getCachedRegions()
-                    val registered = store.getRegisteredIds()
-                    if (cachedRegions.isNotEmpty() && registered.isEmpty()) {
-                        return performLocalRefresh(userId, latitude, longitude, effectiveConfig)
-                    }
+
+            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            return when (refreshAction(LocationCoordinates(latitude, longitude), config)) {
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
+                RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
-                    return Result.success(Unit)
+                    Result.success(Unit)
                 }
             }
-            return performRemoteRefresh(userId, latitude, longitude)
         } finally {
             refreshInProgress.set(false)
         }
     }
+
+    // Decision table for identify/launch refresh. Only the re-fetch question depends on the sync
+    // mode; staleness in time, staleness of the ranking, and OS-registration gaps are mode-agnostic.
+    private fun refreshAction(location: LocationCoordinates, config: GeofenceConfig): RefreshAction {
+        // Each distance is measured from its own reference: re-fetch from the last API fetch, re-rank
+        // from the last registration (the movement-trigger center). Null (never set) → 0 → within radius.
+        val distanceFromLastFetch = store.getLastApiFetchLocation()
+            ?.distanceTo(location.latitude, location.longitude) ?: 0f
+        val distanceFromLastRegistration = store.getLastMovementTriggerLocation()
+            ?.distanceTo(location.latitude, location.longitude) ?: 0f
+
+        return when {
+            isStaleInTime(config) -> RefreshAction.REMOTE
+            syncMode.movementRequiresRemoteFetch(distanceFromLastFetch, config) -> RefreshAction.REMOTE
+            isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
+            hasUnregisteredCache() -> RefreshAction.LOCAL
+            else -> RefreshAction.SKIP
+        }
+    }
+
+    // Cache aged out of its freshness window (or was never fetched).
+    private fun isStaleInTime(config: GeofenceConfig): Boolean {
+        val lastSync = store.getLastSyncTimestamp() ?: return true
+        return clock.currentTimeMillis() - lastSync >= config.remoteFetchRefreshExpiry
+    }
+
+    // The device has left the trigger radius since the nearest-N was last ranked, so the registered
+    // set no longer reflects the closest geofences — re-rank locally (no network). This is exactly the
+    // condition the live movement trigger fires on; refresh() catches an EXIT missed while app was dead.
+    private fun isRankingStale(distanceFromLastRegistration: Float, config: GeofenceConfig): Boolean =
+        distanceFromLastRegistration >= config.localRefreshTriggerRadius
+
+    /** Cache holds regions but none are registered with the OS (e.g. regs lost on sign-out) → re-register. */
+    private fun hasUnregisteredCache(): Boolean =
+        store.getCachedRegions().isNotEmpty() && store.getRegisteredIds().isEmpty()
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
@@ -124,18 +145,18 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("no identified user")
                 return Result.success(Unit)
             }
+
             val anchor = store.getLastApiFetchLocation()
-            val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
-            // Tier B (remote fetch) when:
-            // - no anchor yet (first EXIT after install / clearAll / sign-out), OR
-            // - we've moved beyond the API threshold from the last fetch.
-            // Otherwise Tier A: re-rank the cached regions for the new location.
+            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
+            // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
+            // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
             val needsRemoteFetch = anchor == null ||
-                anchor.distanceTo(latitude, longitude) >= cachedConfig.remoteFetchRefreshTriggerRadius
+                syncMode.movementRequiresRemoteFetch(distanceFromAnchor, config)
             return if (needsRemoteFetch) {
                 performRemoteRefresh(userId, latitude, longitude)
             } else {
-                performLocalRefresh(userId, latitude, longitude, cachedConfig)
+                performLocalRefresh(userId, latitude, longitude, config)
             }
         } finally {
             refreshInProgress.set(false)
@@ -181,36 +202,41 @@ internal class GeofenceRepositoryImpl(
         userId: String,
         latitude: Double,
         longitude: Double
-    ): Result<Unit> = apiService.fetchGeofences(latitude, longitude).fold(
-        onSuccess = { response ->
-            val regions = response.toDomainRegions()
-            // Config preference: server-shipped > last cached > constants.
-            val parsedConfig = response.toDomainConfig()
-            val config = parsedConfig
-                ?: store.getCachedConfig()
-                ?: GeofenceConfig.fallback()
-            registerNearestAndPersist(
-                userId = userId,
-                latitude = latitude,
-                longitude = longitude,
-                regions = regions,
-                config = config,
-                // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
-                // Skip the config save when backend didn't ship one this response —
-                // a null parse must not clobber a previously cached value.
-                onRegistered = {
-                    store.saveCachedRegions(regions)
-                    parsedConfig?.let { store.saveCachedConfig(it) }
-                    store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
-                    store.setLastSyncTimestamp(clock.currentTimeMillis())
-                }
-            )
-        },
-        onFailure = { error ->
-            logger.logSyncFailed(error.message)
-            Result.failure(error)
-        }
-    )
+    ): Result<Unit> {
+        // No location is sent to fetch. The precise lat/lng below drive on-device ranking and the
+        // anchor only — they never leave here.
+        val fetchResult = apiService.fetchGeofences()
+        return fetchResult.fold(
+            onSuccess = { response ->
+                val regions = response.toDomainRegions()
+                // Config preference: server-shipped > last cached > constants.
+                val parsedConfig = response.toDomainConfig()
+                val config = parsedConfig
+                    ?: store.getCachedConfig()
+                    ?: GeofenceConfig.fallback()
+                registerNearestAndPersist(
+                    userId = userId,
+                    latitude = latitude,
+                    longitude = longitude,
+                    regions = regions,
+                    config = config,
+                    // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
+                    // Skip the config save when backend didn't ship one this response —
+                    // a null parse must not clobber a previously cached value.
+                    onRegistered = {
+                        store.saveCachedRegions(regions)
+                        parsedConfig?.let { store.saveCachedConfig(it) }
+                        store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
+                        store.setLastSyncTimestamp(clock.currentTimeMillis())
+                    }
+                )
+            },
+            onFailure = { error ->
+                logger.logSyncFailed(error.message)
+                Result.failure(error)
+            }
+        )
+    }
 
     @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
     private suspend fun performLocalRefresh(
@@ -259,10 +285,18 @@ internal class GeofenceRepositoryImpl(
         onRegistered: () -> Unit = {}
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
-        val nearest = distanceFilter.nearest(regions, latitude, longitude, config.maxBusinessGeofences)
-        // Zero business geofences => register nothing (no movement trigger either).
-        // Customers without configured geofences pay zero runtime cost.
-        val regionsToRegister = if (nearest.isEmpty()) {
+        val nearest = distanceFilter.nearest(
+            regions = regions,
+            latitude = latitude,
+            longitude = longitude,
+            max = config.maxBusinessGeofences,
+            maxDistanceMeters = config.maxMonitoringDistance
+        )
+        // Keep the movement trigger registered whenever the user has registerable geofences — even
+        // if none are near enough now (all beyond maxMonitoringDistance) — so an EXIT re-ranks them
+        // in as the device approaches. A truly empty set (no geofences / kill switch) registers nothing.
+        val hasRegisterableGeofences = regions.isNotEmpty() && config.maxBusinessGeofences > 0
+        val regionsToRegister = if (!hasRegisterableGeofences) {
             emptyList()
         } else {
             listOf(buildMovementTrigger(latitude, longitude, config.localRefreshTriggerRadius)) + nearest
@@ -295,10 +329,10 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Track the user's location at each successful registration so
-                    // boot restore can re-center close to their real position. Clear
-                    // when the business set transitions to empty — no trigger exists.
-                    if (nearest.isNotEmpty()) {
+                    // Track the user's location at each successful registration so boot restore can
+                    // re-center close to their real position. Clear only when nothing is registered
+                    // (no geofences / kill switch) — the trigger, and thus its location, is gone.
+                    if (hasRegisterableGeofences) {
                         store.saveLastMovementTriggerLocation(GeofenceLocation(latitude, longitude))
                     } else {
                         store.clearLastMovementTriggerLocation()

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceSyncMode.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceSyncMode.kt
@@ -1,0 +1,33 @@
+package io.customer.geofence
+
+/**
+ * The kind of refresh a signal calls for, decided independently of what triggered it.
+ *
+ * - [REMOTE] — fetch a fresh set from the API.
+ * - [LOCAL]  — re-rank / re-register the cached set on-device, no network.
+ * - [SKIP]   — cache is current; do nothing.
+ */
+internal enum class RefreshAction { REMOTE, LOCAL, SKIP }
+
+/**
+ * How the SDK fetches a user's geofences. Only [FETCH_ALL] ships: the backend returns the full
+ * (capped) set and the SDK never sends device location.
+ *
+ * A location-based "nearby" mode is deliberately absent so there's no code path that transmits
+ * device location; re-introducing it needs backend support and a deliberate SDK release (never a
+ * runtime/server toggle). Kept as a single-value enum so re-introduction stays a localized change.
+ * Prior implementation is in git history.
+ */
+internal enum class GeofenceSyncMode {
+    FETCH_ALL;
+
+    /**
+     * FETCH_ALL holds the full set, so movement never triggers a re-fetch. A location-bound mode
+     * would re-fetch once the device moved beyond its fetch radius (see class doc).
+     */
+    fun movementRequiresRemoteFetch(distanceFromAnchor: Float, config: GeofenceConfig): Boolean = false
+
+    companion object {
+        val active: GeofenceSyncMode = FETCH_ALL
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -34,6 +34,8 @@ internal data class GeofenceApiConfig(
     val remoteFetchRefreshExpiryTime: Long? = null,
     @SerialName("duplicate_events_expiry_time")
     val duplicateEventsExpiryTime: Long? = null,
+    @SerialName("max_monitoring_distance")
+    val maxMonitoringDistance: Float? = null,
     @SerialName("android")
     val android: GeofenceApiPlatformConfig? = null
 )
@@ -72,20 +74,47 @@ internal fun GeofenceApiResponse.toDomainConfig(): GeofenceConfig? =
 internal fun GeofenceApiResponse.toDomainRegions(): List<GeofenceRegion> =
     geofences.map { it.toDomain() }
 
-private fun GeofenceApiConfig.toDomain(): GeofenceConfig = GeofenceConfig(
-    localRefreshTriggerRadius = localRefreshTriggerRadius?.takeIf { it > 0 }
-        ?: GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS,
-    remoteFetchRefreshTriggerRadius = remoteFetchRefreshTriggerRadius?.takeIf { it > 0 }
-        ?: GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
-    remoteFetchRefreshExpiry = remoteFetchRefreshExpiryTime?.takeIf { it > 0 }
-        ?: GeofenceConstants.STALE_THRESHOLD_MS,
-    duplicateEventsExpiry = duplicateEventsExpiryTime?.takeIf { it > 0 }
-        ?: GeofenceConstants.DEDUPE_COOLDOWN_MS,
-    // Range is 0..99: zero is a valid server-side kill switch; 99 leaves one
-    // OS slot for the movement trigger. Out-of-range values fall back.
-    maxBusinessGeofences = android?.maxBusinessGeofence?.takeIf { it in 0..99 }
-        ?: GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
-)
+// Coerces raw server values into sane bounds so a misconfigured backend can't push the SDK into a
+// pathological state: non-positive values fall back; positive out-of-range values clamp.
+private fun GeofenceApiConfig.toDomain(): GeofenceConfig {
+    val coercedLocalRefresh = localRefreshTriggerRadius?.takeIf { it > 0 }
+        ?.coerceIn(
+            GeofenceConstants.MIN_LOCAL_REFRESH_RADIUS_METERS,
+            GeofenceConstants.MAX_LOCAL_REFRESH_RADIUS_METERS
+        )
+        ?: GeofenceConstants.FALLBACK_LOCAL_REFRESH_RADIUS_METERS
+    // null → default cap; 0 → explicitly disabled (no cap). A positive value below the trigger
+    // radius would create a dead-zone (a geofence inside the trigger but beyond the cap never gets
+    // re-ranked), so fall back to the default.
+    val coercedMaxMonitoringDistance = when {
+        maxMonitoringDistance == null -> GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
+        maxMonitoringDistance == 0f -> GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
+        maxMonitoringDistance < coercedLocalRefresh -> GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
+        else -> maxMonitoringDistance
+    }
+    return GeofenceConfig(
+        localRefreshTriggerRadius = coercedLocalRefresh,
+        remoteFetchRefreshTriggerRadius = remoteFetchRefreshTriggerRadius?.takeIf { it > 0 }
+            ?: GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
+        remoteFetchRefreshExpiry = remoteFetchRefreshExpiryTime?.takeIf { it > 0 }
+            ?.coerceIn(
+                GeofenceConstants.MIN_REMOTE_FETCH_REFRESH_EXPIRY_MS,
+                GeofenceConstants.MAX_REMOTE_FETCH_REFRESH_EXPIRY_MS
+            )
+            ?: GeofenceConstants.STALE_THRESHOLD_MS,
+        duplicateEventsExpiry = duplicateEventsExpiryTime?.takeIf { it > 0 }
+            ?.coerceIn(
+                GeofenceConstants.MIN_DUPLICATE_EVENTS_EXPIRY_MS,
+                GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS
+            )
+            ?: GeofenceConstants.DEDUPE_COOLDOWN_MS,
+        // Range is 0..99: zero is a valid server-side kill switch; 99 leaves one
+        // OS slot for the movement trigger. Out-of-range values fall back.
+        maxBusinessGeofences = android?.maxBusinessGeofence?.takeIf { it in 0..99 }
+            ?: GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES,
+        maxMonitoringDistance = coercedMaxMonitoringDistance
+    )
+}
 
 private fun GeofenceApiRegion.toDomain(): GeofenceRegion = GeofenceRegion(
     id = id,

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
@@ -6,10 +6,8 @@ import io.customer.sdk.core.network.HttpMethod
 import io.customer.sdk.core.network.HttpRequestParams
 
 internal interface GeofenceApiService {
-    suspend fun fetchGeofences(
-        latitude: Double,
-        longitude: Double
-    ): Result<GeofenceApiResponse>
+    /** Returns the full (capped) set with no location sent. */
+    suspend fun fetchGeofences(): Result<GeofenceApiResponse>
 }
 
 internal class GeofenceApiServiceImpl(
@@ -17,19 +15,12 @@ internal class GeofenceApiServiceImpl(
     private val jsonSerializer: GeofenceJsonSerializer
 ) : GeofenceApiService {
 
-    override suspend fun fetchGeofences(
-        latitude: Double,
-        longitude: Double
-    ): Result<GeofenceApiResponse> {
+    override suspend fun fetchGeofences(): Result<GeofenceApiResponse> {
         val params = HttpRequestParams(
             path = ENDPOINT_PATH,
             method = HttpMethod.GET,
-            queryParams = mapOf(
-                "latitude" to latitude.toString(),
-                "longitude" to longitude.toString()
-            )
+            queryParams = emptyMap()
         )
-
         return httpClient.request(params).mapCatching { responseBody ->
             // Lenient at the wire boundary so the SDK doesn't pin a specific
             // type for `id` — accepts either numeric or quoted-string form.

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -13,6 +13,7 @@ import io.customer.geofence.GeofenceRepository
 import io.customer.geofence.GeofenceRepositoryImpl
 import io.customer.geofence.GeofenceServices
 import io.customer.geofence.GeofenceServicesImpl
+import io.customer.geofence.GeofenceSyncMode
 import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.api.GeofenceApiServiceImpl
 import io.customer.geofence.store.GeofenceCooldownStore
@@ -126,7 +127,8 @@ internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
             manager = geofenceManager,
             secureUserStore = secureUserStore,
             clock = SDKComponent.clock,
-            logger = SDKComponent.geofenceLogger
+            logger = SDKComponent.geofenceLogger,
+            syncMode = GeofenceSyncMode.active
         )
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
@@ -13,6 +13,7 @@ import org.robolectric.RobolectricTestRunner
 class GeofenceDistanceFilterTest : RobolectricTest() {
 
     private val filter = GeofenceDistanceFilter()
+    private val noDistanceCap = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfigurationDefault { })
@@ -20,13 +21,13 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
 
     @Test
     fun nearest_givenEmptyList_expectEmpty() {
-        filter.nearest(emptyList(), latitude = 0.0, longitude = 0.0, max = 5).shouldBeEmpty()
+        filter.nearest(emptyList(), latitude = 0.0, longitude = 0.0, max = 5, maxDistanceMeters = noDistanceCap).shouldBeEmpty()
     }
 
     @Test
     fun nearest_givenMaxZero_expectEmpty() {
         val regions = listOf(region("biz-1", 0.0, 0.0))
-        filter.nearest(regions, latitude = 0.0, longitude = 0.0, max = 0).shouldBeEmpty()
+        filter.nearest(regions, latitude = 0.0, longitude = 0.0, max = 0, maxDistanceMeters = noDistanceCap).shouldBeEmpty()
     }
 
     @Test
@@ -36,7 +37,7 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
         val close = region("biz-close", 0.01, 0.0)
         val mid = region("biz-mid", 1.0, 0.0)
 
-        val result = filter.nearest(listOf(far, close, mid), reference.first, reference.second, max = 5)
+        val result = filter.nearest(listOf(far, close, mid), reference.first, reference.second, max = 5, maxDistanceMeters = noDistanceCap)
 
         result.map { it.id } shouldBeEqualTo listOf("biz-close", "biz-mid", "biz-far")
     }
@@ -51,9 +52,38 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
             region("biz-farther", 10.0, 0.0)
         )
 
-        val result = filter.nearest(regions, reference.first, reference.second, max = 2)
+        val result = filter.nearest(regions, reference.first, reference.second, max = 2, maxDistanceMeters = noDistanceCap)
 
         result.map { it.id } shouldBeEqualTo listOf("biz-close", "biz-mid")
+    }
+
+    @Test
+    fun nearest_givenMaxDistance_expectRegionsBeyondCapExcluded() {
+        val close = region("biz-close", 0.01, 0.0) // ~1.1 km
+        val mid = region("biz-mid", 1.0, 0.0) // ~111 km
+        val far = region("biz-far", 5.0, 0.0) // ~555 km
+
+        // 50 km cap: only the ~1.1 km region qualifies; count budget is irrelevant here.
+        val result = filter.nearest(
+            listOf(far, close, mid),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 5,
+            maxDistanceMeters = 50_000f
+        )
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-close")
+    }
+
+    @Test
+    fun nearest_givenNoMaxDistance_expectFarRegionsStillIncluded() {
+        val close = region("biz-close", 0.01, 0.0)
+        val far = region("biz-far", 5.0, 0.0) // ~555 km
+
+        // Default (no cap): distance doesn't exclude, only the count budget does.
+        val result = filter.nearest(listOf(far, close), latitude = 0.0, longitude = 0.0, max = 5, maxDistanceMeters = noDistanceCap)
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-close", "biz-far")
     }
 
     @Test
@@ -62,7 +92,7 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
         val first = region("biz-first", 1.0, 0.0)
         val second = region("biz-second", -1.0, 0.0)
 
-        val result = filter.nearest(listOf(first, second), latitude = 0.0, longitude = 0.0, max = 2)
+        val result = filter.nearest(listOf(first, second), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
 
         result.map { it.id } shouldBeEqualTo listOf("biz-first", "biz-second")
     }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -54,7 +54,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager = manager,
             secureUserStore = secureUserStore,
             clock = clock,
-            logger = logger
+            logger = logger,
+            syncMode = GeofenceSyncMode.active
         )
     }
 
@@ -65,11 +66,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // 1 min ago
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -85,12 +87,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns sampleConfig()
-        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -105,35 +107,152 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns null
-        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
     @Test
-    fun refresh_givenFreshButMovedFarFromAnchor_expectApiCalled() = runTest {
-        // App killed → user travels far → reopens within freshness window.
-        // Time-based check alone would skip and leave geofences stale at the
-        // old location; the distance check forces a fresh fetch.
+    fun refresh_givenMovedBeyondTriggerSinceLastRegistration_expectLocalRerank() = runTest {
+        // refresh() catches a movement EXIT missed while the app was dead: the device is beyond the
+        // trigger radius from where the nearest-N was last ranked, so re-rank locally — and not
+        // remotely, since it's still within the remote radius and time-fresh. Mode-independent.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // time-fresh
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // ~2.2 km from the last registration: beyond the 1 km trigger, within the 5 km remote radius.
+        repository.refresh(latitude = 0.02, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() } // no remote fetch
+        coVerify { manager.replaceGeofences(any(), any()) } // local re-rank
+        verify(exactly = 0) { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenWithinTriggerSinceLastRegistration_expectSkip() = runTest {
+        // The complement: a move smaller than the trigger radius leaves the ranking valid, so a
+        // time-fresh refresh with regs intact skips — the live movement trigger hasn't fired yet.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+
+        // ~550 m from the last registration: within the 1 km trigger radius.
+        repository.refresh(latitude = 0.005, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFetchAllMode_expectFetchWithoutLocation() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null // never synced -> remote fetch
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 37.7749, longitude = -122.4194)
+
+        // Fetch-all sends no location; precise lat/lng stay on-device.
+        coVerify { apiService.fetchGeofences() }
+    }
+
+    @Test
+    fun handleMovement_givenFetchAllModeAndMovedFar_expectLocalRefreshNotRemote() = runTest {
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // 1° latitude ≈ 111 km — far beyond any radius — but fetch-all never re-fetches on movement.
+        repository.handleMovement(latitude = 1.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify { manager.replaceGeofences(any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenFetchAllModeFreshButMovedFar_expectLocalReRankNotRemote() = runTest {
+        // App killed while the user travelled far, reopened within the freshness window: the cached
+        // set is still valid (location-independent) but the registered nearest-N must be re-ranked
+        // for the new location — locally, without a server call.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns setOf("biz-1")
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
-        // 1° latitude ≈ 111 km, way beyond the 5 km remoteFetchRefreshTriggerRadius.
+        // 1° latitude ≈ 111 km — far beyond localRefreshTriggerRadius — but within time freshness.
         repository.refresh(latitude = 1.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(1.0, 0.0) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify { manager.replaceGeofences(any(), any()) }
         verify(exactly = 0) { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFetchAllModeFreshAndNotMoved_expectSkip() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact -> nothing to do
+
+        repository.refresh(latitude = 0.0, longitude = 0.0) // same as anchor
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
+    }
+
+    @Test
+    fun refresh_givenFarFromLastFetchButAtLastRegistration_expectSkip() = runTest {
+        // Ranking staleness is measured from the last registration (movement-trigger center), NOT the
+        // last API fetch. The device sits far from a stale fetch anchor but exactly where it was last
+        // re-ranked, so the ranking is current → SKIP. Guards against measuring from the fetch anchor.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // time-fresh
+        every { store.getCachedConfig() } returns sampleConfig() // local 1 km, remote 5 km
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0) // stale fetch anchor
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(1.0, 0.0) // last re-rank
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 1.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1") // regs intact
+
+        // At the last-registration point (0 m from it), but ~111 km from the fetch anchor.
+        repository.refresh(latitude = 1.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        verify { logger.logSyncSkippedFresh() }
     }
 
     @Test
@@ -143,14 +262,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns
             System.currentTimeMillis() - GeofenceConstants.STALE_THRESHOLD_MS - 1_000L
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any()) }
+        coVerify { apiService.fetchGeofences() }
     }
 
     @Test
@@ -167,7 +286,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -181,14 +300,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns
             sampleConfig(remoteFetchRefreshExpiry = 60 * 60 * 1_000L)
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any()) }
+        coVerify { apiService.fetchGeofences() }
     }
 
     @Test
@@ -197,14 +316,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any(), any()) }
+        coVerify { apiService.fetchGeofences() }
     }
 
     @Test
@@ -214,7 +333,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify { logger.logSyncSkipped(match { it.contains("no identified user") }) }
@@ -227,14 +346,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
     }
 
     @Test
     fun refresh_givenApiFailure_expectFailurePropagatedAndNoPersistOrRegister() = runTest {
         val error = IOException("network down")
         every { secureUserStore.getUserId() } returns "user-42"
-        coEvery { apiService.fetchGeofences(any(), any()) } returns Result.failure(error)
+        coEvery { apiService.fetchGeofences() } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -252,9 +371,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // restore reads it later as the effective coordinates.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         val capturedLoc = slot<GeofenceLocation>()
@@ -271,9 +390,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so any previously-stored location is stale and must be cleared.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(emptyResponse())
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
@@ -283,14 +402,36 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenGeofencesExistButAllBeyondCap_expectMovementTriggerRegisteredAndLocationSaved() = runTest {
+        // Geofences exist but none qualify right now (all beyond maxMonitoringDistance). We must
+        // still register the movement trigger so an EXIT re-ranks and re-registers them as the
+        // device approaches — unlike the truly-empty case, which registers nothing.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // non-empty fetched set
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList() // none near
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        // Only the movement trigger is registered; no business geofences qualified.
+        captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
+        verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
+        verify { logger.logSyncSucceeded(0) }
+    }
+
+    @Test
     fun refresh_givenManagerAddFails_expectMovementTriggerLocationNotPersisted() = runTest {
         // Persistence is gated on add success — a failed registration must leave the
         // last-known good movement location intact (next refresh retries).
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(RuntimeException("boom"))
 
@@ -304,9 +445,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
         val filtered = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { apiService.fetchGeofences(12.34, 56.78) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
-        every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns filtered
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns filtered
         val captured = slot<List<GeofenceRegion>>()
         coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
@@ -314,7 +455,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         verify { store.setLastSyncTimestamp(any()) }
-        verify { distanceFilter.nearest(any(), 12.34, 56.78, 3) }
+        verify { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) }
         verify { logger.logSyncSucceeded(filtered.size) }
         // Store holds the IDs of exactly what was registered (movement trigger + business),
         // so the next refresh's stale-cleanup diff is accurate.
@@ -336,9 +477,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenSuccess_expectCacheAndConfigAndAnchorPersisted() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(12.34, 56.78) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
-        every { distanceFilter.nearest(any(), 12.34, 56.78, 3) } returns
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         val regionsSlot = slot<List<GeofenceRegion>>()
@@ -363,9 +504,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // anchor stale so the next refresh retries instead of skipping as "fresh".
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(RuntimeException("boom"))
 
@@ -393,9 +534,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceRegion("biz-shared", 0.0, 0.0, 100f),
             GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         )
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns newBusiness
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns newBusiness
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
@@ -415,9 +556,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenNoPreviousRegistration_expectNoRemoveCall() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
@@ -435,9 +576,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(newRegion)
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(newRegion)
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns
             Result.failure(RuntimeException("remove boom"))
@@ -466,9 +607,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceConstants.MOVEMENT_TRIGGER_ID,
             "biz-old"
         )
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(emptyResponse())
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
 
@@ -485,9 +626,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // no movement trigger registered, no OS-side geofence activity.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(emptyResponse())
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         val captured = slot<List<GeofenceRegion>>()
         coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
@@ -508,9 +649,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val error = RuntimeException("gms boom")
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-new", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(error)
 
@@ -531,9 +672,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // a second OS registration.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
 
         val addGeofencesActive = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
@@ -551,7 +692,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences() }
         verify { logger.logSyncSkipped(match { it.contains("refresh already in progress") }) }
     }
 
@@ -561,11 +702,11 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so a follow-up refresh isn't permanently locked out.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returnsMany listOf(
+        coEvery { apiService.fetchGeofences() } returnsMany listOf(
             Result.failure(IOException("first call fails")),
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         )
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         val first = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -573,7 +714,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         first.isFailure shouldBeEqualTo true
         second.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 2) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 2) { apiService.fetchGeofences() }
     }
 
     @Test
@@ -582,7 +723,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // the userId recheck inside the state lock prevents writing the previous
         // user's geofences after a sign-out cleared state.
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", "user-B")
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -597,7 +738,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     @Test
     fun refresh_givenUserSignsOutDuringApiCall_expectNoWriteToStoreOrManager() = runTest {
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", null)
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -619,9 +760,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
         every { store.getCachedRegions() } returns listOf(region)
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(region)
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(region)
         val existingSlot = slot<Set<String>>()
         coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
 
@@ -642,9 +783,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
         every { store.getCachedRegions() } returns listOf(cached)
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns listOf(incoming)
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(incoming)
         val existingSlot = slot<Set<String>>()
         coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
 
@@ -734,7 +875,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.handleMovement(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
     }
 
@@ -746,14 +887,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastApiFetchLocation() } returns null
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 1.0, longitude = 2.0)
 
-        coVerify { apiService.fetchGeofences(1.0, 2.0) }
+        coVerify { apiService.fetchGeofences() }
     }
 
     @Test
@@ -766,13 +907,13 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns null
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(cached, any(), any(), any()) } returns cached
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         // ~111m from anchor — well within the fallback 5km threshold.
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -789,57 +930,15 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(cached, any(), any(), any()) } returns
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
         coVerify { manager.replaceGeofences(any(), any()) }
-        verify { distanceFilter.nearest(cached, 0.0, 0.001, any()) }
-    }
-
-    @Test
-    fun handleMovement_givenAnchorBeyondThreshold_expectRemoteFetch() = runTest {
-        // Anchor at (0, 0), current location ~11km away (0, 0.1), threshold 5km
-        // → tier B: API fetch.
-        every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
-        every { store.getCachedConfig() } returns sampleConfig()
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
-
-        repository.handleMovement(latitude = 0.0, longitude = 0.1)
-
-        coVerify { apiService.fetchGeofences(0.0, 0.1) }
-    }
-
-    @Test
-    fun handleMovement_givenAnchorBeyondThreshold_expectCacheAndAnchorPersisted() = runTest {
-        // Tier B via handleMovement must wire through to the same persist path
-        // refresh() uses — new anchor is the current location, cache + config + timestamp written.
-        every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
-        every { store.getCachedConfig() } returns sampleConfig()
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
-            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
-        val anchorSlot = slot<GeofenceLocation>()
-        every { store.saveLastApiFetchLocation(capture(anchorSlot)) } returns Unit
-
-        repository.handleMovement(latitude = 0.0, longitude = 0.1)
-
-        verify { store.saveCachedRegions(any()) }
-        verify { store.saveCachedConfig(any()) }
-        verify { store.setLastSyncTimestamp(any()) }
-        anchorSlot.captured shouldBeEqualTo GeofenceLocation(0.0, 0.1)
+        verify { distanceFilter.nearest(cached, 0.0, 0.001, any(), any()) }
     }
 
     @Test
@@ -850,7 +949,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
@@ -873,14 +972,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         val concurrentApiCalls = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
-        coEvery { apiService.fetchGeofences(any(), any()) } coAnswers {
+        coEvery { apiService.fetchGeofences() } coAnswers {
             val n = concurrentApiCalls.incrementAndGet()
             maxObservedConcurrency.updateAndGet { current -> maxOf(current, n) }
             delay(50)
             concurrentApiCalls.decrementAndGet()
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         }
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns emptyList()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         coroutineScope {
@@ -889,7 +988,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences() }
     }
 
     // ---------- restoreFromCache (boot path) ----------
@@ -928,7 +1027,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns null
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 1.0, 2.0, 100f))
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 1.0, 2.0, 100f))
         coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
@@ -950,18 +1049,18 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(cached, 50.0, 60.0, any()) } returns cached
+        every { distanceFilter.nearest(cached, 50.0, 60.0, any(), any()) } returns cached
         coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         repository.restoreFromCache()
 
         // Distance filter receives movementLoc coords, NOT the anchor's.
-        verify { distanceFilter.nearest(cached, 50.0, 60.0, any()) }
-        verify(exactly = 0) { distanceFilter.nearest(any(), 12.34, 56.78, any()) }
+        verify { distanceFilter.nearest(cached, 50.0, 60.0, any(), any()) }
+        verify(exactly = 0) { distanceFilter.nearest(any(), 12.34, 56.78, any(), any()) }
         // Pins the boot-restore manager variant, not the normal one.
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
-        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
     }
 
     @Test
@@ -976,12 +1075,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(cached, 12.34, 56.78, any()) } returns cached
+        every { distanceFilter.nearest(cached, 12.34, 56.78, any(), any()) } returns cached
         coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
         repository.restoreFromCache()
 
-        verify { distanceFilter.nearest(cached, 12.34, 56.78, any()) }
+        verify { distanceFilter.nearest(cached, 12.34, 56.78, any(), any()) }
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
     }
 
@@ -995,7 +1094,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 50.0, 60.0, 100f))
         every { store.getRegisteredIds() } returns emptySet()
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 50.0, 60.0, 100f))
         coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
 
@@ -1018,9 +1117,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getLastSyncTimestamp() } returns null
-        coEvery { apiService.fetchGeofences(any(), any()) } returns
+        coEvery { apiService.fetchGeofences() } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any()) } returns cached
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
             // Hold the refresh path long enough that restoreFromCache enters mid-flight.
             delay(100)
@@ -1041,20 +1140,60 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
     }
 
+    @Test
+    fun refresh_givenServerMaxMonitoringDistance_expectForwardedToDistanceFilter() = runTest {
+        // The server-configured monitoring cap must reach the distance filter so far geofences
+        // are dropped from the registered set.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null // force a remote fetch
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, maxMonitoringDistance = 50_000f))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify { distanceFilter.nearest(any(), any(), any(), max = 3, maxDistanceMeters = 50_000f) }
+    }
+
     private fun sampleConfig(
-        remoteFetchRefreshExpiry: Long = 86_400_000L
+        remoteFetchRefreshExpiry: Long = 86_400_000L,
+        maxMonitoringDistance: Float = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
     ): GeofenceConfig = GeofenceConfig(
         localRefreshTriggerRadius = 1_000f,
         remoteFetchRefreshTriggerRadius = 5_000f,
         remoteFetchRefreshExpiry = remoteFetchRefreshExpiry,
         duplicateEventsExpiry = 3_600_000L,
-        maxBusinessGeofences = 19
+        maxBusinessGeofences = 19,
+        maxMonitoringDistance = maxMonitoringDistance
     )
+
+    // Config block but no geofences — the "account has zero geofences" case, distinct from
+    // "geofences exist but all are beyond the monitoring distance".
+    private fun emptyResponse(maxBusinessGeofences: Int = 3): GeofenceApiResponse {
+        val json = """
+            {
+              "config": {
+                "local_refresh_trigger_radius": 1000,
+                "remote_fetch_refresh_trigger_radius": 5000,
+                "remote_fetch_refresh_expiry_time": 86400000,
+                "duplicate_events_expiry_time": 3600000,
+                "android": { "max_business_geofence": $maxBusinessGeofences }
+              },
+              "geofences": []
+            }
+        """.trimIndent()
+        return jsonSerializer.decode(GeofenceApiResponse.serializer(), json)
+    }
 
     private fun sampleResponse(
         maxBusinessGeofences: Int,
-        localRefreshTriggerRadius: Float = 1000f
+        localRefreshTriggerRadius: Float = 1000f,
+        maxMonitoringDistance: Float? = null
     ): GeofenceApiResponse {
+        val maxMonitoringDistanceLine =
+            maxMonitoringDistance?.let { "\"max_monitoring_distance\": $it," } ?: ""
         val json = """
             {
               "config": {
@@ -1062,6 +1201,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 "remote_fetch_refresh_trigger_radius": 5000,
                 "remote_fetch_refresh_expiry_time": 86400000,
                 "duplicate_events_expiry_time": 3600000,
+                $maxMonitoringDistanceLine
                 "android": { "max_business_geofence": $maxBusinessGeofences }
               },
               "geofences": [

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -236,6 +236,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
                 "remote_fetch_refresh_trigger_radius": 7500,
                 "remote_fetch_refresh_expiry_time": 86400000,
                 "duplicate_events_expiry_time": 3600000,
+                "max_monitoring_distance": 500000,
                 "android": { "max_business_geofence": 25 }
               },
               "geofences": []
@@ -248,7 +249,8 @@ class GeofenceApiResponseTest : RobolectricTest() {
             remoteFetchRefreshTriggerRadius = 7500f,
             remoteFetchRefreshExpiry = 86_400_000L,
             duplicateEventsExpiry = 3_600_000L,
-            maxBusinessGeofences = 25
+            maxBusinessGeofences = 25,
+            maxMonitoringDistance = 500_000f
         )
     }
 
@@ -258,6 +260,32 @@ class GeofenceApiResponseTest : RobolectricTest() {
         val response = parseResponse("""{ "config": {}, "geofences": [] }""")
 
         response.toDomainConfig() shouldBeEqualTo fallbackConfig()
+    }
+
+    @Test
+    fun toDomainConfig_givenPartialConfig_expectPresentFieldsUsedAndRestFallback() {
+        // Backend rolling fields out gradually: present fields are used (and coerced), each absent
+        // field falls back independently.
+        val response = parseResponse(
+            """
+            {
+              "config": {
+                "local_refresh_trigger_radius": 2000,
+                "android": { "max_business_geofence": 10 }
+              },
+              "geofences": []
+            }
+            """.trimIndent()
+        )
+
+        response.toDomainConfig() shouldBeEqualTo GeofenceConfig(
+            localRefreshTriggerRadius = 2000f,
+            remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
+            remoteFetchRefreshExpiry = GeofenceConstants.STALE_THRESHOLD_MS,
+            duplicateEventsExpiry = GeofenceConstants.DEDUPE_COOLDOWN_MS,
+            maxBusinessGeofences = 10,
+            maxMonitoringDistance = GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
+        )
     }
 
     @Test
@@ -272,6 +300,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
                 "remote_fetch_refresh_trigger_radius": 0,
                 "remote_fetch_refresh_expiry_time": -100,
                 "duplicate_events_expiry_time": 0,
+                "max_monitoring_distance": -1,
                 "android": { "max_business_geofence": -5 }
               },
               "geofences": []
@@ -300,6 +329,67 @@ class GeofenceApiResponseTest : RobolectricTest() {
 
         atLimit?.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
         above?.maxBusinessGeofences shouldBeEqualTo GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+    }
+
+    @Test
+    fun toDomainConfig_givenLocalRefreshRadiusOutOfRange_expectClampedToBounds() {
+        // Positive but absurd radii clamp to the sane bounds instead of being used as-is.
+        val belowMin = parseResponse("""{ "config": { "local_refresh_trigger_radius": 10 }, "geofences": [] }""")
+        val aboveMax = parseResponse("""{ "config": { "local_refresh_trigger_radius": 999999 }, "geofences": [] }""")
+
+        belowMin.toDomainConfig()?.localRefreshTriggerRadius shouldBeEqualTo
+            GeofenceConstants.MIN_LOCAL_REFRESH_RADIUS_METERS
+        aboveMax.toDomainConfig()?.localRefreshTriggerRadius shouldBeEqualTo
+            GeofenceConstants.MAX_LOCAL_REFRESH_RADIUS_METERS
+    }
+
+    @Test
+    fun toDomainConfig_givenExpiriesOutOfRange_expectClampedToBounds() {
+        val response = parseResponse(
+            """
+            {
+              "config": {
+                "remote_fetch_refresh_expiry_time": 1,
+                "duplicate_events_expiry_time": 999999999999
+              },
+              "geofences": []
+            }
+            """.trimIndent()
+        )
+
+        val config = response.toDomainConfig()
+        config?.remoteFetchRefreshExpiry shouldBeEqualTo GeofenceConstants.MIN_REMOTE_FETCH_REFRESH_EXPIRY_MS
+        config?.duplicateEventsExpiry shouldBeEqualTo GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS
+    }
+
+    @Test
+    fun toDomainConfig_givenMaxMonitoringDistanceBelowTriggerRadius_expectFallback() {
+        // A cap below the trigger radius would create a dead-zone, so it falls back to the default.
+        val response = parseResponse(
+            """
+            {
+              "config": {
+                "local_refresh_trigger_radius": 3000,
+                "max_monitoring_distance": 1000
+              },
+              "geofences": []
+            }
+            """.trimIndent()
+        )
+
+        response.toDomainConfig()?.maxMonitoringDistance shouldBeEqualTo
+            GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
+    }
+
+    @Test
+    fun toDomainConfig_givenMaxMonitoringDistanceZero_expectNoCap() {
+        // 0 is the explicit "disable the cap" signal — register regardless of distance.
+        val response = parseResponse(
+            """{ "config": { "max_monitoring_distance": 0 }, "geofences": [] }"""
+        )
+
+        response.toDomainConfig()?.maxMonitoringDistance shouldBeEqualTo
+            GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
     }
 
     // ---------- helpers ----------
@@ -340,6 +430,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
         remoteFetchRefreshTriggerRadius = GeofenceConstants.FALLBACK_REMOTE_FETCH_RADIUS_METERS,
         remoteFetchRefreshExpiry = GeofenceConstants.STALE_THRESHOLD_MS,
         duplicateEventsExpiry = GeofenceConstants.DEDUPE_COOLDOWN_MS,
-        maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES
+        maxBusinessGeofences = GeofenceConstants.FALLBACK_MAX_BUSINESS_GEOFENCES,
+        maxMonitoringDistance = GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
     )
 }

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
@@ -1,0 +1,27 @@
+package io.customer.geofence.api
+
+import io.customer.geofence.GeofenceJsonSerializer
+import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpRequestParams
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.junit.Test
+
+class GeofenceApiServiceTest {
+
+    private val httpClient: CustomerIOHttpClient = mockk(relaxed = true)
+    private val service = GeofenceApiServiceImpl(httpClient, GeofenceJsonSerializer())
+
+    @Test
+    fun fetchGeofences_givenNoLocation_expectNoCoordinatesOnTheWire() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
+
+        service.fetchGeofences()
+
+        capturedParams.captured.queryParams.shouldBeEmpty()
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -114,7 +114,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             remoteFetchRefreshTriggerRadius = 5_000f,
             remoteFetchRefreshExpiry = 86_400_000L,
             duplicateEventsExpiry = 3_600_000L,
-            maxBusinessGeofences = 19
+            maxBusinessGeofences = 19,
+            maxMonitoringDistance = 1_000_000f
         )
 
         store.saveCachedConfig(config)
@@ -226,7 +227,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
                 remoteFetchRefreshTriggerRadius = 5_000f,
                 remoteFetchRefreshExpiry = 1L,
                 duplicateEventsExpiry = 1L,
-                maxBusinessGeofences = 1
+                maxBusinessGeofences = 1,
+                maxMonitoringDistance = 1_000_000f
             )
         )
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
@@ -253,7 +255,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             remoteFetchRefreshTriggerRadius = 5_000f,
             remoteFetchRefreshExpiry = 86_400_000L,
             duplicateEventsExpiry = 3_600_000L,
-            maxBusinessGeofences = 19
+            maxBusinessGeofences = 19,
+            maxMonitoringDistance = 1_000_000f
         )
         store.saveCachedRegions(regions)
         store.saveCachedConfig(config)
@@ -312,7 +315,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
                 remoteFetchRefreshTriggerRadius = 5_000f,
                 remoteFetchRefreshExpiry = 86_400_000L,
                 duplicateEventsExpiry = 3_600_000L,
-                maxBusinessGeofences = 19
+                maxBusinessGeofences = 19,
+                maxMonitoringDistance = 1_000_000f
             )
         )
 
@@ -322,7 +326,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             "remoteFetchRefreshTriggerRadius",
             "remoteFetchRefreshExpiry",
             "duplicateEventsExpiry",
-            "maxBusinessGeofences"
+            "maxBusinessGeofences",
+            "maxMonitoringDistance"
         ).forEach { key -> raw shouldContain "\"$key\"" }
     }
 
@@ -372,6 +377,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
               "remoteFetchRefreshExpiry": 86400000,
               "duplicateEventsExpiry": 3600000,
               "maxBusinessGeofences": 19,
+              "maxMonitoringDistance": 1000000.0,
               "future_field_we_dont_know": "ignore me"
             }
             """.trimIndent()
@@ -382,7 +388,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             remoteFetchRefreshTriggerRadius = 5_000f,
             remoteFetchRefreshExpiry = 86_400_000L,
             duplicateEventsExpiry = 3_600_000L,
-            maxBusinessGeofences = 19
+            maxBusinessGeofences = 19,
+            maxMonitoringDistance = 1_000_000f
         )
     }
 


### PR DESCRIPTION
[MBL-1843](https://linear.app/customerio/issue/MBL-1843/use-coarse-location-for-nearby-geofence-fetch-requests)

### Why
The on-device sync used to send a coarsened device location to the backend. Removing it entirely means the SDK has **no code path that transmits device location**, and lets the backend own "return the right set." Replaces #742 (closed; scope changed from gating fetch-all to removing location-send).

> ⚠️ **Held until backend ships return-all-without-location.** Today `/geofences/nearby` requires lat/long; this PR's no-location fetch depends on that change landing first.

### What
1. **Remove on-device location-send.** `fetchGeofences()` sends no location; dropped the 2-arg overload and `GeofenceCoordinateCoarsener`. `GeofenceSyncMode` stays as a single-value (`FETCH_ALL`) documented seam so re-introducing a location mode is a localized change + deliberate release (prior impl in git history).
2. **`maxMonitoringDistance` cap** (wire `max_monitoring_distance`). Caps how far a business geofence can be from the device to be registered. Semantics: `null` → 1000 km default (don't register another continent's geofence for a local user), `0` → disabled, below the trigger radius → fall back (avoids a dead-zone).
3. **Three-way empty fix.** Distinguishes "no geofences at all" (register nothing) from "geofences exist but all beyond the cap" (register the movement trigger only, so an EXIT re-ranks them in as the device approaches). Without this the cap is self-defeating.
4. **Config self-correction** at the wire→domain boundary: non-positive values fall back, positive out-of-range values clamp (local radius 100 m–5 km, remote-fetch expiry 1 min–7 d, dedupe 1 min–24 h). `geofences` remains the only required wire field (missing → parse fails → preserve cache + retry, fail-safe).

### Testing
- `:geofence` unit suite green (incl. new cap, three-way-empty, and coercion cases).
- apiCheck + ktlint green via pre-commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core geofence sync, privacy behavior, and when remote vs local refresh runs; depends on backend supporting locationless `/geofences/nearby` before release.
> 
> **Overview**
> Stops sending device location on geofence API fetches: `fetchGeofences()` is parameterless with empty query params, while on-device lat/lng still drive ranking and anchors. **`GeofenceSyncMode.FETCH_ALL`** means movement no longer escalates to remote fetch based on distance from the last API anchor; **`refreshAction`** now keys remote vs local vs skip on time staleness, ranking staleness from **last movement-trigger registration** (not fetch anchor), and missing OS registrations.
> 
> Adds **`maxMonitoringDistance`** (`max_monitoring_distance`) so the distance filter can drop far regions; server config is coerced/clamped at parse time. Registration keeps the **movement trigger** when geofences exist but none are within the cap (trigger-only), vs truly empty sets that register nothing. Fallback radii and new clamp bounds are updated in constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430288c67cd4861769d156d5626827b8a8c92717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

