### PR TITLE
refactor(inbox): richer InboxEventListener payload + runtime setInboxEventListener

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -22,6 +22,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public fun <init> (Lio/customer/messaginginapp/MessagingInAppModuleConfig;)V
 	public final fun dismissMessage ()V
 	public fun embedMessage (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
+	public final fun getInboxEventListener ()Lio/customer/messaginginapp/type/InboxEventListener;
 	public fun getModuleConfig ()Lio/customer/messaginginapp/MessagingInAppModuleConfig;
 	public synthetic fun getModuleConfig ()Lio/customer/sdk/core/module/CustomerIOModuleConfig;
 	public fun getModuleName ()Ljava/lang/String;
@@ -34,6 +35,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public fun onMessageDismissed (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public final fun setColorScheme (Lio/customer/messaginginapp/type/ColorScheme;)V
+	public final fun setInboxEventListener (Lio/customer/messaginginapp/type/InboxEventListener;)V
 }
 
 public final class io/customer/messaginginapp/ModuleMessagingInApp$Companion {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -275,30 +275,17 @@ public final class io/customer/messaginginapp/type/InAppMessageKt {
 	public static final fun getMessage (Lio/customer/messaginginapp/type/InAppMessage;)Lio/customer/messaginginapp/gist/data/model/Message;
 }
 
-public final class io/customer/messaginginapp/type/InboxActionMessage {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/customer/messaginginapp/type/InboxActionMessage;
-	public static synthetic fun copy$default (Lio/customer/messaginginapp/type/InboxActionMessage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/customer/messaginginapp/type/InboxActionMessage;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDeliveryId ()Ljava/lang/String;
-	public final fun getMessageId ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class io/customer/messaginginapp/type/InboxEventListener {
-	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InboxActionMessage;Ljava/lang/String;Ljava/lang/String;)Z
-	public abstract fun messageDismissed (Lio/customer/messaginginapp/type/InboxActionMessage;)V
-	public abstract fun messageOpened (Lio/customer/messaginginapp/type/InboxActionMessage;)V
-	public abstract fun messageShown (Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public abstract fun messageActionTaken (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun messageDismissed (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public abstract fun messageOpened (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public abstract fun messageShown (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
 }
 
 public final class io/customer/messaginginapp/type/InboxEventListener$DefaultImpls {
-	public static fun messageDismissed (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
-	public static fun messageOpened (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
-	public static fun messageShown (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/InboxActionMessage;)V
+	public static fun messageDismissed (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public static fun messageOpened (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public static fun messageShown (Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
 }
 
 public abstract interface class io/customer/messaginginapp/type/InlineMessageActionListener {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -14,6 +14,7 @@ import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.type.InAppMessage
+import io.customer.messaginginapp.type.InboxEventListener
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
 import io.customer.sdk.core.di.SDKComponent
@@ -30,6 +31,30 @@ class ModuleMessagingInApp(
     private val gistProvider: GistProvider
         get() = SDKComponent.gistProvider
     private val logger = SDKComponent.logger
+
+    // Runtime-overridable inbox event listener. Seeded from the build-time config value and replaced
+    // in place when the host calls [setInboxEventListener]. Volatile: written from the host thread,
+    // read from the inbox overlay's UI/flow threads.
+    @Volatile
+    private var runtimeInboxEventListener: InboxEventListener? = config.inboxEventListener
+
+    /**
+     * The inbox event listener currently in effect: the runtime override registered via
+     * [setInboxEventListener] if any, otherwise the build-time
+     * [MessagingInAppModuleConfig.Builder.setInboxEventListener] value. The visual inbox reads this
+     * so a listener registered at runtime takes effect without rebuilding the SDK config.
+     */
+    val inboxEventListener: InboxEventListener?
+        get() = runtimeInboxEventListener
+
+    /**
+     * Register (or replace) the inbox event listener at runtime. Overrides any listener set at build
+     * time via [MessagingInAppModuleConfig.Builder.setInboxEventListener]. Mirrors iOS'
+     * `MessagingInApp.shared.setInboxEventListener`.
+     */
+    fun setInboxEventListener(listener: InboxEventListener) {
+        runtimeInboxEventListener = listener
+    }
 
     /**
      * Access the inbox messages instance for managing user inbox messages.

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InboxEventListener.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.type
 
+import io.customer.messaginginapp.gist.data.model.InboxMessage
+
 /**
  * Listener the host app registers to be notified when an action is taken on a visual notification
  * inbox message (e.g. the user taps a button/link inside a rendered message).
@@ -16,51 +18,38 @@ interface InboxEventListener {
     /**
      * Called when a non-dismiss action is taken on an inbox message.
      *
-     * @param message identity of the inbox message the action was taken on.
+     * @param message the inbox message the action was taken on.
      * @param actionName the Jist action name (e.g. `messageAction`).
      * @param actionValue the resolved action value, typically the action's url (may be empty if the
      * action carried no url).
      * @return `true` if the host fully handled the action (the SDK does nothing further); `false`
      * to let the SDK apply its default handling.
      */
-    fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean
+    fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String): Boolean
 
     /**
      * Observational callback fired when a message is first shown/rendered in the inbox view. Fired
      * once per message (deduped) while the view is displayed. Purely informational — it does not
      * affect SDK behavior. Default no-op so the interface stays source-compatible.
      *
-     * @param message identity of the inbox message that was shown.
+     * @param message the inbox message that was shown.
      */
-    fun messageShown(message: InboxActionMessage) {}
+    fun messageShown(message: InboxMessage) {}
 
     /**
      * Observational callback fired when a message is marked opened (the inbox panel opening
      * auto-marks the currently-shown unopened messages). Purely informational. Default no-op so the
      * interface stays source-compatible.
      *
-     * @param message identity of the inbox message that was opened.
+     * @param message the inbox message that was opened.
      */
-    fun messageOpened(message: InboxActionMessage) {}
+    fun messageOpened(message: InboxMessage) {}
 
     /**
      * Observational callback fired when a message is dismissed/removed from the inbox. Purely
      * informational. Default no-op so the interface stays source-compatible.
      *
-     * @param message identity of the inbox message that was dismissed.
+     * @param message the inbox message that was dismissed.
      */
-    fun messageDismissed(message: InboxActionMessage) {}
+    fun messageDismissed(message: InboxMessage) {}
 }
-
-/**
- * Lightweight, public identity of an inbox message handed to [InboxEventListener]. Exposes the
- * stable identifiers a host needs to correlate the action with its own data, without leaking the
- * SDK's internal message/render types.
- *
- * @param messageId the inbox message's queue id.
- * @param deliveryId the message's delivery id, when present.
- */
-data class InboxActionMessage(
-    val messageId: String,
-    val deliveryId: String?
-)

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -362,7 +362,7 @@ private fun InboxListContent(
                 templates = templates,
                 theme = theme,
                 dividerColor = colors.dividerColor,
-                onMessageShown = controller::notifyMessageShown,
+                onMessageShown = { message -> controller.notifyMessageShown(state.visibility, message) },
                 onMessageAction = { message, event ->
                     // Controller resolves the action (dismiss / track+intercept / default nav) and
                     // returns a nav instruction; we (owning the Context) run it.

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -521,8 +521,9 @@ private fun rememberInboxController(): VisualInboxController = remember {
     VisualInboxController(
         visualInbox = module.visualInbox(),
         // Host-registered inbox action/event listener (items 13/14), mirroring the in-app
-        // eventListener; resolved from the same module config the host built. Null when none set.
-        inboxEventListener = module.moduleConfig.inboxEventListener
+        // eventListener. Read from the module on each callback so a listener registered at runtime
+        // via ModuleMessagingInApp.setInboxEventListener takes effect; null when none is set.
+        inboxEventListenerProvider = { module.inboxEventListener }
     )
 }
 

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -53,10 +53,11 @@ internal data class VisualInboxUiState(
  */
 internal class VisualInboxController(
     private val visualInbox: VisualInbox,
-    // Host-registered listener (item 13) notified when a non-dismiss action is taken. When it
-    // returns true the host handled the action and the SDK skips its default navigation. Resolved
-    // from the in-app module config at construction; null when the host registered none.
-    private val inboxEventListener: InboxEventListener? = null,
+    // Provider for the host-registered listener (item 13) notified when a non-dismiss action is
+    // taken. When it returns true the host handled the action and the SDK skips its default
+    // navigation. Invoked on each callback (not snapshotted) so a listener registered at runtime via
+    // ModuleMessagingInApp.setInboxEventListener takes effect; returns null when none is registered.
+    private val inboxEventListenerProvider: () -> InboxEventListener? = { null },
     // Logger for action diagnostics. Defaults to the SDK logger; injectable so unit tests can pass a
     // relaxed mock (the real LogcatLogger calls android.util.Log, which is not mocked on the JVM).
     private val logger: Logger = SDKComponent.logger,
@@ -306,7 +307,7 @@ internal class VisualInboxController(
         actionName: String,
         actionValue: String
     ): Boolean {
-        val listener = inboxEventListener ?: return false
+        val listener = inboxEventListenerProvider() ?: return false
         // Hand the host the canonical InboxMessage (the same type NotificationInbox.getMessages()
         // returns), resolved from the visible set; a missing message means nothing to intercept.
         val inboxMessage = (visibility as? InboxVisibility.Visible)
@@ -327,11 +328,11 @@ internal class VisualInboxController(
     /**
      * Invoke an observational callback (shown / opened / dismissed) on the host listener (if any).
      * A throwing host listener must never break the SDK, so any exception is caught and logged.
-     * Resolved from the same [inboxEventListener] (MessagingInAppModuleConfig.inboxEventListener) as
+     * Resolved from the same [inboxEventListenerProvider] (the module's current inbox listener) as
      * [messageActionTaken]; a null listener is a no-op.
      */
     private inline fun notifyListener(block: InboxEventListener.() -> Unit) {
-        val listener = inboxEventListener ?: return
+        val listener = inboxEventListenerProvider() ?: return
         try {
             listener.block()
         } catch (ex: Exception) {

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -1,11 +1,9 @@
 package io.customer.messaginginbox
 
 import io.customer.jist.JistActionEvent
-import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxMessage
-import io.customer.messaginginapp.type.InboxActionMessage
 import io.customer.messaginginapp.type.InboxEventListener
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.Logger
@@ -171,7 +169,7 @@ internal class VisualInboxController(
                     markedOpenedQueueIds.add(message.queueId)
                     visualInbox.markMessageOpened(message)
                     // Observational host callback (item 14): a message was marked opened.
-                    notifyListener { messageOpened(message.toActionMessage()) }
+                    notifyListener { messageOpened(message) }
                 }
         } finally {
             markInFlight.set(false)
@@ -197,7 +195,7 @@ internal class VisualInboxController(
             deletedQueueIds.add(queueId)
             visualInbox.markMessageDeleted(message)
             // Observational host callback (item 14): a message was dismissed/removed.
-            notifyListener { messageDismissed(message.toActionMessage()) }
+            notifyListener { messageDismissed(message) }
         } finally {
             deleteInFlight.set(false)
         }
@@ -241,7 +239,7 @@ internal class VisualInboxController(
 
         // Host interception (item 13): true => host handled it, SDK runs no default nav (but still
         // honors the dismiss flag below).
-        val handledByHost = notifyHostHandled(message, event.name, url.orEmpty())
+        val handledByHost = notifyHostHandled(visibility, message, event.name, url.orEmpty())
 
         // SDK default navigation (item 12), unless the host handled it.
         val navigation = if (handledByHost) {
@@ -282,11 +280,13 @@ internal class VisualInboxController(
      * of this controller (the view may recompose/re-render the same row many times). Safe to call
      * from the renderer on every render.
      */
-    fun notifyMessageShown(message: JistInboxMessage) {
+    fun notifyMessageShown(visibility: InboxVisibility, message: JistInboxMessage) {
+        // Resolve the canonical InboxMessage (the same type NotificationInbox.getMessages() returns)
+        // from the visible set so the host receives the full message, not the internal render type.
+        val inboxMessage = (visibility as? InboxVisibility.Visible)
+            ?.messages?.firstOrNull { it.queueId == message.queueId } ?: return
         if (!shownQueueIds.add(message.queueId)) return
-        notifyListener {
-            messageShown(InboxActionMessage(messageId = message.queueId, deliveryId = message.deliveryId))
-        }
+        notifyListener { messageShown(inboxMessage) }
     }
 
     /** Track a clicked metric for [message], once per queueId. Reuses [VisualInbox.trackMessageClicked]. */
@@ -300,11 +300,20 @@ internal class VisualInboxController(
     }
 
     /** Invoke the host listener (if any), returning true if the host handled the action. */
-    private fun notifyHostHandled(message: JistInboxMessage, actionName: String, actionValue: String): Boolean {
+    private fun notifyHostHandled(
+        visibility: InboxVisibility,
+        message: JistInboxMessage,
+        actionName: String,
+        actionValue: String
+    ): Boolean {
         val listener = inboxEventListener ?: return false
+        // Hand the host the canonical InboxMessage (the same type NotificationInbox.getMessages()
+        // returns), resolved from the visible set; a missing message means nothing to intercept.
+        val inboxMessage = (visibility as? InboxVisibility.Visible)
+            ?.messages?.firstOrNull { it.queueId == message.queueId } ?: return false
         return try {
             listener.messageActionTaken(
-                message = InboxActionMessage(messageId = message.queueId, deliveryId = message.deliveryId),
+                message = inboxMessage,
                 actionName = actionName,
                 actionValue = actionValue
             )
@@ -340,10 +349,6 @@ internal class VisualInboxController(
     // Dedupe guard for the observational messageShown callback: notified once per queueId.
     private val shownQueueIds = HashSet<String>()
 }
-
-/** Build the public [InboxActionMessage] identity handed to [InboxEventListener] from an [InboxMessage]. */
-private fun InboxMessage.toActionMessage(): InboxActionMessage =
-    InboxActionMessage(messageId = queueId, deliveryId = deliveryId)
 
 /**
  * The SDK's resolved interpretation of a Jist inbox action, derived from the action's

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -172,7 +172,7 @@ class InboxActionTest {
                 return true // host handled it
             }
         }
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
 
         val nav = controller.handleAction(
             visible(messages),
@@ -197,7 +197,7 @@ class InboxActionTest {
         val listener = object : InboxEventListener {
             override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String) = false
         }
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
 
         val nav = controller.handleAction(
             visible(messages),
@@ -217,7 +217,7 @@ class InboxActionTest {
                 throw RuntimeException("boom")
         }
         // Relaxed logger: the catch branch logs the listener failure.
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener, logger = mockk(relaxed = true))
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener }, logger = mockk(relaxed = true))
 
         val nav = controller.handleAction(
             visible(messages),
@@ -258,7 +258,7 @@ class InboxActionTest {
         val messages = listOf(message("a"), message("b"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = RecordingListener()
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
 
         controller.markOpenMessagesOpened(visible(messages))
 
@@ -272,7 +272,7 @@ class InboxActionTest {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = RecordingListener()
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
 
         controller.dismissMessage(visible(messages), "a")
 
@@ -284,7 +284,7 @@ class InboxActionTest {
     fun notifyMessageShown_calledTwiceSameMessage_expectShownFiredOnce() {
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = RecordingListener()
-        val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
         val messageA = message("a")
         val visibility = visible(listOf(messageA))
         val jist = JistInboxAdapter.toJist(messageA)

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -6,7 +6,6 @@ import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.inbox.data.Branding
 import io.customer.messaginginapp.inbox.data.InboxVisibility
 import io.customer.messaginginapp.inbox.jist.JistInboxAdapter
-import io.customer.messaginginapp.type.InboxActionMessage
 import io.customer.messaginginapp.type.InboxEventListener
 import io.mockk.mockk
 import io.mockk.verify
@@ -166,9 +165,9 @@ class InboxActionTest {
     fun handleAction_givenHostHandlesAction_expectTrackedAndNoNav() {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
-        val captured = mutableListOf<Triple<InboxActionMessage, String, String>>()
+        val captured = mutableListOf<Triple<InboxMessage, String, String>>()
         val listener = object : InboxEventListener {
-            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean {
+            override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String): Boolean {
                 captured.add(Triple(message, actionName, actionValue))
                 return true // host handled it
             }
@@ -186,7 +185,7 @@ class InboxActionTest {
         // Still tracked (a click happened) and the listener got message id + delivery + action value.
         verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
         captured.size shouldBeEqualTo 1
-        captured.first().first.messageId shouldBeEqualTo "a"
+        captured.first().first.queueId shouldBeEqualTo "a"
         captured.first().first.deliveryId shouldBeEqualTo "d-a"
         captured.first().third shouldBeEqualTo "https://example.com"
     }
@@ -196,7 +195,7 @@ class InboxActionTest {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = object : InboxEventListener {
-            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String) = false
+            override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String) = false
         }
         val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
 
@@ -214,7 +213,7 @@ class InboxActionTest {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = object : InboxEventListener {
-            override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String): Boolean =
+            override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String): Boolean =
                 throw RuntimeException("boom")
         }
         // Relaxed logger: the catch branch logs the listener failure.
@@ -248,10 +247,10 @@ class InboxActionTest {
         val shown = mutableListOf<String>()
         val opened = mutableListOf<String>()
         val dismissed = mutableListOf<String>()
-        override fun messageActionTaken(message: InboxActionMessage, actionName: String, actionValue: String) = false
-        override fun messageShown(message: InboxActionMessage) { shown.add(message.messageId) }
-        override fun messageOpened(message: InboxActionMessage) { opened.add(message.messageId) }
-        override fun messageDismissed(message: InboxActionMessage) { dismissed.add(message.messageId) }
+        override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String) = false
+        override fun messageShown(message: InboxMessage) { shown.add(message.queueId) }
+        override fun messageOpened(message: InboxMessage) { opened.add(message.queueId) }
+        override fun messageDismissed(message: InboxMessage) { dismissed.add(message.queueId) }
     }
 
     @Test
@@ -286,10 +285,12 @@ class InboxActionTest {
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val listener = RecordingListener()
         val controller = VisualInboxController(visualInbox, inboxEventListener = listener)
-        val jist = JistInboxAdapter.toJist(message("a"))
+        val messageA = message("a")
+        val visibility = visible(listOf(messageA))
+        val jist = JistInboxAdapter.toJist(messageA)
 
-        controller.notifyMessageShown(jist)
-        controller.notifyMessageShown(jist)
+        controller.notifyMessageShown(visibility, jist)
+        controller.notifyMessageShown(visibility, jist)
 
         listener.shown shouldBeEqualTo listOf("a")
     }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/SampleInboxEventListener.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/SampleInboxEventListener.java
@@ -5,7 +5,7 @@ import androidx.annotation.NonNull;
 import java.util.Locale;
 
 import io.customer.android.sample.java_layout.utils.Logger;
-import io.customer.messaginginapp.type.InboxActionMessage;
+import io.customer.messaginginapp.gist.data.model.InboxMessage;
 import io.customer.messaginginapp.type.InboxEventListener;
 
 /**
@@ -23,24 +23,24 @@ public class SampleInboxEventListener implements InboxEventListener {
     }
 
     @Override
-    public boolean messageActionTaken(@NonNull InboxActionMessage message, @NonNull String actionName, @NonNull String actionValue) {
-        logEvent("messageActionTaken. name: %s, value: %s, message: %s", actionName, actionValue, message.getMessageId());
+    public boolean messageActionTaken(@NonNull InboxMessage message, @NonNull String actionName, @NonNull String actionValue) {
+        logEvent("messageActionTaken. name: %s, value: %s, message: %s", actionName, actionValue, message.getQueueId());
         return false;
     }
 
     @Override
-    public void messageShown(@NonNull InboxActionMessage message) {
-        logEvent("messageShown. message: %s", message.getMessageId());
+    public void messageShown(@NonNull InboxMessage message) {
+        logEvent("messageShown. message: %s", message.getQueueId());
     }
 
     @Override
-    public void messageOpened(@NonNull InboxActionMessage message) {
-        logEvent("messageOpened. message: %s", message.getMessageId());
+    public void messageOpened(@NonNull InboxMessage message) {
+        logEvent("messageOpened. message: %s", message.getQueueId());
     }
 
     @Override
-    public void messageDismissed(@NonNull InboxActionMessage message) {
-        logEvent("messageDismissed. message: %s", message.getMessageId());
+    public void messageDismissed(@NonNull InboxMessage message) {
+        logEvent("messageDismissed. message: %s", message.getQueueId());
     }
 
     private void logEvent(@NonNull String format, @NonNull Object... args) {

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/SampleInboxEventListener.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/SampleInboxEventListener.kt
@@ -1,7 +1,7 @@
 package io.customer.android.sample.kotlin_compose.data.sdk
 
 import io.customer.android.sample.kotlin_compose.util.Logger
-import io.customer.messaginginapp.type.InboxActionMessage
+import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.type.InboxEventListener
 
 /**
@@ -14,24 +14,24 @@ import io.customer.messaginginapp.type.InboxEventListener
 class SampleInboxEventListener(private val logger: Logger = Logger()) : InboxEventListener {
 
     override fun messageActionTaken(
-        message: InboxActionMessage,
+        message: InboxMessage,
         actionName: String,
         actionValue: String
     ): Boolean {
-        logEvent("messageActionTaken. name: $actionName, value: $actionValue, message: ${message.messageId}")
+        logEvent("messageActionTaken. name: $actionName, value: $actionValue, message: ${message.queueId}")
         return false
     }
 
-    override fun messageShown(message: InboxActionMessage) {
-        logEvent("messageShown. message: ${message.messageId}")
+    override fun messageShown(message: InboxMessage) {
+        logEvent("messageShown. message: ${message.queueId}")
     }
 
-    override fun messageOpened(message: InboxActionMessage) {
-        logEvent("messageOpened. message: ${message.messageId}")
+    override fun messageOpened(message: InboxMessage) {
+        logEvent("messageOpened. message: ${message.queueId}")
     }
 
-    override fun messageDismissed(message: InboxActionMessage) {
-        logEvent("messageDismissed. message: ${message.messageId}")
+    override fun messageDismissed(message: InboxMessage) {
+        logEvent("messageDismissed. message: ${message.queueId}")
     }
 
     private fun logEvent(message: String) {


### PR DESCRIPTION
Aligns the Android inbox listener with iOS for the wrapper SDKs: `InboxEventListener` callbacks now hand the host the full public `InboxMessage` payload (dropping the lite `InboxActionMessage`), and `ModuleMessagingInApp` gains a runtime `setInboxEventListener(...)` overriding the build-time config value. Pre-release change; no back-compat needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SDK surface changes (removed type and listener signatures) will break existing host implementations; runtime listener reads use `@Volatile` across UI threads, which is low risk but affects action interception behavior.
> 
> **Overview**
> **Breaking inbox listener API:** `InboxActionMessage` is removed and all `InboxEventListener` methods now receive the public `gist.data.model.InboxMessage` (aligned with what `NotificationInbox.getMessages()` returns). Sample apps and unit tests are updated accordingly.
> 
> **Runtime listener registration:** `ModuleMessagingInApp` exposes `inboxEventListener` and `setInboxEventListener`, seeded from build-time config but overridable without rebuilding the SDK (iOS parity). The visual inbox overlay wires the controller through an `inboxEventListenerProvider` so each callback reads the current listener instead of a constructor snapshot.
> 
> **Richer host payloads:** `VisualInboxController` resolves the canonical `InboxMessage` from the visible inbox set for shown, opened, dismissed, and action-intercept callbacks (`notifyMessageShown` now takes `InboxVisibility` plus the Jist row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d844f4939bd9621331161332811d8ffaf392a073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->