### PR TITLE
feat(inbox): message actions and branding-driven chrome colors

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -1,6 +1,7 @@
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lio/customer/messaginginapp/type/InboxEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEventListener ()Lio/customer/messaginginapp/type/InAppEventListener;
+	public final fun getInboxEventListener ()Lio/customer/messaginginapp/type/InboxEventListener;
 	public final fun getRegion ()Lio/customer/sdk/data/model/Region;
 	public final fun getSiteId ()Ljava/lang/String;
 }
@@ -10,6 +11,7 @@ public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder
 	public fun build ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public final fun setEventListener (Lio/customer/messaginginapp/type/InAppEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
+	public final fun setInboxEventListener (Lio/customer/messaginginapp/type/InboxEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 }
 
 public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer/messaginginapp/gist/presentation/GistListener, io/customer/sdk/core/module/CustomerIOModule {
@@ -257,6 +259,23 @@ public final class io/customer/messaginginapp/type/InAppMessage$Companion {
 
 public final class io/customer/messaginginapp/type/InAppMessageKt {
 	public static final fun getMessage (Lio/customer/messaginginapp/type/InAppMessage;)Lio/customer/messaginginapp/gist/data/model/Message;
+}
+
+public final class io/customer/messaginginapp/type/InboxActionMessage {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/customer/messaginginapp/type/InboxActionMessage;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/type/InboxActionMessage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/type/InboxActionMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeliveryId ()Ljava/lang/String;
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/customer/messaginginapp/type/InboxEventListener {
+	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InboxActionMessage;Ljava/lang/String;Ljava/lang/String;)Z
 }
 
 public abstract interface class io/customer/messaginginapp/type/InlineMessageActionListener {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -276,6 +276,15 @@ public final class io/customer/messaginginapp/type/InboxActionMessage {
 
 public abstract interface class io/customer/messaginginapp/type/InboxEventListener {
 	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InboxActionMessage;Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun messageDismissed (Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public abstract fun messageOpened (Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public abstract fun messageShown (Lio/customer/messaginginapp/type/InboxActionMessage;)V
+}
+
+public final class io/customer/messaginginapp/type/InboxEventListener$DefaultImpls {
+	public static fun messageDismissed (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public static fun messageOpened (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public static fun messageShown (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
 }
 
 public abstract interface class io/customer/messaginginapp/type/InlineMessageActionListener {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
@@ -1,6 +1,7 @@
 package io.customer.messaginginapp
 
 import io.customer.messaginginapp.type.InAppEventListener
+import io.customer.messaginginapp.type.InboxEventListener
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.data.model.Region
 
@@ -11,16 +12,28 @@ import io.customer.sdk.data.model.Region
 class MessagingInAppModuleConfig private constructor(
     val siteId: String,
     val region: Region,
-    val eventListener: InAppEventListener?
+    val eventListener: InAppEventListener?,
+    val inboxEventListener: InboxEventListener?
 ) : CustomerIOModuleConfig {
     class Builder(
         private val siteId: String,
         private val region: Region
     ) : CustomerIOModuleConfig.Builder<MessagingInAppModuleConfig> {
         private var eventListener: InAppEventListener? = null
+        private var inboxEventListener: InboxEventListener? = null
 
         fun setEventListener(eventListener: InAppEventListener): Builder {
             this.eventListener = eventListener
+            return this
+        }
+
+        /**
+         * Registers a listener notified when an action is taken on a visual notification inbox
+         * message. The listener can intercept actions (return `true`) to override the SDK's default
+         * navigation. Mirrors [setEventListener] for inbox actions.
+         */
+        fun setInboxEventListener(inboxEventListener: InboxEventListener): Builder {
+            this.inboxEventListener = inboxEventListener
             return this
         }
 
@@ -28,7 +41,8 @@ class MessagingInAppModuleConfig private constructor(
             return MessagingInAppModuleConfig(
                 siteId = siteId,
                 region = region,
-                eventListener = eventListener
+                eventListener = eventListener,
+                inboxEventListener = inboxEventListener
             )
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
@@ -1,0 +1,40 @@
+package io.customer.messaginginapp.type
+
+/**
+ * Listener the host app registers to be notified when an action is taken on a visual notification
+ * inbox message (e.g. the user taps a button/link inside a rendered message).
+ *
+ * Mirrors [InAppEventListener.messageActionTaken], but unlike in-app — where the callback is purely
+ * observational — the inbox callback lets the host **intercept** the action: returning `true`
+ * signals the host handled it and the SDK performs no default behavior; returning `false` (or not
+ * registering a listener at all) lets the SDK run its default handling (open an http(s) url in the
+ * system browser; deeplinks are left to the host).
+ *
+ * The SDK's built-in dismiss action is handled by the SDK regardless of this listener.
+ */
+interface InboxEventListener {
+    /**
+     * Called when a non-dismiss action is taken on an inbox message.
+     *
+     * @param message identity of the inbox message the action was taken on.
+     * @param actionName the Jist action name (e.g. `messageAction`).
+     * @param actionValue the resolved action value, typically the action's url (may be empty if the
+     * action carried no url).
+     * @return `true` if the host fully handled the action (the SDK does nothing further); `false`
+     * to let the SDK apply its default handling.
+     */
+    fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean
+}
+
+/**
+ * Lightweight, public identity of an inbox message handed to [InboxEventListener]. Exposes the
+ * stable identifiers a host needs to correlate the action with its own data, without leaking the
+ * SDK's internal message/render types.
+ *
+ * @param messageId the inbox message's queue id.
+ * @param deliveryId the message's delivery id, when present.
+ */
+data class InboxActionMessage(
+    val messageId: String,
+    val deliveryId: String?
+)

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
@@ -24,6 +24,32 @@ interface InboxEventListener {
      * to let the SDK apply its default handling.
      */
     fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean
+
+    /**
+     * Observational callback fired when a message is first shown/rendered in the inbox view. Fired
+     * once per message (deduped) while the view is displayed. Purely informational — it does not
+     * affect SDK behavior. Default no-op so the interface stays source-compatible.
+     *
+     * @param message identity of the inbox message that was shown.
+     */
+    fun messageShown(message: InboxActionMessage) {}
+
+    /**
+     * Observational callback fired when a message is marked opened (the inbox panel opening
+     * auto-marks the currently-shown unopened messages). Purely informational. Default no-op so the
+     * interface stays source-compatible.
+     *
+     * @param message identity of the inbox message that was opened.
+     */
+    fun messageOpened(message: InboxActionMessage) {}
+
+    /**
+     * Observational callback fired when a message is dismissed/removed from the inbox. Purely
+     * informational. Default no-op so the interface stays source-compatible.
+     *
+     * @param message identity of the inbox message that was dismissed.
+     */
+    fun messageDismissed(message: InboxActionMessage) {}
 }
 
 /**

--- a/messaginginbox/api/messaginginbox.api
+++ b/messaginginbox/api/messaginginbox.api
@@ -1,0 +1,6 @@
+public final class io/customer/messaginginbox/NotificationInboxOverlayKt {
+	public static final fun NotificationInboxBell (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NotificationInboxOverlay (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NotificationInboxView (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
@@ -56,6 +57,7 @@ import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -65,6 +67,7 @@ import io.customer.jist.JistMode
 import io.customer.jist.JistView
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.inbox.VisualInbox
+import io.customer.messaginginapp.inbox.data.Branding
 import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
 import io.customer.sdk.core.di.SDKComponent
@@ -96,7 +99,7 @@ fun NotificationInboxBell(
 
     InboxBellContent(
         unopenedCount = state.unopenedCount,
-        colors = rememberInboxColors(),
+        colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
         onClick = onClick,
         modifier = modifier
     )
@@ -118,9 +121,13 @@ fun NotificationInboxView(
     modifier: Modifier = Modifier
 ) {
     val controller = rememberInboxController()
+    // Collect state for branding-driven chrome colors (the bell/overlay do the same); InboxListContent
+    // collects its own state for the message list.
+    val state by remember(controller) { controller.uiStateFlow() }
+        .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
     InboxListContent(
         controller = controller,
-        colors = rememberInboxColors(),
+        colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
         modifier = modifier.fillMaxSize()
     )
 }
@@ -185,7 +192,7 @@ internal fun NotificationInboxOverlay(
         return
     }
 
-    val colors = rememberInboxColors()
+    val colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding)
 
     Box(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
@@ -212,7 +219,7 @@ internal fun NotificationInboxOverlay(
 
         // Slide-out hovering panel: a floating card (margins on all sides, rounded corners) wrapping
         // the inbox list. Aligned top-end so its top margin is honored.
-        val panelShape = RoundedCornerShape(PANEL_CORNER_RADIUS)
+        val panelShape = RoundedCornerShape(colors.cornerRadius)
         AnimatedVisibility(
             visible = panelExpanded,
             enter = slideInHorizontally(initialOffsetX = { it }) + fadeIn(),
@@ -279,7 +286,7 @@ private fun InboxBellContent(
             Image(
                 painter = painterResource(id = R.drawable.cio_inbox_notifications),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(Color.White)
+                colorFilter = ColorFilter.tint(colors.bellIconColor)
             )
         }
 
@@ -510,35 +517,110 @@ private fun rememberInboxController(): VisualInboxController = remember {
     )
 }
 
-/** Chrome colors resolved from the host app theme (with dark-mode-aware fallbacks). */
+/** Resolved chrome colors for the overlay. See [rememberInboxColors] for the resolution order. */
 private data class InboxColors(
     val bellColor: Color,
+    val bellIconColor: Color,
     val panelColor: Color,
     val textColorPrimary: Color,
     val dividerColor: Color,
-    val badgeColor: Color
+    val badgeColor: Color,
+    val cornerRadius: Dp
 )
 
+/**
+ * Resolves the overlay's chrome colors, driven by backend branding so they are configurable per
+ * workspace across all consumer apps. Every value is resolved in this priority order, with the
+ * literals serving only as a last-resort floor:
+ *   1. `patterns.modes.dark.inbox.*` — dark mode only, AND only when the workspace configured a
+ *      dark palette (`patterns.modes.dark` is OPTIONAL; absent in many workspaces),
+ *   2. `patterns.inbox.*` — the workspace's configured (light) inbox chrome,
+ *   3. the host app's Android theme attr (`colorAccent` / `colorBackground` / `textColor*`),
+ *   4. a literal default.
+ */
 @Composable
-private fun rememberInboxColors(): InboxColors {
+private fun rememberInboxColors(branding: Branding? = null): InboxColors {
     val isDarkTheme = isSystemInDarkTheme()
+    // Tier 3 (host theme) fallbacks, used when the workspace has not configured the branding token.
+    val accent = rememberThemeColor(android.R.attr.colorAccent, Color(0xFF3451FF))
+    val surface = rememberThemeColor(
+        android.R.attr.colorBackground,
+        if (isDarkTheme) Color(0xFF121212) else Color.White
+    )
+    val textPrimary = rememberThemeColor(
+        android.R.attr.textColorPrimary,
+        if (isDarkTheme) Color.White else Color.Black
+    )
     val textColorSecondary = rememberThemeColor(
         android.R.attr.textColorSecondary,
         if (isDarkTheme) Color.LightGray else Color.DarkGray
     )
-    return InboxColors(
-        bellColor = rememberThemeColor(android.R.attr.colorAccent, Color(0xFF3451FF)),
-        panelColor = rememberThemeColor(
-            android.R.attr.colorBackground,
-            if (isDarkTheme) Color(0xFF121212) else Color.White
-        ),
-        textColorPrimary = rememberThemeColor(
-            android.R.attr.textColorPrimary,
-            if (isDarkTheme) Color.White else Color.Black
-        ),
-        dividerColor = textColorSecondary.copy(alpha = 0.12f),
-        badgeColor = Color(0xFFE53935)
-    )
+
+    return remember(branding, isDarkTheme, accent, surface, textPrimary, textColorSecondary) {
+        val light = branding?.inboxChrome
+        // Dark overrides are an OPTIONAL raw map (shape mirrors patterns.inbox, nested under
+        // modes.dark.inbox). Only consulted in dark mode; absent workspaces fall through to `light`.
+        val dark: Map<*, *>? =
+            if (isDarkTheme) branding?.patterns?.modes?.dark?.get("inbox") as? Map<*, *> else null
+
+        val bellColor = dark.childStr("floatingIcon", "background").toColorOrNull()
+            ?: light?.floatingIcon?.background.toColorOrNull()
+            ?: accent
+        val bellIconColor = dark.childStr("floatingIcon", "color").toColorOrNull()
+            ?: light?.floatingIcon?.color.toColorOrNull()
+            // Final fallback: contrast against the resolved bell so a light accent (e.g. Samsung One
+            // UI resolves colorAccent to white) never yields a white icon on a white bell.
+            ?: if (bellColor.luminance() > 0.5f) Color.Black else Color.White
+        val panelColor = dark.str("background").toColorOrNull()
+            ?: light?.background.toColorOrNull()
+            ?: surface
+        val dividerColor = (dark.str("dividerColor") ?: dark.str("borderColor")).toColorOrNull()
+            ?: (light?.dividerColor ?: light?.borderColor).toColorOrNull()
+            ?: textColorSecondary.copy(alpha = 0.12f)
+        val badgeColor = dark.childStr("unreadIndicator", "background").toColorOrNull()
+            ?: light?.unreadIndicator?.background.toColorOrNull()
+            ?: Color(0xFFE53935)
+        val cornerRadius = light?.cornerRadius?.dp ?: PANEL_CORNER_RADIUS
+
+        InboxColors(
+            bellColor = bellColor,
+            bellIconColor = bellIconColor,
+            panelColor = panelColor,
+            textColorPrimary = textPrimary,
+            dividerColor = dividerColor,
+            badgeColor = badgeColor,
+            cornerRadius = cornerRadius
+        )
+    }
+}
+
+/** Reads a top-level String value from a raw branding (dark-mode override) map, or null. */
+private fun Map<*, *>?.str(key: String): String? = this?.get(key) as? String
+
+/** Reads a String from a nested child object of a raw branding (dark-mode override) map, or null. */
+private fun Map<*, *>?.childStr(child: String, key: String): String? =
+    (this?.get(child) as? Map<*, *>)?.get(key) as? String
+
+/**
+ * Parses a branding hex color string (`#RRGGBB` or `#RRGGBBAA`, CSS byte order) into a Compose
+ * [Color], or null when the value is absent / malformed so callers fall through to the next tier.
+ */
+private fun String?.toColorOrNull(): Color? {
+    val hex = this?.trim()?.removePrefix("#") ?: return null
+    return try {
+        when (hex.length) {
+            6 -> Color(0xFF000000L or hex.toLong(16))
+            8 -> {
+                val rgba = hex.toLong(16)
+                val alpha = rgba and 0xFF
+                val rgb = rgba ushr 8
+                Color((alpha shl 24) or rgb)
+            }
+            else -> null
+        }
+    } catch (_: NumberFormatException) {
+        null
+    }
 }
 
 @Composable

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -69,8 +69,6 @@ import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
 import io.customer.sdk.core.di.SDKComponent
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.contentOrNull
 
 /**
  * Drop-in Compose overlay that shows the Customer.io Visual Notification Inbox on top of your app.
@@ -96,7 +94,13 @@ fun NotificationInboxOverlay(
     modifier: Modifier = Modifier
 ) {
     val controller = remember {
-        VisualInboxController(ModuleMessagingInApp.instance().visualInbox())
+        val module = ModuleMessagingInApp.instance()
+        VisualInboxController(
+            visualInbox = module.visualInbox(),
+            // Host-registered inbox action listener (item 13), mirroring the in-app eventListener;
+            // resolved from the same module config the host built. Null when none was registered.
+            inboxEventListener = module.moduleConfig.inboxEventListener
+        )
     }
     NotificationInboxOverlay(modifier = modifier, controller = controller)
 }
@@ -112,6 +116,7 @@ internal fun NotificationInboxOverlay(
     controller: VisualInboxController
 ) {
     var panelExpanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     // Reactive state: re-derived automatically on every relevant store change (see uiStateFlow),
     // so the bell/panel/badge update with no recomposition or user navigation required.
@@ -205,7 +210,12 @@ internal fun NotificationInboxOverlay(
                 textColorPrimary = textColorPrimary,
                 dividerColor = dividerColor,
                 onMessageAction = { message, event ->
-                    handleInboxAction(controller, state.visibility, message, event)
+                    // Controller resolves the action (dismiss / track+intercept / default nav) and
+                    // returns a navigation instruction; the overlay (which owns the Context) runs it.
+                    when (val nav = controller.handleAction(state.visibility, message, event)) {
+                        is InboxNavigation.OpenUrl -> openUrlInBrowser(context, nav.url)
+                        InboxNavigation.None -> Unit
+                    }
                 }
             )
         }
@@ -390,49 +400,20 @@ private fun InboxMessageList(
 }
 
 /**
- * Maps a Jist action to an inbox behavior. Web parity: a "dismiss" action removes (deletes) the
- * message. The live inbox templates emit the action as `name = "messageAction"` with the message's
- * `properties.messageAction = { behavior: "dismiss" }`, so the dismiss signal we match is
- * **`data.behavior == "dismiss"`**. We also accept the Jist-demo sentinels (`name == "dismiss"` or
- * `data.url == "#dismiss"`) as a fallback. Any other action (a real url / other behavior) is a
- * no-op for now — real-url/deep-link navigation is deferred (scope item 12); we log it so it's
- * visible during bring-up.
+ * Default navigation for a resolved openUrl action (item 12): open [url] in the system browser via
+ * an ACTION_VIEW intent. `FLAG_ACTIVITY_NEW_TASK` is set so it works when launched from a non-Activity
+ * context (the overlay may be hosted in an application/service context). Robust to a malformed url or
+ * a device with no browser: any failure is logged, never crashes.
  */
-private fun handleInboxAction(
-    controller: VisualInboxController,
-    visibility: io.customer.messaginginapp.inbox.data.InboxVisibility,
-    message: JistInboxMessage,
-    event: JistActionEvent
-) {
-    val isDismiss = actionBehavior(event) == DISMISS_BEHAVIOR ||
-        event.name == DISMISS_ACTION_NAME ||
-        actionUrl(event) == DISMISS_URL
-    if (isDismiss) {
-        controller.dismissMessage(visibility, message.queueId)
-        return
+private fun openUrlInBrowser(context: android.content.Context, url: String) {
+    try {
+        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
+            .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    } catch (ex: Exception) {
+        SDKComponent.logger.error("$INBOX_LOG_TAG failed to open url '$url' in browser: ${ex.message}")
     }
-    // TODO (item 12 — deferred): real-url / deep-link navigation. TODO (item 13 — deferred): host
-    // action callback API. For now, non-dismiss actions are a no-op.
-    SDKComponent.logger.debug(
-        "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
-            "on ${message.queueId}: navigation deferred, no-op"
-    )
 }
-
-/**
- * Extracts the `url` string from a Jist action event's data object, or null if absent / not a
- * string. Safe casts throughout: a non-object `data` or non-primitive `url` yields null rather
- * than throwing.
- */
-private fun actionUrl(event: JistActionEvent): String? =
-    ((event.data as? JsonObject)?.get("url") as? JsonPrimitive)?.contentOrNull
-
-/**
- * Extracts the `behavior` string from a Jist action event's data object (e.g. the live inbox's
- * `messageAction = { behavior: "dismiss" }`), or null if absent / not a string. Safe casts.
- */
-private fun actionBehavior(event: JistActionEvent): String? =
-    ((event.data as? JsonObject)?.get("behavior") as? JsonPrimitive)?.contentOrNull
 
 @Composable
 private fun LoadingState(
@@ -537,12 +518,6 @@ private fun rememberThemeColor(attrResId: Int, fallbackColor: Color): Color {
 
 /** Consistent, greppable prefix for visual-inbox overlay log lines (matches the data layer's). */
 private const val INBOX_LOG_TAG = "[CIO-Inbox]"
-
-/** Jist action signals that mean "dismiss this message". `behavior` is the live inbox contract
- *  (`messageAction.behavior == "dismiss"`); `name`/`url` are Jist-demo fallbacks. */
-private const val DISMISS_BEHAVIOR = "dismiss"
-private const val DISMISS_ACTION_NAME = "dismiss"
-private const val DISMISS_URL = "#dismiss"
 
 /** Hovering-panel margins: 16dp top/horizontal; a larger bottom inset clears the floating bell. */
 private val PANEL_MARGIN = 16.dp

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -94,8 +94,11 @@ fun NotificationInboxBell(
     val state by remember(controller) { controller.uiStateFlow() }
         .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
 
-    // Only show the bell when the data layer reports the inbox renderable (enabled + has messages).
-    if (!state.isVisible) return
+    // Only show the bell when the inbox is renderable: enabled+Visible AND at least one message has a
+    // template to render (a message whose type has no template is skipped by the list, so if none can
+    // render there is nothing to show).
+    val hasRenderableMessages = rememberHasRenderableMessages(state)
+    if (!state.isVisible || !hasRenderableMessages) return
 
     InboxBellContent(
         unopenedCount = state.unopenedCount,
@@ -180,15 +183,18 @@ internal fun NotificationInboxOverlay(
     // Auto-close the panel + hide the bell when the inbox is no longer renderable. Dismissing the
     // last message empties the list -> the data layer reports the inbox no longer Visible -> the
     // panel collapses and the bell unmounts (see the guard below).
-    LaunchedEffect(state.isVisible, state.messages.isEmpty()) {
-        if (!state.isVisible || state.messages.isEmpty()) {
+    val hasRenderableMessages = rememberHasRenderableMessages(state)
+    LaunchedEffect(state.isVisible, hasRenderableMessages) {
+        if (!state.isVisible || !hasRenderableMessages) {
             panelExpanded = false
         }
     }
 
-    // The bell only appears when the inbox is renderable per the data layer. When the panel is open
-    // we keep the overlay mounted regardless so the close animation can play out.
-    if (!state.isVisible && !panelExpanded) {
+    // The bell only appears when the inbox is renderable: enabled+Visible AND at least one message has
+    // a template. When the panel is open we keep the overlay mounted regardless so the close animation
+    // can play out.
+    val canShowChrome = state.isVisible && hasRenderableMessages
+    if (!canShowChrome && !panelExpanded) {
         return
     }
 
@@ -515,6 +521,21 @@ private fun rememberInboxController(): VisualInboxController = remember {
         // eventListener; resolved from the same module config the host built. Null when none set.
         inboxEventListener = module.moduleConfig.inboxEventListener
     )
+}
+
+/**
+ * Whether any selected message can actually render — its `type` has a decoded template. A message
+ * whose type has no template is skipped by the list, so when none are renderable there is nothing to
+ * show and the overlay hides all chrome rather than leaving a bell over a blank panel.
+ */
+@Composable
+private fun rememberHasRenderableMessages(state: VisualInboxUiState): Boolean {
+    val templates = remember(state.templatesJson) {
+        InboxJistDecoder.decodeTemplates(state.templatesJson)
+    }
+    return remember(state.messages, templates) {
+        state.messages.any { it.type in templates }
+    }
 }
 
 /** Resolved chrome colors for the overlay. See [rememberInboxColors] for the resolution order. */

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -202,7 +202,10 @@ internal fun NotificationInboxOverlay(
 
     Box(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
-            visible = panelExpanded,
+            // Gate on canShowChrome too (matches iOS): if the inbox empties while the panel is open
+            // (dismissing the last message -> Hidden), hide the scrim/panel immediately rather than
+            // waiting on the panelExpanded reset, so the panel auto-dismisses with the inbox.
+            visible = panelExpanded && canShowChrome,
             enter = fadeIn(),
             exit = fadeOut(),
             modifier = Modifier.fillMaxSize()
@@ -227,7 +230,7 @@ internal fun NotificationInboxOverlay(
         // the inbox list. Aligned top-end so its top margin is honored.
         val panelShape = RoundedCornerShape(colors.cornerRadius)
         AnimatedVisibility(
-            visible = panelExpanded,
+            visible = panelExpanded && canShowChrome,
             enter = slideInHorizontally(initialOffsetX = { it }) + fadeIn(),
             exit = slideOutHorizontally(targetOffsetX = { it }) + fadeOut(),
             modifier = Modifier.align(Alignment.TopEnd)

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -60,23 +60,76 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.jist.JistActionEvent
 import io.customer.jist.JistMode
 import io.customer.jist.JistView
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.inbox.VisualInbox
+import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
 import io.customer.sdk.core.di.SDKComponent
 import kotlinx.serialization.json.JsonObject
 
 /**
- * Drop-in Compose overlay that shows the Customer.io Visual Notification Inbox on top of your app.
+ * Floating notification **bell** (with unread badge) you can place anywhere in your Compose UI —
+ * e.g. a top app bar, a tab, or a corner. The bell appears only when the inbox has something to
+ * show and updates reactively as messages arrive or are read; it renders nothing otherwise.
  *
- * It renders a floating notification bell with an unread badge. Tapping the bell slides out a
- * panel listing the user's inbox messages; tapping outside the panel dismisses it. The bell only
- * appears when there is something to show, and it updates automatically as messages arrive or are
- * read — you do not need to refresh or re-navigate.
+ * Pair it with [NotificationInboxView] (which you present however you like — a sheet, a screen, a
+ * popup) by toggling your own visibility state from [onClick]. For the ready-made floating bell +
+ * slide-out panel, use [NotificationInboxOverlay] instead.
+ *
+ * @param onClick invoked when the user taps the bell (e.g. to show/hide your inbox view).
+ * @param modifier Modifier applied to the bell.
+ */
+@Composable
+fun NotificationInboxBell(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val controller = rememberInboxController()
+    val state by remember(controller) { controller.uiStateFlow() }
+        .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
+
+    // Only show the bell when the data layer reports the inbox renderable (enabled + has messages).
+    if (!state.isVisible) return
+
+    InboxBellContent(
+        unopenedCount = state.unopenedCount,
+        colors = rememberInboxColors(),
+        onClick = onClick,
+        modifier = modifier
+    )
+}
+
+/**
+ * The Visual Notification Inbox **message list** — the Jist-rendered messages — that you can embed
+ * directly in your own screen (or present in a sheet/dialog). It fills the [modifier] you give it
+ * and brings no surrounding chrome (no card/scrim), so you control the placement and container.
+ *
+ * Showing this view marks the currently-unread messages as opened (mirroring the panel-open
+ * behavior); tapping a message dismisses it or runs its action. For the ready-made floating bell +
+ * slide-out panel, use [NotificationInboxOverlay]; to drive your own bell, use [NotificationInboxBell].
+ *
+ * @param modifier Modifier applied to the list container.
+ */
+@Composable
+fun NotificationInboxView(
+    modifier: Modifier = Modifier
+) {
+    val controller = rememberInboxController()
+    InboxListContent(
+        controller = controller,
+        colors = rememberInboxColors(),
+        modifier = modifier.fillMaxSize()
+    )
+}
+
+/**
+ * Drop-in Compose overlay that shows the Customer.io Visual Notification Inbox on top of your app:
+ * a floating [NotificationInboxBell] pinned bottom-end that slides out a [NotificationInboxView]
+ * panel; tapping outside the panel dismisses it. The bell only appears when there is something to
+ * show, and everything updates automatically as messages arrive or are read.
  *
  * Mount it once near the top of your Compose hierarchy so it overlays the rest of your content:
  * ```
@@ -85,30 +138,22 @@ import kotlinx.serialization.json.JsonObject
  *     NotificationInboxOverlay()
  * }
  * ```
+ * For custom placement (e.g. a bell in your toolbar, or the list embedded in a screen), use
+ * [NotificationInboxBell] and [NotificationInboxView] directly instead.
  *
  * @param modifier Modifier applied to the root overlay container.
  */
-@InternalCustomerIOApi
 @Composable
 fun NotificationInboxOverlay(
     modifier: Modifier = Modifier
 ) {
-    val controller = remember {
-        val module = ModuleMessagingInApp.instance()
-        VisualInboxController(
-            visualInbox = module.visualInbox(),
-            // Host-registered inbox action listener (item 13), mirroring the in-app eventListener;
-            // resolved from the same module config the host built. Null when none was registered.
-            inboxEventListener = module.moduleConfig.inboxEventListener
-        )
-    }
+    val controller = rememberInboxController()
     NotificationInboxOverlay(modifier = modifier, controller = controller)
 }
 
 /**
- * Internal overload that accepts the [VisualInboxController] directly so Compose UI tests can
- * drive the overlay with a fake [VisualInbox]. The public entry point delegates here after
- * resolving the real data layer from the SDK component.
+ * Internal overload that accepts the [VisualInboxController] directly so Compose UI tests can drive
+ * the overlay with a fake [VisualInbox], and so the bell + panel share a single controller/state.
  */
 @Composable
 internal fun NotificationInboxOverlay(
@@ -116,60 +161,31 @@ internal fun NotificationInboxOverlay(
     controller: VisualInboxController
 ) {
     var panelExpanded by remember { mutableStateOf(false) }
-    val context = LocalContext.current
 
     // Reactive state: re-derived automatically on every relevant store change (see uiStateFlow),
     // so the bell/panel/badge update with no recomposition or user navigation required.
     // Build the Flow once per controller (not on every recomposition) so collection is stable.
     // collectAsStateWithLifecycle pauses collection while the host is STOPPED (backgrounded / overlay
     // off-screen) and resumes on start, avoiding wasted work when the inbox isn't visible.
-    val uiStateFlow = remember(controller) { controller.uiStateFlow() }
-    val state by uiStateFlow.collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
+    val state by remember(controller) { controller.uiStateFlow() }
+        .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
 
-    // Whether any selected message can actually render (its `type` has a decoded template). A message
-    // whose type has no template is skipped by the list, so when NONE are renderable there is nothing
-    // to show — chrome is hidden (below) rather than left as a bell over a blank panel.
-    val renderTemplates = remember(state.templatesJson) {
-        InboxJistDecoder.decodeTemplates(state.templatesJson)
-    }
-    val hasRenderableMessages = remember(state.messages, renderTemplates) {
-        state.messages.any { it.type in renderTemplates }
-    }
-
-    // When the panel opens, auto-mark the currently-selected unopened messages as opened (exactly
-    // once, via the controller's dedupe + in-flight guard). The mark dispatches a store change,
-    // which re-emits through uiStateFlow above so the messages and unread badge update reactively.
-    LaunchedEffect(panelExpanded, state.visibility) {
-        if (!panelExpanded) return@LaunchedEffect
-        controller.markOpenMessagesOpened(state.visibility)
-    }
-
-    // Auto-close the panel + hide the bell when the inbox is no longer renderable. This matches the
-    // web/iOS model: dismissing the last message empties the list -> the data layer reports the
-    // inbox no longer Visible (or messages becomes empty) -> the panel collapses and the bell
-    // unmounts (see the `isVisible && panelExpanded` guard below). Without this, the panel would
-    // stay open over an empty list after the final dismiss.
-    LaunchedEffect(state.isVisible, hasRenderableMessages) {
-        if (!state.isVisible || !hasRenderableMessages) {
+    // Auto-close the panel + hide the bell when the inbox is no longer renderable. Dismissing the
+    // last message empties the list -> the data layer reports the inbox no longer Visible -> the
+    // panel collapses and the bell unmounts (see the guard below).
+    LaunchedEffect(state.isVisible, state.messages.isEmpty()) {
+        if (!state.isVisible || state.messages.isEmpty()) {
             panelExpanded = false
         }
     }
 
-    // The bell only appears when the inbox is renderable: enabled+Visible per the data layer AND at
-    // least one message has a template to render. When the panel is open we keep the overlay mounted
-    // regardless so the close animation can play out.
-    val canShowChrome = state.isVisible && hasRenderableMessages
-    if (!canShowChrome && !panelExpanded) {
+    // The bell only appears when the inbox is renderable per the data layer. When the panel is open
+    // we keep the overlay mounted regardless so the close animation can play out.
+    if (!state.isVisible && !panelExpanded) {
         return
     }
 
-    val isDarkTheme = isSystemInDarkTheme()
-    val bellColor = rememberThemeColor(android.R.attr.colorAccent, Color(0xFF3451FF))
-    val panelColor = rememberThemeColor(android.R.attr.colorBackground, if (isDarkTheme) Color(0xFF121212) else Color.White)
-    val textColorPrimary = rememberThemeColor(android.R.attr.textColorPrimary, if (isDarkTheme) Color.White else Color.Black)
-    val textColorSecondary = rememberThemeColor(android.R.attr.textColorSecondary, if (isDarkTheme) Color.LightGray else Color.DarkGray)
-    val dividerColor = textColorSecondary.copy(alpha = 0.12f)
-    val badgeColor = Color(0xFFE53935)
+    val colors = rememberInboxColors()
 
     Box(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
@@ -178,14 +194,13 @@ internal fun NotificationInboxOverlay(
             exit = fadeOut(),
             modifier = Modifier.fillMaxSize()
         ) {
+            // Full-bleed scrim: dims + captures touches so nothing falls through to host content
+            // behind the open panel; a tap dismisses the panel. No ripple/indication so it doesn't
+            // flash on tap. Dim 0.32 black, matched to iOS.
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    // Scrim dim matched to iOS: 0.32 black (was ~0.6) so both platforms dim equally.
                     .background(Color.Black.copy(alpha = 0.32f))
-                    // Full-bleed scrim captures touches so nothing falls through to host content
-                    // behind the open panel; a tap dismisses the panel. No ripple/indication so
-                    // the scrim does not flash on tap.
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
@@ -195,99 +210,124 @@ internal fun NotificationInboxOverlay(
             )
         }
 
-        // Slide-out hovering panel. Aligned to the top so its top margin is honored; the panel
-        // itself applies the all-sides margins (it is a floating card, not a full-height sheet).
+        // Slide-out hovering panel: a floating card (margins on all sides, rounded corners) wrapping
+        // the inbox list. Aligned top-end so its top margin is honored.
+        val panelShape = RoundedCornerShape(PANEL_CORNER_RADIUS)
         AnimatedVisibility(
             visible = panelExpanded,
             enter = slideInHorizontally(initialOffsetX = { it }) + fadeIn(),
             exit = slideOutHorizontally(targetOffsetX = { it }) + fadeOut(),
             modifier = Modifier.align(Alignment.TopEnd)
         ) {
-            InboxPanel(
-                state = state,
-                bellColor = bellColor,
-                panelColor = panelColor,
-                textColorPrimary = textColorPrimary,
-                dividerColor = dividerColor,
-                onMessageAction = { message, event ->
-                    // Controller resolves the action (dismiss / track+intercept / default nav) and
-                    // returns a navigation instruction; the overlay (which owns the Context) runs it.
-                    when (val nav = controller.handleAction(state.visibility, message, event)) {
-                        is InboxNavigation.OpenUrl -> openUrlInBrowser(context, nav.url)
-                        InboxNavigation.None -> Unit
-                    }
-                }
+            InboxListContent(
+                controller = controller,
+                colors = colors,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = PANEL_MARGIN,
+                        end = PANEL_MARGIN,
+                        top = PANEL_MARGIN,
+                        bottom = PANEL_BOTTOM_MARGIN
+                    )
+                    .widthIn(max = 480.dp)
+                    .shadow(8.dp, panelShape)
+                    .clip(panelShape)
+                    .background(colors.panelColor)
+                    // Absorb taps inside the card so they don't fall through to the dismiss scrim
+                    // (only the scrim closes the inbox). Tap-only absorber: unlike pointerInput,
+                    // clickable does not eat scroll/drag, so the list still scrolls.
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {}
+                    )
             )
         }
 
-        // Floating bell button with unread badge.
-        Box(
+        // Floating bell, pinned bottom-end. Tapping toggles the panel.
+        InboxBellContent(
+            unopenedCount = state.unopenedCount,
+            colors = colors,
+            onClick = { panelExpanded = !panelExpanded },
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp)
+        )
+    }
+}
+
+/** The bell circle + unread badge. Pure UI — no data access; callers supply [unopenedCount]. */
+@Composable
+private fun InboxBellContent(
+    unopenedCount: Int,
+    colors: InboxColors,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(56.dp)
+                .shadow(6.dp, CircleShape)
+                .clip(CircleShape)
+                .background(colors.bellColor)
+                .semantics { contentDescription = "Notifications inbox" }
+                .clickable(role = Role.Button, onClick = onClick)
         ) {
+            Image(
+                painter = painterResource(id = R.drawable.cio_inbox_notifications),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color.White)
+            )
+        }
+
+        if (unopenedCount > 0) {
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
-                    .size(56.dp)
-                    .shadow(6.dp, CircleShape)
+                    .align(Alignment.TopEnd)
+                    .offset(x = 4.dp, y = (-4).dp)
+                    .semantics { contentDescription = "$unopenedCount unread notifications" }
+                    .heightIn(min = 16.dp)
+                    .widthIn(min = 16.dp)
                     .clip(CircleShape)
-                    .background(bellColor)
-                    .semantics { contentDescription = "Notifications inbox" }
-                    .clickable(
-                        role = Role.Button,
-                        onClick = { panelExpanded = !panelExpanded }
-                    )
+                    .background(colors.badgeColor)
+                    .padding(horizontal = 4.dp)
             ) {
-                Image(
-                    painter = painterResource(id = R.drawable.cio_inbox_notifications),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(Color.White)
+                BasicText(
+                    text = unopenedCount.toString(),
+                    style = TextStyle(color = Color.White, fontSize = 10.sp, fontWeight = FontWeight.Bold)
                 )
-            }
-
-            if (state.unopenedCount > 0) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .offset(x = 4.dp, y = (-4).dp)
-                        .semantics {
-                            contentDescription = "${state.unopenedCount} unread notifications"
-                        }
-                        .heightIn(min = 16.dp)
-                        .widthIn(min = 16.dp)
-                        .clip(CircleShape)
-                        .background(badgeColor)
-                        .padding(horizontal = 4.dp)
-                ) {
-                    BasicText(
-                        text = state.unopenedCount.toString(),
-                        style = TextStyle(
-                            color = Color.White,
-                            fontSize = 10.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                    )
-                }
             }
         }
     }
 }
 
+/**
+ * The inbox content (loading / empty / Jist-rendered list), shared by [NotificationInboxView] and
+ * the [NotificationInboxOverlay] panel. Collects state from [controller], marks shown messages
+ * opened, reports per-message "shown", and routes message actions (dismiss / nav). Fills [modifier]
+ * and brings no card chrome of its own.
+ */
 @Composable
-private fun InboxPanel(
-    state: VisualInboxUiState,
-    bellColor: Color,
-    panelColor: Color,
-    textColorPrimary: Color,
-    dividerColor: Color,
-    onMessageAction: (JistInboxMessage, JistActionEvent) -> Unit,
+private fun InboxListContent(
+    controller: VisualInboxController,
+    colors: InboxColors,
     modifier: Modifier = Modifier
 ) {
-    // Decode the raw render inputs once per visibility change. Templates + theme are stable for
-    // the duration the panel shows a given snapshot.
-    val visible = state.visibility as? io.customer.messaginginapp.inbox.data.InboxVisibility.Visible
+    val context = LocalContext.current
+    val state by remember(controller) { controller.uiStateFlow() }
+        .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
+
+    // While the inbox content is shown, mark the currently-unread messages opened (deduped in the
+    // controller). For the overlay this fires when the panel opens; for a standalone view, on appear.
+    LaunchedEffect(state.visibility) {
+        controller.markOpenMessagesOpened(state.visibility)
+    }
+
+    val visible = state.visibility as? InboxVisibility.Visible
     val templates = remember(state.templatesJson) {
         InboxJistDecoder.decodeTemplates(state.templatesJson)
     }
@@ -295,52 +335,27 @@ private fun InboxPanel(
         InboxJistDecoder.toJsonObject(visible?.branding?.theme)
     }
 
-    val panelShape = RoundedCornerShape(PANEL_CORNER_RADIUS)
-    Box(
-        // Hovering card (matches iOS): margins on ALL sides — 16dp top/horizontal and a larger
-        // bottom inset that clears the floating bell — capped at a max width on large screens, with
-        // rounded corners. Margins are applied outside the shaped panel so the slide-out animation still
-        // translates the full card (corners included) off-screen.
-        modifier = modifier
-            .fillMaxSize()
-            .padding(
-                start = PANEL_MARGIN,
-                end = PANEL_MARGIN,
-                top = PANEL_MARGIN,
-                bottom = PANEL_BOTTOM_MARGIN
+    Column(modifier = modifier) {
+        when {
+            state.loading -> LoadingState(color = colors.bellColor)
+            // Render the list only when fully renderable (Visible + has messages); otherwise empty,
+            // so the list is never fed null templates/theme.
+            visible == null || state.messages.isEmpty() -> EmptyState(textColor = colors.textColorPrimary)
+            else -> InboxMessageList(
+                messages = state.messages,
+                templates = templates,
+                theme = theme,
+                dividerColor = colors.dividerColor,
+                onMessageShown = controller::notifyMessageShown,
+                onMessageAction = { message, event ->
+                    // Controller resolves the action (dismiss / track+intercept / default nav) and
+                    // returns a nav instruction; we (owning the Context) run it.
+                    when (val nav = controller.handleAction(state.visibility, message, event)) {
+                        is InboxNavigation.OpenUrl -> openUrlInBrowser(context, nav.url)
+                        InboxNavigation.None -> Unit
+                    }
+                }
             )
-            .widthIn(max = 480.dp)
-            .shadow(8.dp, panelShape)
-            .clip(panelShape)
-            .background(panelColor)
-            // Absorb taps inside the panel so they don't fall through to the dismiss scrim behind it
-            // (a tap on the panel must NOT close the inbox — only a tap on the scrim does). This is a
-            // tap-only absorber: unlike an all-consuming pointerInput, clickable does NOT eat
-            // scroll/drag gestures, so the LazyColumn below still scrolls. No ripple/indication so
-            // the panel does not flash on tap.
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = {}
-            )
-    ) {
-        // No header (title / close button) — matches web. The panel closes via the scrim tap or by
-        // tapping the bell again.
-        Column(modifier = Modifier.fillMaxSize()) {
-            when {
-                state.loading -> LoadingState(bellColor = bellColor)
-                // Render the list only when the inbox is fully renderable (Visible) and has
-                // messages. Anything else (Hidden, or visible-but-no-messages) shows empty so the
-                // list is never fed null templates/theme.
-                visible == null || state.messages.isEmpty() -> EmptyState(textColorPrimary = textColorPrimary)
-                else -> InboxMessageList(
-                    messages = state.messages,
-                    templates = templates,
-                    theme = theme,
-                    dividerColor = dividerColor,
-                    onMessageAction = onMessageAction
-                )
-            }
         }
     }
 }
@@ -351,12 +366,12 @@ private fun InboxMessageList(
     templates: Map<String, List<io.customer.jist.JistTemplate>>,
     theme: JsonObject,
     dividerColor: Color,
+    onMessageShown: (JistInboxMessage) -> Unit,
     onMessageAction: (JistInboxMessage, JistActionEvent) -> Unit,
     modifier: Modifier = Modifier
 ) {
     // No-template fallback (item 16): a message whose `type` has no decoded template can't be
-    // rendered — skip it (do NOT render a blank row) and log so it's diagnosable. Filtering here
-    // (rather than in the data layer) keeps the renderer the single owner of "is this renderable".
+    // rendered — skip it (do NOT render a blank row) and log so it's diagnosable.
     val renderable = remember(messages, templates) {
         messages.filter { message ->
             (message.type in templates).also { hasTemplate ->
@@ -371,12 +386,13 @@ private fun InboxMessageList(
     }
     LazyColumn(modifier = modifier.fillMaxWidth()) {
         items(renderable, key = { it.queueId }) { message ->
+            // Report "shown" once when the row enters composition (controller dedupes per session).
+            LaunchedEffect(message.queueId) { onMessageShown(message) }
             // Decode the per-row Jist data once per message (not on every recomposition).
             val data = remember(message) { InboxJistDecoder.decodeData(message) }
-            // Render each message with Jist: `name` selects the template by message type, `data`
-            // is the message's typed properties, `templates`/`theme` come from the data layer.
-            // `mode = Auto` lets Jist pick light/dark content per the system setting. `formatDate`
-            // turns the decoder's raw ISO dates into web-aligned relative time.
+            // Render with Jist: `name` selects the template by message type, `data` is the typed
+            // properties, `templates`/`theme` come from the data layer, `mode = Auto` follows the
+            // system light/dark setting, `formatDate` renders web-aligned relative time.
             JistView(
                 name = message.type,
                 templates = templates,
@@ -401,9 +417,8 @@ private fun InboxMessageList(
 
 /**
  * Default navigation for a resolved openUrl action (item 12): open [url] in the system browser via
- * an ACTION_VIEW intent. `FLAG_ACTIVITY_NEW_TASK` is set so it works when launched from a non-Activity
- * context (the overlay may be hosted in an application/service context). Robust to a malformed url or
- * a device with no browser: any failure is logged, never crashes.
+ * an ACTION_VIEW intent. `FLAG_ACTIVITY_NEW_TASK` is set so it works from a non-Activity context.
+ * Robust to a malformed url or a device with no browser: any failure is logged, never crashes.
  */
 private fun openUrlInBrowser(context: android.content.Context, url: String) {
     try {
@@ -417,7 +432,7 @@ private fun openUrlInBrowser(context: android.content.Context, url: String) {
 
 @Composable
 private fun LoadingState(
-    bellColor: Color,
+    color: Color,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -427,7 +442,7 @@ private fun LoadingState(
         contentAlignment = Alignment.Center
     ) {
         CustomCircularProgressIndicator(
-            color = bellColor,
+            color = color,
             modifier = Modifier.semantics {
                 contentDescription = "Loading inbox"
                 progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
@@ -438,7 +453,7 @@ private fun LoadingState(
 
 @Composable
 private fun EmptyState(
-    textColorPrimary: Color,
+    textColor: Color,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -449,11 +464,7 @@ private fun EmptyState(
     ) {
         BasicText(
             text = "No notifications yet",
-            style = TextStyle(
-                color = textColorPrimary,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Normal
-            ),
+            style = TextStyle(color = textColor, fontSize = 16.sp, fontWeight = FontWeight.Normal),
             modifier = Modifier.semantics { contentDescription = "Inbox empty" }
         )
     }
@@ -475,22 +486,59 @@ private fun CustomCircularProgressIndicator(
         label = "RotationVal"
     )
 
-    Canvas(
-        modifier = modifier
-            .size(40.dp)
-    ) {
+    Canvas(modifier = modifier.size(40.dp)) {
         val strokeWidth = 4.dp.toPx()
         drawArc(
             color = color,
             startAngle = rotation,
             sweepAngle = 270f,
             useCenter = false,
-            style = Stroke(
-                width = strokeWidth,
-                cap = StrokeCap.Round
-            )
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
         )
     }
+}
+
+/** Builds a [VisualInboxController] wired to the SDK data layer + the host's inbox event listener. */
+@Composable
+private fun rememberInboxController(): VisualInboxController = remember {
+    val module = ModuleMessagingInApp.instance()
+    VisualInboxController(
+        visualInbox = module.visualInbox(),
+        // Host-registered inbox action/event listener (items 13/14), mirroring the in-app
+        // eventListener; resolved from the same module config the host built. Null when none set.
+        inboxEventListener = module.moduleConfig.inboxEventListener
+    )
+}
+
+/** Chrome colors resolved from the host app theme (with dark-mode-aware fallbacks). */
+private data class InboxColors(
+    val bellColor: Color,
+    val panelColor: Color,
+    val textColorPrimary: Color,
+    val dividerColor: Color,
+    val badgeColor: Color
+)
+
+@Composable
+private fun rememberInboxColors(): InboxColors {
+    val isDarkTheme = isSystemInDarkTheme()
+    val textColorSecondary = rememberThemeColor(
+        android.R.attr.textColorSecondary,
+        if (isDarkTheme) Color.LightGray else Color.DarkGray
+    )
+    return InboxColors(
+        bellColor = rememberThemeColor(android.R.attr.colorAccent, Color(0xFF3451FF)),
+        panelColor = rememberThemeColor(
+            android.R.attr.colorBackground,
+            if (isDarkTheme) Color(0xFF121212) else Color.White
+        ),
+        textColorPrimary = rememberThemeColor(
+            android.R.attr.textColorPrimary,
+            if (isDarkTheme) Color.White else Color.Black
+        ),
+        dividerColor = textColorSecondary.copy(alpha = 0.12f),
+        badgeColor = Color(0xFFE53935)
+    )
 }
 
 @Composable

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -1,8 +1,13 @@
 package io.customer.messaginginbox
 
+import io.customer.jist.JistActionEvent
 import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
+import io.customer.messaginginapp.type.InboxActionMessage
+import io.customer.messaginginapp.type.InboxEventListener
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -12,6 +17,9 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Read-only UI snapshot of the visual inbox, derived from the [VisualInbox] data layer. The
@@ -46,6 +54,13 @@ internal data class VisualInboxUiState(
  */
 internal class VisualInboxController(
     private val visualInbox: VisualInbox,
+    // Host-registered listener (item 13) notified when a non-dismiss action is taken. When it
+    // returns true the host handled the action and the SDK skips its default navigation. Resolved
+    // from the in-app module config at construction; null when the host registered none.
+    private val inboxEventListener: InboxEventListener? = null,
+    // Logger for action diagnostics. Defaults to the SDK logger; injectable so unit tests can pass a
+    // relaxed mock (the real LogcatLogger calls android.util.Log, which is not mocked on the JVM).
+    private val logger: Logger = SDKComponent.logger,
     // Dispatcher the uiStateFlow upstream (load/snapshot) runs on. Defaults to IO so the
     // retry/backoff + parsing in load() never runs on the main (collector) thread; injectable so
     // unit tests can substitute a TestDispatcher and keep the flow on virtual time.
@@ -177,4 +192,186 @@ internal class VisualInboxController(
             deleteInFlight.set(false)
         }
     }
+
+    /**
+     * Handle a Jist action taken on an inbox message. Web/iOS parity flow:
+     *  1. A dismiss action (item already shipped) removes the message and returns [InboxNavigation.None].
+     *  2. Any other action is a "click": we track a clicked metric (reusing the existing
+     *     [VisualInbox.trackMessageClicked] plumbing — no new network path) exactly once per
+     *     queueId, then give the host listener (item 13) a chance to intercept. If the host returns
+     *     true it fully handled the action and we return [InboxNavigation.None].
+     *  3. Otherwise the SDK applies its default navigation (item 12): an http(s) / openUrl / newTab
+     *     url opens in the system browser ([InboxNavigation.OpenUrl]); a deeplink is handed back to
+     *     the host ([InboxNavigation.None] after logging — the SDK cannot resolve app routes); a
+     *     missing/malformed url is a logged no-op.
+     *
+     * Returns a [InboxNavigation] the (Context-bearing) overlay executes, keeping this controller
+     * free of Android Intent / Context dependencies so it stays unit-testable.
+     */
+    fun handleAction(
+        visibility: InboxVisibility,
+        message: JistInboxMessage,
+        event: JistActionEvent
+    ): InboxNavigation {
+        val resolution = resolveInboxAction(event)
+        if (resolution is InboxAction.Dismiss) {
+            dismissMessage(visibility, message.queueId)
+            return InboxNavigation.None
+        }
+
+        val url = resolution.url
+        // Track the click against the same InboxMessage the UI renders (resolved from the visible
+        // set), reusing the existing track-clicked plumbing. Deduped per queueId so a repeated tap
+        // before the row updates does not double-count.
+        trackClicked(visibility, message, event.name)
+
+        // Host interception (item 13): true => host handled it, SDK does nothing further.
+        if (notifyHostHandled(message, event.name, url.orEmpty())) {
+            return InboxNavigation.None
+        }
+
+        // SDK default navigation (item 12).
+        return when (resolution) {
+            is InboxAction.OpenUrl -> InboxNavigation.OpenUrl(resolution.url)
+            is InboxAction.Deeplink -> {
+                logger.debug(
+                    "$INBOX_LOG_TAG deeplink '${resolution.url}' on ${message.queueId} not handled by host; " +
+                        "SDK cannot resolve app routes, no-op"
+                )
+                InboxNavigation.None
+            }
+
+            is InboxAction.Unknown -> {
+                logger.debug(
+                    "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
+                        "on ${message.queueId}: no resolvable url/behavior, no-op"
+                )
+                InboxNavigation.None
+            }
+
+            is InboxAction.Dismiss -> InboxNavigation.None // unreachable; handled above
+        }
+    }
+
+    /** Track a clicked metric for [message], once per queueId. Reuses [VisualInbox.trackMessageClicked]. */
+    private fun trackClicked(visibility: InboxVisibility, message: JistInboxMessage, actionName: String?) {
+        val visible = visibility as? InboxVisibility.Visible ?: return
+        if (!clickedQueueIds.add(message.queueId)) return
+        val tracked = visible.messages.firstOrNull { it.queueId == message.queueId } ?: return
+        visualInbox.trackMessageClicked(tracked, actionName)
+    }
+
+    /** Invoke the host listener (if any), returning true if the host handled the action. */
+    private fun notifyHostHandled(message: JistInboxMessage, actionName: String, actionValue: String): Boolean {
+        val listener = inboxEventListener ?: return false
+        return try {
+            listener.messageActionTaken(
+                message = InboxActionMessage(messageId = message.queueId, deliveryId = message.deliveryId),
+                actionName = actionName,
+                actionValue = actionValue
+            )
+        } catch (ex: Exception) {
+            // A throwing host listener must not break the SDK; log and fall back to default nav.
+            logger.error("$INBOX_LOG_TAG inbox event listener threw: ${ex.message}")
+            false
+        }
+    }
+
+    private companion object {
+        const val INBOX_LOG_TAG = "[CIO-Inbox]"
+    }
+
+    // Dedupe guard for click tracking: a message clicked in this session is tracked once.
+    private val clickedQueueIds = HashSet<String>()
 }
+
+/**
+ * The SDK's resolved interpretation of a Jist inbox action, derived from the action's
+ * `name` / `data.behavior` / `data.url` shape. The live inbox emits the dismiss action as
+ * `name = "messageAction"` with `data.behavior == "dismiss"`; other actions carry a `data.url`
+ * (and/or an `openUrl` / `newTab` / `deeplink` behavior). See [resolveInboxAction].
+ */
+internal sealed interface InboxAction {
+    /** The resolved url for the action, when present. */
+    val url: String?
+
+    /** Remove (delete) the message. Web parity for a dismiss action. */
+    object Dismiss : InboxAction {
+        override val url: String? get() = null
+    }
+
+    /** Open [url] in the system browser (http(s) / openUrl / newTab). */
+    data class OpenUrl(override val url: String) : InboxAction
+
+    /** A deeplink the host must resolve (the SDK cannot resolve app routes). */
+    data class Deeplink(override val url: String) : InboxAction
+
+    /** No resolvable url/behavior (e.g. missing/malformed url) — a no-op. */
+    data class Unknown(override val url: String?) : InboxAction
+}
+
+/** Instruction the overlay (which owns an Android Context) executes after [VisualInboxController.handleAction]. */
+internal sealed interface InboxNavigation {
+    /** Nothing for the overlay to do (dismiss, host-handled, deeplink, or no-op already handled). */
+    object None : InboxNavigation
+
+    /** Open [url] in the system browser via an ACTION_VIEW intent. */
+    data class OpenUrl(val url: String) : InboxNavigation
+}
+
+/**
+ * Maps a Jist action event to the SDK's [InboxAction]. Determined from the action `name`,
+ * `data.behavior` and `data.url`:
+ *  - dismiss: `data.behavior == "dismiss"`, or the Jist-demo sentinels `name == "dismiss"` /
+ *    `data.url == "#dismiss"`.
+ *  - openUrl: `data.behavior` is `openUrl` / `newTab`, OR (absent a behavior) `data.url` is an
+ *    http(s) url.
+ *  - deeplink: `data.behavior == "deeplink"`, OR (absent a behavior) `data.url` is a non-http(s)
+ *    scheme url (e.g. `myapp://...`).
+ *  - unknown: no resolvable url/behavior (missing/malformed) — robust to nulls, never throws.
+ */
+internal fun resolveInboxAction(event: JistActionEvent): InboxAction {
+    val behavior = actionBehavior(event)?.lowercase()
+    val url = actionUrl(event)?.takeIf { it.isNotBlank() }
+
+    val isDismiss = behavior == DISMISS_BEHAVIOR ||
+        event.name == DISMISS_ACTION_NAME ||
+        actionUrl(event) == DISMISS_URL
+    if (isDismiss) return InboxAction.Dismiss
+
+    return when (behavior) {
+        OPEN_URL_BEHAVIOR, NEW_TAB_BEHAVIOR -> if (url != null) InboxAction.OpenUrl(url) else InboxAction.Unknown(null)
+        DEEPLINK_BEHAVIOR -> if (url != null) InboxAction.Deeplink(url) else InboxAction.Unknown(null)
+        else -> when {
+            url == null -> InboxAction.Unknown(null)
+            isHttpUrl(url) -> InboxAction.OpenUrl(url)
+            else -> InboxAction.Deeplink(url)
+        }
+    }
+}
+
+/** True for `http://` / `https://` urls (case-insensitive). These open in the system browser. */
+private fun isHttpUrl(url: String): Boolean =
+    url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
+
+/**
+ * Extracts the `url` string from a Jist action event's data object, or null if absent / not a
+ * string. Safe casts throughout: a non-object `data` or non-primitive `url` yields null.
+ */
+private fun actionUrl(event: JistActionEvent): String? =
+    ((event.data as? JsonObject)?.get("url") as? JsonPrimitive)?.contentOrNull
+
+/**
+ * Extracts the `behavior` string from a Jist action event's data object (e.g. the live inbox's
+ * `messageAction = { behavior: "dismiss" }`), or null if absent / not a string. Safe casts.
+ */
+private fun actionBehavior(event: JistActionEvent): String? =
+    ((event.data as? JsonObject)?.get("behavior") as? JsonPrimitive)?.contentOrNull
+
+/** Jist action `behavior` / sentinel constants matched by [resolveInboxAction] (compared lowercase). */
+private const val DISMISS_BEHAVIOR = "dismiss"
+private const val DISMISS_ACTION_NAME = "dismiss"
+private const val DISMISS_URL = "#dismiss"
+private const val OPEN_URL_BEHAVIOR = "openurl"
+private const val NEW_TAB_BEHAVIOR = "newtab"
+private const val DEEPLINK_BEHAVIOR = "deeplink"

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -1,6 +1,7 @@
 package io.customer.messaginginbox
 
 import io.customer.jist.JistActionEvent
+import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
@@ -164,6 +165,8 @@ internal class VisualInboxController(
                 .forEach { message ->
                     markedOpenedQueueIds.add(message.queueId)
                     visualInbox.markMessageOpened(message)
+                    // Observational host callback (item 14): a message was marked opened.
+                    notifyListener { messageOpened(message.toActionMessage()) }
                 }
         } finally {
             markInFlight.set(false)
@@ -188,6 +191,8 @@ internal class VisualInboxController(
             val message = visible.messages.firstOrNull { it.queueId == queueId } ?: return
             deletedQueueIds.add(queueId)
             visualInbox.markMessageDeleted(message)
+            // Observational host callback (item 14): a message was dismissed/removed.
+            notifyListener { messageDismissed(message.toActionMessage()) }
         } finally {
             deleteInFlight.set(false)
         }
@@ -253,6 +258,19 @@ internal class VisualInboxController(
         }
     }
 
+    /**
+     * Observational host callback (item 14): notify that [message] was first shown/rendered in the
+     * inbox view. Deduped per queueId so the host is notified exactly once per message for the life
+     * of this controller (the view may recompose/re-render the same row many times). Safe to call
+     * from the renderer on every render.
+     */
+    fun notifyMessageShown(message: JistInboxMessage) {
+        if (!shownQueueIds.add(message.queueId)) return
+        notifyListener {
+            messageShown(InboxActionMessage(messageId = message.queueId, deliveryId = message.deliveryId))
+        }
+    }
+
     /** Track a clicked metric for [message], once per queueId. Reuses [VisualInbox.trackMessageClicked]. */
     private fun trackClicked(visibility: InboxVisibility, message: JistInboxMessage, actionName: String?) {
         val visible = visibility as? InboxVisibility.Visible ?: return
@@ -277,13 +295,35 @@ internal class VisualInboxController(
         }
     }
 
+    /**
+     * Invoke an observational callback (shown / opened / dismissed) on the host listener (if any).
+     * A throwing host listener must never break the SDK, so any exception is caught and logged.
+     * Resolved from the same [inboxEventListener] (MessagingInAppModuleConfig.inboxEventListener) as
+     * [messageActionTaken]; a null listener is a no-op.
+     */
+    private inline fun notifyListener(block: InboxEventListener.() -> Unit) {
+        val listener = inboxEventListener ?: return
+        try {
+            listener.block()
+        } catch (ex: Exception) {
+            logger.error("$INBOX_LOG_TAG inbox event listener threw: ${ex.message}")
+        }
+    }
+
     private companion object {
         const val INBOX_LOG_TAG = "[CIO-Inbox]"
     }
 
     // Dedupe guard for click tracking: a message clicked in this session is tracked once.
     private val clickedQueueIds = HashSet<String>()
+
+    // Dedupe guard for the observational messageShown callback: notified once per queueId.
+    private val shownQueueIds = HashSet<String>()
 }
+
+/** Build the public [InboxActionMessage] identity handed to [InboxEventListener] from an [InboxMessage]. */
+private fun InboxMessage.toActionMessage(): InboxActionMessage =
+    InboxActionMessage(messageId = queueId, deliveryId = deliveryId)
 
 /**
  * The SDK's resolved interpretation of a Jist inbox action, derived from the action's

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -224,38 +224,51 @@ internal class VisualInboxController(
             return InboxNavigation.None
         }
 
+        // Auto-dismiss-on-click: an action message can carry `data.dismiss == true` alongside its
+        // behavior (e.g. performAction), meaning "run the action AND remove the message". Captured
+        // before any early-return so it applies whether or not the host intercepts the action.
+        val dismissAfterAction = actionDismissFlag(event)
         val url = resolution.url
         // Track the click against the same InboxMessage the UI renders (resolved from the visible
         // set), reusing the existing track-clicked plumbing. Deduped per queueId so a repeated tap
         // before the row updates does not double-count.
         trackClicked(visibility, message, event.name)
 
-        // Host interception (item 13): true => host handled it, SDK does nothing further.
-        if (notifyHostHandled(message, event.name, url.orEmpty())) {
-            return InboxNavigation.None
+        // Host interception (item 13): true => host handled it, SDK runs no default nav (but still
+        // honors the dismiss flag below).
+        val handledByHost = notifyHostHandled(message, event.name, url.orEmpty())
+
+        // SDK default navigation (item 12), unless the host handled it.
+        val navigation = if (handledByHost) {
+            InboxNavigation.None
+        } else {
+            when (resolution) {
+                is InboxAction.OpenUrl -> InboxNavigation.OpenUrl(resolution.url)
+                is InboxAction.Deeplink -> {
+                    logger.debug(
+                        "$INBOX_LOG_TAG deeplink '${resolution.url}' on ${message.queueId} not handled by host; " +
+                            "SDK cannot resolve app routes, no-op"
+                    )
+                    InboxNavigation.None
+                }
+
+                is InboxAction.Unknown -> {
+                    logger.debug(
+                        "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
+                            "on ${message.queueId}: no resolvable url/behavior, no-op"
+                    )
+                    InboxNavigation.None
+                }
+
+                is InboxAction.Dismiss -> InboxNavigation.None // unreachable; handled above
+            }
         }
 
-        // SDK default navigation (item 12).
-        return when (resolution) {
-            is InboxAction.OpenUrl -> InboxNavigation.OpenUrl(resolution.url)
-            is InboxAction.Deeplink -> {
-                logger.debug(
-                    "$INBOX_LOG_TAG deeplink '${resolution.url}' on ${message.queueId} not handled by host; " +
-                        "SDK cannot resolve app routes, no-op"
-                )
-                InboxNavigation.None
-            }
-
-            is InboxAction.Unknown -> {
-                logger.debug(
-                    "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
-                        "on ${message.queueId}: no resolvable url/behavior, no-op"
-                )
-                InboxNavigation.None
-            }
-
-            is InboxAction.Dismiss -> InboxNavigation.None // unreachable; handled above
+        // Honor `data.dismiss == true` after running the action (regardless of host handling / nav).
+        if (dismissAfterAction) {
+            dismissMessage(visibility, message.queueId)
         }
+        return navigation
     }
 
     /**
@@ -409,6 +422,13 @@ private fun actionUrl(event: JistActionEvent): String? =
  */
 private fun actionBehavior(event: JistActionEvent): String? =
     ((event.data as? JsonObject)?.get("behavior") as? JsonPrimitive)?.contentOrNull
+
+/**
+ * True when the action carries `data.dismiss == true` — "auto dismiss on click": remove the message
+ * after running its (non-dismiss) action. Matches both a JSON boolean `true` and the string `"true"`.
+ */
+private fun actionDismissFlag(event: JistActionEvent): Boolean =
+    ((event.data as? JsonObject)?.get("dismiss") as? JsonPrimitive)?.contentOrNull == "true"
 
 /** Jist action `behavior` / sentinel constants matched by [resolveInboxAction] (compared lowercase). */
 private const val DISMISS_BEHAVIOR = "dismiss"

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -274,8 +274,10 @@ internal class VisualInboxController(
     /** Track a clicked metric for [message], once per queueId. Reuses [VisualInbox.trackMessageClicked]. */
     private fun trackClicked(visibility: InboxVisibility, message: JistInboxMessage, actionName: String?) {
         val visible = visibility as? InboxVisibility.Visible ?: return
-        if (!clickedQueueIds.add(message.queueId)) return
         val tracked = visible.messages.firstOrNull { it.queueId == message.queueId } ?: return
+        // Reserve only AFTER confirming the message exists, so a failed lookup never permanently
+        // dedupes (blocks) the click metric for later taps on the same message.
+        if (!clickedQueueIds.add(message.queueId)) return
         visualInbox.trackMessageClicked(tracked, actionName)
     }
 

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -1,0 +1,244 @@
+package io.customer.messaginginbox
+
+import io.customer.jist.JistActionEvent
+import io.customer.messaginginapp.gist.data.model.InboxMessage
+import io.customer.messaginginapp.inbox.VisualInbox
+import io.customer.messaginginapp.inbox.data.Branding
+import io.customer.messaginginapp.inbox.data.InboxVisibility
+import io.customer.messaginginapp.inbox.jist.JistInboxAdapter
+import io.customer.messaginginapp.type.InboxActionMessage
+import io.customer.messaginginapp.type.InboxEventListener
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Date
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.Test
+
+/**
+ * Unit tests for inbox action mapping (items 12 + 13): [resolveInboxAction] (dismiss / openUrl /
+ * deeplink / unknown) and [VisualInboxController.handleAction] (dismiss removes; non-dismiss tracks
+ * clicked + offers host interception + returns the correct default navigation).
+ */
+class InboxActionTest {
+
+    private fun message(queueId: String): InboxMessage = InboxMessage(
+        queueId = queueId,
+        deliveryId = "d-$queueId",
+        expiry = null,
+        sentAt = Date(0),
+        topics = emptyList(),
+        type = "basic",
+        opened = false,
+        priority = null,
+        properties = emptyMap()
+    )
+
+    private fun visible(messages: List<InboxMessage>): InboxVisibility.Visible =
+        InboxVisibility.Visible(templatesJson = "{}", branding = Branding(), messages = messages, fromCache = false)
+
+    /** Builds a Jist action event whose `data` object carries optional `behavior` / `url`. */
+    private fun event(name: String = "messageAction", behavior: String? = null, url: String? = null): JistActionEvent {
+        val data = JsonObject(
+            buildMap {
+                if (behavior != null) put("behavior", JsonPrimitive(behavior))
+                if (url != null) put("url", JsonPrimitive(url))
+            }
+        )
+        return JistActionEvent(component = "button", name = name, data = data, meta = JsonObject(emptyMap()))
+    }
+
+    // --- resolveInboxAction mapping ---
+
+    @Test
+    fun resolve_givenDismissBehavior_expectDismiss() {
+        resolveInboxAction(event(behavior = "dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
+    }
+
+    @Test
+    fun resolve_givenDismissSentinels_expectDismiss() {
+        resolveInboxAction(event(name = "dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
+        resolveInboxAction(event(url = "#dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
+    }
+
+    @Test
+    fun resolve_givenOpenUrlBehavior_expectOpenUrl() {
+        val action = resolveInboxAction(event(behavior = "openUrl", url = "https://example.com"))
+        action.shouldBeInstanceOf<InboxAction.OpenUrl>()
+        action.url shouldBeEqualTo "https://example.com"
+    }
+
+    @Test
+    fun resolve_givenNewTabBehavior_expectOpenUrl() {
+        resolveInboxAction(event(behavior = "newTab", url = "https://x.io")).shouldBeInstanceOf<InboxAction.OpenUrl>()
+    }
+
+    @Test
+    fun resolve_givenHttpUrlNoBehavior_expectOpenUrl() {
+        resolveInboxAction(event(url = "http://plain.example")).shouldBeInstanceOf<InboxAction.OpenUrl>()
+        resolveInboxAction(event(url = "https://plain.example")).shouldBeInstanceOf<InboxAction.OpenUrl>()
+    }
+
+    @Test
+    fun resolve_givenDeeplinkBehavior_expectDeeplink() {
+        val action = resolveInboxAction(event(behavior = "deeplink", url = "myapp://home"))
+        action.shouldBeInstanceOf<InboxAction.Deeplink>()
+        action.url shouldBeEqualTo "myapp://home"
+    }
+
+    @Test
+    fun resolve_givenNonHttpSchemeNoBehavior_expectDeeplink() {
+        resolveInboxAction(event(url = "myapp://profile")).shouldBeInstanceOf<InboxAction.Deeplink>()
+    }
+
+    @Test
+    fun resolve_givenNoUrlOrBehavior_expectUnknown() {
+        resolveInboxAction(event()).shouldBeInstanceOf<InboxAction.Unknown>()
+    }
+
+    @Test
+    fun resolve_givenBlankUrl_expectUnknown() {
+        resolveInboxAction(event(url = "   ")).shouldBeInstanceOf<InboxAction.Unknown>()
+    }
+
+    @Test
+    fun resolve_givenNonObjectData_expectUnknownNoThrow() {
+        // data is a primitive, not an object — safe casts must yield Unknown, never throw.
+        val ev = JistActionEvent(component = "c", name = "x", data = JsonPrimitive("oops"), meta = JsonObject(emptyMap()))
+        resolveInboxAction(ev).shouldBeInstanceOf<InboxAction.Unknown>()
+    }
+
+    // --- handleAction: dismiss vs openUrl vs deeplink vs host-handled ---
+
+    @Test
+    fun handleAction_givenDismiss_expectMarkedDeletedAndNoNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox)
+
+        val nav = controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "dismiss"))
+
+        nav shouldBeEqualTo InboxNavigation.None
+        verify(exactly = 1) { visualInbox.markMessageDeleted(match { it.queueId == "a" }) }
+        // Dismiss is not a click — no clicked metric.
+        verify(exactly = 0) { visualInbox.trackMessageClicked(any(), any()) }
+    }
+
+    @Test
+    fun handleAction_givenOpenUrlNoListener_expectTrackedAndOpenUrlNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox)
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(name = "messageAction", url = "https://example.com")
+        )
+
+        nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
+        (nav as InboxNavigation.OpenUrl).url shouldBeEqualTo "https://example.com"
+        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, "messageAction") }
+    }
+
+    @Test
+    fun handleAction_givenDeeplinkNoListener_expectTrackedAndNoNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        // Relaxed logger mock: the deeplink path logs, and the real LogcatLogger calls
+        // android.util.Log (not mocked on the JVM).
+        val controller = VisualInboxController(visualInbox, logger = mockk(relaxed = true))
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(behavior = "deeplink", url = "myapp://home")
+        )
+
+        // No listener => deeplink is logged + no-op (SDK can't resolve app routes).
+        nav shouldBeEqualTo InboxNavigation.None
+        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, any()) }
+    }
+
+    @Test
+    fun handleAction_givenHostHandlesAction_expectTrackedAndNoNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val captured = mutableListOf<Triple<InboxActionMessage, String, String>>()
+        val listener = object : InboxEventListener {
+            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean {
+                captured.add(Triple(message, actionName, actionValue))
+                return true // host handled it
+            }
+        }
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(name = "messageAction", url = "https://example.com")
+        )
+
+        // Host handled it: even though it was an http url, the SDK does not navigate.
+        nav shouldBeEqualTo InboxNavigation.None
+        // Still tracked (a click happened) and the listener got message id + delivery + action value.
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+        captured.size shouldBeEqualTo 1
+        captured.first().first.messageId shouldBeEqualTo "a"
+        captured.first().first.deliveryId shouldBeEqualTo "d-a"
+        captured.first().third shouldBeEqualTo "https://example.com"
+    }
+
+    @Test
+    fun handleAction_givenHostDeclines_expectSdkDefaultNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val listener = object : InboxEventListener {
+            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String) = false
+        }
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(url = "https://example.com")
+        )
+
+        nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
+    }
+
+    @Test
+    fun handleAction_givenThrowingHostListener_expectFallbackToDefaultNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val listener = object : InboxEventListener {
+            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean =
+                throw RuntimeException("boom")
+        }
+        // Relaxed logger: the catch branch logs the listener failure.
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener, logger = mockk(relaxed = true))
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(url = "https://example.com")
+        )
+
+        // A throwing listener must not crash the SDK; it falls back to default navigation.
+        nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
+    }
+
+    @Test
+    fun handleAction_calledTwiceSameMessage_expectTrackedOnce() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox)
+
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(url = "https://x.io"))
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(url = "https://x.io"))
+
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+    }
+}

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -241,4 +241,56 @@ class InboxActionTest {
 
         verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
     }
+
+    // --- observe callbacks (item 14): shown / opened / dismissed ---
+
+    private class RecordingListener : InboxEventListener {
+        val shown = mutableListOf<String>()
+        val opened = mutableListOf<String>()
+        val dismissed = mutableListOf<String>()
+        override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String) = false
+        override fun messageShown(message: InboxActionMessage) { shown.add(message.messageId) }
+        override fun messageOpened(message: InboxActionMessage) { opened.add(message.messageId) }
+        override fun messageDismissed(message: InboxActionMessage) { dismissed.add(message.messageId) }
+    }
+
+    @Test
+    fun markOpenMessagesOpened_givenUnopened_expectMessageOpenedFired() {
+        val messages = listOf(message("a"), message("b"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val listener = RecordingListener()
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+
+        controller.markOpenMessagesOpened(visible(messages))
+
+        listener.opened shouldBeEqualTo listOf("a", "b")
+        verify(exactly = 1) { visualInbox.markMessageOpened(match { it.queueId == "a" }) }
+        verify(exactly = 1) { visualInbox.markMessageOpened(match { it.queueId == "b" }) }
+    }
+
+    @Test
+    fun dismissMessage_expectMessageDismissedFired() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val listener = RecordingListener()
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+
+        controller.dismissMessage(visible(messages), "a")
+
+        listener.dismissed shouldBeEqualTo listOf("a")
+        verify(exactly = 1) { visualInbox.markMessageDeleted(match { it.queueId == "a" }) }
+    }
+
+    @Test
+    fun notifyMessageShown_calledTwiceSameMessage_expectShownFiredOnce() {
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val listener = RecordingListener()
+        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val jist = JistInboxAdapter.toJist(message("a"))
+
+        controller.notifyMessageShown(jist)
+        controller.notifyMessageShown(jist)
+
+        listener.shown shouldBeEqualTo listOf("a")
+    }
 }


### PR DESCRIPTION
Adds inbox message action handling: a public host listener to intercept/override actions, default system-browser navigation for url actions, and click metric tracking (dismiss behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public SDK APIs and user-facing navigation (external URLs) plus analytics callbacks; behavior is well-tested but affects host integration and message interaction paths.
> 
> **Overview**
> Adds a public **`InboxEventListener`** (via `MessagingInAppModuleConfig.setInboxEventListener`) so hosts can **intercept** inbox taps (`messageActionTaken` returning `true` skips SDK navigation) and observe **shown / opened / dismissed** events on `InboxActionMessage`.
> 
> **`VisualInboxController`** now owns full Jist action handling: dismiss (unchanged), **deduped click metrics**, host interception, **`data.dismiss` auto-remove after non-dismiss actions**, and default **http(s) → system browser** navigation; deeplinks stay with the host.
> 
> The Compose inbox layer is **split and promoted**: public **`NotificationInboxBell`**, **`NotificationInboxView`**, and **`NotificationInboxOverlay`** (overlay is no longer internal-only). Shared **`InboxListContent`** wires actions through the controller; **workspace branding** drives bell/panel/badge colors (with dark-mode overrides and theme fallbacks). Panel/scrim visibility gates on empty inbox to match iOS.
> 
> Unit tests cover **`resolveInboxAction`** and controller behavior including listener edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3391ed28e1dceadf43aefbc8a154cc860d9b43fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->