### PR TITLE
chore(inbox): web-parity interaction (dismiss, auto-hide, relative dates, no-template skip, hovering panel)

### DIFF
--- a/messaginginbox/api/messaginginbox.api
+++ b/messaginginbox/api/messaginginbox.api
@@ -1,6 +1,0 @@
-public final class io/customer/messaginginbox/ComposableSingletons$NotificationInboxOverlayKt {
-	public static final field INSTANCE Lio/customer/messaginginbox/ComposableSingletons$NotificationInboxOverlayKt;
-	public fun <init> ()V
-	public final fun getLambda$-952362317$messaginginbox_release ()Lkotlin/jvm/functions/Function2;
-}
-

--- a/messaginginbox/build.gradle
+++ b/messaginginbox/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     implementation Dependencies.composeUi
     implementation Dependencies.composeUiGraphics
     implementation Dependencies.composeFoundation
-    implementation Dependencies.composeMaterial
     implementation Dependencies.composeRuntime
     implementation Dependencies.coroutinesAndroid
 

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/InboxJistDecoder.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/InboxJistDecoder.kt
@@ -1,8 +1,10 @@
 package io.customer.messaginginbox
 
+import android.text.format.DateUtils
 import io.customer.jist.JistJson
 import io.customer.jist.JistTemplate
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
+import java.time.Instant
 import java.util.Date
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -83,6 +85,24 @@ internal object InboxJistDecoder {
     private fun Date.toInstantString(): String = runCatching {
         java.time.Instant.ofEpochMilli(time).toString()
     }.getOrElse { toString() }
+
+    /**
+     * Jist `formatDate` hook: turns a raw ISO-8601 instant (the decoder feeds dates as ISO strings
+     * via [toInstantString]) into a SYSTEM-LOCALIZED relative-time label ("2 hours ago",
+     * "yesterday", …) via [DateUtils.getRelativeTimeSpanString] — the platform equivalent of web's
+     * `Intl.RelativeTimeFormat`. Localized by the OS, so the inbox is i18n/translation-ready without
+     * us hand-rolling or translating strings. Unparseable input falls back to the raw value.
+     *
+     * `name` is the Jist date-node name (unused here; the same format applies to every inbox date).
+     */
+    fun formatRelativeDate(iso: String, @Suppress("UNUSED_PARAMETER") name: String, now: Instant = Instant.now()): String {
+        val instant = runCatching { Instant.parse(iso) }.getOrNull() ?: return iso
+        return DateUtils.getRelativeTimeSpanString(
+            instant.toEpochMilli(),
+            now.toEpochMilli(),
+            DateUtils.MINUTE_IN_MILLIS
+        ).toString()
+    }
 }
 
 /**

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -1,32 +1,38 @@
 package io.customer.messaginginbox
 
+import android.util.TypedValue
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Badge
-import androidx.compose.material.BadgedBox
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
-import androidx.compose.material.FloatingActionButton
-import androidx.compose.material.Icon
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -36,17 +42,35 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.jist.JistActionEvent
+import io.customer.jist.JistMode
 import io.customer.jist.JistView
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
+import io.customer.sdk.core.di.SDKComponent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Drop-in Compose overlay that shows the Customer.io Visual Notification Inbox on top of your app.
@@ -103,11 +127,30 @@ internal fun NotificationInboxOverlay(
         controller.markOpenMessagesOpened(state.visibility)
     }
 
+    // Auto-close the panel + hide the bell when the inbox is no longer renderable. This matches the
+    // web/iOS model: dismissing the last message empties the list -> the data layer reports the
+    // inbox no longer Visible (or messages becomes empty) -> the panel collapses and the bell
+    // unmounts (see the `isVisible && panelExpanded` guard below). Without this, the panel would
+    // stay open over an empty list after the final dismiss.
+    LaunchedEffect(state.isVisible, state.messages.isEmpty()) {
+        if (!state.isVisible || state.messages.isEmpty()) {
+            panelExpanded = false
+        }
+    }
+
     // The bell only appears when the inbox is renderable per the data layer. When the panel is
     // open we keep the overlay mounted regardless so the close animation can play out.
     if (!state.isVisible && !panelExpanded) {
         return
     }
+
+    val isDarkTheme = isSystemInDarkTheme()
+    val bellColor = rememberThemeColor(android.R.attr.colorAccent, Color(0xFF3451FF))
+    val panelColor = rememberThemeColor(android.R.attr.colorBackground, if (isDarkTheme) Color(0xFF121212) else Color.White)
+    val textColorPrimary = rememberThemeColor(android.R.attr.textColorPrimary, if (isDarkTheme) Color.White else Color.Black)
+    val textColorSecondary = rememberThemeColor(android.R.attr.textColorSecondary, if (isDarkTheme) Color.LightGray else Color.DarkGray)
+    val dividerColor = textColorSecondary.copy(alpha = 0.12f)
+    val badgeColor = Color(0xFFE53935)
 
     Box(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
@@ -119,7 +162,8 @@ internal fun NotificationInboxOverlay(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color(0x99000000))
+                    // Scrim dim matched to iOS: 0.32 black (was ~0.6) so both platforms dim equally.
+                    .background(Color.Black.copy(alpha = 0.32f))
                     // Full-bleed scrim captures touches so nothing falls through to host content
                     // behind the open panel; a tap dismisses the panel. No ripple/indication so
                     // the scrim does not flash on tap.
@@ -132,41 +176,76 @@ internal fun NotificationInboxOverlay(
             )
         }
 
-        // Slide-out panel.
+        // Slide-out hovering panel. Aligned to the top so its top margin is honored; the panel
+        // itself applies the all-sides margins (it is a floating card, not a full-height sheet).
         AnimatedVisibility(
             visible = panelExpanded,
             enter = slideInHorizontally(initialOffsetX = { it }) + fadeIn(),
             exit = slideOutHorizontally(targetOffsetX = { it }) + fadeOut(),
-            modifier = Modifier.align(Alignment.CenterEnd)
+            modifier = Modifier.align(Alignment.TopEnd)
         ) {
             InboxPanel(
                 state = state,
-                onClose = { panelExpanded = false }
+                bellColor = bellColor,
+                panelColor = panelColor,
+                textColorPrimary = textColorPrimary,
+                dividerColor = dividerColor,
+                onMessageAction = { message, event ->
+                    handleInboxAction(controller, state.visibility, message, event)
+                }
             )
         }
 
         // Floating bell button with unread badge.
-        BadgedBox(
-            badge = {
-                if (state.unopenedCount > 0) {
-                    Badge(
-                        modifier = Modifier.semantics {
-                            contentDescription = "${state.unopenedCount} unread notifications"
-                        }
-                    ) {
-                        Text(text = state.unopenedCount.toString())
-                    }
-                }
-            },
+        Box(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp)
         ) {
-            FloatingActionButton(onClick = { panelExpanded = !panelExpanded }) {
-                Icon(
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(56.dp)
+                    .shadow(6.dp, CircleShape)
+                    .clip(CircleShape)
+                    .background(bellColor)
+                    .semantics { contentDescription = "Notifications inbox" }
+                    .clickable(
+                        role = Role.Button,
+                        onClick = { panelExpanded = !panelExpanded }
+                    )
+            ) {
+                Image(
                     painter = painterResource(id = R.drawable.cio_inbox_notifications),
-                    contentDescription = "Notifications inbox"
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(Color.White)
                 )
+            }
+
+            if (state.unopenedCount > 0) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .offset(x = 4.dp, y = (-4).dp)
+                        .semantics {
+                            contentDescription = "${state.unopenedCount} unread notifications"
+                        }
+                        .heightIn(min = 16.dp)
+                        .widthIn(min = 16.dp)
+                        .clip(CircleShape)
+                        .background(badgeColor)
+                        .padding(horizontal = 4.dp)
+                ) {
+                    BasicText(
+                        text = state.unopenedCount.toString(),
+                        style = TextStyle(
+                            color = Color.White,
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                }
             }
         }
     }
@@ -175,7 +254,11 @@ internal fun NotificationInboxOverlay(
 @Composable
 private fun InboxPanel(
     state: VisualInboxUiState,
-    onClose: () -> Unit,
+    bellColor: Color,
+    panelColor: Color,
+    textColorPrimary: Color,
+    dividerColor: Color,
+    onMessageAction: (JistInboxMessage, JistActionEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     // Decode the raw render inputs once per visibility change. Templates + theme are stable for
@@ -188,15 +271,24 @@ private fun InboxPanel(
         InboxJistDecoder.toJsonObject(visible?.branding?.theme)
     }
 
-    Surface(
-        // Fill the available width minus a horizontal margin on each side, capped at a max width
-        // on large screens. Padding is applied outside the Surface so the slide-out animation
-        // still translates the full panel off-screen.
+    val panelShape = RoundedCornerShape(PANEL_CORNER_RADIUS)
+    Box(
+        // Hovering card (matches iOS): margins on ALL sides — 16dp top/horizontal and a larger
+        // bottom inset that clears the floating bell — capped at a max width on large screens, with
+        // rounded corners. Margins are applied outside the shaped panel so the slide-out animation still
+        // translates the full card (corners included) off-screen.
         modifier = modifier
-            .fillMaxHeight()
-            .fillMaxWidth()
+            .fillMaxSize()
+            .padding(
+                start = PANEL_MARGIN,
+                end = PANEL_MARGIN,
+                top = PANEL_MARGIN,
+                bottom = PANEL_BOTTOM_MARGIN
+            )
             .widthIn(max = 480.dp)
-            .padding(horizontal = 16.dp)
+            .shadow(8.dp, panelShape)
+            .clip(panelShape)
+            .background(panelColor)
             // Absorb taps inside the panel so they don't fall through to the dismiss scrim behind it
             // (a tap on the panel must NOT close the inbox — only a tap on the scrim does). This is a
             // tap-only absorber: unlike an all-consuming pointerInput, clickable does NOT eat
@@ -206,35 +298,23 @@ private fun InboxPanel(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
                 onClick = {}
-            ),
-        elevation = 8.dp
+            )
     ) {
-        Column(modifier = Modifier.fillMaxHeight()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(text = "Inbox", fontWeight = FontWeight.Bold)
-                Text(
-                    text = "Close",
-                    modifier = Modifier.clickable(onClick = onClose)
-                )
-            }
-            Divider()
-
+        // No header (title / close button) — matches web. The panel closes via the scrim tap or by
+        // tapping the bell again.
+        Column(modifier = Modifier.fillMaxSize()) {
             when {
-                state.loading -> LoadingState()
+                state.loading -> LoadingState(bellColor = bellColor)
                 // Render the list only when the inbox is fully renderable (Visible) and has
                 // messages. Anything else (Hidden, or visible-but-no-messages) shows empty so the
                 // list is never fed null templates/theme.
-                visible == null || state.messages.isEmpty() -> EmptyState()
+                visible == null || state.messages.isEmpty() -> EmptyState(textColorPrimary = textColorPrimary)
                 else -> InboxMessageList(
                     messages = state.messages,
                     templates = templates,
-                    theme = theme
+                    theme = theme,
+                    dividerColor = dividerColor,
+                    onMessageAction = onMessageAction
                 )
             }
         }
@@ -245,58 +325,212 @@ private fun InboxPanel(
 private fun InboxMessageList(
     messages: List<JistInboxMessage>,
     templates: Map<String, List<io.customer.jist.JistTemplate>>,
-    theme: kotlinx.serialization.json.JsonObject,
+    theme: JsonObject,
+    dividerColor: Color,
+    onMessageAction: (JistInboxMessage, JistActionEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // No-template fallback (item 16): a message whose `type` has no decoded template can't be
+    // rendered — skip it (do NOT render a blank row) and log so it's diagnosable. Filtering here
+    // (rather than in the data layer) keeps the renderer the single owner of "is this renderable".
+    val renderable = remember(messages, templates) {
+        messages.filter { message ->
+            (message.type in templates).also { hasTemplate ->
+                if (!hasTemplate) {
+                    SDKComponent.logger.error(
+                        "$INBOX_LOG_TAG skipping message ${message.queueId}: " +
+                            "no template for type '${message.type}'"
+                    )
+                }
+            }
+        }
+    }
     LazyColumn(modifier = modifier.fillMaxWidth()) {
-        items(messages, key = { it.queueId }) { message ->
+        items(renderable, key = { it.queueId }) { message ->
             // Decode the per-row Jist data once per message (not on every recomposition).
             val data = remember(message) { InboxJistDecoder.decodeData(message) }
             // Render each message with Jist: `name` selects the template by message type, `data`
             // is the message's typed properties, `templates`/`theme` come from the data layer.
+            // `mode = Auto` lets Jist pick light/dark content per the system setting. `formatDate`
+            // turns the decoder's raw ISO dates into web-aligned relative time.
             JistView(
                 name = message.type,
                 templates = templates,
                 data = data,
                 theme = theme,
-                onAction = {
-                    // TODO (items 12/13 — deferred): map Jist actions to inbox click/track and
-                    // deep-link handling. No-op for now.
-                },
+                mode = JistMode.Auto,
+                formatDate = { iso, name -> InboxJistDecoder.formatRelativeDate(iso, name) },
+                onAction = { event -> onMessageAction(message, event) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp)
             )
-            Divider()
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(dividerColor)
+            )
         }
     }
 }
 
+/**
+ * Maps a Jist action to an inbox behavior. Web parity: a "dismiss" action removes (deletes) the
+ * message. The live inbox templates emit the action as `name = "messageAction"` with the message's
+ * `properties.messageAction = { behavior: "dismiss" }`, so the dismiss signal we match is
+ * **`data.behavior == "dismiss"`**. We also accept the Jist-demo sentinels (`name == "dismiss"` or
+ * `data.url == "#dismiss"`) as a fallback. Any other action (a real url / other behavior) is a
+ * no-op for now — real-url/deep-link navigation is deferred (scope item 12); we log it so it's
+ * visible during bring-up.
+ */
+private fun handleInboxAction(
+    controller: VisualInboxController,
+    visibility: io.customer.messaginginapp.inbox.data.InboxVisibility,
+    message: JistInboxMessage,
+    event: JistActionEvent
+) {
+    val isDismiss = actionBehavior(event) == DISMISS_BEHAVIOR ||
+        event.name == DISMISS_ACTION_NAME ||
+        actionUrl(event) == DISMISS_URL
+    if (isDismiss) {
+        controller.dismissMessage(visibility, message.queueId)
+        return
+    }
+    // TODO (item 12 — deferred): real-url / deep-link navigation. TODO (item 13 — deferred): host
+    // action callback API. For now, non-dismiss actions are a no-op.
+    SDKComponent.logger.debug(
+        "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
+            "on ${message.queueId}: navigation deferred, no-op"
+    )
+}
+
+/**
+ * Extracts the `url` string from a Jist action event's data object, or null if absent / not a
+ * string. Safe casts throughout: a non-object `data` or non-primitive `url` yields null rather
+ * than throwing.
+ */
+private fun actionUrl(event: JistActionEvent): String? =
+    ((event.data as? JsonObject)?.get("url") as? JsonPrimitive)?.contentOrNull
+
+/**
+ * Extracts the `behavior` string from a Jist action event's data object (e.g. the live inbox's
+ * `messageAction = { behavior: "dismiss" }`), or null if absent / not a string. Safe casts.
+ */
+private fun actionBehavior(event: JistActionEvent): String? =
+    ((event.data as? JsonObject)?.get("behavior") as? JsonPrimitive)?.contentOrNull
+
 @Composable
