### PR TITLE
chore(geofence): acquire location without emitting analytics events

### DIFF
--- a/geofence/api/geofence.api
+++ b/geofence/api/geofence.api
@@ -8,16 +8,28 @@ public final class io/customer/geofence/GeofenceBroadcastReceiver : android/cont
 	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
 }
 
+public final class io/customer/geofence/GeofenceLocationMode : java/lang/Enum {
+	public static final field AUTOMATIC Lio/customer/geofence/GeofenceLocationMode;
+	public static final field MANUAL Lio/customer/geofence/GeofenceLocationMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/customer/geofence/GeofenceLocationMode;
+	public static fun values ()[Lio/customer/geofence/GeofenceLocationMode;
+}
+
 public final class io/customer/geofence/GeofenceModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
+	public synthetic fun <init> (Lio/customer/geofence/GeofenceLocationMode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getLocationMode ()Lio/customer/geofence/GeofenceLocationMode;
 }
 
 public final class io/customer/geofence/GeofenceModuleConfig$Builder : io/customer/sdk/core/module/CustomerIOModuleConfig$Builder {
 	public fun <init> ()V
 	public fun build ()Lio/customer/geofence/GeofenceModuleConfig;
 	public synthetic fun build ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
+	public final fun setLocationMode (Lio/customer/geofence/GeofenceLocationMode;)Lio/customer/geofence/GeofenceModuleConfig$Builder;
 }
 
 public final class io/customer/geofence/ModuleGeofence : io/customer/sdk/core/module/CustomerIOModule {
+	public static final field Companion Lio/customer/geofence/ModuleGeofence$Companion;
 	public fun <init> ()V
 	public fun <init> (Lio/customer/geofence/GeofenceModuleConfig;)V
 	public synthetic fun <init> (Lio/customer/geofence/GeofenceModuleConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -25,5 +37,11 @@ public final class io/customer/geofence/ModuleGeofence : io/customer/sdk/core/mo
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun initialize ()V
+	public static final fun instance ()Lio/customer/geofence/ModuleGeofence;
+	public final fun refreshFromCurrentLocation ()V
+}
+
+public final class io/customer/geofence/ModuleGeofence$Companion {
+	public final fun instance ()Lio/customer/geofence/ModuleGeofence;
 }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLocationMode.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLocationMode.kt
@@ -1,0 +1,13 @@
+package io.customer.geofence
+
+/**
+ * How the geofence module acquires the location it needs. Location acquired for
+ * geofencing is never sent to analytics.
+ */
+enum class GeofenceLocationMode {
+    /** The SDK acquires a fix itself when it needs one and none is available. Default. */
+    AUTOMATIC,
+
+    /** The host drives it via [ModuleGeofence.refreshFromCurrentLocation]. */
+    MANUAL
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceModuleConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceModuleConfig.kt
@@ -3,12 +3,26 @@ package io.customer.geofence
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 
 /**
- * Geofence module configuration. Currently exposes no tunables; the builder
- * is here so customer code stays stable as geofence-specific options become
- * configurable.
+ * Geofence module configuration.
  */
-class GeofenceModuleConfig private constructor() : CustomerIOModuleConfig {
+class GeofenceModuleConfig private constructor(
+    /**
+     * How the module acquires the device location it needs for geofencing.
+     * Default is [GeofenceLocationMode.AUTOMATIC].
+     */
+    val locationMode: GeofenceLocationMode
+) : CustomerIOModuleConfig {
     class Builder : CustomerIOModuleConfig.Builder<GeofenceModuleConfig> {
-        override fun build(): GeofenceModuleConfig = GeofenceModuleConfig()
+        private var locationMode: GeofenceLocationMode = GeofenceLocationMode.AUTOMATIC
+
+        /** Sets how the module acquires location for geofencing. */
+        fun setLocationMode(mode: GeofenceLocationMode): Builder {
+            this.locationMode = mode
+            return this
+        }
+
+        override fun build(): GeofenceModuleConfig = GeofenceModuleConfig(
+            locationMode = locationMode
+        )
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -1,6 +1,7 @@
 package io.customer.geofence
 
 import android.annotation.SuppressLint
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
@@ -37,10 +38,19 @@ internal interface GeofenceServices {
     fun onUserSignedOut()
 
     /**
+     * Arms a host-initiated refresh so the next acquired fix drives a sync even without
+     * a prior no-location skip. The fetch itself is kicked by
+     * [ModuleGeofence.refreshFromCurrentLocation] — kept out of this broadcast-reachable
+     * facade, which must not depend on the location module.
+     */
+    fun onRefreshRequested()
+
+    /**
      * Re-attempts a refresh when a fresh GPS fix arrives after a prior sync was
-     * skipped for not-yet-available location. On fresh install identify can race
-     * ahead of the first fix; without this hook the SDK would self-heal only on
-     * sign-out / next cold launch.
+     * skipped for not-yet-available location, or after a host-initiated
+     * [onRefreshRequested]. On fresh install identify can race ahead of the first
+     * fix; without this hook the SDK would self-heal only on sign-out / next cold
+     * launch.
      */
     fun onLocationAcquired(latitude: Double, longitude: Double)
 }
@@ -48,6 +58,7 @@ internal interface GeofenceServices {
 internal class GeofenceServicesImpl(
     private val repository: GeofenceRepository,
     private val secureUserStore: SecureUserStore,
+    private val regionStore: GeofenceRegionStore,
     private val scope: CoroutineScope,
     private val logger: GeofenceLogger,
     private val permissionChecker: GeofencePermissionChecker
@@ -57,6 +68,10 @@ internal class GeofenceServicesImpl(
     // successful trigger. onLocationAcquired only fires when this is set,
     // so streamed location updates don't cause repeated refreshes.
     private val lastSkippedForNoLocation = AtomicBoolean(false)
+
+    // Set by a host-initiated refresh; the next acquired fix drives a sync
+    // regardless of the no-location rearm flag.
+    private val explicitRefreshRequested = AtomicBoolean(false)
 
     override fun onMovementTriggerExit(latitude: Double?, longitude: Double?) {
         triggerSync(
@@ -85,17 +100,34 @@ internal class GeofenceServicesImpl(
         )
     }
 
+    override fun onRefreshRequested() {
+        explicitRefreshRequested.set(true)
+    }
+
     override fun onLocationAcquired(latitude: Double, longitude: Double) {
-        // Only act on the rising edge of a no-location skip; otherwise this
-        // becomes a per-update refresh storm on hosts that stream locations.
-        if (!lastSkippedForNoLocation.compareAndSet(true, false)) return
+        // Act on a host-initiated refresh or the rising edge of a no-location skip;
+        // otherwise this becomes a per-update refresh storm on hosts that stream
+        // locations. Clear both flags so a single fix is consumed once.
+        val requested = explicitRefreshRequested.compareAndSet(true, false)
+        val rearmed = lastSkippedForNoLocation.compareAndSet(true, false)
+        if (!requested && !rearmed) return
         val userId = secureUserStore.getUserId()
-        // No user: a future identify catches the now-cached location.
+        // No user yet: skip; a later identify re-triggers.
         if (userId.isNullOrEmpty()) return
         onUserIdentified(latitude, longitude)
     }
 
     override fun onUserSignedOut() {
+        // Drop any pending refresh intent so a previous user's request can't drive a
+        // sync for the next user — sign-out wipes user-scoped session state.
+        explicitRefreshRequested.set(false)
+        lastSkippedForNoLocation.set(false)
+        // Clear the registration-center anchor synchronously: repository.reset() also
+        // clears it but runs on `scope`, so an in-process re-login (ResetEvent then
+        // UserChangedEvent) would read the previous user's center and rank the new
+        // user's geofences around it. Clearing it now makes the next identify fall
+        // back to a no-location skip and acquire a fresh fix instead.
+        regionStore.clearLastMovementTriggerLocation()
         // Snapshot the userId synchronously — the datapipelines `ResetEvent`
         // subscriber races to clear `secureUserStore`, so a deferred read
         // inside `reset()` could see null and misclassify a normal sign-out

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -1,10 +1,12 @@
 package io.customer.geofence
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.geofence.di.geofenceCooldownFilter
 import io.customer.geofence.di.geofenceDeliveryFlusher
 import io.customer.geofence.di.geofenceLogger
+import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
 import io.customer.location.LocationCoordinates
 import io.customer.location.ModuleLocation
@@ -26,12 +28,11 @@ private const val MODULE_NAME = "Geofence"
  * geofences are registered with the OS, transitions are persisted and forwarded
  * to the CDP, and the local set is refreshed when the user moves far enough.
  *
- * Requires [ModuleLocation] to be registered alongside it — geofencing reacts
- * to location fixes published by the location module. Customers wanting only
- * the geofencing feature should still register [ModuleLocation] (any tracking
- * mode other than OFF) and feed it location either by calling
- * `setLastKnownLocation` from the host app or letting `ON_APP_START` capture
- * fixes automatically.
+ * Requires [ModuleLocation] to be registered alongside it — geofencing uses its
+ * location provider regardless of the location tracking mode, and works even when
+ * location tracking is OFF (geofence fixes never emit analytics). With the default
+ * [GeofenceLocationMode.AUTOMATIC] the SDK acquires the location it needs on its own;
+ * with [GeofenceLocationMode.MANUAL] the host drives it via [refreshFromCurrentLocation].
  *
  * Usage:
  * ```
@@ -68,6 +69,41 @@ class ModuleGeofence @JvmOverloads constructor(
     }
 
     /**
+     * Requests a one-shot location fix and refreshes the nearby geofence set from
+     * it, without emitting a "CIO Location Update" analytics event. Works
+     * regardless of [GeofenceModuleConfig.locationMode].
+     *
+     * Call this after the host app has been granted location permission — the
+     * primary way to drive geofencing when [GeofenceLocationMode.MANUAL] is set.
+     */
+    @OptIn(InternalCustomerIOApi::class)
+    fun refreshFromCurrentLocation() {
+        val locationModule = runCatching { ModuleLocation.instance() }.getOrNull()
+        if (locationModule == null) {
+            SDKComponent.geofenceLogger.logMissingLocationModule()
+            return
+        }
+        // Arm first so the returning fix drives a sync even without a prior
+        // no-location skip, then request a silent (no-analytics) fix.
+        SDKComponent.android().geofenceServices.onRefreshRequested()
+        locationModule.locationServices.requestLocationUpdateSilently()
+    }
+
+    /**
+     * In [GeofenceLocationMode.AUTOMATIC], acquires a silent (no-analytics) fix when none is
+     * available; the returning fix drives the sync via [GeofenceServices.onLocationAcquired].
+     * MANUAL leaves it to the host. Lives here (not [GeofenceServices]) as it needs [ModuleLocation].
+     */
+    @VisibleForTesting
+    @OptIn(InternalCustomerIOApi::class)
+    internal fun autoAcquireIfNeeded(locationModule: ModuleLocation, currentLocation: LocationCoordinates?) {
+        if (currentLocation != null) return
+        if (moduleConfig.locationMode != GeofenceLocationMode.AUTOMATIC) return
+        // No-ops without location permission.
+        locationModule.locationServices.requestLocationUpdateSilently()
+    }
+
+    /**
      * Subscribe to the SDK-wide events geofencing reacts to: fresh location fixes,
      * identify (prime the new user's nearby set), and sign-out (wipe user state).
      */
@@ -83,15 +119,16 @@ class ModuleGeofence @JvmOverloads constructor(
             sdkAndroid.geofenceServices.onLocationAcquired(it.latitude, it.longitude)
         }
 
-        // On identify, snapshot the current location and prime the geofence
-        // pipeline so the new user's session has its nearby set fetched.
+        // On identify, prime the geofence pipeline so the new user's session has its
+        // nearby set fetched, anchored at the current registration center.
         eventBus.subscribe<Event.UserChangedEvent> {
             if (!it.userId.isNullOrEmpty()) {
-                val location = locationModule.lastKnownLocationOrNull()
+                val anchor = refreshAnchor(sdkAndroid, locationModule)
                 sdkAndroid.geofenceServices.onUserIdentified(
-                    latitude = location?.latitude,
-                    longitude = location?.longitude
+                    latitude = anchor?.latitude,
+                    longitude = anchor?.longitude
                 )
+                autoAcquireIfNeeded(locationModule, anchor)
             }
         }
 
@@ -133,19 +170,48 @@ class ModuleGeofence @JvmOverloads constructor(
                 )
             )
 
-            // Defensive sync at launch: if a user identified in a previous session is
-            // still persisted, kick off a geofence refresh now. The repository's
-            // freshness threshold makes this a cheap no-op when identify also fires
-            // shortly after init (the common case), so it only does work when the host
-            // app doesn't call identify on this launch and the last sync is stale.
+            // Defensive sync at launch: if a user identified in a previous session is still
+            // persisted, kick off a geofence refresh now (anchored at the registration center).
+            // The repository's freshness threshold makes this a cheap no-op when identify also
+            // fires shortly after init (the common case).
             val existingUserId = sdkAndroid.secureUserStore.getUserId()
             if (!existingUserId.isNullOrEmpty()) {
-                val cachedLocation = locationModule.lastKnownLocationOrNull()
+                val anchor = refreshAnchor(sdkAndroid, locationModule)
                 sdkAndroid.geofenceServices.onAppLaunch(
-                    latitude = cachedLocation?.latitude,
-                    longitude = cachedLocation?.longitude
+                    latitude = anchor?.latitude,
+                    longitude = anchor?.longitude
                 )
+                autoAcquireIfNeeded(locationModule, anchor)
             }
+        }
+    }
+
+    private fun refreshAnchor(sdkAndroid: AndroidSDKComponent, locationModule: ModuleLocation): LocationCoordinates? =
+        resolveAnchor(
+            registrationCenter = sdkAndroid.geofenceRegionStore.getLastMovementTriggerLocation(),
+            lastKnown = locationModule.lastKnownLocationOrNull()
+        )
+
+    /**
+     * Location to anchor an identify/launch refresh at: the last registration center (walked by
+     * background movement EXITs) if set, else the location cache. Movement never updates the cache,
+     * so on relaunch it can be stale — ranking a refresh from it after the device moved while the
+     * app was dead would clobber the good registration with a set ranked around a stale position.
+     */
+    @VisibleForTesting
+    internal fun resolveAnchor(registrationCenter: GeofenceLocation?, lastKnown: LocationCoordinates?): LocationCoordinates? =
+        registrationCenter?.let { LocationCoordinates(latitude = it.latitude, longitude = it.longitude) } ?: lastKnown
+
+    companion object {
+        /**
+         * Returns the initialized [ModuleGeofence] instance.
+         *
+         * @throws IllegalStateException if the module hasn't been registered with the SDK
+         */
+        @JvmStatic
+        fun instance(): ModuleGeofence {
+            return SDKComponent.modules[MODULE_NAME] as? ModuleGeofence
+                ?: throw IllegalStateException("ModuleGeofence not initialized. Add ModuleGeofence to CustomerIOConfigBuilder before calling CustomerIO.initialize().")
         }
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -141,6 +141,7 @@ internal val AndroidSDKComponent.geofenceServices: GeofenceServices
         GeofenceServicesImpl(
             repository = geofenceRepository,
             secureUserStore = secureUserStore,
+            regionStore = geofenceRegionStore,
             scope = SDKComponent.scopeProvider.geofenceScope,
             logger = SDKComponent.geofenceLogger,
             permissionChecker = geofencePermissionChecker

--- a/geofence/src/test/java/io/customer/geofence/GeofenceModuleConfigTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceModuleConfigTest.kt
@@ -1,0 +1,23 @@
+package io.customer.geofence
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceModuleConfigTest {
+
+    @Test
+    fun build_givenNoOverrides_expectAutomaticDefault() {
+        val config = GeofenceModuleConfig.Builder().build()
+
+        config.locationMode shouldBeEqualTo GeofenceLocationMode.AUTOMATIC
+    }
+
+    @Test
+    fun build_givenManualLocationMode_expectManual() {
+        val config = GeofenceModuleConfig.Builder()
+            .setLocationMode(GeofenceLocationMode.MANUAL)
+            .build()
+
+        config.locationMode shouldBeEqualTo GeofenceLocationMode.MANUAL
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -1,6 +1,7 @@
 package io.customer.geofence
 
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +23,7 @@ class GeofenceServicesTest : RobolectricTest() {
 
     private val repository: GeofenceRepository = mockk(relaxed = true)
     private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val regionStore: GeofenceRegionStore = mockk(relaxed = true)
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val permissionChecker: GeofencePermissionChecker = mockk(relaxed = true) {
         every { hasRequiredLocationPermissions() } returns true
@@ -32,6 +34,7 @@ class GeofenceServicesTest : RobolectricTest() {
         GeofenceServicesImpl(
             repository = repository,
             secureUserStore = secureUserStore,
+            regionStore = regionStore,
             scope = scope,
             logger = logger,
             permissionChecker = permissionChecker
@@ -131,6 +134,36 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun onLocationAcquired_givenExplicitRefreshRequested_expectRefreshWithoutPriorSkip() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        // Host-initiated refresh arms the pipeline; the returning fix drives the sync
+        // even without any prior no-location skip.
+        services.onRefreshRequested()
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify { repository.refresh(12.0, 34.0) }
+    }
+
+    @Test
+    fun onLocationAcquired_givenExplicitRefreshRequested_expectConsumedOnce() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onRefreshRequested()
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        services.onLocationAcquired(latitude = 56.0, longitude = 78.0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.refresh(56.0, 78.0) }
+    }
+
+    @Test
     fun onLocationAcquired_givenNoPriorSkip_expectNoOp() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
         val services = servicesWith(this)
@@ -171,6 +204,38 @@ class GeofenceServicesTest : RobolectricTest() {
         // Only the initial identify call should reach the repository.
         coVerify(exactly = 1) { repository.refresh(any(), any()) }
         coVerify(exactly = 0) { repository.refresh(3.0, 4.0) }
+    }
+
+    @Test
+    fun onLocationAcquired_afterSignOut_expectNoRefreshFromStaleRefreshFlag() = runTest(StandardTestDispatcher()) {
+        // A pending refresh from the previous session must not survive sign-out and
+        // drive a sync for the next user's first fix.
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.reset(any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onRefreshRequested()
+        services.onUserSignedOut()
+        advanceUntilIdle()
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+    }
+
+    @Test
+    fun onUserSignedOut_expectRegistrationAnchorClearedSynchronously() = runTest(StandardTestDispatcher()) {
+        // The persisted registration center is user-scoped. It must be dropped
+        // synchronously on sign-out — before repository.reset() runs on the scope —
+        // so an in-process re-login can't rank the next user's geofences around the
+        // previous user's location.
+        coEvery { repository.reset(any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserSignedOut()
+
+        verify { regionStore.clearLastMovementTriggerLocation() }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
@@ -1,0 +1,73 @@
+package io.customer.geofence
+
+import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.location.LocationCoordinates
+import io.customer.location.LocationServices
+import io.customer.location.ModuleLocation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+
+@OptIn(InternalCustomerIOApi::class)
+class ModuleGeofenceTest {
+
+    private val mockLocationServices: LocationServices = mockk(relaxed = true)
+    private val mockLocationModule: ModuleLocation = mockk {
+        every { locationServices } returns mockLocationServices
+    }
+
+    private fun moduleWith(mode: GeofenceLocationMode) =
+        ModuleGeofence(GeofenceModuleConfig.Builder().setLocationMode(mode).build())
+
+    @Test
+    fun autoAcquireIfNeeded_givenNoLocationAndAutomatic_expectSilentFetch() {
+        moduleWith(GeofenceLocationMode.AUTOMATIC).autoAcquireIfNeeded(mockLocationModule, currentLocation = null)
+
+        verify { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun autoAcquireIfNeeded_givenNoLocationAndManual_expectNoFetch() {
+        moduleWith(GeofenceLocationMode.MANUAL).autoAcquireIfNeeded(mockLocationModule, currentLocation = null)
+
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun autoAcquireIfNeeded_givenLocationAlreadyAvailable_expectNoFetch() {
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .autoAcquireIfNeeded(mockLocationModule, currentLocation = LocationCoordinates(latitude = 1.0, longitude = 2.0))
+
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun resolveAnchor_givenRegistrationCenter_expectItPreferredOverLastKnown() {
+        val anchor = moduleWith(GeofenceLocationMode.AUTOMATIC).resolveAnchor(
+            registrationCenter = GeofenceLocation(latitude = 10.0, longitude = 20.0),
+            lastKnown = LocationCoordinates(latitude = 1.0, longitude = 2.0)
+        )
+
+        anchor shouldBeEqualTo LocationCoordinates(latitude = 10.0, longitude = 20.0)
+    }
+
+    @Test
+    fun resolveAnchor_givenNoRegistrationCenter_expectFallsBackToLastKnown() {
+        val anchor = moduleWith(GeofenceLocationMode.AUTOMATIC).resolveAnchor(
+            registrationCenter = null,
+            lastKnown = LocationCoordinates(latitude = 1.0, longitude = 2.0)
+        )
+
+        anchor shouldBeEqualTo LocationCoordinates(latitude = 1.0, longitude = 2.0)
+    }
+
+    @Test
+    fun resolveAnchor_givenNeither_expectNull() {
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .resolveAnchor(registrationCenter = null, lastKnown = null)
+            .shouldBeNull()
+    }
+}

--- a/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
@@ -18,7 +18,26 @@ internal class LocationOrchestrator(
 ) {
 
     suspend fun requestLocationUpdate() {
-        if (!config.isEnabled) {
+        acquireLocation(forceFetch = false, onAcquired = locationTracker::onLocationReceived)
+    }
+
+    /**
+     * Like [requestLocationUpdate] but skips the "CIO Location Update" track event and fetches
+     * regardless of tracking mode: geofencing needs a fix even when location tracking is OFF.
+     */
+    suspend fun requestLocationUpdateSilently() {
+        acquireLocation(forceFetch = true, onAcquired = locationTracker::onLocationReceivedWithoutTracking)
+    }
+
+    /**
+     * @param forceFetch when true, bypasses the tracking-mode (OFF) gate so an internal caller
+     *   can still get a fix; the location permission check below always applies.
+     */
+    private suspend fun acquireLocation(
+        forceFetch: Boolean,
+        onAcquired: (Double, Double) -> Unit
+    ) {
+        if (!forceFetch && !config.isEnabled) {
             logger.debug("Location tracking is disabled, ignoring requestLocationUpdate.")
             return
         }
@@ -34,7 +53,7 @@ internal class LocationOrchestrator(
                 granularity = LocationGranularity.DEFAULT
             )
             logger.debug("Tracking location: lat=${snapshot.latitude}, lng=${snapshot.longitude}")
-            locationTracker.onLocationReceived(snapshot.latitude, snapshot.longitude)
+            onAcquired(snapshot.latitude, snapshot.longitude)
         } catch (e: CancellationException) {
             logger.debug("Location request was cancelled.")
             throw e

--- a/location/src/main/kotlin/io/customer/location/LocationServices.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationServices.kt
@@ -52,9 +52,23 @@ interface LocationServices {
     fun requestLocationUpdate()
 
     /**
-     * Returns the most recent location observed by the SDK (set via
-     * [setLastKnownLocation] or captured by [requestLocationUpdate]), or null if
-     * none yet. Internal API for other SDK modules to read cached location.
+     * Requests a single location update for internal consumers (e.g. geofencing) with
+     * no analytics side effects: no "CIO Location Update" track event, and the fix is
+     * not persisted or added to identify context. It is readable via
+     * [getLastKnownLocation].
+     *
+     * Requires location permission like [requestLocationUpdate], but fetches regardless
+     * of the tracking mode — geofencing needs a fix even when tracking is OFF.
+     * Internal API for other SDK modules.
+     */
+    @InternalCustomerIOApi
+    fun requestLocationUpdateSilently()
+
+    /**
+     * Returns the most recent location the SDK observed from any source — host
+     * [setLastKnownLocation], [requestLocationUpdate], or a silent
+     * [requestLocationUpdateSilently] fix — or null if none yet. Internal API for
+     * other SDK modules.
      */
     @InternalCustomerIOApi
     fun getLastKnownLocation(): LocationCoordinates?

--- a/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
@@ -44,12 +44,21 @@ internal class LocationServicesImpl(
     }
 
     override fun requestLocationUpdate() {
+        launchLocationRequest(orchestrator::requestLocationUpdate)
+    }
+
+    @OptIn(InternalCustomerIOApi::class)
+    override fun requestLocationUpdateSilently() {
+        launchLocationRequest(orchestrator::requestLocationUpdateSilently)
+    }
+
+    private fun launchLocationRequest(request: suspend () -> Unit) {
         // If a request is already in flight, ignore the new call
         if (currentLocationJob?.isActive == true) return
 
         currentLocationJob = scope.launch {
             try {
-                orchestrator.requestLocationUpdate()
+                request()
             } finally {
                 // Only clear if this is still the current job — prevents
                 // a cancelled job's finally from nulling a newer job's reference
@@ -61,7 +70,7 @@ internal class LocationServicesImpl(
     }
 
     @OptIn(InternalCustomerIOApi::class)
-    override fun getLastKnownLocation(): LocationCoordinates? = locationTracker.lastLocation
+    override fun getLastKnownLocation(): LocationCoordinates? = locationTracker.lastKnownLocation
 
     /**
      * Cancels any in-flight location request.

--- a/location/src/main/kotlin/io/customer/location/LocationTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationTracker.kt
@@ -47,12 +47,20 @@ internal class LocationTracker(
     // as the SDK is initialized, the weak ref is valid.
     private val dataPipelineRef = WeakReference(dataPipeline)
 
+    // Analytics location: enriches identify context, gates the ON_APP_START re-fetch,
+    // and is persisted. Set only by the tracking path, so silent fixes stay out of analytics.
     @Volatile
-    internal var lastLocation: LocationCoordinates? = null
+    internal var trackedLocation: LocationCoordinates? = null
+        private set
+
+    // Latest fix from any source (incl. silent geofence fixes), for cross-module reads
+    // via [LocationServices.getLastKnownLocation]. In-memory only; never analytics.
+    @Volatile
+    internal var lastKnownLocation: LocationCoordinates? = null
         private set
 
     override fun getIdentifyContext(): Map<String, Any> {
-        val location = lastLocation ?: return emptyMap()
+        val location = trackedLocation ?: return emptyMap()
         return mapOf(
             "location_latitude" to location.latitude,
             "location_longitude" to location.longitude
@@ -67,7 +75,8 @@ internal class LocationTracker(
      * guaranteeing no stale data is available for a subsequent identify().
      */
     override fun resetContext() {
-        lastLocation = null
+        trackedLocation = null
+        lastKnownLocation = null
         locationPreferenceStore.clearCachedLocation()
         locationSyncFilter.clearSyncedData()
         logger.debug("Location state reset")
@@ -81,7 +90,9 @@ internal class LocationTracker(
     fun restorePersistedLocation() {
         val lat = locationPreferenceStore.getCachedLatitude() ?: return
         val lng = locationPreferenceStore.getCachedLongitude() ?: return
-        lastLocation = LocationCoordinates(latitude = lat, longitude = lng)
+        val restored = LocationCoordinates(latitude = lat, longitude = lng)
+        trackedLocation = restored
+        lastKnownLocation = restored
         logger.debug("Restored persisted location: lat=$lat, lng=$lng")
     }
 
@@ -92,10 +103,24 @@ internal class LocationTracker(
     fun onLocationReceived(latitude: Double, longitude: Double) {
         logger.debug("Location update received: lat=$latitude, lng=$longitude")
 
-        lastLocation = LocationCoordinates(latitude = latitude, longitude = longitude)
+        val location = LocationCoordinates(latitude = latitude, longitude = longitude)
+        trackedLocation = location
+        lastKnownLocation = location
         locationPreferenceStore.saveCachedLocation(latitude, longitude)
 
         trySendLocationTrack(latitude, longitude)
+        eventBus.publish(Event.LocationAcquired(latitude = latitude, longitude = longitude))
+    }
+
+    /**
+     * Like [onLocationReceived] but with no analytics side effects: no track event and
+     * [trackedLocation]/persistence are left untouched, so it never reaches identify
+     * context. Updates [lastKnownLocation] so geofencing can read it back.
+     */
+    fun onLocationReceivedWithoutTracking(latitude: Double, longitude: Double) {
+        logger.debug("Location update received (geofence-only, not tracked): lat=$latitude, lng=$longitude")
+
+        lastKnownLocation = LocationCoordinates(latitude = latitude, longitude = longitude)
         eventBus.publish(Event.LocationAcquired(latitude = latitude, longitude = longitude))
     }
 

--- a/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
+++ b/location/src/main/kotlin/io/customer/location/ModuleLocation.kt
@@ -97,20 +97,21 @@ class ModuleLocation @JvmOverloads constructor(
             scope = locationScope
         )
 
-        // When OFF, skip all background machinery — no restoration, no enrichment,
-        // no event subscriptions. LocationServicesImpl has its own isEnabled guards
+        // Register as IdentifyHook regardless of tracking mode. Its resetContext() clears the
+        // in-memory location on sign-out (analytics.reset) — needed even when tracking is OFF,
+        // because silent geofence fixes still populate lastKnownLocation and it must not leak to
+        // the next user. When OFF, getIdentifyContext() stays empty (trackedLocation is never set),
+        // so nothing is enriched. When enabled, it also carries location into the identify context.
+        SDKComponent.identifyHookRegistry.register(locationTracker)
+
+        // When OFF, skip the rest of the background machinery — no restoration, no track
+        // subscription, no lifecycle observer. LocationServicesImpl has its own isEnabled guards
         // for the public API, so callers get silent no-ops with helpful log messages.
         if (!moduleConfig.isEnabled) return
 
         val services = _locationServices ?: return
 
         locationTracker.restorePersistedLocation()
-
-        // Register as IdentifyHook so location is added to identify event context
-        // and cleared synchronously during analytics.reset(). This ensures every
-        // identify() call carries the device's current location in the event context —
-        // the primary way location reaches a user's profile.
-        SDKComponent.identifyHookRegistry.register(locationTracker)
 
         // On identify, attempt to send a supplementary "CIO Location Update" track event.
         // The identify event itself already carries location via context enrichment —
@@ -120,9 +121,9 @@ class ModuleLocation @JvmOverloads constructor(
                 locationTracker.onUserIdentified()
 
                 // ON_APP_START's lifecycle one-shot fires per process, but resetContext()
-                // wipes lastLocation on logout — a subsequent identify in the same process
+                // wipes trackedLocation on logout — a subsequent identify in the same process
                 // needs a fresh fetch. MANUAL deliberately doesn't auto-fetch.
-                if (locationTracker.lastLocation == null &&
+                if (locationTracker.trackedLocation == null &&
                     moduleConfig.trackingMode == LocationTrackingMode.ON_APP_START
                 ) {
                     services.requestLocationUpdate()
@@ -180,6 +181,9 @@ private class UninitializedLocationServices(
     override fun setLastKnownLocation(location: Location) = logNotInitialized()
 
     override fun requestLocationUpdate() = logNotInitialized()
+
+    @OptIn(InternalCustomerIOApi::class)
+    override fun requestLocationUpdateSilently() = logNotInitialized()
 
     @OptIn(InternalCustomerIOApi::class)
     override fun getLastKnownLocation(): LocationCoordinates? {

--- a/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
+++ b/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
@@ -1,0 +1,79 @@
+package io.customer.location
+
+import io.customer.location.provider.LocationProvider
+import io.customer.location.type.AuthorizationStatus
+import io.customer.location.type.LocationGranularity
+import io.customer.location.type.LocationSnapshot
+import io.customer.sdk.core.util.Logger
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LocationOrchestratorTest {
+
+    private val logger = mockk<Logger>(relaxUnitFun = true)
+    private val tracker = mockk<LocationTracker>(relaxUnitFun = true)
+    private val provider = mockk<LocationProvider>()
+
+    private fun orchestrator(mode: LocationTrackingMode) = LocationOrchestrator(
+        config = LocationModuleConfig.Builder().setLocationTrackingMode(mode).build(),
+        logger = logger,
+        locationTracker = tracker,
+        locationProvider = provider
+    )
+
+    private fun givenAuthorizedFix() {
+        coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.AUTHORIZED_FOREGROUND
+        coEvery { provider.requestLocation(LocationGranularity.DEFAULT) } returns LocationSnapshot(
+            latitude = 37.7749,
+            longitude = -122.4194,
+            timestamp = Date(),
+            horizontalAccuracy = 10.0
+        )
+    }
+
+    @Test
+    fun requestLocationUpdate_givenModeOff_expectNoFix() = runTest {
+        orchestrator(LocationTrackingMode.OFF).requestLocationUpdate()
+
+        coVerify(exactly = 0) { provider.requestLocation(any()) }
+        verify(exactly = 0) { tracker.onLocationReceived(any(), any()) }
+    }
+
+    @Test
+    fun requestLocationUpdate_givenModeEnabledAndAuthorized_expectTrackedFix() = runTest {
+        givenAuthorizedFix()
+
+        orchestrator(LocationTrackingMode.MANUAL).requestLocationUpdate()
+
+        verify { tracker.onLocationReceived(37.7749, -122.4194) }
+        verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
+    }
+
+    @Test
+    fun requestLocationUpdateSilently_givenModeOff_expectFixWithoutTracking() = runTest {
+        givenAuthorizedFix()
+
+        orchestrator(LocationTrackingMode.OFF).requestLocationUpdateSilently()
+
+        coVerify { provider.requestLocation(LocationGranularity.DEFAULT) }
+        verify { tracker.onLocationReceivedWithoutTracking(37.7749, -122.4194) }
+        verify(exactly = 0) { tracker.onLocationReceived(any(), any()) }
+    }
+
+    @Test
+    fun requestLocationUpdateSilently_givenPermissionDenied_expectNoFix() = runTest {
+        coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.DENIED
+
+        orchestrator(LocationTrackingMode.OFF).requestLocationUpdateSilently()
+
+        coVerify(exactly = 0) { provider.requestLocation(any()) }
+        verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
+    }
+}

--- a/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
+++ b/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
@@ -1,5 +1,7 @@
 package io.customer.location
 
+import io.customer.base.internal.InternalCustomerIOApi
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,7 +11,7 @@ import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, InternalCustomerIOApi::class)
 class LocationServicesImplTest {
 
     // -- Mode OFF tests --
@@ -60,6 +62,25 @@ class LocationServicesImplTest {
         services.setLastKnownLocation(37.7749, -122.4194)
 
         verify { tracker.onLocationReceived(37.7749, -122.4194) }
+    }
+
+    // -- requestLocationUpdateSilently --
+
+    @Test
+    fun requestLocationUpdateSilently_expectSilentOrchestratorCall() {
+        val config = LocationModuleConfig.Builder()
+            .setLocationTrackingMode(LocationTrackingMode.MANUAL)
+            .build()
+        val tracker: LocationTracker = mockk(relaxUnitFun = true)
+        val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
+        val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
+        val scope = TestScope(UnconfinedTestDispatcher())
+
+        val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
+        services.requestLocationUpdateSilently()
+
+        coVerify { orchestrator.requestLocationUpdateSilently() }
+        coVerify(exactly = 0) { orchestrator.requestLocationUpdate() }
     }
 
     // -- Coordinate validation tests --

--- a/location/src/test/java/io/customer/location/LocationTrackerTest.kt
+++ b/location/src/test/java/io/customer/location/LocationTrackerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.slot
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeEmpty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -93,6 +94,28 @@ class LocationTrackerTest {
         captured.captured shouldBeEqualTo Event.LocationAcquired(latitude = 37.7749, longitude = -122.4194)
     }
 
+    // -- onLocationReceivedWithoutTracking --
+
+    @Test
+    fun givenLocationReceivedWithoutTracking_expectNoAnalyticsSideEffects() {
+        tracker.onLocationReceivedWithoutTracking(37.7749, -122.4194)
+
+        verify(exactly = 0) { dataPipeline.track(any(), any()) }
+        verify(exactly = 0) { store.saveCachedLocation(any(), any()) }
+        tracker.getIdentifyContext().shouldBeEmpty()
+    }
+
+    @Test
+    fun givenLocationReceivedWithoutTracking_expectPublishedAndReadableViaLastKnownLocation() {
+        val captured = slot<Event.LocationAcquired>()
+
+        tracker.onLocationReceivedWithoutTracking(37.7749, -122.4194)
+
+        verify { mockEventBus.publish(capture(captured)) }
+        captured.captured shouldBeEqualTo Event.LocationAcquired(latitude = 37.7749, longitude = -122.4194)
+        tracker.lastKnownLocation shouldBeEqualTo LocationCoordinates(latitude = 37.7749, longitude = -122.4194)
+    }
+
     // -- syncCachedLocationIfNeeded --
 
     @Test
@@ -143,6 +166,8 @@ class LocationTrackerTest {
         context.shouldNotBeEmpty()
         context["location_latitude"] shouldBeEqualTo 37.7749
         context["location_longitude"] shouldBeEqualTo -122.4194
+        // Also seeds the cross-module field so geofencing has a fix at cold start.
+        tracker.lastKnownLocation shouldBeEqualTo LocationCoordinates(latitude = 37.7749, longitude = -122.4194)
     }
 
     @Test
@@ -236,8 +261,9 @@ class LocationTrackerTest {
 
         tracker.resetContext()
 
-        // In-memory location cleared — no stale data for next identify
+        // Both in-memory fields cleared — no stale data for next identify
         tracker.getIdentifyContext().shouldBeEmpty()
+        tracker.lastKnownLocation.shouldBeNull()
         // Persistence and sync filter also cleared synchronously
         verify { store.clearCachedLocation() }
         verify { syncFilter.clearSyncedData() }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -23,6 +23,7 @@ import com.google.android.material.snackbar.Snackbar;
 import io.customer.android.sample.java_layout.R;
 import io.customer.android.sample.java_layout.databinding.ActivityLocationTestBinding;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
+import io.customer.geofence.ModuleGeofence;
 import io.customer.location.ModuleLocation;
 import io.customer.sdk.CustomerIO;
 
@@ -55,8 +56,8 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
     private LocationListener locationListener;
     private PendingPermissionPurpose pendingPurpose = PendingPermissionPurpose.NONE;
     private boolean wasFineDeniedPermanently = false;
-    // Whether requestLocationUpdate() has been called for the current BACKGROUND_GRANTED
-    // session. Prevents redundant SDK fetches when onResume fires after a launcher callback
+    // Whether a geofence refresh has been triggered for the current BACKGROUND_GRANTED
+    // session. Prevents redundant fetches when onResume fires after a launcher callback
     // already triggered one; cleared if permission is revoked so we re-arm for the next grant.
     private boolean bgGrantHandled = false;
 
@@ -80,9 +81,9 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                         case BACKGROUND_UPGRADE:
                             if (hasBackgroundLocation()) {
                                 // Pre-Q: fine granted is implicitly background. No second permission
-                                // to request — trigger the post-grant SDK fetch directly (same as the
-                                // backgroundLocationLauncher path).
-                                triggerPostGrantSdkFetch();
+                                // to request — trigger the post-grant geofence refresh directly (same
+                                // as the backgroundLocationLauncher path).
+                                triggerPostGrantGeofenceRefresh();
                             } else {
                                 // API 29+: foreground just granted; rationale → background prompt.
                                 showBackgroundLocationRationale();
@@ -111,10 +112,9 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
     private final ActivityResultLauncher<String> backgroundLocationLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
                 if (hasBackgroundLocation()) {
-                    // Granted — kick off a fetch so geofences register now. The SDK's auto-fetch
-                    // lifecycle hook fires once per process and has already run, so an explicit
-                    // request is needed after a runtime grant.
-                    triggerPostGrantSdkFetch();
+                    // Granted — refresh geofences now. The SDK's auto-acquire runs on identify/
+                    // launch, so an explicit refresh is needed after a mid-session runtime grant.
+                    triggerPostGrantGeofenceRefresh();
                 }
                 // Not granted: respect the user's choice (API 29 dialog declined, API 30+ silent
                 // deny, or backed out of Settings). The next tap re-shows the rationale dialog,
@@ -146,9 +146,11 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
         bgGrantHandled = (computeBgPermissionState() == BgPermissionState.BACKGROUND_GRANTED);
     }
 
-    private void triggerPostGrantSdkFetch() {
+    private void triggerPostGrantGeofenceRefresh() {
         bgGrantHandled = true;
-        ModuleLocation.instance().getLocationServices().requestLocationUpdate();
+        // Refresh geofences from the current location without emitting a location analytics
+        // event (unlike requestLocationUpdate()).
+        ModuleGeofence.instance().refreshFromCurrentLocation();
     }
 
     private void setupBackgroundPermissionButton() {
@@ -394,9 +396,9 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
         if (computeBgPermissionState() == BgPermissionState.BACKGROUND_GRANTED) {
             if (!bgGrantHandled) {
                 // Settings round-trip granted background while we were away — fire the same
-                // post-grant SDK fetch the launcher callbacks do, so geofences register without
-                // waiting for the next process start.
-                triggerPostGrantSdkFetch();
+                // post-grant geofence refresh the launcher callbacks do, so geofences register
+                // without waiting for the next process start.
+                triggerPostGrantGeofenceRefresh();
             }
         } else {
             bgGrantHandled = false; // permission revoked — re-arm for the next grant cycle


### PR DESCRIPTION
## What

Let hosts use geofencing without emitting "CIO Location Update" analytics events or enriching identify context — geofencing acquires the location it needs through an internal, analytics-free path.

- New internal `LocationServices.requestLocationUpdateSilently()` (`@InternalCustomerIOApi`): one-shot fix that publishes `LocationAcquired` and updates `lastKnownLocation` only — no track event, no persistence, not added to identify context. Requires location permission, but fetches regardless of tracking mode (geofencing needs a fix even when tracking is OFF).
- `LocationTracker` location split into `trackedLocation` (analytics / identify / persisted) and `lastKnownLocation` (any source incl. silent; backs `getLastKnownLocation`).
- New `GeofenceLocationMode { AUTOMATIC (default), MANUAL }` config. AUTOMATIC self-acquires a silent fix on identify and app launch when none is available; MANUAL leaves it to the host.
- New public `ModuleGeofence.instance()` + `ModuleGeofence.refreshFromCurrentLocation()` — the host drives a refresh after granting location permission.
- Identify/launch refresh anchors at the current registration center (falling back to the location cache), so a refresh after background movement doesn't re-rank from a stale cached fix.

## Why

Customers who only want geofencing shouldn't be forced to emit location analytics. Routing geofence's location needs through an internal path decouples the two: geofence fixes never reach the analytics pipeline or identify context.

## Notes

- `GeofenceServicesImpl` stays module-free so the broadcast/boot cold-start path never touches modules (they aren't registered then, e.g. in wrappers).
- No public *location* API change (silent primitive + `getLastKnownLocation` are `@InternalCustomerIOApi`). Public *geofence* API adds the enum, the config setter, `instance()`, and `refreshFromCurrentLocation()`.
- Refresh runs on identify and app launch (not on every foreground — intentionally, to avoid churn when the app is switched to often); the registration-center anchoring matches iOS.
- iOS parity: mirrors iOS field split, GeofenceLocationMode, refreshFromCurrentLocation, module-free broadcast path, silent bypasses tracking-mode OFF.
- Sample app drives geofencing via `refreshFromCurrentLocation()` after a background permission grant.

## Linear

https://linear.app/customerio/issue/MBL-1978/route-geofence-location-updates-through-an-internal-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-module location handling, user sign-out/session boundaries, and geofence refresh anchoring—areas where subtle bugs could affect privacy or wrong-user geofence ranking, though behavior is covered by new tests.
> 
> **Overview**
> Enables **geofencing without location analytics** by routing geofence-driven fixes through an internal silent location path and expanding geofence configuration and host APIs.
> 
> The location module adds **`requestLocationUpdateSilently()`** (internal): one-shot GPS that updates **`lastKnownLocation`** and publishes **`LocationAcquired`** only—no CIO Location Update track, persistence, or identify enrichment—and can run when tracking mode is **OFF**. **`LocationTracker`** splits **tracked** vs **last-known** state so silent fixes never touch analytics.
> 
> Geofencing adds **`GeofenceLocationMode`** (**AUTOMATIC** default / **MANUAL**), **`ModuleGeofence.instance()`**, and **`refreshFromCurrentLocation()`** for host-driven refreshes after permission grants. **AUTOMATIC** silently acquires a fix on identify/launch when no anchor exists; **MANUAL** relies on the host. Identify/launch refreshes anchor on the **registration center** (fallback: location cache). **`GeofenceServices`** arms explicit refreshes, consumes one fix per request, and on sign-out clears pending refresh flags and the registration anchor synchronously to avoid cross-user leakage.
> 
> The sample app triggers **`refreshFromCurrentLocation()`** after background location is granted instead of **`requestLocationUpdate()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2ad669783d1ac4a612984cd6df33609683da57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->