### PR TITLE
chore(geofence): unique transition id + at-least-once delivery

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
@@ -61,3 +61,35 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
         }
     }
 }
+
+/**
+ * At-least-once counterpart to [claimSendRestore] for channels whose payload carries a stable
+ * backend dedup id (geofence: `transitionId`).
+ *
+ * Unlike [claimSendRestore], the entry is **not** removed before sending — it stays until [send]
+ * is confirmed, so a process death mid-send leaves the row for a retry or the foreground flush
+ * instead of dropping it. The cost is a possible double-delivery (a concurrent channel, or a retry
+ * after an ambiguous success), safe only because the backend dedupes on the stable id.
+ *
+ * The presence check is best-effort — not atomic with [send] — so it only trims a duplicate when
+ * another channel already removed the entry. On failure the row is left in place (never removed)
+ * so the next attempt can deliver it.
+ */
+@InternalCustomerIOApi
+suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore<T>.sendRemoveOnSuccess(
+    entry: T,
+    isRetryable: (Throwable?) -> Boolean = { it is IOException },
+    send: suspend () -> Result<Unit>
+): PendingDeliveryResult {
+    if (loadAll().none { it.key == entry.key }) return PendingDeliveryResult.AlreadyClaimed
+
+    val result = send()
+    return when {
+        result.isSuccess -> {
+            remove(entry.key)
+            PendingDeliveryResult.Delivered
+        }
+        isRetryable(result.exceptionOrNull()) -> PendingDeliveryResult.Retryable(result.exceptionOrNull())
+        else -> PendingDeliveryResult.Failed(result.exceptionOrNull())
+    }
+}

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -10,16 +10,20 @@ import kotlinx.coroutines.launch
 
 /**
  * Drains a [PendingDeliveryStore] through an opportunistic in-process channel
- * (typically an app-foreground handoff), guaranteeing exactly-once delivery
- * against the durable WorkManager channel that also consumes the same store.
+ * (typically an app-foreground handoff), coordinating with the durable
+ * WorkManager channel that also consumes the same store.
  *
  * For each pending entry it: cancels that entry's WorkManager unique work — so
  * the worker can't also deliver — then atomically
  * [claims][PendingDeliveryStore.claim] it and hands it to the caller's
  * [publish] block. Cancel happens before the claim on purpose: an `ENQUEUED`
  * or running worker flips to `CANCELLED` immediately, narrowing the window in
- * which both channels could race. The claim is what actually guarantees
- * exactly-once — cancellation is best-effort and can lose across process death.
+ * which both channels could race. Cancellation is best-effort and can lose
+ * across process death, so the claim is what makes this flush deliver each
+ * entry at most once. Whether the *system* is exactly- or at-least-once depends
+ * on the paired worker: one that also claims before sending (push) is
+ * exactly-once; one that sends-then-removes (geofence) is at-least-once and
+ * relies on a stable id in the payload for downstream dedupe.
  *
  * Entries are processed in isolation: one failed cancel/publish does not abort
  * the batch, and an unclaimed or failed entry survives for the next flush. The
@@ -77,11 +81,12 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                             workManager.cancelUniqueWork(entry.key).await()
                             callbacks.onWorkCancelled(entry)
                         }
-                        // Atomically claim before publishing so the worker (which
-                        // also claims before sending) cannot deliver the same entry.
-                        // Claiming per-entry here, rather than batching a remove at
-                        // the end, also means a mid-loop CancellationException can't
-                        // strand an already-published entry for re-publish next flush.
+                        // Atomically claim before publishing so this flush delivers
+                        // each entry at most once (and a worker that also claims —
+                        // push — can't deliver the same entry). Claiming per-entry
+                        // here, rather than batching a remove at the end, also means a
+                        // mid-loop CancellationException can't strand an already-
+                        // published entry for re-publish next flush.
                         if (!store.claim(entry.key)) return@forEach
                         publish(entry)
                         callbacks.onPublished(entry)

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -98,4 +98,92 @@ class PendingDeliveryClaimTest : RobolectricTest() {
         result shouldBeInstanceOf PendingDeliveryResult.Retryable::class
         store.loadAll() shouldBeEqualTo listOf(entry)
     }
+
+    @Test
+    fun sendRemoveOnSuccess_givenEntryNotPresent_expectAlreadyClaimedAndSendNotInvoked() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("absent")
+        var sendInvoked = false
+
+        val result = store.sendRemoveOnSuccess(entry) {
+            sendInvoked = true
+            Result.success(Unit)
+        }
+
+        result shouldBeEqualTo PendingDeliveryResult.AlreadyClaimed
+        sendInvoked shouldBeEqualTo false
+    }
+
+    @Test
+    fun sendRemoveOnSuccess_givenSendSucceeds_expectDeliveredAndEntryRemoved() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("ok")
+        store.append(entry)
+
+        val result = store.sendRemoveOnSuccess(entry) { Result.success(Unit) }
+
+        result shouldBeEqualTo PendingDeliveryResult.Delivered
+        store.loadAll() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun sendRemoveOnSuccess_whileSending_expectEntryStillPresentUntilSuccess() = runBlocking<Unit> {
+        // The core difference from claimSendRestore: the row is NOT removed before the send, so a
+        // process death mid-send leaves it for a retry/flush instead of dropping it.
+        val store = newStore()
+        val entry = TestEntry("in-flight")
+        store.append(entry)
+
+        store.sendRemoveOnSuccess(entry) {
+            store.loadAll() shouldBeEqualTo listOf(entry)
+            Result.success(Unit)
+        }
+
+        store.loadAll() shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun sendRemoveOnSuccess_givenIOException_expectRetryableAndEntryKept() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("retry")
+        store.append(entry)
+        val cause = IOException("network down")
+
+        val result = store.sendRemoveOnSuccess(entry) { Result.failure(cause) }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Retryable::class
+        (result as PendingDeliveryResult.Retryable).cause shouldBeEqualTo cause
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+
+    @Test
+    fun sendRemoveOnSuccess_givenNonRetryableError_expectFailedAndEntryKept() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("fail")
+        store.append(entry)
+        val cause = IllegalStateException("400 bad request")
+
+        val result = store.sendRemoveOnSuccess(entry) { Result.failure(cause) }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Failed::class
+        (result as PendingDeliveryResult.Failed).cause shouldBeEqualTo cause
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+
+    @Test
+    fun sendRemoveOnSuccess_givenFailureThenRetry_expectEntryKeptThenDelivered() = runBlocking<Unit> {
+        // The durability promise end-to-end: a failed send leaves the row, and the next attempt
+        // (a retry, or the foreground flush) reclaims and delivers it.
+        val store = newStore()
+        val entry = TestEntry("reclaim")
+        store.append(entry)
+
+        val first = store.sendRemoveOnSuccess(entry) { Result.failure(IOException("network down")) }
+        first shouldBeInstanceOf PendingDeliveryResult.Retryable::class
+        store.loadAll() shouldBeEqualTo listOf(entry)
+
+        val second = store.sendRemoveOnSuccess(entry) { Result.success(Unit) }
+        second shouldBeEqualTo PendingDeliveryResult.Delivered
+        store.loadAll() shouldBeEqualTo emptyList()
+    }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -136,11 +136,11 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             logger.logTransitionEmitting(geofenceId, transition.name)
 
             // Record the transition durably before scheduling. Two channels then
-            // race to deliver it exactly once, arbitrated by the shared store's
-            // atomic claim: the WorkManager worker (direct HTTP, survives process
-            // death) and the foreground flush (analytics pipeline). Append first
-            // so a WorkManager scheduling failure still leaves the entry for the
-            // flush; isolate the scheduler so it can't abandon the rest of the batch.
+            // deliver it at least once, deduped downstream by transitionId: the
+            // WorkManager worker (direct HTTP, survives process death) and the
+            // foreground flush (analytics pipeline). Append first so a WorkManager
+            // scheduling failure still leaves the entry for the flush; isolate the
+            // scheduler so it can't abandon the rest of the batch.
             // Snapshot userId so a sign-out + sign-in before delivery can't
             // reattribute this transition. Empty userId is treated as "not
             // identified" per the SDK's `isUserIdentified` convention.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -18,6 +18,7 @@ import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
+import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -148,6 +149,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 transition = transition,
                 timestamp = timestamp,
                 userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() },
+                // Minted once here so every delivery attempt for this transition carries the same id.
+                transitionId = UUID.randomUUID().toString(),
                 geofenceName = androidComponent.geofenceRegionStore.getCachedRegionName(geofenceId)
             )
             androidComponent.pendingGeofenceDeliveryStore.append(entry)

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -15,8 +15,9 @@ import io.customer.sdk.data.store.PendingDeliveryFlusher
  * transitions delivered.
  *
  * The shared [PendingDeliveryFlusher] cancels each transition's WorkManager
- * delivery and atomically claims it, so it can't be delivered twice (once here
- * via the pipeline, once by the worker via direct HTTP). The entry's
+ * delivery and atomically claims it before publishing here, so this path stays
+ * the primary deliverer; the worker (send-then-remove) can still race a
+ * duplicate via direct HTTP, deduped downstream by transitionId. The entry's
  * snapshotted userId rides through on [io.customer.sdk.communication.Event.GeofenceTransitionEvent]
  * so the pipeline subscriber attributes the track event to it.
  *

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -37,7 +37,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logTransitionEmitting(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: queued for exactly-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
+        logger.debug("Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
     }
 
     fun logTransitionSuppressed(geofenceId: String, transitionName: String) {
@@ -129,7 +129,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logEventDeliverySkippedAlreadyDelivered(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: worker skipped — already delivered via the analytics pipeline (claim lost)", tag = TAG)
+        logger.debug("Geofence '$geofenceId' $transitionName: worker skipped — entry no longer in store (already delivered via the analytics pipeline)", tag = TAG)
     }
 
     fun logForegroundFlushSnapshot(count: Int) {

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -123,7 +123,8 @@ class ModuleGeofence @JvmOverloads constructor(
         val mainThreadPoster: MainThreadPoster = HandlerMainThreadPoster()
         mainThreadPoster.post {
             // Flush pending OS-delivered transitions to the analytics pipeline on
-            // every foreground entry (exactly-once against the WorkManager worker).
+            // every foreground entry (at-least-once with the WorkManager worker,
+            // deduped downstream by transitionId).
             ProcessLifecycleOwner.get().lifecycle.addObserver(
                 GeofenceLifecycleObserver(
                     deliveryFlusher = sdkAndroid.geofenceDeliveryFlusher,

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -59,7 +59,8 @@ internal val AndroidSDKComponent.geofenceEventTracker: GeofenceEventTracker
     }
 
 // Shared by the WorkManager worker, the async fallback, and the foreground flush
-// so all three coordinate exactly-once delivery over one lock/file.
+// so all three coordinate delivery over one lock/file (at-least-once, deduped
+// downstream by transitionId).
 internal val AndroidSDKComponent.pendingGeofenceDeliveryStore: PendingDeliveryStore<PendingGeofenceDelivery>
     get() = singleton {
         PendingDeliveryStore(

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -23,6 +23,8 @@ internal data class PendingGeofenceDelivery(
     /** Unix epoch **seconds** at receiver time. Use [toGeofenceTransitionEvent] when a [Date] is needed. */
     val timestamp: Long,
     val userId: String?,