-private fun LoadingState(modifier: Modifier = Modifier) {
+private fun LoadingState(
+    bellColor: Color,
+    modifier: Modifier = Modifier
+) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .padding(32.dp),
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator(
-            modifier = Modifier.semantics { contentDescription = "Loading inbox" }
+        CustomCircularProgressIndicator(
+            color = bellColor,
+            modifier = Modifier.semantics {
+                contentDescription = "Loading inbox"
+                progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
+            }
         )
     }
 }
 
 @Composable
-private fun EmptyState(modifier: Modifier = Modifier) {
+private fun EmptyState(
+    textColorPrimary: Color,
+    modifier: Modifier = Modifier
+) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .padding(32.dp),
         contentAlignment = Alignment.Center
     ) {
-        Text(
+        BasicText(
             text = "No notifications yet",
+            style = TextStyle(
+                color = textColorPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Normal
+            ),
             modifier = Modifier.semantics { contentDescription = "Inbox empty" }
         )
     }
 }
+
+@Composable
+private fun CustomCircularProgressIndicator(
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    val transition = rememberInfiniteTransition(label = "ProgressTransition")
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "RotationVal"
+    )
+
+    Canvas(
+        modifier = modifier
+            .size(40.dp)
+    ) {
+        val strokeWidth = 4.dp.toPx()
+        drawArc(
+            color = color,
+            startAngle = rotation,
+            sweepAngle = 270f,
+            useCenter = false,
+            style = Stroke(
+                width = strokeWidth,
+                cap = StrokeCap.Round
+            )
+        )
+    }
+}
+
+@Composable
+private fun rememberThemeColor(attrResId: Int, fallbackColor: Color): Color {
+    val context = LocalContext.current
+    return remember(context, attrResId, fallbackColor) {
+        try {
+            val typedValue = TypedValue()
+            if (context.theme.resolveAttribute(attrResId, typedValue, true)) {
+                if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                    Color(typedValue.data)
+                } else if (typedValue.resourceId != 0) {
+                    Color(ContextCompat.getColor(context, typedValue.resourceId))
+                } else {
+                    fallbackColor
+                }
+            } else {
+                fallbackColor
+            }
+        } catch (_: Throwable) {
+            fallbackColor
+        }
+    }
+}
+
+/** Consistent, greppable prefix for visual-inbox overlay log lines (matches the data layer's). */
+private const val INBOX_LOG_TAG = "[CIO-Inbox]"
+
+/** Jist action signals that mean "dismiss this message". `behavior` is the live inbox contract
+ *  (`messageAction.behavior == "dismiss"`); `name`/`url` are Jist-demo fallbacks. */
+private const val DISMISS_BEHAVIOR = "dismiss"
+private const val DISMISS_ACTION_NAME = "dismiss"
+private const val DISMISS_URL = "#dismiss"
+
+/** Hovering-panel margins: 16dp top/horizontal; a larger bottom inset clears the floating bell. */
+private val PANEL_MARGIN = 16.dp
+private val PANEL_BOTTOM_MARGIN = 88.dp
+private val PANEL_CORNER_RADIUS = 12.dp

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -119,6 +119,16 @@ internal fun NotificationInboxOverlay(
     val uiStateFlow = remember(controller) { controller.uiStateFlow() }
     val state by uiStateFlow.collectAsState(initial = VisualInboxUiState(loading = true))
 
+    // Whether any selected message can actually render (its `type` has a decoded template). A message
+    // whose type has no template is skipped by the list, so when NONE are renderable there is nothing
+    // to show — chrome is hidden (below) rather than left as a bell over a blank panel.
+    val renderTemplates = remember(state.templatesJson) {
+        InboxJistDecoder.decodeTemplates(state.templatesJson)
+    }
+    val hasRenderableMessages = remember(state.messages, renderTemplates) {
+        state.messages.any { it.type in renderTemplates }
+    }
+
     // When the panel opens, auto-mark the currently-selected unopened messages as opened (exactly
     // once, via the controller's dedupe + in-flight guard). The mark dispatches a store change,
     // which re-emits through uiStateFlow above so the messages and unread badge update reactively.
@@ -132,15 +142,17 @@ internal fun NotificationInboxOverlay(
     // inbox no longer Visible (or messages becomes empty) -> the panel collapses and the bell
     // unmounts (see the `isVisible && panelExpanded` guard below). Without this, the panel would
     // stay open over an empty list after the final dismiss.
-    LaunchedEffect(state.isVisible, state.messages.isEmpty()) {
-        if (!state.isVisible || state.messages.isEmpty()) {
+    LaunchedEffect(state.isVisible, hasRenderableMessages) {
+        if (!state.isVisible || !hasRenderableMessages) {
             panelExpanded = false
         }
     }
 
-    // The bell only appears when the inbox is renderable per the data layer. When the panel is
-    // open we keep the overlay mounted regardless so the close animation can play out.
-    if (!state.isVisible && !panelExpanded) {
+    // The bell only appears when the inbox is renderable: enabled+Visible per the data layer AND at
+    // least one message has a template to render. When the panel is open we keep the overlay mounted
+    // regardless so the close animation can play out.
+    val canShowChrome = state.isVisible && hasRenderableMessages
+    if (!canShowChrome && !panelExpanded) {
         return
     }
 

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -56,6 +56,12 @@ internal class VisualInboxController(
     private val markedOpenedQueueIds = HashSet<String>()
     private val markInFlight = AtomicBoolean(false)
 
+    // Dedupe guard for dismiss (mark-deleted), mirroring the mark-opened guards above: queueIds
+    // already dismissed in this session, plus an in-flight flag so a duplicate action event (e.g. a
+    // double-tap before the store re-emits and removes the row) does not issue a second delete.
+    private val deletedQueueIds = HashSet<String>()
+    private val deleteInFlight = AtomicBoolean(false)
+
     /**
      * Reactive stream of UI snapshots. Merges two sources, distinguished by whether the emission
      * may FETCH:
@@ -146,6 +152,29 @@ internal class VisualInboxController(
                 }
         } finally {
             markInFlight.set(false)
+        }
+    }
+
+    /**
+     * Dismiss (remove) a single message in response to a Jist `dismiss` action, exactly once.
+     * Mirrors [markOpenMessagesOpened]: the [queueId] is resolved against the data layer's
+     * [InboxVisibility.Visible.messages] — the same [io.customer.messaginginapp.gist.data.model.InboxMessage]
+     * set the UI renders — so there is no Jist re-correlation, and the delete reuses the existing
+     * NotificationInbox plumbing via [VisualInbox.markMessageDeleted]. Guarded by [deleteInFlight]
+     * (no re-entry while a dismiss runs) and [deletedQueueIds] (a message dismissed in this session
+     * is never re-deleted, e.g. on a duplicate action event before the row is removed). Removing the
+     * last message empties the list, which the overlay reacts to by auto-closing the panel.
+     */
+    fun dismissMessage(visibility: InboxVisibility, queueId: String) {
+        val visible = visibility as? InboxVisibility.Visible ?: return
+        if (queueId in deletedQueueIds) return
+        if (!deleteInFlight.compareAndSet(false, true)) return
+        try {
+            val message = visible.messages.firstOrNull { it.queueId == queueId } ?: return
+            deletedQueueIds.add(queueId)
+            visualInbox.markMessageDeleted(message)
+        } finally {
+            deleteInFlight.set(false)
         }
     }
 }

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxJistDecoderTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxJistDecoderTest.kt
@@ -1,6 +1,7 @@
 package io.customer.messaginginbox
 
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
+import java.time.Instant
 import java.util.Date
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -145,5 +146,17 @@ class InboxJistDecoderTest {
                 jistMessage(queueId = "c", opened = false)
             )
         ) shouldBeEqualTo 2
+    }
+
+    // --- formatRelativeDate (Jist formatDate hook) ---
+
+    private val now: Instant = Instant.parse("2026-06-20T12:00:00Z")
+
+    @Test
+    fun formatRelativeDate_givenUnparseable_expectRawValueReturned() {
+        // Valid timestamps are formatted by android.text.format.DateUtils (system-localized), which
+        // isn't exercised in plain JVM unit tests. We verify the parse-failure fallback, which
+        // returns the raw input before ever touching DateUtils.
+        InboxJistDecoder.formatRelativeDate("not-a-date", name = "sentAt", now = now) shouldBeEqualTo "not-a-date"
     }
 }

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/VisualInboxControllerTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/VisualInboxControllerTest.kt
@@ -307,4 +307,50 @@ class VisualInboxControllerTest {
 
         verify(exactly = 0) { visualInbox.markMessageOpened(any()) }
     }
+
+    @Test
+    fun dismissMessage_givenVisibleMatch_expectMarkedDeletedOnce() {
+        val messages = listOf(message("a"), message("b"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+
+        VisualInboxController(visualInbox).dismissMessage(visible(messages), "b")
+
+        // The queueId resolves against visible.messages (the same InboxMessage set the UI renders),
+        // so the delete reuses the data-layer plumbing for that exact message.
+        verify(exactly = 1) { visualInbox.markMessageDeleted(match { it.queueId == "b" }) }
+        verify(exactly = 0) { visualInbox.markMessageDeleted(match { it.queueId == "a" }) }
+    }
+
+    @Test
+    fun dismissMessage_calledTwiceSameId_expectDeletedOnce() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox)
+
+        // A duplicate action event (e.g. double-tap before the store removes the row) must not
+        // issue a second delete (dedupe guard).
+        controller.dismissMessage(visible(messages), "a")
+        controller.dismissMessage(visible(messages), "a")
+
+        verify(exactly = 1) { visualInbox.markMessageDeleted(any()) }
+    }
+
+    @Test
+    fun dismissMessage_givenUnknownId_expectNoOp() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+
+        VisualInboxController(visualInbox).dismissMessage(visible(messages), "missing")
+
+        verify(exactly = 0) { visualInbox.markMessageDeleted(any()) }
+    }
+
+    @Test
+    fun dismissMessage_givenHidden_expectNoOp() {
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+
+        VisualInboxController(visualInbox).dismissMessage(InboxVisibility.Hidden("x"), "a")
+
+        verify(exactly = 0) { visualInbox.markMessageDeleted(any()) }
+    }
 }


