### PR TITLE
fix(inbox): backfill inbox on SSE-connect transitions (fresh-login empty inbox)

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
@@ -72,12 +72,7 @@ internal class SseLifecycleManager(
         // Anonymous users should use polling instead of SSE
         if (state.shouldUseSse) {
             sseLogger.logAppForegrounded()
-            // The SSE endpoint does not send pending messages on connect — it only delivers
-            // new messages that arrive after the connection is established. Perform a one-time
-            // HTTP fetch to retrieve any messages sent while the app was backgrounded and the
-            // SSE connection was disconnected.
-            gistQueue.fetchUserMessages()
-            sseConnectionManager.startConnection()
+            startSseConnectionWithBackfill()
         } else {
             sseLogger.logAppForegroundedSseNotUsed(state.sseEnabled, state.isUserIdentified)
         }
@@ -90,6 +85,21 @@ internal class SseLifecycleManager(
 
         sseLogger.logAppBackgrounded()
         sseConnectionManager.stopConnection()
+    }
+
+    /**
+     * Starts the SSE connection, preceded by a one-time HTTP backfill fetch.
+     *
+     * The SSE endpoint does not send pending messages on connect — it only delivers messages that
+     * arrive AFTER the connection is established. So every transition INTO the SSE-connected state
+     * (app foregrounded, user becomes identified, or the SSE flag is enabled while foregrounded)
+     * must first fetch the messages that already exist for the user. Without this, on a fresh
+     * login the existing inbox is never retrieved until the next foreground — which is why it
+     * previously appeared only after a background/relaunch.
+     */
+    private fun startSseConnectionWithBackfill() {
+        gistQueue.fetchUserMessages()
+        sseConnectionManager.startConnection()
     }
 
     private fun subscribeToSseFlagChanges() {
@@ -106,7 +116,7 @@ internal class SseLifecycleManager(
             // Only start SSE connection if shouldUseSse (enabled AND user identified)
             if (state.shouldUseSse) {
                 sseLogger.logSseEnabledWhileForegrounded()
-                sseConnectionManager.startConnection()
+                startSseConnectionWithBackfill()
             } else if (sseEnabled && !state.isUserIdentified) {
                 // SSE enabled but user is anonymous - don't start SSE
                 sseLogger.logSseEnabledButUserAnonymous()
@@ -135,7 +145,7 @@ internal class SseLifecycleManager(
             if (state.shouldUseSse) {
                 // User became identified and SSE is enabled - start SSE connection
                 sseLogger.logEnablingSseForIdentifiedUser()
-                sseConnectionManager.startConnection()
+                startSseConnectionWithBackfill()
             } else if (!isIdentified && state.sseEnabled) {
                 // User became anonymous and SSE flag is enabled - stop SSE, fall back to polling
                 sseLogger.logDisablingSseForAnonymousUser()

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManagerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManagerTest.kt
@@ -764,4 +764,75 @@ class SseLifecycleManagerTest : JUnitTest() {
         // Then - SSE should NOT start (SSE flag is disabled)
         verify(exactly = 0) { sseConnectionManager.startConnection() }
     }
+
+    // =====================
+    // Backfill fetch on SSE-connect transitions (identify / sse-flag), not just foreground.
+    // SSE does not deliver pending messages on connect, so switching into the SSE-connected
+    // state must fetch existing messages; otherwise a fresh login shows an empty inbox until
+    // the next foreground. Regression for the "inbox empty on fresh login until bg/fg" bug.
+    // =====================
+
+    @Test
+    fun testUserBecomesIdentified_whenForegroundedAndSseEnabled_thenFetchesUserMessages() {
+        // Given - anonymous + SSE enabled + foregrounded
+        stateFlow.value = InAppMessagingState(
+            sseEnabled = true,
+            userId = null,
+            anonymousId = "anonymous-123"
+        )
+        lifecycleManager = SseLifecycleManager(
+            inAppMessagingManager = inAppMessagingManager,
+            processLifecycleOwner = processLifecycleOwner,
+            sseConnectionManager = sseConnectionManager,
+            sseLogger = sseLogger,
+            gistQueue = gistQueue,
+            mainThreadPoster = mainThreadPoster
+        )
+
+        val observerSlot = slot<androidx.lifecycle.LifecycleObserver>()
+        verify { lifecycle.addObserver(capture(observerSlot)) }
+        val observer = observerSlot.captured as androidx.lifecycle.DefaultLifecycleObserver
+        observer.onStart(processLifecycleOwner)
+        // Foregrounding while anonymous does not fetch (polling handles anonymous)
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
+
+        // When - user becomes identified (shouldUseSse flips true)
+        stateFlow.value = InAppMessagingState(
+            sseEnabled = true,
+            userId = "user-123",
+            anonymousId = "anonymous-123"
+        )
+        userIdentificationChangeCallback?.invoke(true)
+
+        // Then - backfill fetch fires so existing messages load without a foreground
+        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+    }
+
+    @Test
+    fun testSseFlagChange_whenForegroundedAndUserIdentified_thenFetchesUserMessages() {
+        // Given - identified user + SSE disabled + foregrounded
+        stateFlow.value = InAppMessagingState(sseEnabled = false, userId = "user-123")
+        lifecycleManager = SseLifecycleManager(
+            inAppMessagingManager = inAppMessagingManager,
+            processLifecycleOwner = processLifecycleOwner,
+            sseConnectionManager = sseConnectionManager,
+            sseLogger = sseLogger,
+            gistQueue = gistQueue,
+            mainThreadPoster = mainThreadPoster
+        )
+
+        val observerSlot = slot<androidx.lifecycle.LifecycleObserver>()
+        verify { lifecycle.addObserver(capture(observerSlot)) }
+        val observer = observerSlot.captured as androidx.lifecycle.DefaultLifecycleObserver
+        observer.onStart(processLifecycleOwner)
+        // Foregrounding while SSE disabled does not fetch here (polling handles it)
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
+
+        // When - SSE flag flips true (shouldUseSse becomes true)
+        stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
+        sseFlagChangeCallback?.invoke(true)
+
+        // Then - backfill fetch fires
+        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+    }
 }


### PR DESCRIPTION
## Problem
On a **fresh install + login**, the Visual Inbox stayed empty until the app was backgrounded→foregrounded. Reported as "don't see inbox till relaunch"; actually any lifecycle STOP→START recovered it.

## Root cause (device-verified, Samsung S24)
SSE does **not** deliver pending messages on connect. Only `SseLifecycleManager.handleForegrounded()` performed the one-time HTTP backfill (`gistQueue.fetchUserMessages()`). The **identify** and **SSE-enable** transitions (`subscribeToUserIdentificationChanges` / `subscribeToSseFlagChanges`) started the SSE connection **without** that fetch, and `observeInboxChanges` (a StateFlow) doesn't re-emit when only the templates/branding cache changes — so on fresh login the existing messages were never fetched until the next foreground.

## Fix
Route all three transitions into the SSE-connected state through a shared `startSseConnectionWithBackfill()` (fetch-then-connect). One file: `SseLifecycleManager.kt`.

## Verification
- Device: fresh install + login → inbox **Visible** in ~300ms, no relaunch (was: empty until bg/fg).
- Regression tests added asserting `fetchUserMessages()` fires on the identify and SSE-enable transitions.

Draft, targeting `feat/overlay-inbox`. iOS has the same bug + fix (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lifecycle fix in in-app messaging with targeted unit tests; no auth or data-model changes.
> 
> **Overview**
> Fixes the **empty Visual Inbox after fresh login** by ensuring HTTP message backfill runs whenever the app enters the SSE-connected state, not only on foreground.
> 
> **`SseLifecycleManager`** introduces **`startSseConnectionWithBackfill()`** (`gistQueue.fetchUserMessages()` then `startConnection()`). Foreground already did the fetch; **user identify** and **SSE flag enable** while foregrounded now use the same path instead of starting SSE alone. SSE does not replay pending messages on connect, so those transitions previously left existing inbox messages unfetched until the next background/foreground cycle.
> 
> **Regression tests** assert `fetchUserMessages()` runs when a foregrounded user becomes identified with SSE on, and when SSE is enabled for an already-identified foregrounded user.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4deaf7d9a9f36245f02fd2f47c0e39c86dafbd4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->