### PR TITLE
chore(inbox): android cleanups (lifecycle-aware collection, gson reuse, desugaring docs)

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -18,6 +18,11 @@ object Dependencies {
         "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.COROUTINES}"
     const val androidxCoreKtx = "androidx.core:core-ktx:${Versions.ANDROIDX_KTX}"
     const val androidxProcessLifecycle = "androidx.lifecycle:lifecycle-process:${Versions.ANDROIDX_LIFECYCLE_PROCESS}"
+
+    // Lifecycle-aware Compose state collection (`collectAsStateWithLifecycle`) so the overlay pauses
+    // flow collection while the host is backgrounded / the overlay is off-screen. Shares the lifecycle
+    // release version with lifecycle-process above.
+    const val androidxLifecycleRuntimeCompose = "androidx.lifecycle:lifecycle-runtime-compose:${Versions.ANDROIDX_LIFECYCLE_PROCESS}"
     const val androidxAnnotations =
         "androidx.annotation:annotation:${Versions.ANDROIDX_ANNOTATIONS}"
     const val coroutinesCore =

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/data/InboxRepository.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/data/InboxRepository.kt
@@ -279,7 +279,7 @@ internal class InboxRepository(
      * Tolerant of any shape: returns the top-level key count, or -1 if unparseable.
      */
     private fun templateNamesCount(rawJson: String): Int = runCatching {
-        Gson().fromJson(rawJson, JsonObject::class.java).keySet().size
+        gson.fromJson(rawJson, JsonObject::class.java).keySet().size
     }.getOrDefault(-1)
 
     /**

--- a/messaginginbox/build.gradle
+++ b/messaginginbox/build.gradle
@@ -24,7 +24,10 @@ android {
         consumerProguardFiles "consumer-rules.pro"
     }
 
-    // Core library desugaring: required because Jist (io.customer.android:jist) uses java.time.
+    // Core library desugaring: Jist (io.customer.android:jist) uses java.time, which is only
+    // available natively on API 26+. Because this module (and the SDK) support minSdk < 26, desugaring
+    // is required so Jist's java.time usage works on older devices in customer apps. It stays until
+    // Jist drops java.time or this module's minSdk is raised to 26 — it is NOT a local-build artifact.
     compileOptions {
         coreLibraryDesugaringEnabled true
     }
@@ -61,6 +64,7 @@ dependencies {
     implementation Dependencies.composeUiGraphics
     implementation Dependencies.composeFoundation
     implementation Dependencies.composeRuntime
+    implementation Dependencies.androidxLifecycleRuntimeCompose
     implementation Dependencies.coroutinesAndroid
 
     // Testing

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -35,7 +35,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,6 +59,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.jist.JistActionEvent
 import io.customer.jist.JistMode
@@ -116,8 +116,10 @@ internal fun NotificationInboxOverlay(
     // Reactive state: re-derived automatically on every relevant store change (see uiStateFlow),
     // so the bell/panel/badge update with no recomposition or user navigation required.
     // Build the Flow once per controller (not on every recomposition) so collection is stable.
+    // collectAsStateWithLifecycle pauses collection while the host is STOPPED (backgrounded / overlay
+    // off-screen) and resumes on start, avoiding wasted work when the inbox isn't visible.
     val uiStateFlow = remember(controller) { controller.uiStateFlow() }
-    val state by uiStateFlow.collectAsState(initial = VisualInboxUiState(loading = true))
+    val state by uiStateFlow.collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
 
     // Whether any selected message can actually render (its `type` has a decoded template). A message
     // whose type has no template is skipped by the list, so when NONE are renderable there is nothing


### PR DESCRIPTION
Small Android-only follow-ups stacked on the web-parity PR (#751):

- **collectAsStateWithLifecycle**: the overlay now pauses flow collection while the host is backgrounded / off-screen (adds `lifecycle-runtime-compose`).
- **gson reuse**: `InboxRepository.templateNamesCount` uses the class-level `gson` instead of a fresh `Gson()` (addresses review nit).
- **desugaring rationale**: clarified that core-library desugaring is required for Jist's `java.time` on minSdk < 26 in customer apps (not a local-build artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk polish: lifecycle-aware Compose collection may briefly delay UI updates when resuming from background, but behavior is otherwise unchanged.
> 
> **Overview**
> Small Android inbox follow-ups: **lifecycle-aware UI state**, a **Gson reuse** fix, and **build/docs** clarity.
> 
> The notification inbox overlay now collects `uiStateFlow` with **`collectAsStateWithLifecycle`** instead of `collectAsState`, wired through a new **`lifecycle-runtime-compose`** dependency so flow collection pauses while the host lifecycle is **STOPPED** (app backgrounded / overlay not active).
> 
> In **`InboxRepository`**, `templateNamesCount` parses logging JSON with the repository’s shared **`gson`** instance instead of allocating **`Gson()`** on each call.
> 
> **`messaginginapp/build.gradle`** comments now spell out why **core library desugaring** stays enabled for Jist’s **`java.time`** on **minSdk &lt; 26** in customer apps (not a local-build workaround).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef7ec87a227e6a0d239cb6f74e19a404ac18bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->