### PR TITLE
chore(inbox): migrate messaginginbox to shared publish plugin

### DIFF
--- a/messaginginbox/build.gradle
+++ b/messaginginbox/build.gradle
@@ -1,4 +1,3 @@
-import io.customer.android.Configurations
 import io.customer.android.Dependencies
 import io.customer.android.Versions
 
@@ -8,12 +7,11 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.compose'
 }
 
-ext {
-    PUBLISH_GROUP_ID = Configurations.artifactGroup
-    PUBLISH_ARTIFACT_ID = "messaging-inbox"
-}
+apply plugin: 'io.customer.android.publish-module'
 
-apply from: "${rootDir}/scripts/publish-module.gradle"
+customerIoPublish {
+    artifactId = "messaging-inbox"
+}
 apply from: "${rootDir}/scripts/android-config.gradle"
 apply from: "${rootDir}/scripts/codecov-android.gradle"
 apply from: "${rootDir}/scripts/android-module-testing.gradle"


### PR DESCRIPTION
Fixes the Android sample-app build failure on `feat/overlay-inbox` after it was rebased onto latest `main`.

**Root cause:** `main` #738 adopted the shared `io.customer.android.publish` plugin and deleted `scripts/publish-module.gradle`. `messaginginbox` was created before #738 and still used `apply from: "${rootDir}/scripts/publish-module.gradle"`, which no longer exists — aborting project evaluation before `android-config.gradle` sets `compileSdk`, so AGP failed with "project ':messaginginbox' does not specify compileSdk" and both sample apps failed to build.

**Fix:** migrate `messaginginbox/build.gradle` to `apply plugin: 'io.customer.android.publish-module'` + `customerIoPublish { artifactId = ... }`, matching every sibling module.

Draft, targeting `feat/overlay-inbox`. Merging this makes #769's sample-app build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/publishing Gradle wiring only; no runtime or API changes in the inbox module.
> 
> **Overview**
> **Fixes sample-app evaluation** for `:messaginginbox` after `scripts/publish-module.gradle` was removed on `main` (#738).
> 
> `messaginginbox/build.gradle` now uses `apply plugin: 'io.customer.android.publish-module'` and `customerIoPublish { artifactId = "messaging-inbox" }` instead of the deleted `publish-module.gradle` script and local `PUBLISH_*` `ext` properties. Maven coordinates stay the same; only the publishing setup is aligned with sibling modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce8f1e02f5d57eba5aa984df9a3367ebeb62451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->