### PR TITLE
feat(in-app): add dark mode support for in-app messages

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -1,5 +1,6 @@
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lio/customer/messaginginapp/type/ColorScheme;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getColorScheme ()Lio/customer/messaginginapp/type/ColorScheme;
 	public final fun getEventListener ()Lio/customer/messaginginapp/type/InAppEventListener;
 	public final fun getRegion ()Lio/customer/sdk/data/model/Region;
 	public final fun getSiteId ()Ljava/lang/String;
@@ -9,6 +10,7 @@ public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder
 	public fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;)V
 	public fun build ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
+	public final fun setColorScheme (Lio/customer/messaginginapp/type/ColorScheme;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 	public final fun setEventListener (Lio/customer/messaginginapp/type/InAppEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 }
 
@@ -227,6 +229,17 @@ public final class io/customer/messaginginapp/inbox/NotificationInbox {
 
 public abstract interface class io/customer/messaginginapp/inbox/NotificationInboxChangeListener {
 	public abstract fun onMessagesChanged (Ljava/util/List;)V
+}
+
+public final class io/customer/messaginginapp/type/ColorScheme : java/lang/Enum {
+	public static final field AUTO Lio/customer/messaginginapp/type/ColorScheme;
+	public static final field DARK Lio/customer/messaginginapp/type/ColorScheme;
+	public static final field LIGHT Lio/customer/messaginginapp/type/ColorScheme;
+	public static final field RENDERER_DARK Ljava/lang/String;
+	public static final field RENDERER_LIGHT Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/customer/messaginginapp/type/ColorScheme;
+	public static fun values ()[Lio/customer/messaginginapp/type/ColorScheme;
 }
 
 public abstract interface class io/customer/messaginginapp/type/InAppEventListener {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -31,6 +31,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public fun onMessageCancelled (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public fun onMessageDismissed (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	public final fun setColorScheme (Lio/customer/messaginginapp/type/ColorScheme;)V
 }
 
 public final class io/customer/messaginginapp/ModuleMessagingInApp$Companion {

--- a/messaginginapp/src/main/AndroidManifest.xml
+++ b/messaginginapp/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <application>
         <activity
             android:name=".gist.presentation.GistModalActivity"
+            android:configChanges="uiMode"
             android:exported="false"
             android:theme="@style/GistActivityTheme" />
     </application>

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
@@ -1,5 +1,6 @@
 package io.customer.messaginginapp
 
+import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.data.model.Region
@@ -11,16 +12,23 @@ import io.customer.sdk.data.model.Region
 class MessagingInAppModuleConfig private constructor(
     val siteId: String,
     val region: Region,
-    val eventListener: InAppEventListener?
+    val eventListener: InAppEventListener?,
+    val colorScheme: ColorScheme
 ) : CustomerIOModuleConfig {
     class Builder(
         private val siteId: String,
         private val region: Region
     ) : CustomerIOModuleConfig.Builder<MessagingInAppModuleConfig> {
         private var eventListener: InAppEventListener? = null
+        private var colorScheme: ColorScheme = ColorScheme.AUTO
 
         fun setEventListener(eventListener: InAppEventListener): Builder {
             this.eventListener = eventListener
+            return this
+        }
+
+        fun setColorScheme(colorScheme: ColorScheme): Builder {
+            this.colorScheme = colorScheme
             return this
         }
 
@@ -28,7 +36,8 @@ class MessagingInAppModuleConfig private constructor(
             return MessagingInAppModuleConfig(
                 siteId = siteId,
                 region = region,
-                eventListener = eventListener
+                eventListener = eventListener,
+                colorScheme = colorScheme
             )
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -2,11 +2,14 @@ package io.customer.messaginginapp
 
 import io.customer.messaginginapp.di.gistCustomAttributes
 import io.customer.messaginginapp.di.gistProvider
+import io.customer.messaginginapp.di.inAppMessagingManager
 import io.customer.messaginginapp.di.notificationInbox
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.presentation.GistListener
 import io.customer.messaginginapp.gist.presentation.GistProvider
 import io.customer.messaginginapp.inbox.NotificationInbox
+import io.customer.messaginginapp.state.InAppMessagingAction
+import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.type.InAppMessage
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
@@ -36,6 +39,10 @@ class ModuleMessagingInApp(
 
     fun dismissMessage() {
         gistProvider.dismissMessage()
+    }
+
+    fun setColorScheme(colorScheme: ColorScheme) {
+        SDKComponent.inAppMessagingManager.dispatch(InAppMessagingAction.SetColorScheme(colorScheme))
     }
 
     private fun setCustomAttribute(key: String, value: Any) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/di/DIGraphMessagingInApp.kt
@@ -39,7 +39,8 @@ internal val SDKComponent.gistProvider: GistProvider
     get() = singleton<GistProvider> {
         GistSdk(
             siteId = inAppModuleConfig.siteId,
-            dataCenter = inAppModuleConfig.region.code
+            dataCenter = inAppModuleConfig.region.code,
+            colorScheme = inAppModuleConfig.colorScheme
         )
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/engine/EngineWebConfiguration.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/model/engine/EngineWebConfiguration.kt
@@ -8,5 +8,6 @@ internal data class EngineWebConfiguration(
     val endpoint: String,
     val livePreview: Boolean = false,
     val properties: Map<String, Any?>? = null,
-    val customAttributes: Map<String, Any>? = null
+    val customAttributes: Map<String, Any>? = null,
+    val colorScheme: String? = null
 )

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -10,6 +10,7 @@ import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.state.ModalMessageState
 import io.customer.messaginginapp.store.InAppPreferenceStore
+import io.customer.messaginginapp.type.ColorScheme
 import io.customer.sdk.core.di.SDKComponent
 
 internal interface GistProvider {
@@ -24,7 +25,8 @@ internal interface GistProvider {
 internal class GistSdk(
     siteId: String,
     dataCenter: String,
-    environment: GistEnvironment = GistEnvironment.PROD
+    environment: GistEnvironment = GistEnvironment.PROD,
+    colorScheme: ColorScheme = ColorScheme.AUTO
 ) : GistProvider {
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
     private val state: InAppMessagingState
@@ -39,7 +41,7 @@ internal class GistSdk(
     private val sseLifecycleManager = SDKComponent.sseLifecycleManager
 
     init {
-        inAppMessagingManager.dispatch(InAppMessagingAction.Initialize(siteId = siteId, dataCenter = dataCenter, environment = environment))
+        inAppMessagingManager.dispatch(InAppMessagingAction.Initialize(siteId = siteId, dataCenter = dataCenter, environment = environment, colorScheme = colorScheme))
     }
 
     override fun reset() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -141,7 +141,10 @@ internal class EngineWebView @JvmOverloads constructor(
     override fun updateColorScheme(scheme: String) {
         lastResolvedColorScheme = scheme
         val json = Gson().toJson(mapOf("action" to "updateColorScheme", "colorScheme" to scheme))
-        webView?.evaluateJavascript("window.postMessage($json, '*');", null)
+        webView?.evaluateJavascript(
+            "window.dispatchEvent(new MessageEvent('message', { data: $json }));",
+            null
+        )
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -170,8 +170,10 @@ internal class EngineWebView @JvmOverloads constructor(
             selector = { it.colorScheme }
         ) { colorScheme ->
             val resolved = colorScheme.resolve(context.resources.configuration.uiMode)
-            if (resolved != lastResolvedColorScheme) {
-                post { updateColorScheme(resolved) }
+            post {
+                if (resolved != lastResolvedColorScheme) {
+                    updateColorScheme(resolved)
+                }
             }
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -135,6 +135,8 @@ internal class EngineWebView @JvmOverloads constructor(
 
     override fun stopLoading() {
         webView?.stopLoading()
+        colorSchemeJob?.cancel()
+        colorSchemeJob = null
         // remove lifecycle observer to stop receiving further lifecycle events
         onLifecyclePaused()
         viewLifecycleOwner?.removeObserver(this)

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -157,7 +157,8 @@ internal class EngineWebView @JvmOverloads constructor(
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun setup(configuration: EngineWebConfiguration) {
-        lastResolvedColorScheme = configuration.colorScheme
+        val initialColorScheme = configuration.colorScheme
+        lastResolvedColorScheme = initialColorScheme
         setupTimeout()
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageData = mapOf("options" to configuration)
@@ -187,9 +188,9 @@ internal class EngineWebView @JvmOverloads constructor(
                         // Post the JSON message to the current frame's listeners
                         // Ensures internal JavaScript communication via window.addEventListener('message') remains functional
                         window.postMessage($jsonString, '*');
-                        
+
                         // Override window.parent.postMessage to route messages to the native Android interface
-                        // This is necessary only for legacy message because WebView can only attach one native interface 
+                        // This is necessary only for legacy message because WebView can only attach one native interface
                         // and we have already added it as ${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.
                         window.parent.postMessage = function(message) {
                             window.${EngineWebViewInterface.JAVASCRIPT_INTERFACE_NAME}.postMessage(JSON.stringify(message));
@@ -197,6 +198,13 @@ internal class EngineWebView @JvmOverloads constructor(
                     """.trim()
                     view.evaluateJavascript(script) { result ->
                         logger.debug("JavaScript execution result: $result")
+                    }
+                    // If color scheme changed during page load (e.g. system theme toggled
+                    // between loadUrl and onPageFinished), send the current value so it
+                    // overrides the stale one baked into the initial options JSON.
+                    val currentScheme = lastResolvedColorScheme
+                    if (currentScheme != null && currentScheme != initialColorScheme) {
+                        updateColorScheme(currentScheme)
                     }
                 }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -27,6 +27,7 @@ import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.sdk.core.di.SDKComponent
 import java.util.Timer
 import java.util.TimerTask
+import kotlinx.coroutines.Job
 
 internal class EngineWebView @JvmOverloads constructor(
     context: Context,
@@ -41,6 +42,7 @@ internal class EngineWebView @JvmOverloads constructor(
     private val engineWebViewInterface = EngineWebViewInterface(this)
     private val logger = SDKComponent.logger
     private var lastResolvedColorScheme: String? = null
+    private var colorSchemeJob: Job? = null
 
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
 
@@ -98,6 +100,8 @@ internal class EngineWebView @JvmOverloads constructor(
      * It stops loading WebView, removes JavaScript interface, and clears reference to WebView.
      */
     override fun releaseResources() {
+        colorSchemeJob?.cancel()
+        colorSchemeJob = null
         try {
             val view = webView ?: return
             logger.debug("Cleaning up EngineWebView")
@@ -158,10 +162,23 @@ internal class EngineWebView @JvmOverloads constructor(
         }
     }
 
+    private fun subscribeToColorSchemeChanges() {
+        colorSchemeJob?.cancel()
+        colorSchemeJob = inAppMessagingManager.subscribeToAttribute(
+            selector = { it.colorScheme }
+        ) { colorScheme ->
+            val resolved = colorScheme.resolve(context.resources.configuration.uiMode)
+            if (resolved != lastResolvedColorScheme) {
+                post { updateColorScheme(resolved) }
+            }
+        }
+    }
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun setup(configuration: EngineWebConfiguration) {
         val initialColorScheme = configuration.colorScheme
         lastResolvedColorScheme = initialColorScheme
+        subscribeToColorSchemeChanges()
         setupTimeout()
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageData = mapOf("options" to configuration)

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -2,6 +2,7 @@ package io.customer.messaginginapp.gist.presentation.engine
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.net.http.SslError
 import android.util.AttributeSet
@@ -21,6 +22,7 @@ import io.customer.messaginginapp.di.inAppMessagingManager
 import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.gist.utilities.ElapsedTimer
 import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.sdk.core.di.SDKComponent
 import java.util.Timer
@@ -38,6 +40,7 @@ internal class EngineWebView @JvmOverloads constructor(
     private var elapsedTimer: ElapsedTimer = ElapsedTimer()
     private val engineWebViewInterface = EngineWebViewInterface(this)
     private val logger = SDKComponent.logger
+    private var lastResolvedColorScheme: String? = null
 
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
 
@@ -135,8 +138,26 @@ internal class EngineWebView @JvmOverloads constructor(
         bootstrapped()
     }
 
+    override fun updateColorScheme(scheme: String) {
+        lastResolvedColorScheme = scheme
+        val json = Gson().toJson(mapOf("action" to "updateColorScheme", "colorScheme" to scheme))
+        webView?.evaluateJavascript("window.postMessage($json, '*');", null)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        val colorSchemeMode = state.colorScheme
+        if (colorSchemeMode != ColorScheme.AUTO) return
+
+        val resolved = colorSchemeMode.resolve(newConfig.uiMode)
+        if (resolved != lastResolvedColorScheme) {
+            updateColorScheme(resolved)
+        }
+    }
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun setup(configuration: EngineWebConfiguration) {
+        lastResolvedColorScheme = configuration.colorScheme
         setupTimeout()
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageData = mapOf("options" to configuration)

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
@@ -15,6 +15,9 @@ internal val inAppMessagingReducer: Reducer<InAppMessagingState> = { state, acti
                 sessionId = UUID.randomUUID().toString()
             )
 
+        is InAppMessagingAction.SetColorScheme ->
+            state.copy(colorScheme = action.colorScheme)
+
         is InAppMessagingAction.SetPageRoute ->
             state.copy(currentRoute = action.route)
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
@@ -11,6 +11,7 @@ internal val inAppMessagingReducer: Reducer<InAppMessagingState> = { state, acti
                 siteId = action.siteId,
                 dataCenter = action.dataCenter,
                 environment = action.environment,
+                colorScheme = action.colorScheme,
                 sessionId = UUID.randomUUID().toString()
             )
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
@@ -8,6 +8,7 @@ import io.customer.messaginginapp.type.ColorScheme
 
 internal sealed class InAppMessagingAction {
     data class Initialize(val siteId: String, val dataCenter: String, val environment: GistEnvironment, val colorScheme: ColorScheme = ColorScheme.AUTO) : InAppMessagingAction()
+    data class SetColorScheme(val colorScheme: ColorScheme) : InAppMessagingAction()
     data class SetPollingInterval(val interval: Long) : InAppMessagingAction()
     data class SetSseEnabled(val enabled: Boolean) : InAppMessagingAction()
     data class SetPageRoute(val route: String) : InAppMessagingAction()

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
@@ -4,9 +4,10 @@ import io.customer.messaginginapp.gist.GistEnvironment
 import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.MessagePosition
+import io.customer.messaginginapp.type.ColorScheme
 
 internal sealed class InAppMessagingAction {
-    data class Initialize(val siteId: String, val dataCenter: String, val environment: GistEnvironment) : InAppMessagingAction()
+    data class Initialize(val siteId: String, val dataCenter: String, val environment: GistEnvironment, val colorScheme: ColorScheme = ColorScheme.AUTO) : InAppMessagingAction()
     data class SetPollingInterval(val interval: Long) : InAppMessagingAction()
     data class SetSseEnabled(val enabled: Boolean) : InAppMessagingAction()
     data class SetPageRoute(val route: String) : InAppMessagingAction()

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingState.kt
@@ -3,11 +3,13 @@ package io.customer.messaginginapp.state
 import io.customer.messaginginapp.gist.GistEnvironment
 import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.gist.data.model.Message
+import io.customer.messaginginapp.type.ColorScheme
 
 internal data class InAppMessagingState(
     val siteId: String = "",
     val dataCenter: String = "",
     val environment: GistEnvironment = GistEnvironment.PROD,
+    val colorScheme: ColorScheme = ColorScheme.AUTO,
     val pollInterval: Long = 600_000L,
     val userId: String? = null,
     val anonymousId: String? = null,
@@ -44,6 +46,7 @@ internal data class InAppMessagingState(
         append("siteId='$siteId',\n")
         append("dataCenter='$dataCenter',\n")
         append("environment=$environment,\n")
+        append("colorScheme=$colorScheme,\n")
         append("pollInterval=$pollInterval,\n")
         append("userId=$userId,\n")
         append("anonymousId=$anonymousId,\n")
@@ -62,6 +65,7 @@ internal data class InAppMessagingState(
             if (siteId != other.siteId) put("siteId", siteId to other.siteId)
             if (dataCenter != other.dataCenter) put("dataCenter", dataCenter to other.dataCenter)
             if (environment != other.environment) put("environment", environment to other.environment)
+            if (colorScheme != other.colorScheme) put("colorScheme", colorScheme to other.colorScheme)
             if (pollInterval != other.pollInterval) put("pollInterval", pollInterval to other.pollInterval)
             if (userId != other.userId) put("userId", userId to other.userId)
             if (anonymousId != other.anonymousId) put("anonymousId", anonymousId to other.anonymousId)

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/ColorScheme.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/ColorScheme.kt
@@ -1,0 +1,25 @@
+package io.customer.messaginginapp.type
+
+import android.content.res.Configuration
+
+enum class ColorScheme {
+    LIGHT,
+    DARK,
+    AUTO;
+
+    internal fun resolve(uiMode: Int): String {
+        return when (this) {
+            LIGHT -> RENDERER_LIGHT
+            DARK -> RENDERER_DARK
+            AUTO -> {
+                val nightMode = uiMode and Configuration.UI_MODE_NIGHT_MASK
+                if (nightMode == Configuration.UI_MODE_NIGHT_YES) RENDERER_DARK else RENDERER_LIGHT
+            }
+        }
+    }
+
+    internal companion object {
+        const val RENDERER_LIGHT = "light"
+        const val RENDERER_DARK = "dark"
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/bridge/EngineWebViewDelegate.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/bridge/EngineWebViewDelegate.kt
@@ -20,4 +20,5 @@ internal interface EngineWebViewDelegate {
     fun getView(): View
     fun setAlpha(alpha: Float)
     fun bringToFront()
+    fun updateColorScheme(scheme: String)
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -100,6 +100,7 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
     @UiThread
     internal fun loadMessage(message: Message) {
         val store = inAppMessagingManager.getCurrentState()
+        val uiMode = SDKComponent.android().applicationContext.resources.configuration.uiMode
         val config = EngineWebConfiguration(
             siteId = store.siteId,
             dataCenter = store.dataCenter,
@@ -107,7 +108,8 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
             instanceId = message.instanceId,
             endpoint = store.environment.getEngineApiUrl(),
             properties = message.properties,
-            customAttributes = SDKComponent.gistCustomAttributes.toMap()
+            customAttributes = SDKComponent.gistCustomAttributes.toMap(),
+            colorScheme = store.colorScheme.resolve(uiMode)
         )
 
         currentMessage = message

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -100,7 +100,9 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
     @UiThread
     internal fun loadMessage(message: Message) {
         val store = inAppMessagingManager.getCurrentState()
-        val uiMode = SDKComponent.android().applicationContext.resources.configuration.uiMode
+        val viewContext = engineWebViewDelegate?.getView()?.context
+        val uiMode = (viewContext ?: SDKComponent.android().applicationContext)
+            .resources.configuration.uiMode
         val config = EngineWebConfiguration(
             siteId = store.siteId,
             dataCenter = store.dataCenter,

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -100,9 +100,8 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
     @UiThread
     internal fun loadMessage(message: Message) {
         val store = inAppMessagingManager.getCurrentState()
-        val viewContext = engineWebViewDelegate?.getView()?.context
-        val uiMode = (viewContext ?: SDKComponent.android().applicationContext)
-            .resources.configuration.uiMode
+        val uiMode = engineWebViewDelegate?.getView()?.context
+            ?.resources?.configuration?.uiMode ?: 0
         val config = EngineWebConfiguration(
             siteId = store.siteId,
             dataCenter = store.dataCenter,

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
@@ -14,6 +14,7 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.testutils.core.JUnitTest
 import io.customer.messaginginapp.testutils.extension.createGistAction
 import io.customer.messaginginapp.testutils.extension.createInAppMessage
@@ -440,6 +441,7 @@ class InAppMessageViewControllerTest : JUnitTest() {
         controller.loadMessage(givenMessage)
 
         controller.currentMessage shouldBeEqualTo givenMessage
+        val uiMode = SDKComponent.android().applicationContext.resources.configuration.uiMode
         val expectedConfig = EngineWebConfiguration(
             siteId = givenStoreState.siteId,
             dataCenter = givenStoreState.dataCenter,
@@ -447,7 +449,8 @@ class InAppMessageViewControllerTest : JUnitTest() {
             instanceId = givenMessage.instanceId,
             endpoint = givenStoreState.environment.getEngineApiUrl(),
             properties = givenMessage.properties,
-            customAttributes = SDKComponent.gistCustomAttributes.toMap()
+            customAttributes = SDKComponent.gistCustomAttributes.toMap(),
+            colorScheme = givenStoreState.colorScheme.resolve(uiMode)
         )
         assertCalledOnce { engineWebViewDelegate.setup(expectedConfig) }
     }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
@@ -14,7 +14,6 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.state.InAppMessagingState
-import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.testutils.core.JUnitTest
 import io.customer.messaginginapp.testutils.extension.createGistAction
 import io.customer.messaginginapp.testutils.extension.createInAppMessage

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InlineMessageViewControllerBehaviorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InlineMessageViewControllerBehaviorTest.kt
@@ -480,15 +480,14 @@ class InlineMessageViewControllerBehaviorTest : JUnitTest() {
             colorScheme = moduleConfig.colorScheme.resolve(uiMode)
         )
         verifyOrder {
-
-        elapsedTimer.start(any())
-        viewCallback.onLoadingStarted()
-        viewDelegate.createEngineWebViewInstance()
-        engineWebViewDelegate.setAlpha(0.0F)
-        engineWebViewDelegate.listener = controller
-        viewDelegate.addView(engineWebViewDelegate)
-        viewDelegate.isVisible = true
-        engineWebViewDelegate.setup(expectedConfig)
+            elapsedTimer.start(any())
+            viewCallback.onLoadingStarted()
+            viewDelegate.createEngineWebViewInstance()
+            engineWebViewDelegate.setAlpha(0.0F)
+            engineWebViewDelegate.listener = controller
+            viewDelegate.addView(engineWebViewDelegate)
+            viewDelegate.isVisible = true
+            engineWebViewDelegate.setup(expectedConfig)
         }
     }
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InlineMessageViewControllerBehaviorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InlineMessageViewControllerBehaviorTest.kt
@@ -467,7 +467,8 @@ class InlineMessageViewControllerBehaviorTest : JUnitTest() {
         controller: InlineInAppMessageViewController,
         viewCallback: InlineInAppMessageViewCallback,
         expectedMessage: Message
-    ) = verifyOrder {
+    ) {
+        val uiMode = SDKComponent.android().applicationContext.resources.configuration.uiMode
         val expectedConfig = EngineWebConfiguration(
             siteId = moduleConfig.siteId,
             dataCenter = gistDataCenter,
@@ -475,8 +476,10 @@ class InlineMessageViewControllerBehaviorTest : JUnitTest() {
             instanceId = expectedMessage.instanceId,
             endpoint = gistEnvironment.getEngineApiUrl(),
             properties = expectedMessage.properties,
-            customAttributes = SDKComponent.gistCustomAttributes.toMap()
+            customAttributes = SDKComponent.gistCustomAttributes.toMap(),
+            colorScheme = moduleConfig.colorScheme.resolve(uiMode)
         )
+        verifyOrder {
 
         elapsedTimer.start(any())
         viewCallback.onLoadingStarted()
@@ -486,6 +489,7 @@ class InlineMessageViewControllerBehaviorTest : JUnitTest() {
         viewDelegate.addView(engineWebViewDelegate)
         viewDelegate.isVisible = true
         engineWebViewDelegate.setup(expectedConfig)
+        }
     }
 
     private fun assertMessageDisplayedCalls(


### PR DESCRIPTION

https://github.com/user-attachments/assets/be6b31f6-4703-4005-97c2-9e911eefa582

## Summary
- Adds `ColorScheme` enum (`LIGHT`, `DARK`, `AUTO`) as a public API on `MessagingInAppModuleConfig`
- `AUTO` (the default) resolves the current system/app dark mode state and sends `"light"` or `"dark"` to the Gist renderer via the existing `postMessage` protocol
- Live theme changes are detected via `View.onConfigurationChanged()` and pushed to active WebViews through the `updateColorScheme` action — matching the same message format used by gist-web
- `GistModalActivity` now declares `android:configChanges="uiMode"` so modal messages survive dark mode toggles instead of being dismissed
- Color scheme flows through the Redux state store (`Initialize` action → `InAppMessagingState`) for consistency and testability
- Exposes `ModuleMessagingInApp.setColorScheme()` for runtime changes — the new value persists in the state store for the session and is pushed to any active WebViews immediately

## Usage
```kotlin
// Default: follows system dark mode automatically
MessagingInAppModuleConfig.Builder(siteId, region).build()

// Force light or dark at init
MessagingInAppModuleConfig.Builder(siteId, region)
    .setColorScheme(ColorScheme.LIGHT)
    .build()

// Change at runtime (persists for the session)
ModuleMessagingInApp.instance().setColorScheme(ColorScheme.DARK)
```

## Test plan
- [ ] Trigger an in-app message with system dark mode OFF → message renders in light mode
- [ ] Toggle system dark mode ON → newly triggered messages render in dark mode
- [ ] With `ColorScheme.LIGHT` configured → messages always render light regardless of system setting
- [ ] With `ColorScheme.DARK` configured → messages always render dark regardless of system setting
- [ ] Toggle dark mode while an in-app message is displayed → message updates live without being dismissed
- [ ] Call `setColorScheme()` at runtime → active and future messages reflect the new setting
- [ ] Existing unit tests pass


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the in-app WebView bridge and modal activity lifecycle; regressions could affect message display or theme sync, but changes are additive with defaults preserved.
> 
> **Overview**
> Adds public **`ColorScheme`** (`LIGHT`, `DARK`, `AUTO`) on **`MessagingInAppModuleConfig`** (default `AUTO`) and **`ModuleMessagingInApp.setColorScheme()`** for runtime updates. The choice is stored in Redux (`Initialize` / `SetColorScheme`) and passed into **`EngineWebConfiguration`** as resolved `"light"` / `"dark"` for the Gist WebView.
> 
> **`EngineWebView`** pushes live updates via `updateColorScheme` (`MessageEvent` with `action: updateColorScheme`), subscribes to state changes, and reacts to **`onConfigurationChanged`** when mode is `AUTO`. **`GistModalActivity`** declares **`android:configChanges="uiMode"`** so modals are not recreated on theme toggles. Unit tests assert **`colorScheme`** on web configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f7be20cb3a076b8c7e3c8cf511142cd8462672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->