### PR DESCRIPTION
Web-parity follow-up for the Android visual notification inbox overlay: tap-to-dismiss (Jist `dismiss` action), auto-hide the panel/bell when the list empties, web-aligned relative dates, skip messages with no template, `JistMode.Auto` dark mode, 0.32 scrim, and a hovering-card panel (margins on all sides, rounded corners, max width 480dp).

Deferred (not in this PR): real-url / deep-link navigation (#12), host action callback API (#13), full chrome theming from branding.patterns.inbox (#17), custom/SVG bell asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbox delete/open flows and large overlay UI rewrites; dismiss is guarded but incorrect action parsing could delete the wrong message or leave stale UI until store updates.
> 
> **Overview**
> Brings the Android **Notification Inbox** overlay closer to web/iOS: **dismiss** on Jist actions (`behavior: dismiss` and fallbacks) via new `VisualInboxController.dismissMessage` (deduped like mark-opened), **auto-close** of the panel and bell when visibility drops or no messages have a template, and **OS-localized relative dates** through `InboxJistDecoder.formatRelativeDate` wired into `JistView`.
> 
> **UI** drops **Compose Material** (dependency removed) in favor of Foundation/custom chrome: hovering card panel (margins, 12dp corners, 480dp max width, 0.32 scrim), no header (scrim/bell only), custom bell FAB and badge, theme-aware colors, `JistMode.Auto`, and list rows that skip unknown template types with logging. Non-dismiss Jist actions remain no-ops (deep links deferred).
> 
> Tests cover dismiss dedupe/edge cases and unparseable date fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2735b6c7be88f103f76c44d6490b0102d6cc3514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->