### PR TITLE
chore(geofence): single "Geofence Transition" event payload

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
+++ b/core/src/main/kotlin/io/customer/sdk/util/EventNames.kt
@@ -15,7 +15,7 @@ object EventNames {
     // Event name for location updates tracked by the Location module
     const val LOCATION_UPDATE = "CIO Location Update"
 
-    // Event names for geofence transitions tracked by the Location module
-    const val GEOFENCE_ENTERED = "geofence_entered"
-    const val GEOFENCE_EXITED = "geofence_exited"
+    // Event name for geofence transitions tracked by the Location module.
+    // One name for every transition; the direction rides the `transition` property.
+    const val GEOFENCE_TRANSITION = "Geofence Transition"
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -174,10 +174,6 @@ class CustomerIO private constructor(
             secureUserStore.clearAll()
         }
         eventBus.subscribe<Event.GeofenceTransitionEvent> { geofenceEvent ->
-            val eventName = when (geofenceEvent.transition) {
-                Event.GeofenceTransition.ENTER -> EventNames.GEOFENCE_ENTERED
-                Event.GeofenceTransition.EXIT -> EventNames.GEOFENCE_EXITED
-            }
             // Snapshotted userId (if any) overrides current SDK identity for this one event so a
             // sign-out + sign-in between queue and flush cannot reattribute. Null snapshot → no
             // override → natural anonymousId path.
@@ -192,7 +188,7 @@ class CustomerIO private constructor(
                 }
             }
             track(
-                name = eventName,
+                name = EventNames.GEOFENCE_TRANSITION,
                 properties = geofenceEvent.properties.sanitizeForJson(),
                 serializationStrategy = JsonAnySerializer.serializersModule.serializer(),
                 enrichment = enrichment

--- a/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/GeofenceEventSubscriptionTest.kt
@@ -3,6 +3,7 @@ package io.customer.datapipelines
 import io.customer.commontest.config.TestConfig
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
+import io.customer.datapipelines.testutils.extensions.encodeToJsonValue
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.trackEvents
 import io.customer.sdk.communication.Event
@@ -14,11 +15,12 @@ import io.mockk.slot
 import java.util.Date
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
 import org.junit.jupiter.api.Test
 
 /**
  * Verifies the EventBus subscription wired up in CustomerIO.subscribeToJourneyEvents
- * correctly maps Event.GeofenceTransitionEvent → "Geofence Entered/Exited" track event
+ * maps Event.GeofenceTransitionEvent → the "Geofence Transition" track event
  * and forwards the properties.
  *
  * Captures the subscription handler with a mock EventBus at SDK init time, then invokes
@@ -54,11 +56,11 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
     }
 
     @Test
-    fun handler_givenEnterTransition_expectTrackWithGeofenceEnteredEventName() = runTest {
+    fun handler_givenEnterTransition_expectTrackWithGeofenceTransitionEventName() = runTest {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-1",
             transition = Event.GeofenceTransition.ENTER,
-            properties = mapOf("geofence_id" to "biz-1", "transition_type" to "enter"),
+            properties = mapOf("geofenceId" to "biz-1", "transition" to "enter"),
             userId = "user-A",
             timestamp = Date()
         )
@@ -66,15 +68,17 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "geofence_entered"
+        val tracked = outputReaderPlugin.trackEvents.last()
+        tracked.event shouldBeEqualTo "Geofence Transition"
+        tracked.properties shouldContain ("transition" to "enter").encodeToJsonValue()
     }
 
     @Test
-    fun handler_givenExitTransition_expectTrackWithGeofenceExitedEventName() = runTest {
+    fun handler_givenExitTransition_expectTrackWithGeofenceTransitionEventName() = runTest {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-2",
             transition = Event.GeofenceTransition.EXIT,
-            properties = mapOf("geofence_id" to "biz-2", "transition_type" to "exit"),
+            properties = mapOf("geofenceId" to "biz-2", "transition" to "exit"),
             userId = "user-A",
             timestamp = Date()
         )
@@ -82,7 +86,9 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         handlerSlot.captured.invoke(event)
 
         outputReaderPlugin.trackEvents.size shouldBeEqualTo 1
-        outputReaderPlugin.trackEvents.last().event shouldBeEqualTo "geofence_exited"
+        val tracked = outputReaderPlugin.trackEvents.last()
+        tracked.event shouldBeEqualTo "Geofence Transition"
+        tracked.properties shouldContain ("transition" to "exit").encodeToJsonValue()
     }
 
     @Test
@@ -93,7 +99,7 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-3",
             transition = Event.GeofenceTransition.ENTER,
-            properties = mapOf("geofence_id" to "biz-3"),
+            properties = mapOf("geofenceId" to "biz-3"),
             userId = "user-pinned-A",
             timestamp = Date()
         )
@@ -111,7 +117,7 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-4",
             transition = Event.GeofenceTransition.ENTER,
-            properties = mapOf("geofence_id" to "biz-4"),
+            properties = mapOf("geofenceId" to "biz-4"),
             userId = null,
             timestamp = Date()
         )
@@ -129,7 +135,7 @@ class GeofenceEventSubscriptionTest : JUnitTest() {
         val event = Event.GeofenceTransitionEvent(
             geofenceId = "biz-5",
             transition = Event.GeofenceTransition.ENTER,
-            properties = mapOf("geofence_id" to "biz-5"),
+            properties = mapOf("geofenceId" to "biz-5"),
             userId = "user-A",
             timestamp = transitionTime
         )

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
  * A geographic region to monitor for enter/exit transitions.
  *
  * `id` is the OS request ID — derived from the backend's numeric geofence ID
- * so it stays stable and matches the `geofence_id` key on transition events.
+ * so it stays stable and matches the `geofenceId` key on transition events.
  */
 @Serializable
 internal data class GeofenceRegion(

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -48,7 +48,7 @@ internal data class GeofenceApiPlatformConfig(
 
 @Serializable
 internal data class GeofenceApiRegion(
-    // Used as the OS request ID and the `geofence_id` key on transition events.
+    // Used as the OS request ID and the `geofenceId` key on transition events.
     @SerialName("id")
     val id: String,
     @SerialName("name")

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -29,15 +29,15 @@ internal data class PendingGeofenceDelivery(
     override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
 
     /**
-     * Properties carried on the tracked "Geofence Entered/Exited" event. Kept
-     * here so the producer, the worker's direct-HTTP send, and the foreground
-     * flush all build an identical property set.
+     * Properties carried on the tracked "Geofence Transition" event. Kept here
+     * so the worker's direct-HTTP send and the foreground flush build an
+     * identical property set. Timestamp is not a property — each delivery path
+     * sets it on the event envelope from [timestamp].
      */
     fun toEventProperties(): Map<String, Any> = buildMap {
-        geofenceName?.let { put("geofence_name", it) }
-        put("geofence_id", geofenceId)
-        put("transition_type", transition.name.lowercase())
-        put("timestamp", timestamp)
+        put("transition", transition.name.lowercase())
+        put("geofenceId", geofenceId)
+        geofenceName?.let { put("geofenceName", it) }
     }
 
     /**

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
@@ -2,7 +2,6 @@ package io.customer.geofence.worker
 
 import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.store.PendingGeofenceDelivery
-import io.customer.sdk.communication.Event
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
@@ -40,15 +39,10 @@ internal class GeofenceEventTrackerImpl(
             )
         }
 
-        val eventName = when (entry.transition) {
-            Event.GeofenceTransition.ENTER -> EventNames.GEOFENCE_ENTERED
-            Event.GeofenceTransition.EXIT -> EventNames.GEOFENCE_EXITED
-        }
-
         val bodyJson = JSONObject().apply {
             put("properties", JSONObject(entry.toEventProperties()))
             Iso8601TimestampFormatter.fromUnixSeconds(entry.timestamp)?.let { put("timestamp", it) }
-            put("event", eventName)
+            put("event", EventNames.GEOFENCE_TRANSITION)
             put("userId", userId)
         }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -166,7 +166,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         val scheduled = entrySlot.captured
         scheduled.geofenceId shouldBeEqualTo "biz-geofence-1"
         scheduled.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
-        scheduled.toEventProperties()["transition_type"] shouldBeEqualTo "enter"
+        scheduled.toEventProperties()["transition"] shouldBeEqualTo "enter"
         scheduled.timestamp.shouldNotBeNull()
 
         // Durably recorded for the foreground flush, and not published inline:
@@ -239,7 +239,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
         entrySlot.captured.transition shouldBeEqualTo Event.GeofenceTransition.EXIT
-        entrySlot.captured.toEventProperties()["transition_type"] shouldBeEqualTo "exit"
+        entrySlot.captured.toEventProperties()["transition"] shouldBeEqualTo "exit"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -50,14 +50,15 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
-    fun toEventProperties_expectOnlyGeofenceTransitionAndTimestamp() {
+    fun toEventProperties_expectTransitionAndGeofenceIdNoTimestamp() {
         val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 50L, "user-A")
 
         val props = entry.toEventProperties()
 
-        props["geofence_id"] shouldBeEqualTo "biz-4"
-        props["transition_type"] shouldBeEqualTo "enter"
-        props["timestamp"] shouldBeEqualTo 50L
+        props["geofenceId"] shouldBeEqualTo "biz-4"
+        props["transition"] shouldBeEqualTo "enter"
+        // Timestamp rides the event envelope, not the properties.
+        props.keys shouldNotContain "timestamp"
         props.keys shouldNotContain "latitude"
         props.keys shouldNotContain "longitude"
     }
@@ -66,7 +67,7 @@ class PendingGeofenceDeliveryTest {
     fun toEventProperties_givenGeofenceName_expectNamePresent() {
         val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = "Ferry Building")
 
-        entry.toEventProperties()["geofence_name"] shouldBeEqualTo "Ferry Building"
+        entry.toEventProperties()["geofenceName"] shouldBeEqualTo "Ferry Building"
     }
 
     @Test
@@ -74,7 +75,7 @@ class PendingGeofenceDeliveryTest {
         // Region not in the cached set => omit the property rather than send a synthetic value.
         val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = null)
 
-        entry.toEventProperties().keys shouldNotContain "geofence_name"
+        entry.toEventProperties().keys shouldNotContain "geofenceName"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
@@ -49,27 +49,28 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         capturedParams.captured.path shouldBeEqualTo "/track"
         val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
-        body.getString("event") shouldBeEqualTo "geofence_entered"
+        body.getString("event") shouldBeEqualTo "Geofence Transition"
         body.getString("userId") shouldBeEqualTo "user-42"
         body.getString("timestamp") shouldBeEqualTo "2009-02-13T23:31:30.000Z"
         val props = body.getJSONObject("properties")
-        props.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
-        props.getString("transition_type") shouldBeEqualTo "enter"
-        props.getLong("timestamp") shouldBeEqualTo 1_234_567_890L
+        props.getString("geofenceId") shouldBeEqualTo "biz-geofence-1"
+        props.getString("transition") shouldBeEqualTo "enter"
+        // Timestamp lives on the envelope (asserted above), not in properties.
+        props.has("timestamp") shouldBeEqualTo false
         props.has("latitude") shouldBeEqualTo false
         props.has("longitude") shouldBeEqualTo false
     }
 
     @Test
-    fun trackEvent_givenExitTransition_expectExitedEventName() = runTest {
+    fun trackEvent_givenExitTransition_expectExitTransitionProperty() = runTest {
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
 
         tracker.trackEvent(entry(transition = Event.GeofenceTransition.EXIT))
 
         val body = JSONObject(capturedParams.captured.body.shouldNotBeNull())
-        body.getString("event") shouldBeEqualTo "geofence_exited"
-        body.getJSONObject("properties").getString("transition_type") shouldBeEqualTo "exit"
+        body.getString("event") shouldBeEqualTo "Geofence Transition"
+        body.getJSONObject("properties").getString("transition") shouldBeEqualTo "exit"
     }
 
     @Test


### PR DESCRIPTION
## What

Update the geofence transition event payload to a single event with a `transition` property, matching iOS.

**Before** — two events, snake_case properties, redundant timestamp:
```jsonc
{ "event": "geofence_entered" | "geofence_exited",
  "properties": { "geofence_id": "...", "transition_type": "enter|exit",
                  "geofence_name": "...", "timestamp": 1234567890 } }
```

**After** — one event, camelCase properties, timestamp only on the envelope:
```jsonc
{ "event": "Geofence Transition",
  "timestamp": "2009-02-13T23:31:30.000Z",   // envelope, top-level
  "properties": { "transition": "enter|exit", "geofenceId": "...",
                  "geofenceName": "..." } }   // geofenceName omitted when unavailable
```

## Details

- One event name for both directions; direction rides the `transition` property.
- Properties switch to camelCase (`transition`, `geofenceId`, `geofenceName`).
- `timestamp` dropped from properties — **both delivery paths already set the canonical timestamp on the event envelope** (pipeline via `event.timestamp`, worker via top-level ISO-8601 `timestamp`), so nothing is lost.
- Built once in `PendingGeofenceDelivery.toEventProperties()`, so both the worker direct-HTTP path and the foreground/pipeline path stay identical.
- Internal WorkManager `inputData` keys and the incoming API `transition_types` field are unchanged (not on the wire).

## iOS parity

Exact match with iOS `GeofenceMetric` (`"Geofence Transition"`, `transition`/`geofenceId`/`geofenceName`, timestamp on the envelope).

No public API change.

[MBL-1876](https://linear.app/customerio/issue/MBL-1876/update-geofence-events-payload-in-mobile-sdks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for Journeys or analytics that keyed off old event names and snake_case property keys; delivery and attribution logic is unchanged but downstream consumers must migrate.
> 
> **Overview**
> Geofence enter/exit tracking now emits a **single** `"Geofence Transition"` event instead of separate `geofence_entered` / `geofence_exited` names. Enter vs exit is expressed only via a **`transition`** property (`enter` / `exit`).
> 
> **Property shape** moves to camelCase (`geofenceId`, `geofenceName`, `transition`) and drops **`timestamp` from properties**—both the analytics pipeline and the WorkManager direct-HTTP path already set ISO-8601 timestamp on the event envelope. `PendingGeofenceDelivery.toEventProperties()` remains the single source so worker and foreground flush stay aligned.
> 
> `CustomerIO`’s `GeofenceTransitionEvent` subscription and `GeofenceEventTracker` no longer branch on transition type for the event name. Tests are updated for the new wire format; no public SDK API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496c470d281a99e2b4326d1c1370e3364e2d91a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->