### PR TITLE
chore(geofence): transition event shape updates + reboot re-registration

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/Clock.kt
@@ -8,9 +8,13 @@ import java.util.concurrent.TimeUnit
 interface Clock {
     fun currentTimeMillis(): Long
     fun currentTimeSeconds(): Long
+
+    /** Milliseconds since boot (monotonic within a boot, resets to ~0 on reboot). */
+    fun elapsedRealtime(): Long
 }
 
 internal class SystemClock : Clock {
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
     override fun currentTimeSeconds(): Long = TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis())
+    override fun elapsedRealtime(): Long = android.os.SystemClock.elapsedRealtime()
 }

--- a/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
+++ b/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
@@ -16,6 +16,6 @@ object EventNames {
     const val LOCATION_UPDATE = "CIO Location Update"
 
     // Event names for geofence transitions tracked by the Location module
-    const val GEOFENCE_ENTERED = "CIO Geofence Entered"
-    const val GEOFENCE_EXITED = "CIO Geofence Exited"
+    const val GEOFENCE_ENTERED = "geofence_entered"
+    const val GEOFENCE_EXITED = "geofence_exited"
 }

--- a/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
@@ -66,7 +66,7 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "CIO Geofence Entered"
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "geofence_entered"
     }
 
     @Test
@@ -82,7 +82,7 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "CIO Geofence Exited"
+        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "geofence_exited"
     }
 
     @Test

--- a/geofence/build.gradle
+++ b/geofence/build.gradle
@@ -1,4 +1,3 @@
-import io.customer.android.Configurations
 import io.customer.android.Dependencies
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -8,12 +7,11 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization'
 }
 
