### PR TITLE
feat(inbox): register a Visual Inbox event listener in sample apps

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -53,6 +53,7 @@ public class CustomerIORepository {
             builder.addCustomerIOModule(new ModuleMessagingInApp(
                     new MessagingInAppModuleConfig.Builder(sdkConfig.getSiteId(), sdkConfig.getRegion())
                             .setEventListener(new InAppMessageEventListener(appGraph.getLogger()))
+                            .setInboxEventListener(new SampleInboxEventListener(appGraph.getLogger()))
                             .build()
             ));
         }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/SampleInboxEventListener.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/SampleInboxEventListener.java
@@ -1,0 +1,49 @@
+package io.customer.android.sample.java_layout.sdk;
+
+import androidx.annotation.NonNull;
+
+import java.util.Locale;
+
+import io.customer.android.sample.java_layout.utils.Logger;
+import io.customer.messaginginapp.type.InboxActionMessage;
+import io.customer.messaginginapp.type.InboxEventListener;
+
+/**
+ * Sample implementation for {@link InboxEventListener}.
+ * <p>
+ * Observational: it logs each callback and returns {@code false} from
+ * {@link #messageActionTaken} so the SDK still applies its default action handling (e.g. opening an
+ * http(s) url). Return {@code true} instead to fully handle the action and suppress that default.
+ */
+public class SampleInboxEventListener implements InboxEventListener {
+    private final Logger logger;
+
+    public SampleInboxEventListener(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean messageActionTaken(@NonNull InboxActionMessage message, @NonNull String actionName, @NonNull String actionValue) {
+        logEvent("messageActionTaken. name: %s, value: %s, message: %s", actionName, actionValue, message.getMessageId());
+        return false;
+    }
+
+    @Override
+    public void messageShown(@NonNull InboxActionMessage message) {
+        logEvent("messageShown. message: %s", message.getMessageId());
+    }
+
+    @Override
+    public void messageOpened(@NonNull InboxActionMessage message) {
+        logEvent("messageOpened. message: %s", message.getMessageId());
+    }
+
+    @Override
+    public void messageDismissed(@NonNull InboxActionMessage message) {
+        logEvent("messageDismissed. message: %s", message.getMessageId());
+    }
+
+    private void logEvent(@NonNull String format, @NonNull Object... args) {
+        logger.v(String.format(Locale.ENGLISH, "[CIO-Inbox] sample listener: " + format, args));
+    }
+}

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
@@ -3,6 +3,7 @@ package io.customer.android.sample.kotlin_compose
 import android.app.Application
 import io.customer.android.sample.kotlin_compose.data.models.setValuesFromBuilder
 import io.customer.android.sample.kotlin_compose.data.sdk.InAppMessageEventListener
+import io.customer.android.sample.kotlin_compose.data.sdk.SampleInboxEventListener
 import io.customer.android.sample.kotlin_compose.di.ServiceLocator
 import io.customer.location.ModuleLocation
 import io.customer.messaginginapp.MessagingInAppModuleConfig
@@ -34,7 +35,9 @@ class MainApplication : Application() {
                     config = MessagingInAppModuleConfig.Builder(
                         siteId = configuration.siteId,
                         region = Region.US
-                    ).setEventListener(InAppMessageEventListener()).build()
+                    ).setEventListener(InAppMessageEventListener())
+                        .setInboxEventListener(SampleInboxEventListener())
+                        .build()
                 )
             )
             .addCustomerIOModule(ModuleMessagingPushFCM())

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/SampleInboxEventListener.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/SampleInboxEventListener.kt
@@ -1,0 +1,40 @@
+package io.customer.android.sample.kotlin_compose.data.sdk
+
+import io.customer.android.sample.kotlin_compose.util.Logger
+import io.customer.messaginginapp.type.InboxActionMessage
+import io.customer.messaginginapp.type.InboxEventListener
+
+/**
+ * Sample implementation for `InboxEventListener`.
+ *
+ * Observational: it logs each callback and returns `false` from [messageActionTaken] so the SDK
+ * still applies its default action handling (e.g. opening an http(s) url). Return `true` instead to
+ * fully handle the action and suppress that default.
+ */
+class SampleInboxEventListener(private val logger: Logger = Logger()) : InboxEventListener {
+
+    override fun messageActionTaken(
+        message: InboxActionMessage,
+        actionName: String,
+        actionValue: String
+    ): Boolean {
+        logEvent("messageActionTaken. name: $actionName, value: $actionValue, message: ${message.messageId}")
+        return false
+    }
+
+    override fun messageShown(message: InboxActionMessage) {
+        logEvent("messageShown. message: ${message.messageId}")
+    }
+
+    override fun messageOpened(message: InboxActionMessage) {
+        logEvent("messageOpened. message: ${message.messageId}")
+    }
+
+    override fun messageDismissed(message: InboxActionMessage) {
+        logEvent("messageDismissed. message: ${message.messageId}")
+    }
+
+    private fun logEvent(message: String) {
+        logger.v("[CIO-Inbox] sample listener: $message")
+    }
+}

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
@@ -6,14 +6,20 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -34,7 +40,8 @@ import io.customer.android.sample.kotlin_compose.ui.components.VersionText
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesNavigationActivity
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesTabbedActivity
 import io.customer.base.internal.InternalCustomerIOApi
