### PR TITLE
docs: rewrite AGENTS.md with verified commands and CI requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,268 +1,138 @@
 # AGENTS.md
 
-This file provides guidance to AI coding agents when working with code in this repository.
+Guidance for AI coding agents and new contributors working in this repository (the Customer.io Android SDK). This is a public repository: never commit credentials, API keys, tokens, or customer data, in code, config, tests, or docs.
 
-# Customer.io Android SDK - Developer Guide
+## Golden rules
 
-After completing planned changes to the code, ALWAYS build the code to make sure it's working, before continuing to the next step.
-After making changes to Unit Tests, ALWAYS test the changed test classes. Avoid testing the whole module or the whole SDK, unless absolutely necessary.
+- After completing planned code changes, ALWAYS build the affected module before moving on.
+- After changing unit tests, run the changed test classes. Avoid running the whole module or SDK suite unless necessary.
+- Never hand-edit generated code or `.api` files. If the public API changed intentionally, regenerate dumps with `./gradlew apiDump`.
+- Never bump pinned dependency or tool versions as a drive-by (see Dependency policy).
+- Do not modify root or module `build.gradle` files unless the task requires it.
+- Avoid non-null assertions (`!!`) outside tests.
 
 ## Commands
+
 - Build all modules: `./gradlew assembleDebug`
-- Build single module: `./gradlew :MODULE_NAME:assembleDebug` (e.g., `./gradlew :core:assembleDebug`)
-- Test single module: `./gradlew :MODULE_NAME:test` (e.g., `./gradlew :core:test`)
-- Test single class: `./gradlew :MODULE_NAME:test --tests "ClassName"`
-- Lint: `make lint` or `./gradlew lintDebug`
-- Format: `make format` (run before lint)
-- Install local Maven artifacts: `make install-local-sdk`
+- Build one module: `./gradlew :core:assembleDebug`
+- Unit test one module: `./gradlew :core:test`
+- Unit test one class: `./gradlew :core:test --tests "ClassNameTest"`
+- Format Kotlin: `make format` (ktlint autoformat)
+- Lint Kotlin: `make lint` (installs pinned ktlint, formats, then reports remaining errors)
+- Android Lint, per module (what CI runs): `./gradlew :MODULE:lintDebug`
+- Regenerate public API dumps: `./gradlew apiDump` (alias: `make generate-public-api`)
+- Validate public API: `make validate-public-api`
+- Publish SDK artifacts to local Maven for sample/integration testing: `./gradlew publishToMavenLocal`
 
-## Code Style
-- **Kotlin 1.8.21** with object-oriented and functional programming patterns
-- Naming: PascalCase for classes, camelCase for properties/methods/variables
-- Package naming: `io.customer.sdk.*` for public APIs, `io.customer.MODULE.*` for module-specific code
-- Always use dependency injection via `DIGraphShared` and module-specific DI graphs
-- Modular architecture (Core, DataPipelines, MessagingPush, MessagingInApp, etc.)
-- Document public APIs with KDoc comments
-- Error handling: prefer sealed classes for typed errors, use Result types when appropriate
-- Avoid non-null assertions (!!) except in tests where values are guaranteed
-- Use explicit null checks and safe calls (?.) for nullable types
-- Keep classes small and with single responsibility
-- Keep methods focused and well-named
+## Toolchain
 
-## Prohibited Actions
-- DO NOT modify any generated code or `.api` files manually
-- DO NOT expose internal modules or APIs to SDK users
-- DO NOT modify root `build.gradle` or module `build.gradle` files unless specifically asked
-- DO NOT commit configuration files with actual credentials
-- DO NOT include files with credentials in generated code
-- DO NOT use Android features unavailable in API 21+ unless compatibility checks are included
-- DO NOT bypass the DI system with direct instantiation of internal classes
+- Kotlin 2.1.21, AGP 8.9.3, Gradle 8.14, Java 17 (zulu on CI)
+- compileSdk 36, targetSdk 36, minSdk 21
+- Compose BOM 2025.10.00 (messaginginapp-compose module)
+- All versions live in `buildSrc/src/main/kotlin/io.customer/android/Versions.kt`
 