+    /** Stable id minted once at capture so every delivery attempt dedupes to one event backend-side. Not part of [key]. */
+    val transitionId: String,
     /** Null when the fired geofence isn't in the cached region set. */
     val geofenceName: String? = null
 ) : PendingDeliveryStore.PendingDeliveryEntry {
@@ -37,6 +39,7 @@ internal data class PendingGeofenceDelivery(
     fun toEventProperties(): Map<String, Any> = buildMap {
         put("transition", transition.name.lowercase())
         put("geofenceId", geofenceId)
+        put("transitionId", transitionId)
         geofenceName?.let { put("geofenceName", it) }
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
@@ -7,7 +7,7 @@ import io.customer.sdk.core.network.HttpRequestParams
 import io.customer.sdk.core.util.DispatchersProvider
 import io.customer.sdk.core.util.Iso8601TimestampFormatter
 import io.customer.sdk.data.store.PendingDeliveryStore
-import io.customer.sdk.data.store.claimSendRestore
+import io.customer.sdk.data.store.sendRemoveOnSuccess
 import io.customer.sdk.util.EventNames
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -58,10 +58,11 @@ internal class GeofenceEventTrackerImpl(
 
 /**
  * Async fallback when WorkManager is unavailable. Fire-and-forget; does not
- * survive process death. Uses the same [claimSendRestore] contract as the
- * worker — claim before sending — so that if the foreground flush fires while
- * this HTTP call is in flight, only one channel delivers: a lost claim skips
- * the send, and a failed send restores the entry for the flush to retry.
+ * survive process death. Uses the same [sendRemoveOnSuccess] contract as the
+ * worker — the entry stays in the store until the send is confirmed, so a
+ * failed send (or a death mid-request) leaves it for the foreground flush to
+ * retry rather than dropping it. The duplicate this can produce (overlap with
+ * the flush) is deduped backend-side via the stable transitionId.
  *
  * Entries with a null [PendingGeofenceDelivery.userId] are left untouched here;
  * the foreground flush handles them via the analytics pipeline's anonymousId.
@@ -78,7 +79,7 @@ internal class AsyncGeofenceEventTracker(
             return
         }
         CoroutineScope(dispatcher.background).launch {
-            pendingStore.claimSendRestore(entry) {
+            pendingStore.sendRemoveOnSuccess(entry) {
                 tracker.trackEvent(entry)
             }
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -19,10 +19,12 @@ import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.data.store.PendingDeliveryResult
 import io.customer.sdk.data.store.claimSendRestore
+import java.util.UUID
 
 private const val KEY_GEOFENCE_ID = "geofence_id"
 private const val KEY_GEOFENCE_NAME = "geofence_name"
 private const val KEY_TRANSITION = "transition"
+private const val KEY_TRANSITION_ID = "transition_id"
 private const val KEY_TIMESTAMP = "timestamp"
 private const val KEY_USER_ID = "user_id"
 
@@ -38,6 +40,7 @@ internal class GeofenceEventScheduler(
         val input = Data.Builder()
             .putString(KEY_GEOFENCE_ID, entry.geofenceId)
             .putString(KEY_TRANSITION, entry.transition.name)
+            .putString(KEY_TRANSITION_ID, entry.transitionId)
             .putLong(KEY_TIMESTAMP, entry.timestamp)
             .apply {
                 entry.userId?.let { putString(KEY_USER_ID, it) }
@@ -111,6 +114,8 @@ internal class GeofenceEventWorker(
             transition = transition,
             timestamp = timestamp,
             userId = userId,
+            // Always set by the scheduler; fall back to a fresh id so an unexpected miss still delivers.
+            transitionId = inputData.getString(KEY_TRANSITION_ID) ?: UUID.randomUUID().toString(),
             geofenceName = inputData.getString(KEY_GEOFENCE_NAME)
         )
 

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -18,7 +18,7 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.data.store.PendingDeliveryResult
-import io.customer.sdk.data.store.claimSendRestore
+import io.customer.sdk.data.store.sendRemoveOnSuccess
 import java.util.UUID
 
 private const val KEY_GEOFENCE_ID = "geofence_id"
@@ -126,12 +126,12 @@ internal class GeofenceEventWorker(
             return Result.success()
         }
 
-        // Shared exactly-once decision: claim before sending so we don't double
-        // deliver against the foreground flush (which also claims before
-        // publishing), and restore the entry on failure so a retry or the flush
-        // can deliver it later.
+        // At-least-once delivery: keep the row until the send is confirmed, so a process death
+        // mid-request leaves it for a WorkManager retry or the foreground flush rather than
+        // dropping it. The duplicate this can produce (overlap with the flush, or a retry after
+        // an ambiguous success) is deduped backend-side via the stable transitionId.
         return when (
-            val outcome = store.claimSendRestore(entry) {
+            val outcome = store.sendRemoveOnSuccess(entry) {
                 SDKComponent.android().geofenceEventTracker.trackEvent(entry)
             }
         ) {

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -25,6 +25,7 @@ import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -168,6 +169,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         scheduled.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
         scheduled.toEventProperties()["transition"] shouldBeEqualTo "enter"
         scheduled.timestamp.shouldNotBeNull()
+        // A unique id is minted at capture and carried in properties.
+        scheduled.transitionId.shouldNotBeBlank()
+        scheduled.toEventProperties()["transitionId"] shouldBeEqualTo scheduled.transitionId
 
         // Durably recorded for the foreground flush, and not published inline:
         // exactly-once is now arbitrated by the store, not a double-send.

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -11,25 +11,28 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun key_expectGeofenceIdTransitionTimestampComposite() {
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A", transitionId = "tid-1")
 
         // Doubles as the WorkManager unique-work name so the flush can cancel by key.
+        // transitionId is intentionally NOT part of the key.
         entry.key shouldBeEqualTo "biz-1_ENTER_1234"
     }
 
     @Test
     fun serialization_givenRoundTrip_expectEqualEntry() {
-        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 99L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-2", Event.GeofenceTransition.EXIT, 99L, "user-A", transitionId = "tid-2")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
 
         restored shouldBeEqualTo entry
+        // The minted id must survive persistence so retries reuse it.
+        restored.transitionId shouldBeEqualTo "tid-2"
     }
 
     @Test
     fun serialization_givenUserIdSnapshot_expectRoundTripPreservesIt() {
-        val entry = PendingGeofenceDelivery("biz-u", Event.GeofenceTransition.ENTER, 3L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-u", Event.GeofenceTransition.ENTER, 3L, "user-A", transitionId = "tid-u")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -40,7 +43,7 @@ class PendingGeofenceDeliveryTest {
     @Test
     fun serialization_givenNullUserId_expectRoundTripPreservesNull() {
         // Anonymous entries are queued by the receiver for the foreground flush.
-        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 5L, userId = null)
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 5L, userId = null, transitionId = "tid-anon")
 
         val json = Json.encodeToString(PendingGeofenceDelivery.serializer(), entry)
         val restored = Json.decodeFromString(PendingGeofenceDelivery.serializer(), json)
@@ -50,13 +53,14 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
-    fun toEventProperties_expectTransitionAndGeofenceIdNoTimestamp() {
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 50L, "user-A")
+    fun toEventProperties_expectTransitionGeofenceIdAndTransitionIdNoTimestamp() {
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-4")
 
         val props = entry.toEventProperties()
 
         props["geofenceId"] shouldBeEqualTo "biz-4"
         props["transition"] shouldBeEqualTo "enter"
+        props["transitionId"] shouldBeEqualTo "tid-4"
         // Timestamp rides the event envelope, not the properties.
         props.keys shouldNotContain "timestamp"
         props.keys shouldNotContain "latitude"
@@ -65,7 +69,7 @@ class PendingGeofenceDeliveryTest {
 
     @Test
     fun toEventProperties_givenGeofenceName_expectNamePresent() {
-        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = "Ferry Building")
+        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-5", geofenceName = "Ferry Building")
 
         entry.toEventProperties()["geofenceName"] shouldBeEqualTo "Ferry Building"
     }
@@ -73,7 +77,7 @@ class PendingGeofenceDeliveryTest {
     @Test
     fun toEventProperties_givenNullGeofenceName_expectNameOmitted() {
         // Region not in the cached set => omit the property rather than send a synthetic value.
-        val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 50L, "user-A", geofenceName = null)
+        val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-6", geofenceName = null)
 
         entry.toEventProperties().keys shouldNotContain "geofenceName"
     }
@@ -83,7 +87,7 @@ class PendingGeofenceDeliveryTest {
         // `timestamp` is unix seconds; `Event.timestamp` is a `Date` (millis).
         // The conversion lives on the data class so no caller can hand-roll
         // `Date(entry.timestamp)` and silently produce a January 1970 instant.
-        val entry = PendingGeofenceDelivery("biz-t", Event.GeofenceTransition.ENTER, 1_700_000_000L, "user-A")
+        val entry = PendingGeofenceDelivery("biz-t", Event.GeofenceTransition.ENTER, 1_700_000_000L, "user-A", transitionId = "tid-t")
 
         val event = entry.toGeofenceTransitionEvent()
 
@@ -91,5 +95,7 @@ class PendingGeofenceDeliveryTest {
         event.geofenceId shouldBeEqualTo "biz-t"
         event.transition shouldBeEqualTo Event.GeofenceTransition.ENTER
         event.userId shouldBeEqualTo "user-A"
+        // transitionId travels in properties on the EventBus path too.
+        event.properties["transitionId"] shouldBeEqualTo "tid-t"
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -47,7 +47,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryAndUserId() = runTest {
         every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
-        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 42L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 42L, "user-42", transitionId = "tid-1")
 
         asyncTracker.trackEvent(entry)
 
@@ -62,7 +62,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenClaimLost_expectNoSend() = runTest {
         // Foreground flush already claimed + delivered this entry: do not double-send.
         every { mockStore.claim(any()) } returns false
-        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 7L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 7L, "user-42", transitionId = "tid-3")
 
         asyncTracker.trackEvent(entry)
 
@@ -74,7 +74,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
         every { mockStore.claim(any()) } returns true
         coEvery { mockTracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42")
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42", transitionId = "tid-4")
 
         asyncTracker.trackEvent(entry)
 
@@ -86,7 +86,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     fun trackEvent_givenNullUserId_expectNoClaimAndNoSend() = runTest {
         // Anonymous session: HTTP needs a userId, so we leave the entry in
         // the store for the foreground flush to publish via anonymousId.
-        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 11L, userId = null)
+        val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 11L, userId = null, transitionId = "tid-anon")
 
         asyncTracker.trackEvent(entry)
 

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -44,53 +44,52 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
-    fun trackEvent_givenClaimWonAndSuccess_expectTrackerCalledWithEntryAndUserId() = runTest {
-        every { mockStore.claim(any()) } returns true
-        coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
+    fun trackEvent_givenPendingEntryAndSuccess_expectSentThenRemoved() = runTest {
         val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 42L, "user-42", transitionId = "tid-1")
+        every { mockStore.loadAll() } returns listOf(entry)
+        coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
 
         asyncTracker.trackEvent(entry)
 
-        // Claim before send (shared exactly-once contract), then deliver with the snapshotted entry.
-        verify(exactly = 1) { mockStore.claim("biz-1_ENTER_42") }
+        // At-least-once contract: send with the snapshotted entry, remove only after success.
         coVerify(exactly = 1) { mockTracker.trackEvent(entry) }
-        // claim() already removed it; success must not re-append.
-        verify(exactly = 0) { mockStore.append(any()) }
+        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42") }
     }
 
     @Test
-    fun trackEvent_givenClaimLost_expectNoSend() = runTest {
-        // Foreground flush already claimed + delivered this entry: do not double-send.
-        every { mockStore.claim(any()) } returns false
+    fun trackEvent_givenEntryAlreadyDelivered_expectNoSend() = runTest {
+        // Foreground flush already delivered + removed this entry: do not re-send.
+        every { mockStore.loadAll() } returns emptyList()
         val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 7L, "user-42", transitionId = "tid-3")
 
         asyncTracker.trackEvent(entry)
 
         coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
+        verify(exactly = 0) { mockStore.remove(any()) }
     }
 
     @Test
-    fun trackEvent_givenFailure_expectEntryRestoredForFlush() = runTest {
-        every { mockStore.claim(any()) } returns true
+    fun trackEvent_givenFailure_expectEntryKeptForFlush() = runTest {
+        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42", transitionId = "tid-4")
+        every { mockStore.loadAll() } returns listOf(entry)
         coEvery { mockTracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
-        val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42", transitionId = "tid-4")
 
         asyncTracker.trackEvent(entry)
 
-        // Restored so the foreground flush can still deliver it.
-        verify(exactly = 1) { mockStore.append(entry) }
+        // Never removed, so the foreground flush can still deliver it.
+        verify(exactly = 0) { mockStore.remove(any()) }
     }
 
     @Test
-    fun trackEvent_givenNullUserId_expectNoClaimAndNoSend() = runTest {
+    fun trackEvent_givenNullUserId_expectNoLoadAndNoSend() = runTest {
         // Anonymous session: HTTP needs a userId, so we leave the entry in
         // the store for the foreground flush to publish via anonymousId.
         val entry = PendingGeofenceDelivery("biz-anon", Event.GeofenceTransition.ENTER, 11L, userId = null, transitionId = "tid-anon")
 
         asyncTracker.trackEvent(entry)
 
-        verify(exactly = 0) { mockStore.claim(any()) }
+        verify(exactly = 0) { mockStore.loadAll() }
         coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
         verify { mockLogger.logEventDeliveryDeferredAnonymous("biz-anon", "ENTER") }
     }

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -57,6 +57,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 transition = Event.GeofenceTransition.ENTER,
                 timestamp = 1_234L,
                 userId = "user-42",
+                transitionId = "tid-sched",
                 geofenceName = "Coffee Shop"
             )
         )
@@ -73,6 +74,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val input = workRequestSlot.captured.workSpec.input
         input.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
         input.getString("transition") shouldBeEqualTo "ENTER"
+        input.getString("transition_id") shouldBeEqualTo "tid-sched"
         input.getLong("timestamp", -1L) shouldBeEqualTo 1_234L
         input.getString("user_id") shouldBeEqualTo "user-42"
         input.getString("geofence_name") shouldBeEqualTo "Coffee Shop"
@@ -95,7 +97,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 geofenceId = "biz-anon",
                 transition = Event.GeofenceTransition.ENTER,
                 timestamp = 5L,
-                userId = null
+                userId = null,
+                transitionId = "tid-anon"
             )
         )
 
@@ -112,7 +115,8 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
             geofenceId = "biz-geofence-3",
             transition = Event.GeofenceTransition.ENTER,
             timestamp = 42L,
-            userId = "user-42"
+            userId = "user-42",
+            transitionId = "tid-fallback"
         )
 
         scheduler.schedule(entry)

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventTrackerTest.kt
@@ -36,8 +36,9 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         geofenceId: String = "biz-geofence-1",
         transition: Event.GeofenceTransition = Event.GeofenceTransition.ENTER,
         timestamp: Long = 1_234_567_890L,
-        userId: String? = "user-42"
-    ) = PendingGeofenceDelivery(geofenceId, transition, timestamp, userId)
+        userId: String? = "user-42",
+        transitionId: String = "transition-99"
+    ) = PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, transitionId)
 
     @Test
     fun trackEvent_givenEnterTransition_expectPostToTrackWithCorrectBody() = runTest {
@@ -55,6 +56,7 @@ class GeofenceEventTrackerTest : RobolectricTest() {
         val props = body.getJSONObject("properties")
         props.getString("geofenceId") shouldBeEqualTo "biz-geofence-1"
         props.getString("transition") shouldBeEqualTo "enter"
+        props.getString("transitionId") shouldBeEqualTo "transition-99"
         // Timestamp lives on the envelope (asserted above), not in properties.
         props.has("timestamp") shouldBeEqualTo false
         props.has("latitude") shouldBeEqualTo false

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -48,9 +48,10 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         transition: Event.GeofenceTransition,
         timestamp: Long = 0L,
         userId: String? = "user-42",
+        transitionId: String = "tid-seed",
         geofenceName: String? = null
     ): PendingGeofenceDelivery =
-        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, geofenceName)
+        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, transitionId, geofenceName)
             .also { store.append(it) }
 
     @Test
@@ -177,12 +178,14 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         transition: String?,
         timestamp: Long = 0L,
         userId: String? = "user-42",
+        transitionId: String? = "tid-seed",
         geofenceName: String? = null
     ): Data {
         val builder = Data.Builder()
             .putLong("timestamp", timestamp)
         geofenceId?.let { builder.putString("geofence_id", it) }
         transition?.let { builder.putString("transition", it) }
+        transitionId?.let { builder.putString("transition_id", it) }
         userId?.let { builder.putString("user_id", it) }
         geofenceName?.let { builder.putString("geofence_name", it) }
         return builder.build()

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -41,7 +41,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         store.removeAll()
     }
 
-    // The worker claims its entry from the shared store before sending, so seed the
+    // The worker only delivers an entry that's still in the shared store, so seed the
     // store with the matching entry to model "this transition is still pending".
     private fun seed(
         geofenceId: String,
@@ -55,7 +55,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
             .also { store.append(it) }
 
     @Test
-    fun doWork_givenClaimableEntry_expectSuccessTrackerCalledAndEntryRemoved() = runTest {
+    fun doWork_givenPendingEntry_expectSuccessTrackerCalledAndEntryRemoved() = runTest {
         val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 99L)
         val inputData = buildInputData("biz-1", "ENTER", 99L, "user-42")
         coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
@@ -90,9 +90,9 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     }
 
     @Test
-    fun doWork_givenClaimLost_expectSuccessWithoutTracking() = runTest {
-        // No matching entry in the store (the foreground flush already delivered it):
-        // the worker's claim fails, so it must not send a duplicate.
+    fun doWork_givenEntryAlreadyDelivered_expectSuccessWithoutTracking() = runTest {
+        // No matching entry in the store (the foreground flush already delivered + removed it):
+        // the worker sees it's gone, so it must not send a duplicate.
         val inputData = buildInputData("biz-already-delivered", "ENTER", timestamp = 0L, userId = "user-42")
 
         val result = createWorker(inputData).doWork()
@@ -159,7 +159,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     }
 
     @Test
-    fun doWork_givenNullUserId_expectDeferredWithoutClaimingOrTracking() = runTest {
+    fun doWork_givenNullUserId_expectDeferredWithoutTracking() = runTest {
         // Anonymous-at-queue-time path: HTTP needs a userId so we leave the
         // entry intact for the foreground flush (analytics pipeline + anonymousId).
         seed("biz-anon", Event.GeofenceTransition.ENTER, timestamp = 0L, userId = null)


### PR DESCRIPTION
## What

Two related changes to geofence transition delivery, each in its own commit (base: `feature/geofence-on-device`):

1. **`transitionId`** — a UUID minted once when a transition is captured, persisted on the pending row, and emitted in `properties` on both delivery paths (WorkManager direct-HTTP + analytics pipeline). It stays stable across delivery retries so the backend can dedupe. Mirrors iOS.

2. **At-least-once worker delivery** — the geofence worker moves from claim-then-send to send-then-remove-on-success (new `sendRemoveOnSuccess` helper). The pending row is kept until delivery is confirmed, so a process kill mid-request leaves it for a WorkManager retry or the foreground flush instead of dropping it. Push delivery is untouched (keeps `claimSendRestore`).

## Why

- **`transitionId`** gives production a stable key to identify and deduplicate geofence events.
- The old **claim-then-send** path removed the row *before* the network call, so if the process was killed mid-send the event was silently dropped — WorkManager would re-run the worker, find nothing in the store, and send nothing. This is most likely in exactly the conditions geofencing runs in (backgrounded / cold-started process, memory pressure, OEM battery managers, slow networks).
- **Send-then-remove** keeps the row until delivery is confirmed, so WorkManager's own retry (or the foreground flush) recovers it. The only cost is a possible duplicate — when a delivery is in flight at the moment the foreground flush runs, or on a retry after an ambiguous success — which is rare and harmless, since the backend dedupes it via `transitionId` (#1). Commit 2 rides on top of commit 1 for that reason.

## Linear

https://linear.app/customerio/issue/MBL-1760/android-execute-geofencing-validation-and-lifecycle-testing

## Notes

- ~84 added lines of production (excl. tests) across 10 files; much of it is comment/doc updates reconciling the delivery guarantee (the actual logic change is small). No public API change.
- Tests: `sendRemoveOnSuccess` unit cases (incl. proof the row is kept during the send, and a fail-then-retry reclaim), worker outcome tests, and `transitionId` persistence / properties / receiver→worker plumbing across both delivery paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence event delivery semantics (possible duplicate HTTP vs flush) and adds a required serialized field on pending rows; mitigated by stable transitionId and extensive tests, but relies on backend dedupe.
> 
> **Overview**
> Adds a **`transitionId`** (UUID at capture) on pending geofence rows and in track **properties** on both WorkManager HTTP and foreground analytics paths, persisted through serialization and WorkManager input so retries reuse the same id for backend dedupe.
> 
> Geofence HTTP delivery switches from **`claimSendRestore`** to new **`sendRemoveOnSuccess`**: the pending row stays until send succeeds, avoiding silent loss on process death mid-request; failures leave the row for WorkManager retry or foreground flush. Push keeps claim-before-send; **`PendingDeliveryFlusher`** docs now describe geofence as at-least-once with payload dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8931655992a25f6d75854d34b1f5a5bda8a51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->