-import io.customer.messaginginbox.NotificationInboxOverlay
+import io.customer.messaginginbox.NotificationInboxBell
+import io.customer.messaginginbox.NotificationInboxView
 import io.customer.sdk.CustomerIO
 import kotlinx.coroutines.launch
 
@@ -68,7 +75,7 @@ fun DashboardRoute(
     )
 }
 
-@OptIn(InternalCustomerIOApi::class)
+@OptIn(InternalCustomerIOApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
     userState: State<User>,
@@ -109,10 +116,28 @@ fun DashboardScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
-        // Overlay visual notification inbox (floating bell + slide-out panel) rendered on top of
-        // the dashboard. The floating bell shows only when the inbox data layer reports the
-        // inbox as visible.
-        NotificationInboxOverlay()
+        // Granular Visual Notification Inbox composition (vs the drop-in NotificationInboxOverlay
+        // used by the java_layout sample): the host places the bell where it wants and presents the
+        // message list itself. This is the same composition the wrapper SDKs (React Native / Flutter)
+        // build on. Here the bell is pinned bottom-end and opens the Jist-rendered list in a modal
+        // bottom sheet. Both the bell and the list render only when the data layer reports the inbox
+        // visible (enabled + at least one renderable message).
+        var showInboxSheet by remember { mutableStateOf(false) }
+        NotificationInboxBell(
+            onClick = { showInboxSheet = true },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        )
+        if (showInboxSheet) {
+            ModalBottomSheet(onDismissRequest = { showInboxSheet = false }) {
+                NotificationInboxView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(480.dp)
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
java_layout and kotlin_compose register a log-only InboxEventListener via the in-app module config builder, demonstrating the inbox action/observational callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to sample apps (SDK wiring demos and Compose UI); no production SDK or auth/data-path changes.
> 
> **Overview**
> Both **java_layout** and **kotlin_compose** now register a log-only **`SampleInboxEventListener`** on **`MessagingInAppModuleConfig.Builder`** via **`setInboxEventListener`**, demonstrating inbox lifecycle and action callbacks while leaving default action handling enabled (**`messageActionTaken`** returns **`false`**).
> 
> The **kotlin_compose** dashboard no longer uses the drop-in **`NotificationInboxOverlay`**. It composes **`NotificationInboxBell`** (bottom-end) and opens **`NotificationInboxView`** in a **`ModalBottomSheet`**, illustrating the same granular pattern wrapper SDKs use for bell placement and list presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6643bfb063c929bef81179010aef8307f622ffbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->