-ext {
-    PUBLISH_GROUP_ID = Configurations.artifactGroup
-    PUBLISH_ARTIFACT_ID = "geofence"
+apply plugin: 'io.customer.android.publish-module'
+customerIoPublish {
+    artifactId = "geofence"
 }
 
-apply from: "${rootDir}/scripts/publish-module.gradle"
 apply from: "${rootDir}/scripts/android-config.gradle"
 apply from: "${rootDir}/scripts/codecov-android.gradle"
 apply from: "${rootDir}/scripts/android-module-testing.gradle"

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -147,7 +147,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 geofenceId = geofenceId,
                 transition = transition,
                 timestamp = timestamp,
-                userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+                userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() },
+                geofenceName = androidComponent.geofenceRegionStore.getCachedRegionName(geofenceId)
             )
             androidComponent.pendingGeofenceDeliveryStore.append(entry)
             // Anonymous entries can only be delivered via the foreground flush —

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
@@ -45,7 +45,7 @@ internal class GeofenceManager(
      * can fire spurious EXIT events; skipping the overlap avoids that.
      * Default `emptySet()` means "OS state unknown, register everything".
      */
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun replaceGeofences(
         regions: List<GeofenceRegion>,
         existingBusinessIds: Set<String> = emptySet()
@@ -62,11 +62,11 @@ internal class GeofenceManager(
      * while the device was off, EXIT fires immediately and the next
      * handleMovement self-heals with real coordinates.
      */
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun replaceGeofencesForBootRestore(regions: List<GeofenceRegion>): Result<Unit> =
         replaceGeofencesInternal(regions, movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_EXIT)
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun replaceGeofencesInternal(
         regions: List<GeofenceRegion>,
         movementInitialTrigger: Int,
@@ -123,7 +123,7 @@ internal class GeofenceManager(
         return Result.success(Unit)
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun registerBatch(
         regions: List<GeofenceRegion>,
         initialTrigger: Int

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -22,10 +22,10 @@ import kotlinx.coroutines.sync.withLock
  *   location.
  */
 internal interface GeofenceRepository {
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun refresh(latitude: Double, longitude: Double): Result<Unit>
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit>
 
     /**
@@ -35,7 +35,7 @@ internal interface GeofenceRepository {
      * during boot. Skips silently when there's nothing to restore — no user,
      * no anchor, or no cached config.
      */
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun restoreFromCache(): Result<Unit>
 
     /**
@@ -71,7 +71,7 @@ internal class GeofenceRepositoryImpl(
     // write block — the long-running API call happens outside the lock.
     private val stateMutex = Mutex()
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
         if (!refreshInProgress.compareAndSet(false, true)) {
             logger.logSyncSkipped("refresh already in progress")
@@ -113,6 +113,9 @@ internal class GeofenceRepositoryImpl(
             syncMode.movementRequiresRemoteFetch(distanceFromLastFetch, config) -> RefreshAction.REMOTE
             isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
             hasUnregisteredCache() -> RefreshAction.LOCAL
+            // Without this a fresh-cache launch after a reboot would SKIP — registeredIds survive the
+            // reboot but GMS doesn't, leaving nothing monitored. Re-rank locally to re-register.
+            osStateWipedByReboot() -> RefreshAction.LOCAL
             else -> RefreshAction.SKIP
         }
     }
@@ -133,7 +136,16 @@ internal class GeofenceRepositoryImpl(
     private fun hasUnregisteredCache(): Boolean =
         store.getCachedRegions().isNotEmpty() && store.getRegisteredIds().isEmpty()
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    /**
+     * Uptime regressed since the last registration → the device rebooted, which wipes GMS geofences
+     * even though registeredIds survive. Covers a missed BOOT_COMPLETED (stopped state, OEM battery
+     * managers, emulator). Read by both [refreshAction] (force re-register over SKIP) and
+     * [registerWithBusinessDiff] (re-register all rather than trust registeredIds).
+     */
+    private fun osStateWipedByReboot(): Boolean =
+        store.getLastRegistrationUptime()?.let { clock.elapsedRealtime() < it } ?: false
+
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
         if (!refreshInProgress.compareAndSet(false, true)) {
             logger.logSyncSkipped("refresh already in progress")
@@ -163,7 +175,7 @@ internal class GeofenceRepositoryImpl(
         }
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun restoreFromCache(): Result<Unit> {
         // Bypasses the in-flight gate: after a reboot, app-launch refresh's
         // registerWithBusinessDiff would see persisted registeredIds matching
@@ -197,7 +209,7 @@ internal class GeofenceRepositoryImpl(
         )
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun performRemoteRefresh(
         userId: String,
         latitude: Double,
@@ -238,7 +250,7 @@ internal class GeofenceRepositoryImpl(
         )
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun performLocalRefresh(
         userId: String,
         latitude: Double,
@@ -260,21 +272,27 @@ internal class GeofenceRepositoryImpl(
      * param drift forces a re-register so GMS doesn't keep stale values.
      * Boot restore bypasses this; OS state is empty after reboot.
      */
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun registerWithBusinessDiff(regions: List<GeofenceRegion>): Result<Unit> {
-        val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
-        val cachedById = store.getCachedRegions().associateBy { it.id }
-        val existingBusinessIds = regions
-            .filter { it.id in registeredBusinessIds && cachedById[it.id] == it }
-            .map { it.id }
-            .toSet()
+        // After a reboot GMS is empty, so re-register everything rather than trust the surviving
+        // registeredIds (which would otherwise be skipped as "unchanged").
+        val existingBusinessIds = if (osStateWipedByReboot()) {
+            emptySet()
+        } else {
+            val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+            val cachedById = store.getCachedRegions().associateBy { it.id }
+            regions
+                .filter { it.id in registeredBusinessIds && cachedById[it.id] == it }
+                .map { it.id }
+                .toSet()
+        }
         return manager.replaceGeofences(
             regions = regions,
             existingBusinessIds = existingBusinessIds
         )
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION])
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun registerNearestAndPersist(
         userId: String,
         latitude: Double,
@@ -329,6 +347,9 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // Stamp device uptime so the next refresh can detect a reboot (which wipes OS
+                    // geofences) and force a full re-register instead of trusting registeredIds.
+                    store.setLastRegistrationUptime(clock.elapsedRealtime())
                     // Track the user's location at each successful registration so boot restore can
                     // re-center close to their real position. Clear only when nothing is registered
                     // (no geofences / kill switch) — the trigger, and thus its location, is gone.

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -48,8 +48,15 @@ internal interface GeofenceRegionStore {
     fun saveCachedRegions(regions: List<GeofenceRegion>)
     fun getCachedRegions(): List<GeofenceRegion>
 
+    /** Name of the cached region with [id], or null if it isn't cached. */
+    fun getCachedRegionName(id: String): String? = getCachedRegions().find { it.id == id }?.name
+
     fun saveRegisteredIds(ids: Set<String>)
     fun getRegisteredIds(): Set<String>
+
+    /** Device uptime at the last successful OS registration; null if never registered. Drives reboot detection. */
+    fun getLastRegistrationUptime(): Long?
+    fun setLastRegistrationUptime(uptimeMs: Long)
 
     fun saveCachedConfig(config: GeofenceConfig)
     fun getCachedConfig(): GeofenceConfig?
@@ -98,6 +105,14 @@ internal class GeofenceRegionStoreImpl(
     override fun getRegisteredIds(): Set<String> =
         readJson(KEY_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
 
+    override fun getLastRegistrationUptime(): Long? = prefs.read {
+        if (contains(KEY_LAST_REGISTRATION_UPTIME)) getLong(KEY_LAST_REGISTRATION_UPTIME, 0L) else null
+    }
+
+    override fun setLastRegistrationUptime(uptimeMs: Long) {
+        prefs.edit { putLong(KEY_LAST_REGISTRATION_UPTIME, uptimeMs) }
+    }
+
     override fun saveCachedConfig(config: GeofenceConfig) =
         writeJson(KEY_CACHED_CONFIG, GeofenceConfig.serializer(), config)
 
@@ -133,6 +148,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_API_FETCH_LOCATION)
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
+            remove(KEY_LAST_REGISTRATION_UPTIME)
         }
     }
 
@@ -183,6 +199,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"
         const val KEY_LAST_SYNC = "last_sync_timestamp"
+        const val KEY_LAST_REGISTRATION_UPTIME = "last_registration_uptime"
         const val CRYPTO_KEY_ALIAS = "cio_geofence_location_key"
         val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
         val ID_SET_SERIALIZER = SetSerializer(String.serializer())

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -22,7 +22,9 @@ internal data class PendingGeofenceDelivery(
     val transition: Event.GeofenceTransition,
     /** Unix epoch **seconds** at receiver time. Use [toGeofenceTransitionEvent] when a [Date] is needed. */
     val timestamp: Long,
-    val userId: String?
+    val userId: String?,
+    /** Null when the fired geofence isn't in the cached region set. */
+    val geofenceName: String? = null
 ) : PendingDeliveryStore.PendingDeliveryEntry {
     override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
 
@@ -32,6 +34,7 @@ internal data class PendingGeofenceDelivery(
      * flush all build an identical property set.
      */
     fun toEventProperties(): Map<String, Any> = buildMap {
+        geofenceName?.let { put("geofence_name", it) }
         put("geofence_id", geofenceId)
         put("transition_type", transition.name.lowercase())
         put("timestamp", timestamp)

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -21,6 +21,7 @@ import io.customer.sdk.data.store.PendingDeliveryResult
 import io.customer.sdk.data.store.claimSendRestore
 
 private const val KEY_GEOFENCE_ID = "geofence_id"
+private const val KEY_GEOFENCE_NAME = "geofence_name"
 private const val KEY_TRANSITION = "transition"
 private const val KEY_TIMESTAMP = "timestamp"
 private const val KEY_USER_ID = "user_id"
@@ -40,6 +41,7 @@ internal class GeofenceEventScheduler(
             .putLong(KEY_TIMESTAMP, entry.timestamp)
             .apply {
                 entry.userId?.let { putString(KEY_USER_ID, it) }
+                entry.geofenceName?.let { putString(KEY_GEOFENCE_NAME, it) }
             }
             .build()
 
@@ -104,7 +106,13 @@ internal class GeofenceEventWorker(
 
         val userId = inputData.getString(KEY_USER_ID)
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
-        val entry = PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
+        val entry = PendingGeofenceDelivery(
+            geofenceId = geofenceId,
+            transition = transition,
+            timestamp = timestamp,
+            userId = userId,
+            geofenceName = inputData.getString(KEY_GEOFENCE_NAME)
+        )
 
         // No identified user at queue time — direct HTTP needs a userId, so
         // leave the entry in the store for the foreground flush instead.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -304,6 +304,22 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
+    fun dispatchTransition_givenCachedRegionName_expectNameOnEntry() = runTest {
+        every { mockStore.getCachedRegionName("biz-geofence") } returns "Coffee Shop"
+        val entrySlot = slot<PendingGeofenceDelivery>()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.geofenceName shouldBeEqualTo "Coffee Shop"
+    }
+
+    @Test
     fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduled() = runTest {
         every { mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER) } returns false
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -568,6 +568,75 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenDeviceRebootedSinceLastRegistration_expectAllBusinessReRegistered() = runTest {
+        // Uptime regressed => device rebooted => GMS dropped every geofence. Re-register all
+        // business (empty existing set) even though registeredIds still lists them, covering the
+        // case where the BOOT_COMPLETED receiver never fired.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 10_000L
+        every { clock.elapsedRealtime() } returns 5_000L
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
+    fun refresh_givenNoRebootAndBusinessUnchanged_expectBusinessKept() = runTest {
+        // Uptime advanced normally => no reboot => trust registeredIds and keep the unchanged
+        // business geofence (skip re-upsert).
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L
+        coEvery { apiService.fetchGeofences() } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun refresh_givenFreshCacheButRebooted_expectLocalReRegisterInsteadOfSkip() = runTest {
+        // Reboot after a fresh-cache launch: time-fresh + ranking-fresh + registeredIds intact would
+        // normally SKIP, but GMS was wiped by the reboot. Uptime regression forces a LOCAL re-register
+        // (no network) instead of leaving nothing monitored.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getLastRegistrationUptime() } returns 10_000L
+        every { clock.elapsedRealtime() } returns 5_000L
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences() }
+        coVerify(exactly = 1) { manager.replaceGeofences(any(), any()) }
+        existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
     fun refresh_givenAddSucceedsButStaleRemovalFails_expectUnremovedStalePreserved() = runTest {
         // Order: add succeeds, then stale removal fails. The new batch is registered
         // and we treat the sync as successful — but we must preserve the unremoved

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -67,6 +67,20 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun getCachedRegionName_givenCachedId_expectName() {
+        store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee")))
+
+        store.getCachedRegionName("biz-1") shouldBeEqualTo "Coffee"
+    }
+
+    @Test
+    fun getCachedRegionName_givenUnknownId_expectNull() {
+        store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee")))
+
+        store.getCachedRegionName("biz-missing") shouldBeEqualTo null
+    }
+
+    @Test
     fun saveCachedRegions_givenSubsequentSave_expectOverwrite() {
         store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f)))
         val replacement = listOf(GeofenceRegion("biz-2", 1.0, 2.0, 75f))
@@ -98,6 +112,18 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRegisteredIds(emptySet())
 
         store.getRegisteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun getLastRegistrationUptime_givenNothingStored_expectNull() {
+        store.getLastRegistrationUptime().shouldBeNull()
+    }
+
+    @Test
+    fun setLastRegistrationUptime_thenGet_expectRoundTrip() {
+        store.setLastRegistrationUptime(123_456L)
+
+        store.getLastRegistrationUptime() shouldBeEqualTo 123_456L
     }
 
     // --- Cached config ---
@@ -263,6 +289,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRegisteredIds(setOf("biz-1"))
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
+        store.setLastRegistrationUptime(99_999L)
         store.setLastSyncTimestamp(12_345L)
 
         store.clearUserScopedState()
@@ -271,6 +298,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getRegisteredIds().shouldBeEmpty()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
+        store.getLastRegistrationUptime().shouldBeNull()
         // Workspace-level: preserved.
         store.getCachedRegions() shouldBeEqualTo regions
         store.getCachedConfig() shouldBeEqualTo config

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -63,6 +63,21 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
+    fun toEventProperties_givenGeofenceName_expectNamePresent() {
+        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = "Ferry Building")
+
+        entry.toEventProperties()["geofence_name"] shouldBeEqualTo "Ferry Building"
+    }
+
+    @Test
+    fun toEventProperties_givenNullGeofenceName_expectNameOmitted() {
+        // Region not in the cached set => omit the property rather than send a synthetic value.
+        val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = null)
+
+        entry.toEventProperties().keys shouldNotContain "geofence_name"
+    }
+
+    @Test
     fun toGeofenceTransitionEvent_givenSecondsTimestamp_expectEventTimestampInMillis() {
         // `timestamp` is unix seconds; `Event.timestamp` is a `Date` (millis).
         // The conversion lives on the data class so no caller can hand-roll

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -56,7 +56,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 geofenceId = "biz-geofence-1",
                 transition = Event.GeofenceTransition.ENTER,
                 timestamp = 1_234L,
-                userId = "user-42"
+                userId = "user-42",
+                geofenceName = "Coffee Shop"
             )
         )
 
@@ -74,6 +75,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         input.getString("transition") shouldBeEqualTo "ENTER"
         input.getLong("timestamp", -1L) shouldBeEqualTo 1_234L
         input.getString("user_id") shouldBeEqualTo "user-42"
+        input.getString("geofence_name") shouldBeEqualTo "Coffee Shop"
         input.hasKeyWithValueOfType("latitude", Double::class.javaObjectType) shouldBeEqualTo false
         input.hasKeyWithValueOfType("longitude", Double::class.javaObjectType) shouldBeEqualTo false
 
@@ -100,6 +102,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         verify { workManager.enqueueUniqueWork(any(), any(), capture(workRequestSlot)) }
         val input = workRequestSlot.captured.workSpec.input
         input.hasKeyWithValueOfType("user_id", String::class.java) shouldBeEqualTo false
+        input.hasKeyWithValueOfType("geofence_name", String::class.java) shouldBeEqualTo false
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
@@ -49,7 +49,7 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         capturedParams.captured.path shouldBeEqualTo "/track"
         val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
-        body.getString("event") shouldBeEqualTo "CIO Geofence Entered"
+        body.getString("event") shouldBeEqualTo "geofence_entered"
         body.getString("userId") shouldBeEqualTo "user-42"
         body.getString("timestamp") shouldBeEqualTo "2009-02-13T23:31:30.000Z"
         val props = body.getJSONObject("properties")
@@ -68,7 +68,7 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         tracker.trackEvent(entry(transition = Event.GeofenceTransition.EXIT))
 
         val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
-        body.getString("event") shouldBeEqualTo "CIO Geofence Exited"
+        body.getString("event") shouldBeEqualTo "geofence_exited"
         body.getJSONObject("properties").getString("transition_type") shouldBeEqualTo "exit"
     }
 

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -47,9 +47,10 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         geofenceId: String,
         transition: Event.GeofenceTransition,
         timestamp: Long = 0L,
-        userId: String? = "user-42"
+        userId: String? = "user-42",
+        geofenceName: String? = null
     ): PendingGeofenceDelivery =
-        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
+        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, geofenceName)
             .also { store.append(it) }
 
     @Test
@@ -63,6 +64,17 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 1) { tracker.trackEvent(entry) }
         store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun doWork_givenGeofenceNameInInput_expectNameOnTrackedEntry() = runTest {
+        val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 99L, geofenceName = "Coffee Shop")
+        val inputData = buildInputData("biz-1", "ENTER", 99L, "user-42", geofenceName = "Coffee Shop")
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+
+        createWorker(inputData).doWork()
+
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
     }
 
     @Test
@@ -164,13 +176,15 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         geofenceId: String?,
         transition: String?,
         timestamp: Long = 0L,
-        userId: String? = "user-42"
+        userId: String? = "user-42",
+        geofenceName: String? = null
     ): Data {
         val builder = Data.Builder()
             .putLong("timestamp", timestamp)
         geofenceId?.let { builder.putString("geofence_id", it) }
         transition?.let { builder.putString("transition", it) }
         userId?.let { builder.putString("user_id", it) }
+        geofenceName?.let { builder.putString("geofence_name", it) }
         return builder.build()
     }
 

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets the SDK's geofence boot receiver re-register geofences after a device reboot. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.
     tools:replace is needed because SDK declares a network security config as well for automated tests.

--- a/samples/kotlin_compose/src/main/AndroidManifest.xml
+++ b/samples/kotlin_compose/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Lets the SDK's geofence boot receiver re-register geofences after a device reboot. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.
     tools:replace is needed because SDK declares a network security config as well for automated tests.


### PR DESCRIPTION
[MBL-1760](https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing)

### Why
Findings from geofencing validation + lifecycle testing: align the transition event shape with the backend/iOS, and close a reboot gap where business geofences could silently stop being monitored.

### What
**Transition event shape**
- Rename tracked events to `geofence_entered` / `geofence_exited` (applied in both delivery paths: analytics pipeline + WorkManager direct-HTTP).
- Add `geofence_name` to event properties — resolved once at the receiver and carried via the entry + WorkManager `inputData`, so both delivery paths agree on the name (and it's captured at transition time, like the `userId`/`timestamp` snapshots). Omitted when the region isn't cached.
- Migrate the geofence module to the shared `io.customer.android.publish-module` plugin (`artifactId "geofence"`).

**Reboot re-registration**
- GMS drops all geofences on reboot; only `GeofenceBootReceiver` re-registers them, but `BOOT_COMPLETED` isn't always delivered (stopped state, OEM battery managers, emulator). Stamp device uptime (`Clock.elapsedRealtime`) on each successful registration; when a later refresh sees a smaller uptime, the device rebooted since — treat OS state as empty and re-register all business geofences instead of trusting the surviving `registeredIds`.

### Testing
- `:geofence` + `:datapipelines` unit suites green; apiCheck + ktlint via pre-commit.
- On-device journey verified (enter/exit firing + exactly-once delivery). Reboot path under on-device validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming geofence track events is a breaking change for existing Journeys/automation; reboot and re-registration logic touches core geofence sync but is covered by new unit tests.
> 
> **Overview**
> Aligns geofence transition analytics with backend/iOS and fixes monitoring gaps after reboot when `BOOT_COMPLETED` is missed.
> 
> **Transition events** rename tracked names from `CIO Geofence Entered` / `CIO Geofence Exited` to **`geofence_entered`** / **`geofence_exited`** (datapipelines + WorkManager direct HTTP). **`geofence_name`** is snapshotted at the receiver from the cached region, carried on `PendingGeofenceDelivery` and WorkManager `inputData`, and included in properties when known (omitted if uncached). The geofence module **`build.gradle`** switches to the shared **`io.customer.android.publish-module`** plugin.
> 
> **Reboot recovery** adds **`Clock.elapsedRealtime()`**, persists **`last_registration_uptime`** on successful OS registration, and treats uptime regression as “GMS wiped geofences”: **`refresh`** can force a **local** re-register instead of **SKIP**, and **`registerWithBusinessDiff`** re-registers all business geofences instead of trusting persisted `registeredIds`. Sample apps declare **`RECEIVE_BOOT_COMPLETED`** for boot restore.
> 
> Geofence APIs drop **`ACCESS_BACKGROUND_LOCATION`** from `@RequiresPermission` ( **`ACCESS_FINE_LOCATION`** only on registration paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e9d349ee47611b205ce9dc5c581de0a518fd18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->