-## Android-Specific Considerations
-- **Minimum SDK**: API 21 (Android 5.0)
-- **Target SDK**: API 33+ (follow current Android recommendations)
-- **Kotlin Version**: 1.8.21 - when adding new dependencies, ensure they're compatible with this Kotlin version
-- **Compose BOM**: 2023.03.00 (compatible with compileSdk 33)
-- Always check API level compatibility when using newer Android features
-- Use AndroidX libraries instead of deprecated support libraries
-- Handle Android lifecycle properly (Activities, Fragments, Services)
-- Consider memory implications of long-running operations
-- Use appropriate threading (Main thread for UI, background for network/disk)
-- Follow Android security best practices (no hardcoded secrets, proper permissions)
-- When adding new dependencies, verify Kotlin compatibility in `buildSrc/src/main/kotlin/io.customer/android/Versions.kt`
+## CI: what gates your PR and how to fix it
 
-## Memory and Performance
-- Use appropriate collection types (List vs Array, mutable vs immutable)
-- Avoid memory leaks by properly managing listeners and callbacks
-- Use weak references for callbacks that reference Activities/Contexts
-- Consider object pooling for frequently created objects
-- Profile memory usage during development
-- Use ProGuard/R8 rules appropriately for release builds
-- Monitor SDK binary size impact
+Every check below runs on pull requests. Know them before you push.
 
-## Threading and Concurrency
-- Use Kotlin coroutines for asynchronous operations
-- Prefer structured concurrency over raw threads
-- Always specify appropriate Dispatchers (Main, IO, Default)
-- Handle cancellation properly in coroutines
-- Use thread-safe data structures when sharing state
-- Document threading requirements in public APIs
-- Test concurrent code thoroughly
+1. **PR title lint.** The PR title must be a conventional commit message, for example `feat(inbox): ...`, `fix: ...`, `ci: ...`, `chore(geofence): ...`. The merged PR title drives semantic-release: `feat` = minor, `fix` = patch, breaking change (`!` or BREAKING CHANGE footer) = major; `ci`, `chore`, `docs`, `test`, `refactor` produce no release.
+2. **Kotlin Lint.** Runs the pinned ktlint (0.48.2, installed by `scripts/get-ktlint.sh`) in check mode. Fix locally with `make format`, then `make lint`. The version is pinned deliberately: new ktlint releases are not backward compatible. Do not upgrade it as part of an unrelated change.
+3. **Android Lint.** Runs `:MODULE:lintDebug` for core, datapipelines, messagingpush, messaginginapp, and tracking-migration.
+4. **API check (binary compatibility).** Runs `./gradlew apiCheck` against the committed `.api` dumps. If you intentionally changed the public API, run `./gradlew apiDump` and commit the result. Unintentional diffs mean you broke binary compatibility, fix the code instead.
+5. **Unit tests.** Per-module matrix (messagingpush, messaginginapp, base, datapipelines, core, tracking-migration) running `runJacocoTestReport`, with coverage uploaded to Codecov. The upload is configured to fail the job on error, so a failed upload can fail your PR even when tests pass. Rerun the job if the failure is in the upload step, not the tests.
+6. **Instrumentation tests.** Runs `connectedDebugAndroidTest` for both sample apps (kotlin_compose, java_layout) on an API 31 x86_64 emulator with a 45-minute timeout.
+7. **Snapshot publish.** Every PR publishes `<branch-name>-SNAPSHOT` artifacts to the Maven Central snapshots repository and comments the version on the PR, so branch names must be valid in a Maven version string. Requires repository signing secrets, so this job cannot succeed on PRs from forks.
+8. **SDK binary size report.** Builds base and head branches, compares SDK size, and comments the diff on the PR. Large unexplained size increases will draw review scrutiny.
 
-## Testing Strategy
-- Write both JVM unit tests and Android instrumentation tests
-- Use `UnitTest` base class for standard unit tests
-- Use `AndroidTest` base class for instrumentation tests
-- Use `RobolectricTest` for Android framework testing without device
-- Mock dependencies using MockK framework
-- Use test doubles and stubs from `common-test` module
-- Follow AAA pattern (Arrange, Act, Assert)
-- Name tests with `testMethodName_whenCondition_thenExpectedResult` format
+Gotcha: the `location` module currently has unit tests but is not in the Android Lint or unit-test CI matrices. If you touch `location/`, run `./gradlew :location:test` and `./gradlew :location:lintDebug` locally; CI will not do it for you.
 
-## Committing and Git Workflow
-- Use `lefthook` for git hooks (install with `lefthook install`)
-- Run `make format` before committing
-- Run `make lint` to ensure code quality
-- Follow conventional commit messages
-- Use feature branches off `main` branch
-- Create pull requests for all changes
-- Ensure CI passes before merging
+## Dependency policy
 
