### PR TITLE
chore(geofence): re-fetch geofences on login

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -146,13 +146,14 @@ class CustomerIO private constructor(
         // subscribe to journey events emitted from push/in-app module to send them via data pipelines
         subscribeToJourneyEvents()
         // republish profile/anonymous events for late-added modules
-        publishUserChanged(analytics.userId())
+        publishUserChanged()
     }
 
     /** Persists the userId before publishing so subscribers that read [secureUserStore] don't race the event. */
-    private fun publishUserChanged(userId: String?) {
+    private fun publishUserChanged(userId: String? = analytics.userId()) {
+        val anonymousId = analytics.anonymousId()
         secureUserStore.saveUserId(userId)
-        eventBus.publish(Event.UserChangedEvent(userId = userId, anonymousId = analytics.anonymousId()))
+        eventBus.publish(Event.UserChangedEvent(userId = userId, anonymousId = anonymousId))
     }
 
     private fun subscribeToJourneyEvents() {

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -146,13 +146,13 @@ class CustomerIO private constructor(
         // subscribe to journey events emitted from push/in-app module to send them via data pipelines
         subscribeToJourneyEvents()
         // republish profile/anonymous events for late-added modules
-        postUserIdentificationEvents()
+        publishUserChanged(analytics.userId())
     }
 
-    private fun postUserIdentificationEvents() {
-        val userId = analytics.userId()
-        val anonymousId = analytics.anonymousId()
-        eventBus.publish(Event.UserChangedEvent(userId = userId, anonymousId = anonymousId))
+    /** Persists the userId before publishing so subscribers that read [secureUserStore] don't race the event. */
+    private fun publishUserChanged(userId: String?) {
+        secureUserStore.saveUserId(userId)
+        eventBus.publish(Event.UserChangedEvent(userId = userId, anonymousId = analytics.anonymousId()))
     }
 
     private fun subscribeToJourneyEvents() {
@@ -164,11 +164,6 @@ class CustomerIO private constructor(
         }
         eventBus.subscribe<Event.RegisterDeviceTokenEvent> {
             registerDeviceToken(deviceToken = it.token)
-        }
-        // Cache user identity encrypted for direct API calls (WorkManager workers,
-        // BroadcastReceivers) that run without full SDK initialization.
-        eventBus.subscribe<Event.UserChangedEvent> {
-            secureUserStore.saveUserId(it.userId)
         }
         eventBus.subscribe<Event.ResetEvent> {
             secureUserStore.clearAll()
@@ -307,10 +302,9 @@ class CustomerIO private constructor(
             traits = traits,
             serializationStrategy = serializationStrategy
         )
-        // publish event to EventBus for other modules to consume
-        // Must come after analytics.identify() so that analytics.userId() returns the
-        // new userId when downstream subscribers (e.g. location resync) gate on it.
-        eventBus.publish(Event.UserChangedEvent(userId = userId, anonymousId = analytics.anonymousId()))
+        // Publish for other modules. Must come after analytics.identify() so analytics.userId()
+        // returns the new userId for subscribers that gate on it (e.g. location resync).
+        publishUserChanged(userId)
 
         if (isFirstTimeIdentifying || isChangingIdentifiedProfile) {
             logger.debug("first time identified or changing identified profile")

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
@@ -7,18 +7,24 @@ import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
 
 class DataPipelineEventBusInteractionTest : JUnitTest() {
     private lateinit var eventBus: EventBus
+
+    // 'mock' prefix to avoid shadowing the real androidSDKComponent.secureUserStore.
+    private val mockSecureUserStore: SecureUserStore = mockk(relaxed = true)
 
     override fun setup(testConfig: TestConfig) {
         super.setup(
             testConfiguration {
                 diGraph {
                     sdk { overrideDependency<EventBus>(mockk(relaxed = true)) }
+                    android { overrideDependency<SecureUserStore>(mockSecureUserStore) }
                 }
             }
         )
@@ -36,5 +42,16 @@ class DataPipelineEventBusInteractionTest : JUnitTest() {
         assertCalledOnce { eventBus.subscribe(Event.TrackPushMetricEvent::class, any()) }
         assertCalledOnce { eventBus.subscribe(Event.TrackInAppMetricEvent::class, any()) }
         assertCalledOnce { eventBus.subscribe(Event.RegisterDeviceTokenEvent::class, any()) }
+    }
+
+    @Test
+    fun givenIdentify_expectSecureUserStoreWrittenSynchronously() {
+        // identify() must persist the userId to secureUserStore synchronously (before the
+        // UserChangedEvent is delivered) so subscribers gating on it (geofence sync) and
+        // direct-API consumers see the new identity immediately. EventBus is mocked, so this
+        // passes only if the write happens in identify() itself, not via event dispatch.
+        sdkInstance.identify("user-sync")
+
+        verify(exactly = 1) { mockSecureUserStore.saveUserId("user-sync") }
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -372,11 +372,12 @@ internal class GeofenceRepositoryImpl(
             logger.logSyncSkipped("reset superseded by signed-in user")
             return@withLock Result.success(Unit)
         }
-        // Clear OS-side FIRST, then wipe user-specific store state. On
+        // Clear OS-side FIRST, then wipe user-scoped store state. On
         // manager.clearAll failure preserve everything so the next refresh's
         // stale-cleanup diff retries removal — without it, unremoved OS regs
-        // orphan with no record to drive cleanup. Workspace cache (regions,
-        // config, lastSync) is always preserved.
+        // orphan with no record to drive cleanup. Cached regions/config are
+        // kept; the freshness timestamp is dropped (in clearUserScopedState)
+        // so the next login re-fetches.
         manager.clearAll().also { result ->
             if (result.isSuccess) {
                 store.clearUserScopedState()

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -16,24 +16,26 @@ import kotlinx.serialization.builtins.SetSerializer
 import kotlinx.serialization.builtins.serializer
 
 /**
- * State for the geofence sync pipeline. Keys are split into two lifecycles:
+ * State for the geofence sync pipeline. Keys split by sign-out lifecycle
+ * (see [clearUserScopedState]):
  *
- * Workspace-level (survive sign-out — see [clearUserScopedState]):
- *   cachedRegions     — full backend response; source for tier-A re-rank.
- *   cachedConfig      — last server-driven thresholds.
- *   lastSyncTimestamp — freshness throttle for identify / app-launch.
+ * Preserved across sign-out:
+ *   cachedRegions — full backend response; source for tier-A re-rank.
+ *   cachedConfig  — last server-driven thresholds.
  *
- * User-specific (wiped on sign-out):
+ * Cleared on sign-out:
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
  *                                  closer to the user's real position than the anchor.
+ *   lastSyncTimestamp           — freshness throttle; cleared so the next login re-fetches.
  *
- * Split rationale: backend `/v1/geofences/nearby` is workspace-scoped (no
- * userId on the wire), so the workspace cache is valid for any user in the
- * same workspace. Preserving it across sign-out skips a redundant API call
- * on a quick re-login. If backend ever adds per-user filtering, revisit.
+ * Rationale: backend `/v1/geofences/nearby` is workspace-scoped (no userId on
+ * the wire), so cached regions/config stay valid for any user in the workspace
+ * and are kept. Dropping the freshness timestamp makes the next login re-fetch
+ * instead of riding the prior session's window. If backend ever adds per-user
+ * filtering, revisit.
  *
  * Decoding is schema-drift safe via [GeofenceJsonSerializer]: parse failures
  * wipe the key and return null/empty rather than propagating an exception up
@@ -72,9 +74,9 @@ internal interface GeofenceRegionStore {
     fun setLastSyncTimestamp(timestamp: Long)
 
     /**
-     * Sign-out wipe. Drops user-specific keys (anchor, movement-trigger
-     * location, registered IDs); preserves workspace cache (regions, config,
-     * last-sync) so a quick re-login skips a redundant API call.
+     * Sign-out wipe. Drops the anchor, movement-trigger location, registered
+     * IDs and the freshness timestamp (so the next login re-fetches); keeps
+     * cached regions/config.
      */
     fun clearUserScopedState()
 
@@ -149,6 +151,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
             remove(KEY_LAST_REGISTRATION_UPTIME)
+            remove(KEY_LAST_SYNC)
         }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -77,10 +77,11 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
     @Test
     fun refresh_givenFreshCacheButOsRegsWiped_expectLocalRefreshFromCache() = runTest {
-        // Sign-out → sign-in within the freshness window: workspace cache
-        // survived but OS regs + registeredIds were wiped. Must re-register
-        // from cache instead of skipping, otherwise the new user has no OS
-        // geofences until the next stale-window expiry.
+        // Safety net: cache is still time-fresh but no OS regs are live
+        // (registeredIds empty) — re-register from cache rather than skip, else
+        // nothing is monitored until the stale window expires. (Sign-out clears
+        // the freshness timestamp, so the sign-out path takes REMOTE, not this
+        // branch.)
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
@@ -865,10 +866,10 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
     @Test
     fun reset_givenManagerSucceeds_expectUserScopedStateClearedAndWorkspaceCachePreserved() = runTest {
-        // Sign-out cleanup: drop OS registrations + wipe user-specific state
-        // (anchor, movement-trigger location, registered IDs). Workspace
-        // cache (regions, config, last-sync) survives so a quick re-login
-        // skips a redundant API hit.
+        // Sign-out cleanup: drop OS registrations + wipe user-scoped state
+        // (anchor, movement-trigger location, registered IDs, freshness
+        // timestamp). Cached regions/config survive; the dropped timestamp
+        // makes the next login re-fetch.
         every { secureUserStore.getUserId() } returns null
         coEvery { manager.clearAll() } returns Result.success(Unit)
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -272,9 +272,9 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun clearUserScopedState_expectUserKeysRemovedAndWorkspaceCachePreserved() {
-        // Sign-out path: drop user-specific state but keep workspace-level
-        // cache so a quick re-login skips a redundant API call.
+    fun clearUserScopedState_expectUserKeysAndFreshnessRemovedButCachePreserved() {
+        // Sign-out path: drop user-scoped state and the freshness timestamp
+        // (so the next login re-fetches) but keep cached regions/config.
         val regions = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f))
         val config = GeofenceConfig(
             localRefreshTriggerRadius = 1_000f,
@@ -299,10 +299,11 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()
-        // Workspace-level: preserved.
+        // Freshness throttle: wiped so the next login re-fetches.
+        store.getLastSyncTimestamp().shouldBeNull()
+        // Cached regions/config: preserved.
         store.getCachedRegions() shouldBeEqualTo regions
         store.getCachedConfig() shouldBeEqualTo config
-        store.getLastSyncTimestamp() shouldBeEqualTo 12_345L
     }
 
     // --- Schema-drift / corruption safety ---


### PR DESCRIPTION
## What

Two related fixes that make geofence sync reliable on login.

### 1. Re-fetch geofences on login (clear the freshness window on sign-out)

Clear the last-sync freshness timestamp on sign-out so the next login performs a fresh `/geofences/nearby` fetch, instead of riding the previous session's cache window.

- `clearUserScopedState()` now also drops `lastSyncTimestamp`. With it gone, the first `refreshAction` after login sees no fresh-cache marker → `REMOTE` (re-fetch).
- Cached **regions/config are kept** — they're workspace-scoped (`/geofences/nearby` carries no userId), so they stay valid for any user and serve as the config source when a response omits one. User-scoped state (anchor, movement-trigger location, registered IDs) was already cleared on sign-out.

**Why:** picks up server-side geofence/config changes on each login rather than waiting out the cached expiry window; also makes the freshness window testable across a logout/login (previously sticky until app-data clear).

**iOS parity:** brings Android in line with iOS, which **already** clears its sync timestamp + location on sign-out (`GeofenceStorage.clearUserScopedState`) and re-fetches on next login. iOS likewise keeps its cached geofences/config. No fetch-failure cache fallback on either side (a failed login fetch registers nothing and self-heals on the next sync) — matched here.

### 2. Fix: geofence sync skipped on first identify (race) — separate commit

On a fresh identify the geofence sync could log `sync triggered: user-identified` immediately followed by `sync skipped: no identified user`, leaving nothing registered until the next app launch.

**Cause:** `UserChangedEvent` had two independent EventBus subscribers running as separate coroutines — one persisting `secureUserStore.saveUserId(...)`, the geofence one calling `refresh()` which *reads* `secureUserStore.getUserId()`. With no ordering guarantee, the geofence refresh could read the store before it was written → guard skip. Worked on relaunch only because the store was already persisted from the prior session.

**Fix:** persist `secureUserStore` **synchronously before** publishing `UserChangedEvent` — mirroring the existing "write `analytics` before publish" ordering one line up — via a single `publishUserChanged()` helper. The reactive `UserChangedEvent → saveUserId` subscriber is removed: it's the same single writer, just moved to where it's guaranteed visible to peer subscribers (and to the WorkManager/BroadcastReceiver direct-API consumers the store backs). Reset clearing is unchanged (`ResetEvent → clearAll()`).

## Notes

- No public API change (internal store/repository/identify wiring only).
- A failed login fetch registers nothing until the next sync trigger (app launch) — unchanged failure behavior, matches iOS.

[MBL-1760](https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering of identity persistence relative to EventBus subscribers and geofence refresh gating on `secureUserStore`; incorrect ordering could still skip sync or use stale cache, but scope is internal SDK wiring with added regression tests.
> 
> **Overview**
> Makes **geofence sync reliable on login** and fixes a **first-identify skip** caused by an EventBus race.
> 
> **Login re-fetch:** Sign-out now clears `lastSyncTimestamp` in `clearUserScopedState()` (workspace **cached regions/config stay**). The next `refresh` no longer treats the prior session as time-fresh, so login triggers a remote `/geofences/nearby` fetch instead of skipping on the old window—aligned with iOS behavior.
> 
> **Identify race:** `CustomerIO` centralizes user notifications in `publishUserChanged()`, which **writes `secureUserStore` before** publishing `UserChangedEvent`. The separate subscriber that saved the user id on the event is removed. Geofence refresh (and other readers of `secureUserStore`) no longer see an empty user when `UserChangedEvent` fires right after `identify()`.
> 
> Tests cover synchronous `saveUserId` on identify and updated sign-out store expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79eab279d4af3355c48f919c9bcd74ca78a5a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

