### PR TITLE
ci: pin shared CI refs to immutable versions

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Send Slack Notification for Sample App Builds
         if: ${{ always() && env.IS_PRIMARY_APP == 'true' }}
-        uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@main
+        uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@e64ad53841ed1b30b2022778702cb30c8f931231 # main as of 2026-07-01; bump deliberately, do not track a branch
         with:
           build_status: ${{ job.status }}
           app_icon_emoji: ":android:"

--- a/samples/fastlane/Fastfile
+++ b/samples/fastlane/Fastfile
@@ -1,7 +1,9 @@
-# There are some re-usable functions in other Fastfile files in the org we can re-use. 
+# There are some re-usable functions in other Fastfile files in the org we can re-use.
+# Pinned to a customerio-ios release tag so changes to the shared Fastfile roll out
+# here deliberately instead of the moment they land on that repo's main branch.
 import_from_git(
-  url: "https://github.com/customerio/customerio-ios.git", 
-  branch: "main",
+  url: "https://github.com/customerio/customerio-ios.git",
+  branch: "4.5.3", # git tag on customerio-ios; file verified identical to main as of 2026-07-01
   path: "Apps/fastlane/Fastfile"
 )
 


### PR DESCRIPTION
## Why

Two shared-tooling refs were consumed at branch heads: the `slack-notify-sample-app` action from `mobile-ci-tools@main`, and the shared Fastfile imported from `customerio-ios` at `branch: "main"`. Any push to either repo silently changes builds here, the "nobody changed anything and CI broke" failure class.

## What

- Pin the `slack-notify-sample-app` action to the commit `mobile-ci-tools@main` resolves to today.
- Pin the shared Fastfile import to the `customerio-ios` `4.5.3` release tag. The file is byte-identical between that tag and customerio-ios main as of today, so this is a behavior-preserving no-op.

Future updates to either arrive as deliberate version-bump PRs instead of instant rollouts.

## Follow-ups

- Once customerio/mobile-ci-tools cuts versioned release tags (companion PR adds a Tag release workflow there), move the SHA pin to a `v1` tag.
- Longer term the shared Fastfile should live in mobile-ci-tools and be versioned with it, rather than riding along on iOS SDK release tags.