-## Project Structure
-- `buildSrc/` - Centralized dependency and version management
-- `core/` - Central SDK infrastructure (DI, EventBus, shared utilities)
-- `base/` - Base classes and shared functionality
-- `datapipelines/` - Primary tracking and analytics functionality
-- `messagingpush/` - Push notification handling (FCM)
-- `messaginginapp/` - In-app messaging functionality
+- All dependency versions are declared in `buildSrc/src/main/kotlin/io.customer/android/Versions.kt`.
+- The Segment analytics-kotlin dependency is strictly pinned (`!!`). This is deliberate, for binary compatibility with customer apps. Do not bump it casually; treat any change to it as a reviewed, standalone task.
+- minSdk 21 is a customer-facing support commitment. Some dependencies are intentionally held at versions that still support it. Check a dependency's minSdk before bumping.
+- When updating the AGP version, also update the gradle compatibility workflow (see the comment in Versions.kt).
+
+## Code style
+
+- Kotlin, PascalCase classes, camelCase members.
+- Packages: `io.customer.sdk.*` for public APIs, `io.customer.MODULE.*` for module code.
+- Dependency injection everywhere: `DIGraphShared` plus module-specific DI graphs. Do not instantiate internal classes directly.
+- Prefer sealed classes for typed errors; use safe calls for nullables.
+- KDoc on public APIs. Do not expose internal modules or APIs to SDK users.
+- Kotlin coroutines for async work; specify dispatchers explicitly; use thread-safe structures for shared state.
+
+## Testing
+
+- Base classes in `common-test`: `UnitTest` (JVM), `JUnit5Test`, `RobolectricTest` (Android framework on JVM), `AndroidTest` (instrumentation).
+- The suite is a JUnit 4 and JUnit 5 mix (JUnit BOM 5.9.3). Match the framework the surrounding test class already uses.
+- Mocking with MockK. Robolectric for Android framework behavior without a device.
+- Test naming convention: `methodName_givenCondition_expectResult`, for example `identify_givenFirstIdentify_expectDeviceRegistered`.
+- Follow Arrange, Act, Assert.
+
+## Git workflow
+
+- Branch off `main`. There is no develop branch.
+- Install hooks once: `lefthook install`. Pre-commit runs `make format` and public API validation; pre-push runs the ktlint check. If CI lint fails, your hooks probably are not installed.
+- Commit messages follow conventional commits. The PR title matters most (squash merge), and it is what semantic-release reads.
+- Releases are fully automated with semantic-release from `main` (and `beta`/`alpha` prerelease branches) to Maven Central. There is no manual version bump; do not edit version numbers in the repo.
+
+## Project structure
+
+- `buildSrc/` - centralized dependency and version management
+- `core/` - central SDK infrastructure (DI, EventBus, shared utilities)
+- `base/` - base classes and shared functionality
+- `datapipelines/` - primary tracking and analytics functionality
+- `messagingpush/` - push notification handling (FCM)
+- `messaginginapp/` - in-app messaging
 - `messaginginapp-compose/` - Jetpack Compose support for in-app messaging
-- `tracking-migration/` - Legacy API migration utilities
-- `common-test/` - Shared testing infrastructure and utilities
-- `samples/` - Example applications demonstrating SDK usage
-- `docs/` - Developer documentation and guides
-- `scripts/` - Build and deployment automation scripts
+- `location/` - location and geofence functionality
+- `tracking-migration/` - legacy API migration utilities
+- `common-test/` - shared testing infrastructure
+- `samples/` - sample apps (java_layout, kotlin_compose)
+- `docs/dev-notes/` - developer documentation
+- `scripts/` - build and automation scripts
 
-## Architecture Overview
+## Architecture
 
