### PR TITLE
chore(geofence): emit numeric geofenceId on transition events

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -36,7 +36,9 @@ internal data class PendingGeofenceDelivery(
      */
     fun toEventProperties(): Map<String, Any> = buildMap {
         put("transition", transition.name.lowercase())
-        put("geofenceId", geofenceId)
+        // Backend prefers a numeric geofenceId; emit a number when it parses, else the raw
+        // string. Long (not Int) so large backend ids don't silently fall back to a string.
+        put("geofenceId", geofenceId.toLongOrNull() ?: geofenceId)
         geofenceName?.let { put("geofenceName", it) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -55,12 +55,21 @@ class PendingGeofenceDeliveryTest {
 
         val props = entry.toEventProperties()
 
+        // Non-numeric id falls back to the raw string.
         props["geofenceId"] shouldBeEqualTo "biz-4"
         props["transition"] shouldBeEqualTo "enter"
         // Timestamp rides the event envelope, not the properties.
         props.keys shouldNotContain "timestamp"
         props.keys shouldNotContain "latitude"
         props.keys shouldNotContain "longitude"
+    }
+
+    @Test
+    fun toEventProperties_givenNumericGeofenceId_expectEmittedAsNumber() {
+        // Backend prefers a numeric geofenceId — a parseable id is sent as a Long, not a string.
+        val entry = PendingGeofenceDelivery("12345", Event.GeofenceTransition.ENTER, 50L, "user-A")
+
+        entry.toEventProperties()["geofenceId"] shouldBeEqualTo 12345L
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
@@ -74,6 +74,17 @@ class GeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
+    fun trackEvent_givenNumericGeofenceId_expectUnquotedNumberOnWire() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("ok")
+
+        tracker.trackEvent(entry(geofenceId = "12345"))
+
+        // Backend prefers a number — the wire body must carry it unquoted.
+        capturedParams.captured.body.shouldNotBeNull() shouldContain "\"geofenceId\":12345"
+    }
+
+    @Test
     fun trackEvent_givenHttpFailure_expectFailureResult() = runTest {
         val error = RuntimeException("boom")
         coEvery { httpClient.request(any()) } returns Result.failure(error)


### PR DESCRIPTION
Backend prefers a numeric `geofenceId`. `toEventProperties()` now emits it as a number when the id parses, falling back to the raw string otherwise:

```kotlin
put("geofenceId", geofenceId.toLongOrNull() ?: geofenceId)
```

`Long` (not `Int`) so large backend ids don't silently fall back to a string; same JSON wire format either way. Both delivery paths handle it — worker `JSONObject` serializes the number unquoted, pipeline `sanitizeValue` passes it through to `JsonAnySerializer`.

Tests: numeric → `Long`, non-numeric → string fallback, plus a worker wire-format check asserting the body carries `"geofenceId":12345` unquoted.

No public API change.

[MBL-1760](https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small serialization tweak in geofence analytics properties with backward-compatible string fallback; no auth or public API changes.
> 
> **Overview**
> **Geofence Transition** event properties now send **`geofenceId` as a JSON number** when the stored id parses as a **`Long`**, instead of always sending a string. Non-numeric ids still use the raw string via `geofenceId.toLongOrNull() ?: geofenceId`, so both the worker direct-HTTP path and the foreground flush (which share `toEventProperties()`) stay aligned with backend expectations.
> 
> Tests cover numeric → `Long`, non-numeric fallback, and worker wire format (`"geofenceId":12345` unquoted). No public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daddcf241d0cee6b30826c94f8342b60848fbe2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->