-### Module Initialization Pattern
+### SDK initialization pattern
+
 ```kotlin
-// Configure the SDK with builder pattern
-CustomerIOBuilder(application, <CDP_API_KEY>).apply {
-    // If you're in the EU, set Region.EU. Default is Region.US and optional.
-    region(Region.US)
+CustomerIOBuilder(application, "YOUR_CDP_API_KEY").apply {
+    region(Region.US) // Region.EU if applicable
 
-    // Optional: Enable in-app messaging by adding siteId and Region
     addCustomerIOModule(
         ModuleMessagingInApp(
-            // If you're in the EU, set Region.EU
-            MessagingInAppModuleConfig.Builder(<SITE_ID>, Region.US).build()
+            MessagingInAppModuleConfig.Builder("YOUR_SITE_ID", Region.US).build()
+        )
     )
-    )
-
-    // Optional: Enable support for push notifications
     addCustomerIOModule(ModuleMessagingPushFCM())
-
-    // Completes setup and initializes the SDK
     build()
 }
 
-// Use the SDK
 CustomerIO.instance().identify("user-id")
 CustomerIO.instance().track("event-name")
 ```
 
-### Dependency Injection
-- All modules use constructor-based dependency injection
-- `DIGraphShared` serves as the central dependency registry
-- Module-specific DI graphs extend the shared graph
-- Test code can override dependencies for isolation
-- Avoid static dependencies and global state
+### Dependency injection
 
-### Inter-Module Communication
-- Event-driven architecture using `EventBus`
-- Type-safe event publishing and subscription
-- Events defined as sealed classes for type safety
-- Modules communicate without direct dependencies
-- Key events include profile changes, device registration, etc.
+- Constructor-based DI; `DIGraphShared` is the central registry, module graphs extend it.
+- Tests override dependencies through the DI graph for isolation.
+- Avoid static dependencies and global state.
 
-## Building
+### Inter-module communication
 
-### Building the Entire SDK
-```bash
-./gradlew assembleDebug
-```
+- Event-driven via `EventBus` with type-safe sealed-class events (profile changes, device registration, etc.).
+- Modules must not depend on each other directly.
 
-### Building a Single Module
-```bash
-./gradlew :core:assembleDebug
-./gradlew :datapipelines:assembleDebug
-```
+## Sample apps
 
-### Building for Release
-```bash
-./gradlew assembleRelease
-```
+- `samples/java_layout` (Java, XML views) and `samples/kotlin_compose` (Kotlin, Compose).
+- Both include a `google-services.json` for Firebase; replace credentials with your own workspace values in the app initialization code when testing.
+- To test local SDK changes in a sample app: `./gradlew publishToMavenLocal`, then build the sample (`cd samples/kotlin_compose && ./gradlew installDebug`).
+- View SDK logs: `adb logcat -s CustomerIO`.
 
-## Testing
+## Release and publishing (context, not something agents do)
 
-### Running All Tests
-```bash
-./gradlew test
-```
-
-### Running Tests for a Specific Module
-```bash
-./gradlew :core:test
-./gradlew :datapipelines:test
-```
-
-### Running a Specific Test Class
-```bash
-./gradlew :core:test --tests "EventBusTest"
-```
-
-### Running Android Instrumentation Tests
-```bash
-./gradlew connectedAndroidTest
-```
-
-### Test Categories
-- **Unit Tests**: Test individual components in isolation using JVM
-- **Integration Tests**: Test module interactions and SDK behavior
-- **Android Tests**: Test Android-specific functionality on device/emulator
-- **Robolectric Tests**: Test Android components in JVM environment
-
-## Development Workflow
-
-### Setting up Local Development
-1. Clone the repository
-2. Install lefthook: `lefthook install`
-3. Run initial build: `./gradlew assembleDebug`
-4. Run tests: `./gradlew test`
-
-### Making Changes
-1. Create feature branch from `develop`
-2. Implement changes following code style guidelines
-3. Add/update tests for new functionality
-4. Run `make format` and `make lint`
-5. Build and test locally
-6. Commit with descriptive message
-7. Create pull request
-
-### Sample Applications
-
-The SDK includes two sample applications for testing and demonstration:
-
-#### Java/XML Layout Sample (`samples/java_layout/`)
-- Traditional Android Views with Java
-- Demonstrates basic SDK integration patterns
-- Shows push notification setup
-- Includes various tracking scenarios
-- Build and install: `cd samples/java_layout && ./gradlew installDebug`
-
-#### Kotlin Compose Sample (`samples/kotlin_compose/`)
-- Modern UI with Jetpack Compose and Kotlin
-- Demonstrates advanced SDK features
-- Shows in-app messaging with Compose integration
-- Includes comprehensive SDK configuration examples
-- Build and install: `cd samples/kotlin_compose && ./gradlew installDebug`
-
-#### Using Sample Apps for Development
-```bash
-# Install local SDK artifacts first
-make install-local-sdk
-
-# Run Java sample app
-cd samples/java_layout
-./gradlew installDebug
-
-# Run Kotlin Compose sample app  
-cd samples/kotlin_compose
-./gradlew installDebug
-
-# View logs from sample apps
-adb logcat -s CustomerIO
-```
-
-#### Sample App Configuration
-- Both apps require `google-services.json` for Firebase integration
-- Test credentials should be configured in the app's initialization code
-- Sample apps automatically use local SDK artifacts when `make install-local-sdk` is run
-- Use sample apps to test new features before writing unit tests
-- Sample apps serve as integration tests for the SDK
-
-## Debugging and Troubleshooting
-- Enable verbose logging in debug builds
-- Use Android Studio debugger for step-through debugging
-- Check logcat for SDK-specific log messages
-- Use `adb` commands for device debugging
-- Monitor network traffic for API calls
-- Use memory profiler for performance analysis
-
-## Release and Publishing
-- Artifacts published to Maven Central
-- Version management via semantic versioning
-- Alpha/Beta/Production release channels
-- Automated publishing via GitHub Actions
-- GPG signing required for Maven artifacts
-- Binary compatibility validation enforced
+- semantic-release runs on merge to `main`; artifacts publish to Maven Central with GPG signing.
+- Binary compatibility validation and the `.api` dumps are part of the release contract; that is why apiCheck gates PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+Agent guidance for this repository lives in [AGENTS.md](AGENTS.md).
+
+@AGENTS.md


### PR DESCRIPTION
## Why

AGENTS.md had drifted badly from the codebase and would mislead anyone (human or agent) following it: Kotlin 1.8.21 (actual 2.1.21), target SDK 33 (actual 36), Compose BOM 2023.03.00 (actual 2025.10.00), a `make install-local-sdk` target that does not exist, instructions to branch off a `develop` branch that does not exist, the wrong test naming convention, and no mention of the `location` module. It also said nothing about most of the checks that actually gate PRs here, like the conventional-commit title lint.

## What

A full verification pass and rewrite. Every command and claim was checked against the repo (Makefile, gradle files, buildSrc/Versions.kt, lefthook.yml, workflows, scripts).

New:
- "CI: what gates your PR" section covering all eight PR checks: title lint, pinned ktlint (and why it is pinned), per-module Android Lint, apiCheck and fixing it with `./gradlew apiDump`, unit test matrix and Codecov upload behavior, instrumentation tests, snapshot publish (and why it cannot pass on fork PRs), and the binary size report
- Dependency policy section: Versions.kt as the single source, the deliberate Segment strict pin, the minSdk 21 support commitment, the AGP/compatibility-workflow coupling
- A note that the `location` module is missing from the lint and unit-test CI matrices, so it needs local runs
- `CLAUDE.md` pointer file so Claude Code loads the same guidance

Fixes: toolchain versions, local-Maven publish command (`./gradlew publishToMavenLocal`), branch-off-main workflow, test naming convention (`methodName_givenCondition_expectResult`), project structure including `location`.

No internal information; verified suitable for a public repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to contributor/agent guidance; no runtime, API, or build logic is modified.
> 
> **Overview**
> **Rewrites `AGENTS.md`** so agent and contributor guidance matches the repo after a verification pass against Makefile, Gradle, `Versions.kt`, hooks, and workflows. Outdated toolchain numbers, a nonexistent `make install-local-sdk` target, branching off `develop`, and the old test naming style are corrected; **`location/`** is added to the module map with a note that CI does not lint or unit-test it yet.
> 
> **New or expanded sections** include golden rules (build after changes, `apiDump`, no drive-by version bumps), a **Toolchain** block, **CI: what gates your PR** (eight checks: conventional PR title, pinned ktlint, Android Lint modules, `apiCheck`/`apiDump`, unit tests and Codecov, sample instrumentation, snapshot publish on forks, binary size report), **Dependency policy** (Versions.kt, Segment pin, minSdk 21, AGP workflow coupling), tighter **Testing** / **Git workflow** (branch from `main`, lefthook, semantic-release), and trimmed architecture/sample/release notes. Long redundant build/test/debug sections are removed in favor of the verified command list.
> 
> **Adds `CLAUDE.md`** as a short pointer to `AGENTS.md` (with `@AGENTS.md`) so Claude Code loads the same guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 969c5e59918fef365f0bc3c67ff1bf6f9959360c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->