### PR TITLE
chore(geofence): emit one transition event per geoset

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -56,14 +56,23 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     private val listSerializer = ListSerializer(elementSerializer)
 
     /** Append a new entry, evicting the head if the store is at capacity. */
-    fun append(entry: T) {
+    fun append(entry: T) = appendAll(listOf(entry))
+
+    /**
+     * Append entries in one read-modify-write so a batch (e.g. a transition's per-geoset fan-out)
+     * persists atomically — a crash can't save some and lose the rest. Evicts from the head when
+     * over capacity. Named distinctly from [append] so a single-arg `append(x)` never resolves
+     * ambiguously against this overload (e.g. in mocked `append(any())` verifications).
+     */
+    fun appendAll(entries: List<T>) {
+        if (entries.isEmpty()) return
         lock.withLock {
-            val entries = readAll().toMutableList()
-            entries.add(entry)
-            while (entries.size > maxEntries) {
-                entries.removeAt(0)
+            val all = readAll().toMutableList()
+            all.addAll(entries)
+            while (all.size > maxEntries) {
+                all.removeAt(0)
             }
-            writeAll(entries)
+            writeAll(all)
         }
     }
 

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -65,6 +65,35 @@ class PendingDeliveryStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun appendAll_givenMultipleEntries_expectAllPersistedAfterExisting() {
+        val store = newStore()
+        store.append(entry("a"))
+
+        store.appendAll(listOf(entry("b"), entry("c")))
+
+        store.loadAll().map { it.id } shouldBeEqualTo listOf("a", "b", "c")
+    }
+
+    @Test
+    fun appendAll_givenEmpty_expectNoChange() {
+        val store = newStore()
+        store.append(entry("a"))
+
+        store.appendAll(emptyList())
+
+        store.loadAll().map { it.id } shouldBeEqualTo listOf("a")
+    }
+
+    @Test
+    fun appendAll_givenOverCapacity_expectOldestEvicted() {
+        val store = newStore(maxEntries = 2)
+
+        store.appendAll(listOf(entry("a"), entry("b"), entry("c")))
+
+        store.loadAll().map { it.id } shouldBeEqualTo listOf("b", "c")
+    }
+
+    @Test
     fun remove_givenExistingKey_expectEntryRemoved() {
         val store = newStore()
         val keep = entry("keep")

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -135,34 +135,47 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
             }
             logger.logTransitionEmitting(geofenceId, transition.name)
 
-            // Record the transition durably before scheduling. Two channels then
-            // deliver it at least once, deduped downstream by transitionId: the
-            // WorkManager worker (direct HTTP, survives process death) and the
-            // foreground flush (analytics pipeline). Append first so a WorkManager
-            // scheduling failure still leaves the entry for the flush; isolate the
-            // scheduler so it can't abandon the rest of the batch.
-            // Snapshot userId so a sign-out + sign-in before delivery can't
-            // reattribute this transition. Empty userId is treated as "not
-            // identified" per the SDK's `isUserIdentified` convention.
-            val entry = PendingGeofenceDelivery(
-                geofenceId = geofenceId,
-                transition = transition,
-                timestamp = timestamp,
-                userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() },
-                // Minted once here so every delivery attempt for this transition carries the same id.
-                transitionId = UUID.randomUUID().toString(),
-                geofenceName = androidComponent.geofenceRegionStore.getCachedRegionName(geofenceId)
-            )
-            androidComponent.pendingGeofenceDeliveryStore.append(entry)
-            // Anonymous entries can only be delivered via the foreground flush —
-            // skip the WorkManager schedule that would just no-op on null userId.
-            if (entry.userId != null) {
-                try {
-                    scheduler.schedule(entry)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logger.logSchedulerFailed(geofenceId, transition.name, e.message)
+            // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
+            // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
+            val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+            // One transitionId for the whole crossing, shared across the per-geoset fan-out below.
+            val transitionId = UUID.randomUUID().toString()
+            val cachedRegion = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
+            val geofenceName = cachedRegion?.name?.takeIf { it.isNotEmpty() }
+            // One event per geoset; a fence with no geosets still emits one (null geoset) so a real
+            // OS transition is never dropped. Distinct so a fence listing the same geoset twice
+            // doesn't fan out to duplicate events.
+            val geosetIds: List<String?> = cachedRegion?.geosetIds?.distinct()?.takeIf { it.isNotEmpty() } ?: listOf(null)
+            val entries = geosetIds.map { geosetId ->
+                PendingGeofenceDelivery(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    timestamp = timestamp,
+                    userId = userId,
+                    transitionId = transitionId,
+                    geofenceName = geofenceName,
+                    geosetId = geosetId
+                )
+            }
+
+            // Persist the whole fan-out in one atomic write before any send, so an app kill
+            // mid-batch can't save some geosets and lose the rest (the cooldown is already spent,
+            // so a lost row would never retry). Two channels then deliver each entry at least once,
+            // deduped downstream by (transitionId, geoset): the WorkManager worker (direct HTTP,
+            // survives process death) and the foreground flush (analytics pipeline).
+            androidComponent.pendingGeofenceDeliveryStore.appendAll(entries)
+            entries.forEach { entry ->
+                // Anonymous entries can only be delivered via the foreground flush —
+                // skip the WorkManager schedule that would just no-op on null userId.
+                // Isolate the scheduler so one failure can't abandon the rest of the batch.
+                if (entry.userId != null) {
+                    try {
+                        scheduler.schedule(entry)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.logSchedulerFailed(geofenceId, transition.name, e.message)
+                    }
                 }
             }
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
@@ -42,3 +42,16 @@ internal data class GeofenceConfig(
         )
     }
 }
+
+/**
+ * Radius (m) for the remote geofence fetch: the max of the monitoring cap and the re-fetch radius,
+ * so the set covers both what we'll monitor and everywhere the device can reach before the next
+ * re-fetch. A disabled cap (`Float.MAX_VALUE`) collapses to the finite fallback. Operates on the
+ * already-coerced config, so the value is always in a sane range.
+ */
+internal fun GeofenceConfig.remoteSearchRadiusMeters(): Double {
+    val cap = maxMonitoringDistance.takeIf {
+        it != GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
+    } ?: GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS
+    return maxOf(cap, remoteFetchRefreshTriggerRadius).toDouble()
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -31,7 +31,9 @@ internal data class GeofenceRegion(
         GeofenceTransitionType.EXIT
     ),
     @SerialName("lastUpdated")
-    val lastUpdated: Long = 0L
+    val lastUpdated: Long = 0L,
+    @SerialName("geosetIds")
+    val geosetIds: List<String> = emptyList()
 )
 
 /** Transition types a geofence can monitor, mapped to GMS constants. */
@@ -66,3 +68,10 @@ internal fun GeofenceRegion.toGmsTransitionTypes(): Int {
     transitionTypes.forEach { mask = mask or it.gmsValue }
     return mask
 }
+
+/**
+ * Equal for OS-registration purposes: everything but [geosetIds], which drive event fan-out, not
+ * GMS registration. A geoset-only change updates the cache without a needless re-register.
+ */
+internal fun GeofenceRegion.equalsIgnoringGeosetIds(other: GeofenceRegion): Boolean =
+    copy(geosetIds = other.geosetIds) == other

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -6,6 +6,7 @@ import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.api.toDomainConfig
 import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.geofence.store.getCachedConfigOrFallback
 import io.customer.location.LocationCoordinates
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
@@ -84,7 +85,7 @@ internal class GeofenceRepositoryImpl(
                 return Result.success(Unit)
             }
 
-            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            val config = store.getCachedConfigOrFallback()
             return when (refreshAction(LocationCoordinates(latitude, longitude), config)) {
                 RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
@@ -159,7 +160,7 @@ internal class GeofenceRepositoryImpl(
             }
 
             val anchor = store.getLastApiFetchLocation()
-            val config = store.getCachedConfig() ?: GeofenceConfig.fallback()
+            val config = store.getCachedConfigOrFallback()
             val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
             // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
             // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
@@ -199,7 +200,7 @@ internal class GeofenceRepositoryImpl(
             logger.logSyncSkipped("no cached state to restore")
             return Result.success(Unit)
         }
-        val cachedConfig = store.getCachedConfig() ?: GeofenceConfig.fallback()
+        val cachedConfig = store.getCachedConfigOrFallback()
         return performLocalRefresh(
             userId = userId,
             latitude = effectiveLocation.latitude,
@@ -217,16 +218,17 @@ internal class GeofenceRepositoryImpl(
     ): Result<Unit> {
         // NEARBY sends the device location so the backend can return the nearby set; FETCH_ALL sends
         // none. The request carries no user identity, so the location isn't attributable to a user.
+        // Search radius comes from the cached config (or fallback) — the fresh config only arrives in
+        // this response, so it can't inform the request that fetches it.
         val fetchLocation = if (syncMode == GeofenceSyncMode.NEARBY) GeofenceLocation(latitude, longitude) else null
-        val fetchResult = apiService.fetchGeofences(fetchLocation)
+        val requestRadiusMeters = store.getCachedConfigOrFallback().remoteSearchRadiusMeters()
+        val fetchResult = apiService.fetchGeofences(fetchLocation, requestRadiusMeters)
         return fetchResult.fold(
             onSuccess = { response ->
                 val regions = response.toDomainRegions()
                 // Config preference: server-shipped > last cached > constants.
                 val parsedConfig = response.toDomainConfig()
-                val config = parsedConfig
-                    ?: store.getCachedConfig()
-                    ?: GeofenceConfig.fallback()
+                val config = parsedConfig ?: store.getCachedConfigOrFallback()
                 registerNearestAndPersist(
                     userId = userId,
                     latitude = latitude,
@@ -283,7 +285,10 @@ internal class GeofenceRepositoryImpl(
             val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
             val cachedById = store.getCachedRegions().associateBy { it.id }
             regions
-                .filter { it.id in registeredBusinessIds && cachedById[it.id] == it }
+                .filter { region ->
+                    val cached = cachedById[region.id]
+                    region.id in registeredBusinessIds && cached?.equalsIgnoringGeosetIds(region) == true
+                }
                 .map { it.id }
                 .toSet()
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Wire shape of `GET /v1/geofences/nearby`. Backend ships only `geofences`
- * today; `config` and per-region `transition_types` / `last_updated` are
- * nullable forward-compat slots the SDK will honor when backend adds them.
+ * Wire shape of `POST /geofences/nearest`. `config` and the per-region
+ * `name` / `transition_types` / `last_updated` fields are optional forward-compat
+ * slots the SDK honors if the backend sends them and silently skips otherwise.
  */
 @Serializable
 internal data class GeofenceApiResponse(
@@ -64,7 +64,9 @@ internal data class GeofenceApiRegion(
     @SerialName("transition_types")
     val transitionTypes: List<String>? = null,
     @SerialName("last_updated")
-    val lastUpdated: Long? = null
+    val lastUpdated: Long? = null,
+    @SerialName("geoset_ids")
+    val geosetIds: List<String> = emptyList()
 )
 
 /** Returns `null` when backend didn't send a `config` block — gates the cache save. */
@@ -124,7 +126,8 @@ private fun GeofenceApiRegion.toDomain(): GeofenceRegion = GeofenceRegion(
     longitude = longitude,
     radius = radius.toFloat(),
     transitionTypes = resolveTransitionTypes(transitionTypes),
-    lastUpdated = lastUpdated ?: 0L
+    lastUpdated = lastUpdated ?: 0L,
+    geosetIds = geosetIds
 )
 
 /**

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiService.kt
@@ -5,15 +5,20 @@ import io.customer.geofence.GeofenceLocation
 import io.customer.sdk.core.network.CustomerIOHttpClient
 import io.customer.sdk.core.network.HttpMethod
 import io.customer.sdk.core.network.HttpRequestParams
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 internal interface GeofenceApiService {
     /**
-     * Fetches geofences. When [location] is null (FETCH_ALL) the backend returns the full (capped)
-     * set and no location is sent. When non-null (NEARBY) the location is sent so the backend
-     * returns the nearby set. The request carries no user identity, so the location is not
-     * attributable to a user.
+     * Fetches geofences. When [location] is non-null (NEARBY) it's sent with [radiusMeters] in the
+     * request body so the backend returns the nearest set within that radius; when null (FETCH_ALL)
+     * no body is sent and the backend returns the full (capped) set. The request carries no user
+     * identity, so the location is not attributable to a user.
      */
-    suspend fun fetchGeofences(location: GeofenceLocation? = null): Result<GeofenceApiResponse>
+    suspend fun fetchGeofences(
+        location: GeofenceLocation? = null,
+        radiusMeters: Double = 0.0
+    ): Result<GeofenceApiResponse>
 }
 
 internal class GeofenceApiServiceImpl(
@@ -21,14 +26,22 @@ internal class GeofenceApiServiceImpl(
     private val jsonSerializer: GeofenceJsonSerializer
 ) : GeofenceApiService {
 
-    override suspend fun fetchGeofences(location: GeofenceLocation?): Result<GeofenceApiResponse> {
-        val queryParams = location
-            ?.let { mapOf("latitude" to it.latitude.toString(), "longitude" to it.longitude.toString()) }
-            ?: emptyMap()
+    override suspend fun fetchGeofences(
+        location: GeofenceLocation?,
+        radiusMeters: Double
+    ): Result<GeofenceApiResponse> {
+        // `limit` is optional on the endpoint and omitted — the SDK caps the count locally.
+        val body = location?.let {
+            jsonSerializer.encode(
+                GeofenceNearestRequest.serializer(),
+                GeofenceNearestRequest(latitude = it.latitude, longitude = it.longitude, radius = radiusMeters)
+            )
+        }
         val params = HttpRequestParams(
             path = ENDPOINT_PATH,
-            method = HttpMethod.GET,
-            queryParams = queryParams
+            method = HttpMethod.POST,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = body
         )
         return httpClient.request(params).mapCatching { responseBody ->
             // Lenient at the wire boundary so the SDK doesn't pin a specific
@@ -38,6 +51,17 @@ internal class GeofenceApiServiceImpl(
     }
 
     private companion object {
-        private const val ENDPOINT_PATH = "/geofences/nearby"
+        private const val ENDPOINT_PATH = "/geofences/nearest"
     }
 }
+
+/** Wire shape of the `POST /geofences/nearest` request body. */
+@Serializable
+private data class GeofenceNearestRequest(
+    @SerialName("latitude")
+    val latitude: Double,
+    @SerialName("longitude")
+    val longitude: Double,
+    @SerialName("radius")
+    val radius: Double
+)

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.builtins.serializer
  *                                  closer to the user's real position than the anchor.
  *   lastSyncTimestamp           — freshness throttle; cleared so the next login re-fetches.
  *
- * Rationale: backend `/v1/geofences/nearby` is workspace-scoped (no userId on
+ * Rationale: the backend geofence fetch is workspace-scoped (no userId on
  * the wire), so cached regions/config stay valid for any user in the workspace
  * and are kept. Dropping the freshness timestamp makes the next login re-fetch
  * instead of riding the prior session's window. If backend ever adds per-user
@@ -50,8 +50,8 @@ internal interface GeofenceRegionStore {
     fun saveCachedRegions(regions: List<GeofenceRegion>)
     fun getCachedRegions(): List<GeofenceRegion>
 
-    /** Name of the cached region with [id], or null if it isn't cached. */
-    fun getCachedRegionName(id: String): String? = getCachedRegions().find { it.id == id }?.name
+    /** The cached region with [id], or null if it isn't cached. */
+    fun getCachedRegion(id: String): GeofenceRegion? = getCachedRegions().find { it.id == id }
 
     fun saveRegisteredIds(ids: Set<String>)
     fun getRegisteredIds(): Set<String>
@@ -82,6 +82,10 @@ internal interface GeofenceRegionStore {
 
     fun clearAll()
 }
+
+/** Cached config, or the constant fallback when none is cached. */
+internal fun GeofenceRegionStore.getCachedConfigOrFallback(): GeofenceConfig =
+    getCachedConfig() ?: GeofenceConfig.fallback()
 
 internal class GeofenceRegionStoreImpl(
     context: Context,

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -23,12 +23,17 @@ internal data class PendingGeofenceDelivery(
     /** Unix epoch **seconds** at receiver time. Use [toGeofenceTransitionEvent] when a [Date] is needed. */
     val timestamp: Long,
     val userId: String?,
-    /** Stable id minted once at capture so every delivery attempt dedupes to one event backend-side. Not part of [key]. */
+    /**
+     * Identifies the physical crossing, shared across its per-geoset fan-out (geosets differ by
+     * [geosetId]); backend dedup is keyed (transitionId, geoset). Not part of [key].
+     */
     val transitionId: String,
     /** Null when the fired geofence isn't in the cached region set. */
-    val geofenceName: String? = null
+    val geofenceName: String? = null,
+    /** Part of [key] so per-geoset entries for one crossing don't collide; null when the fence has no geosets. */
+    val geosetId: String? = null
 ) : PendingDeliveryStore.PendingDeliveryEntry {
-    override val key: String get() = "${geofenceId}_${transition.name}_$timestamp"
+    override val key: String get() = "${geofenceId}_${transition.name}_${timestamp}_${geosetId ?: "none"}"
 
     /**
      * Properties carried on the tracked "Geofence Transition" event. Kept here
@@ -40,6 +45,7 @@ internal data class PendingGeofenceDelivery(
         put("transition", transition.name.lowercase())
         put("geofenceId", geofenceId)
         put("transitionId", transitionId)
+        geosetId?.let { put("geosetId", it.toLongOrNull() ?: it) }
         geofenceName?.let { put("geofenceName", it) }
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -27,6 +27,7 @@ private const val KEY_TRANSITION = "transition"
 private const val KEY_TRANSITION_ID = "transition_id"
 private const val KEY_TIMESTAMP = "timestamp"
 private const val KEY_USER_ID = "user_id"
+private const val KEY_GEOSET_ID = "geoset_id"
 
 /**
  * Schedules a [GeofenceEventWorker] for guaranteed delivery of a geofence transition event.
@@ -45,6 +46,7 @@ internal class GeofenceEventScheduler(
             .apply {
                 entry.userId?.let { putString(KEY_USER_ID, it) }
                 entry.geofenceName?.let { putString(KEY_GEOFENCE_NAME, it) }
+                entry.geosetId?.let { putString(KEY_GEOSET_ID, it) }
             }
             .build()
 
@@ -59,8 +61,7 @@ internal class GeofenceEventScheduler(
             .addTag(WORK_MANAGER_TAG_GEOFENCE)
             .build()
 
-        // entry.key ("${geofenceId}_${transition}_${timestamp}") doubles as the
-        // unique-work name so the foreground flush can cancel this worker by key.
+        // entry.key doubles as the unique-work name so the foreground flush can cancel this worker by key.
         // Second-precision timestamp: same-second bursts collide (KEEP dedupes them);
         // later transitions get distinct keys so an offline-queued worker can't block legitimate re-entries.
         val workManager = workManagerProvider.getWorkManager()
@@ -116,7 +117,8 @@ internal class GeofenceEventWorker(
             userId = userId,
             // Always set by the scheduler; fall back to a fresh id so an unexpected miss still delivers.
             transitionId = inputData.getString(KEY_TRANSITION_ID) ?: UUID.randomUUID().toString(),
-            geofenceName = inputData.getString(KEY_GEOFENCE_NAME)
+            geofenceName = inputData.getString(KEY_GEOFENCE_NAME),
+            geosetId = inputData.getString(KEY_GEOSET_ID)
         )
 
         // No identified user at queue time — direct HTTP needs a userId, so

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -27,6 +27,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldNotContain
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -309,7 +310,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
     @Test
     fun dispatchTransition_givenCachedRegionName_expectNameOnEntry() = runTest {
-        every { mockStore.getCachedRegionName("biz-geofence") } returns "Coffee Shop"
+        every { mockStore.getCachedRegion("biz-geofence") } returns
+            GeofenceRegion("biz-geofence", 0.0, 0.0, 100f, name = "Coffee Shop")
         val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
@@ -321,6 +323,86 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
         entrySlot.captured.geofenceName shouldBeEqualTo "Coffee Shop"
+    }
+
+    @Test
+    fun dispatchTransition_givenRegionWithMultipleGeosets_expectOneEventPerGeoset() = runTest {
+        every { mockStore.getCachedRegion("biz-geofence") } returns
+            GeofenceRegion("biz-geofence", 0.0, 0.0, 100f, name = "Mall", geosetIds = listOf("7", "8", "9"))
+        val scheduled = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { mockScheduler.schedule(capture(scheduled)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        // One event per geoset, in order, surfacing geosetId as a string property.
+        scheduled.map { it.geosetId } shouldBeEqualTo listOf("7", "8", "9")
+        // Numeric geoset ids are emitted as numbers so the type matches the server's int64.
+        scheduled.map { it.toEventProperties()["geosetId"] } shouldBeEqualTo listOf(7L, 8L, 9L)
+        // Same physical crossing => one shared transitionId, but distinct keys so entries don't collide.
+        scheduled.map { it.transitionId }.toSet().size shouldBeEqualTo 1
+        scheduled.map { it.key }.toSet().size shouldBeEqualTo 3
+        // Cooldown is a single gate for the crossing, not per geoset.
+        verify(exactly = 1) { mockCooldownFilter.tryAcquire("biz-geofence", Event.GeofenceTransition.ENTER) }
+        pendingStore.loadAll().size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun dispatchTransition_givenRegionWithDuplicateGeosets_expectDedupedInOrder() = runTest {
+        every { mockStore.getCachedRegion("biz-geofence") } returns
+            GeofenceRegion("biz-geofence", 0.0, 0.0, 100f, geosetIds = listOf("7", "8", "7"))
+        val scheduled = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { mockScheduler.schedule(capture(scheduled)) } returns Unit
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        // Duplicate geoset is dropped (order preserved) — no duplicate event for it.
+        scheduled.map { it.geosetId } shouldBeEqualTo listOf("7", "8")
+        pendingStore.loadAll().size shouldBeEqualTo 2
+    }
+
+    @Test
+    fun dispatchTransition_givenRegionWithSingleGeoset_expectSingleEventWithGeoset() = runTest {
+        every { mockStore.getCachedRegion("biz-geofence") } returns
+            GeofenceRegion("biz-geofence", 0.0, 0.0, 100f, geosetIds = listOf("5"))
+        val entrySlot = slot<PendingGeofenceDelivery>()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.geosetId shouldBeEqualTo "5"
+    }
+
+    @Test
+    fun dispatchTransition_givenRegionWithNoGeosets_expectSingleEventWithoutGeoset() = runTest {
+        // Default relaxed store returns a null region => no geosets => a single event is still emitted
+        // so a real OS transition is never dropped.
+        val entrySlot = slot<PendingGeofenceDelivery>()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
+        entrySlot.captured.geosetId.shouldBeNull()
+        entrySlot.captured.toEventProperties().keys shouldNotContain "geosetId"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceConfigTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceConfigTest.kt
@@ -1,0 +1,40 @@
+package io.customer.geofence
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class GeofenceConfigTest {
+
+    private fun config(
+        maxMonitoringDistance: Float,
+        remoteFetchRefreshTriggerRadius: Float = 5_000f
+    ): GeofenceConfig = GeofenceConfig(
+        localRefreshTriggerRadius = 1_000f,
+        remoteFetchRefreshTriggerRadius = remoteFetchRefreshTriggerRadius,
+        remoteFetchRefreshExpiry = 86_400_000L,
+        duplicateEventsExpiry = 3_600_000L,
+        maxBusinessGeofences = 19,
+        maxMonitoringDistance = maxMonitoringDistance
+    )
+
+    @Test
+    fun remoteSearchRadiusMeters_givenMonitoringCapLargerThanTrigger_expectCap() {
+        config(maxMonitoringDistance = 50_000f).remoteSearchRadiusMeters() shouldBeEqualTo 50_000.0
+    }
+
+    @Test
+    fun remoteSearchRadiusMeters_givenTriggerLargerThanMonitoringCap_expectTrigger() {
+        // A tight monitoring cap must not shrink the search below the re-fetch radius, or a fence the
+        // device approaches before the next re-fetch would be absent from the set.
+        config(maxMonitoringDistance = 2_000f, remoteFetchRefreshTriggerRadius = 5_000f)
+            .remoteSearchRadiusMeters() shouldBeEqualTo 5_000.0
+    }
+
+    @Test
+    fun remoteSearchRadiusMeters_givenDisabledCap_expectFiniteFallbackNotFloatMax() {
+        // Disabled cap (Float.MAX_VALUE) must collapse to the finite fallback so the wire value stays sane.
+        config(maxMonitoringDistance = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS)
+            .remoteSearchRadiusMeters() shouldBeEqualTo
+            GeofenceConstants.FALLBACK_MAX_MONITORING_DISTANCE_METERS.toDouble()
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -75,7 +75,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -97,7 +97,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -117,7 +117,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -140,7 +140,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // ~2.2 km from the last registration: beyond the 1 km trigger, within the 5 km remote radius.
         repository.refresh(latitude = 0.02, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) } // no remote fetch
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) } // no remote fetch
         coVerify { manager.replaceGeofences(any(), any()) } // local re-rank
         verify(exactly = 0) { logger.logSyncSkippedFresh() }
     }
@@ -160,7 +160,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // ~550 m from the last registration: within the 1 km trigger radius.
         repository.refresh(latitude = 0.005, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
@@ -169,7 +169,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenFetchAllMode_expectFetchWithoutLocation() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null // never synced -> remote fetch
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -177,7 +177,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 37.7749, longitude = -122.4194)
 
         // Fetch-all sends no location; precise lat/lng stay on-device.
-        coVerify { apiService.fetchGeofences(null) }
+        coVerify { apiService.fetchGeofences(null, any()) }
     }
 
     @Test
@@ -194,7 +194,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // 1° latitude ≈ 111 km — far beyond any radius — but fetch-all never re-fetches on movement.
         repository.handleMovement(latitude = 1.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -203,7 +203,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository = buildRepository(GeofenceSyncMode.NEARBY)
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null // never synced -> remote fetch
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -211,7 +211,27 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 37.7749, longitude = -122.4194)
 
         // NEARBY sends the device location to the API.
-        coVerify { apiService.fetchGeofences(GeofenceLocation(37.7749, -122.4194)) }
+        coVerify { apiService.fetchGeofences(GeofenceLocation(37.7749, -122.4194), any()) }
+    }
+
+    @Test
+    fun refresh_givenNearbyMode_expectSearchRadiusFromConfig() = runTest {
+        // radius = max(maxMonitoringDistance, remoteFetchRefreshTriggerRadius). Here the monitoring
+        // cap (2 km) is tighter than the re-fetch radius (5 km), so the re-fetch radius wins — the
+        // set must still cover everywhere the device can travel before the next re-fetch.
+        repository = buildRepository(GeofenceSyncMode.NEARBY)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        every { store.getCachedConfig() } returns sampleConfig(maxMonitoringDistance = 2_000f)
+        val radiusSlot = slot<Double>()
+        coEvery { apiService.fetchGeofences(any(), capture(radiusSlot)) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        radiusSlot.captured shouldBeEqualTo 5_000.0
     }
 
     @Test
@@ -223,7 +243,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L // time-fresh
         every { store.getCachedConfig() } returns sampleConfig() // remoteFetchRefreshTriggerRadius = 5 km
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -231,7 +251,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // 1° latitude ≈ 111 km from the anchor — beyond the 5 km fetch radius.
         repository.refresh(latitude = 1.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(GeofenceLocation(1.0, 0.0)) }
+        coVerify { apiService.fetchGeofences(GeofenceLocation(1.0, 0.0), any()) }
     }
 
     @Test
@@ -240,7 +260,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
         every { store.getCachedConfig() } returns sampleConfig() // remoteFetchRefreshTriggerRadius = 5 km
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -248,7 +268,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // 1° latitude ≈ 111 km, far beyond the 5 km fetch radius -> re-fetch from server.
         repository.handleMovement(latitude = 1.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(GeofenceLocation(1.0, 0.0)) }
+        coVerify { apiService.fetchGeofences(GeofenceLocation(1.0, 0.0), any()) }
     }
 
     @Test
@@ -266,7 +286,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // 0.01° latitude ≈ 1.1 km, within the 5 km fetch radius -> local re-rank only.
         repository.handleMovement(latitude = 0.01, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -289,7 +309,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // 1° latitude ≈ 111 km — far beyond localRefreshTriggerRadius — but within time freshness.
         repository.refresh(latitude = 1.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
         verify(exactly = 0) { logger.logSyncSkippedFresh() }
     }
@@ -306,7 +326,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0) // same as anchor
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
@@ -327,7 +347,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // At the last-registration point (0 m from it), but ~111 km from the fetch anchor.
         repository.refresh(latitude = 1.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
@@ -339,14 +359,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns
             System.currentTimeMillis() - GeofenceConstants.STALE_THRESHOLD_MS - 1_000L
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -363,7 +383,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkippedFresh() }
     }
 
@@ -377,14 +397,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedConfig() } returns
             sampleConfig(remoteFetchRefreshExpiry = 60 * 60 * 1_000L)
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -393,14 +413,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify { apiService.fetchGeofences(any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -410,7 +430,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify { logger.logSyncSkipped(match { it.contains("no identified user") }) }
@@ -423,14 +443,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
     fun refresh_givenApiFailure_expectFailurePropagatedAndNoPersistOrRegister() = runTest {
         val error = IOException("network down")
         every { secureUserStore.getUserId() } returns "user-42"
-        coEvery { apiService.fetchGeofences(any()) } returns Result.failure(error)
+        coEvery { apiService.fetchGeofences(any(), any()) } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -448,7 +468,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // restore reads it later as the effective coordinates.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -467,7 +487,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so any previously-stored location is stale and must be cleared.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(emptyResponse())
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -485,7 +505,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // device approaches — unlike the truly-empty case, which registers nothing.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // non-empty fetched set
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList() // none near
         val captured = slot<List<GeofenceRegion>>()
@@ -506,7 +526,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // last-known good movement location intact (next refresh retries).
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -522,7 +542,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
         val filtered = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns filtered
         val captured = slot<List<GeofenceRegion>>()
@@ -554,7 +574,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenSuccess_expectCacheAndConfigAndAnchorPersisted() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
         every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -581,7 +601,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // anchor stale so the next refresh retries instead of skipping as "fresh".
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -611,7 +631,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceRegion("biz-shared", 0.0, 0.0, 100f),
             GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         )
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns newBusiness
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -633,7 +653,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenNoPreviousRegistration_expectNoRemoveCall() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -654,7 +674,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { store.getLastRegistrationUptime() } returns 10_000L
         every { clock.elapsedRealtime() } returns 5_000L
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -675,7 +695,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { store.getLastRegistrationUptime() } returns 5_000L
         every { clock.elapsedRealtime() } returns 10_000L
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -708,7 +728,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 1) { manager.replaceGeofences(any(), any()) }
         existingSlot.captured.shouldBeEmpty()
     }
@@ -722,7 +742,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(newRegion)
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -753,7 +773,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             GeofenceConstants.MOVEMENT_TRIGGER_ID,
             "biz-old"
         )
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(emptyResponse())
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
@@ -772,7 +792,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // no movement trigger registered, no OS-side geofence activity.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(emptyResponse())
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         val captured = slot<List<GeofenceRegion>>()
@@ -795,7 +815,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val error = RuntimeException("gms boom")
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf("biz-old")
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 5))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-new", 0.0, 0.0, 100f))
@@ -818,7 +838,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // a second OS registration.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
 
@@ -838,7 +858,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
         verify { logger.logSyncSkipped(match { it.contains("refresh already in progress") }) }
     }
 
@@ -848,7 +868,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // so a follow-up refresh isn't permanently locked out.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returnsMany listOf(
+        coEvery { apiService.fetchGeofences(any(), any()) } returnsMany listOf(
             Result.failure(IOException("first call fails")),
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         )
@@ -860,7 +880,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         first.isFailure shouldBeEqualTo true
         second.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 2) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 2) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -869,7 +889,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // the userId recheck inside the state lock prevents writing the previous
         // user's geofences after a sign-out cleared state.
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", "user-B")
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -884,7 +904,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     @Test
     fun refresh_givenUserSignsOutDuringApiCall_expectNoWriteToStoreOrManager() = runTest {
         every { secureUserStore.getUserId() } returnsMany listOf("user-A", null)
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
 
         val result = repository.refresh(latitude = 0.0, longitude = 0.0)
@@ -906,7 +926,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
         every { store.getCachedRegions() } returns listOf(region)
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(region)
         val existingSlot = slot<Set<String>>()
@@ -929,7 +949,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns null
         every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
         every { store.getCachedRegions() } returns listOf(cached)
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(incoming)
         val existingSlot = slot<Set<String>>()
@@ -938,6 +958,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
+    fun refresh_givenRemoteFetchAndOnlyGeosetsDiffer_expectIdKeptNotReRegistered() = runTest {
+        // Backend changed only biz-1's geoset membership, not its geometry. Geosets drive event
+        // fan-out, not OS registration, so biz-1 stays in existingBusinessIds — avoiding a needless
+        // GMS re-register (which would fire a spurious INITIAL ENTER).
+        val cached = GeofenceRegion("biz-1", 1.0, 2.0, 100f, geosetIds = listOf("1"))
+        val incoming = cached.copy(geosetIds = listOf("1", "2", "3"))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(cached)
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(incoming)
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured shouldContainSame setOf("biz-1")
     }
 
     @Test
@@ -1021,7 +1063,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.handleMovement(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
     }
 
@@ -1033,14 +1075,14 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastApiFetchLocation() } returns null
         every { store.getCachedConfig() } returns sampleConfig()
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
         repository.handleMovement(latitude = 1.0, longitude = 2.0)
 
-        coVerify { apiService.fetchGeofences(any()) }
+        coVerify { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -1059,7 +1101,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // ~111m from anchor — well within the fallback 5km threshold.
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
     }
 
@@ -1082,7 +1124,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.handleMovement(latitude = 0.0, longitude = 0.001)
 
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
         coVerify { manager.replaceGeofences(any(), any()) }
         verify { distanceFilter.nearest(cached, 0.0, 0.001, any(), any()) }
     }
@@ -1118,7 +1160,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         val concurrentApiCalls = AtomicInteger(0)
         val maxObservedConcurrency = AtomicInteger(0)
-        coEvery { apiService.fetchGeofences(any()) } coAnswers {
+        coEvery { apiService.fetchGeofences(any(), any()) } coAnswers {
             val n = concurrentApiCalls.incrementAndGet()
             maxObservedConcurrency.updateAndGet { current -> maxOf(current, n) }
             delay(50)
@@ -1134,7 +1176,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 1) { apiService.fetchGeofences(any(), any()) }
     }
 
     // ---------- restoreFromCache (boot path) ----------
@@ -1206,7 +1248,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Pins the boot-restore manager variant, not the normal one.
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { apiService.fetchGeofences(any(), any()) }
     }
 
     @Test
@@ -1263,7 +1305,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getLastSyncTimestamp() } returns null
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
@@ -1293,7 +1335,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns null // force a remote fetch
         every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
+        coEvery { apiService.fetchGeofences(any(), any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3, maxMonitoringDistance = 50_000f))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -51,7 +51,8 @@ class GeofenceApiResponseTest : RobolectricTest() {
                   "radius": 500,
                   "external_id": "ext-abc",
                   "transition_types": ["enter", "exit"],
-                  "last_updated": 1778760000
+                  "last_updated": 1778760000,
+                  "geoset_ids": [7, 8, 9]
                 }
               ]
             }
@@ -67,8 +68,31 @@ class GeofenceApiResponseTest : RobolectricTest() {
             radius = 500f,
             externalId = "ext-abc",
             transitionTypes = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT),
-            lastUpdated = 1_778_760_000L
+            lastUpdated = 1_778_760_000L,
+            geosetIds = listOf("7", "8", "9")
         )
+    }
+
+    @Test
+    fun parseAndMap_givenNoGeosetIds_expectEmpty() {
+        val regions = parseRegions(
+            """{ "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100 } ] }"""
+        )
+
+        regions[0].geosetIds.shouldBeEmpty()
+    }
+
+    @Test
+    fun parseAndMap_givenNumericGeosetIdsOnWire_expectStringsInOrder() {
+        // Server contract: geoset_ids arrive as JSON numbers ([]int64). The SDK treats them as opaque
+        // string identifiers (like `id`), coercing each element without reordering.
+        val regions = parseRegions(
+            """
+            { "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100, "geoset_ids": [1, 3, 7] } ] }
+            """.trimIndent()
+        )
+
+        regions[0].geosetIds shouldBeEqualTo listOf("1", "3", "7")
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiServiceTest.kt
@@ -3,13 +3,15 @@ package io.customer.geofence.api
 import io.customer.geofence.GeofenceJsonSerializer
 import io.customer.geofence.GeofenceLocation
 import io.customer.sdk.core.network.CustomerIOHttpClient
+import io.customer.sdk.core.network.HttpMethod
 import io.customer.sdk.core.network.HttpRequestParams
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
-import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContain
 import org.junit.Test
 
 class GeofenceApiServiceTest {
@@ -18,23 +20,40 @@ class GeofenceApiServiceTest {
     private val service = GeofenceApiServiceImpl(httpClient, GeofenceJsonSerializer())
 
     @Test
-    fun fetchGeofences_givenNoLocation_expectNoCoordinatesOnTheWire() = runTest {
+    fun fetchGeofences_givenAnyRequest_expectPostToNearest() = runTest {
+        val capturedParams = slot<HttpRequestParams>()
+        coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
+
+        service.fetchGeofences(GeofenceLocation(latitude = 1.0, longitude = 2.0))
+
+        capturedParams.captured.method shouldBeEqualTo HttpMethod.POST
+        capturedParams.captured.path shouldBeEqualTo "/geofences/nearest"
+    }
+
+    @Test
+    fun fetchGeofences_givenNoLocation_expectNoBody() = runTest {
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
 
         service.fetchGeofences(location = null)
 
-        capturedParams.captured.queryParams.shouldBeEmpty()
+        capturedParams.captured.body.shouldBeNull()
     }
 
     @Test
-    fun fetchGeofences_givenLocation_expectCoordinatesOnTheWire() = runTest {
+    fun fetchGeofences_givenLocation_expectCoordinatesInJsonBody() = runTest {
         val capturedParams = slot<HttpRequestParams>()
         coEvery { httpClient.request(capture(capturedParams)) } returns Result.success("{}")
 
-        service.fetchGeofences(GeofenceLocation(latitude = 37.7749295, longitude = -122.4194155))
+        service.fetchGeofences(
+            GeofenceLocation(latitude = 37.7749295, longitude = -122.4194155),
+            radiusMeters = 20000.0
+        )
 
-        capturedParams.captured.queryParams["latitude"] shouldBeEqualTo "37.7749295"
-        capturedParams.captured.queryParams["longitude"] shouldBeEqualTo "-122.4194155"
+        val body = capturedParams.captured.body!!
+        body shouldContain "\"latitude\":37.7749295"
+        body shouldContain "\"longitude\":-122.4194155"
+        body shouldContain "\"radius\":20000.0"
+        capturedParams.captured.headers["Content-Type"] shouldBeEqualTo "application/json"
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -67,17 +67,18 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun getCachedRegionName_givenCachedId_expectName() {
-        store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee")))
+    fun getCachedRegion_givenCachedId_expectRegion() {
+        val region = GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee", geosetIds = listOf("3", "4"))
+        store.saveCachedRegions(listOf(region))
 
-        store.getCachedRegionName("biz-1") shouldBeEqualTo "Coffee"
+        store.getCachedRegion("biz-1") shouldBeEqualTo region
     }
 
     @Test
-    fun getCachedRegionName_givenUnknownId_expectNull() {
+    fun getCachedRegion_givenUnknownId_expectNull() {
         store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee")))
 
-        store.getCachedRegionName("biz-missing") shouldBeEqualTo null
+        store.getCachedRegion("biz-missing") shouldBeEqualTo null
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -10,12 +10,23 @@ import org.junit.Test
 class PendingGeofenceDeliveryTest {
 
     @Test
-    fun key_expectGeofenceIdTransitionTimestampComposite() {
+    fun key_givenNoGeoset_expectNoneSuffix() {
         val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A", transitionId = "tid-1")
 
         // Doubles as the WorkManager unique-work name so the flush can cancel by key.
         // transitionId is intentionally NOT part of the key.
-        entry.key shouldBeEqualTo "biz-1_ENTER_1234"
+        entry.key shouldBeEqualTo "biz-1_ENTER_1234_none"
+    }
+
+    @Test
+    fun key_givenGeoset_expectGeosetInKey() {
+        // The per-geoset fan-out shares (geofenceId, transition, timestamp); the geoset keeps keys
+        // distinct so the entries don't overwrite each other in the store / WorkManager.
+        val enter7 = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A", transitionId = "tid-1", geosetId = "7")
+        val enter8 = enter7.copy(geosetId = "8")
+
+        enter7.key shouldBeEqualTo "biz-1_ENTER_1234_7"
+        enter8.key shouldBeEqualTo "biz-1_ENTER_1234_8"
     }
 
     @Test
@@ -80,6 +91,30 @@ class PendingGeofenceDeliveryTest {
         val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-6", geofenceName = null)
 
         entry.toEventProperties().keys shouldNotContain "geofenceName"
+    }
+
+    @Test
+    fun toEventProperties_givenNumericGeoset_expectGeosetIdAsLong() {
+        // Emitted as a number so the property type matches the server's int64 geoset id.
+        val entry = PendingGeofenceDelivery("biz-7", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-7", geosetId = "42")
+
+        entry.toEventProperties()["geosetId"] shouldBeEqualTo 42L
+    }
+
+    @Test
+    fun toEventProperties_givenNonNumericGeoset_expectGeosetIdAsString() {
+        // Non-numeric ids (should the backend ever send them) pass through unchanged rather than being dropped.
+        val entry = PendingGeofenceDelivery("biz-7", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-7", geosetId = "gs-abc")
+
+        entry.toEventProperties()["geosetId"] shouldBeEqualTo "gs-abc"
+    }
+
+    @Test
+    fun toEventProperties_givenNullGeoset_expectGeosetIdOmitted() {
+        // A fence with no geosets emits a single event carrying no geosetId.
+        val entry = PendingGeofenceDelivery("biz-8", Event.GeofenceTransition.ENTER, 50L, "user-A", transitionId = "tid-8", geosetId = null)
+
+        entry.toEventProperties().keys shouldNotContain "geosetId"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -53,7 +53,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
         // At-least-once contract: send with the snapshotted entry, remove only after success.
         coVerify(exactly = 1) { mockTracker.trackEvent(entry) }
-        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42") }
+        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42_none") }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -69,7 +69,7 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
                 capture(workRequestSlot)
             )
         }
-        uniqueKeySlot.captured shouldBeEqualTo "biz-geofence-1_ENTER_1234"
+        uniqueKeySlot.captured shouldBeEqualTo "biz-geofence-1_ENTER_1234_none"
 
         val input = workRequestSlot.captured.workSpec.input
         input.getString("geofence_id") shouldBeEqualTo "biz-geofence-1"
@@ -84,6 +84,31 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
         constraints.requiredNetworkType shouldBeEqualTo NetworkType.CONNECTED
+    }
+
+    @Test
+    fun schedule_givenGeoset_expectGeosetIdInKeyAndInputData() = runTest {
+        every { workManagerProvider.getWorkManager() } returns workManager
+        val workRequestSlot = slot<OneTimeWorkRequest>()
+        val uniqueKeySlot = slot<String>()
+
+        scheduler.schedule(
+            PendingGeofenceDelivery(
+                geofenceId = "biz-geofence-1",
+                transition = Event.GeofenceTransition.ENTER,
+                timestamp = 1_234L,
+                userId = "user-42",
+                transitionId = "tid-sched",
+                geosetId = "9"
+            )
+        )
+
+        verify(exactly = 1) {
+            workManager.enqueueUniqueWork(capture(uniqueKeySlot), ExistingWorkPolicy.KEEP, capture(workRequestSlot))
+        }
+        // Key carries the geoset so per-geoset workers don't collide under ExistingWorkPolicy.KEEP.
+        uniqueKeySlot.captured shouldBeEqualTo "biz-geofence-1_ENTER_1234_9"
+        workRequestSlot.captured.workSpec.input.getString("geoset_id") shouldBeEqualTo "9"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -49,9 +49,10 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         timestamp: Long = 0L,
         userId: String? = "user-42",
         transitionId: String = "tid-seed",
-        geofenceName: String? = null
+        geofenceName: String? = null,
+        geosetId: String? = null
     ): PendingGeofenceDelivery =
-        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, transitionId, geofenceName)
+        PendingGeofenceDelivery(geofenceId, transition, timestamp, userId, transitionId, geofenceName, geosetId)
             .also { store.append(it) }
 
     @Test
@@ -76,6 +77,21 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         createWorker(inputData).doWork()
 
         coVerify(exactly = 1) { tracker.trackEvent(entry) }
+    }
+
+    @Test
+    fun doWork_givenGeosetIdInInput_expectGeosetOnTrackedEntryAndRemoved() = runTest {
+        // Round-trips geosetId through inputData: the reconstructed entry must match the stored
+        // per-geoset key (biz-1_ENTER_99_7), so the durable path sends + removes the right event.
+        val entry = seed("biz-1", Event.GeofenceTransition.ENTER, 99L, geosetId = "7")
+        val inputData = buildInputData("biz-1", "ENTER", 99L, "user-42", geosetId = "7")
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+
+        val result = createWorker(inputData).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.success()
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
+        store.loadAll().isEmpty().shouldBeTrue()
     }
 
     @Test
@@ -142,7 +158,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         result shouldBeEqualTo ListenableWorker.Result.retry()
         // Restored so a WorkManager retry — or the foreground flush — can deliver later.
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0_none")
     }
 
     @Test
@@ -155,7 +171,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         val result = createWorker(inputData).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.failure()
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0_none")
     }
 
     @Test
@@ -170,7 +186,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
         // Entry must NOT be removed — flush still needs it.
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz-anon_ENTER_0")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz-anon_ENTER_0_none")
     }
 
     private fun buildInputData(
@@ -179,7 +195,8 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         timestamp: Long = 0L,
         userId: String? = "user-42",
         transitionId: String? = "tid-seed",
-        geofenceName: String? = null
+        geofenceName: String? = null,
+        geosetId: String? = null
     ): Data {
         val builder = Data.Builder()
             .putLong("timestamp", timestamp)
@@ -188,6 +205,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         transitionId?.let { builder.putString("transition_id", it) }
         userId?.let { builder.putString("user_id", it) }
         geofenceName?.let { builder.putString("geofence_name", it) }
+        geosetId?.let { builder.putString("geoset_id", it) }
         return builder.build()
     }
 


### PR DESCRIPTION
## What
- Nearby sync is now `POST /geofences/nearest` with body `{latitude, longitude, radius}` (was `GET /geofences/nearby`). `radius = max(monitoring cap, re-fetch radius)`, sourced from cached config; `limit` omitted (SDK caps locally).
- Response gains `geoset_ids`; `name` / `transition_types` / `last_updated` kept optional (silently honored if the backend still sends them).
- One transition event is emitted **per geoset** (`geosetId` property). A fence with no geosets still emits a single event (no `geosetId`), so a real OS transition is never dropped.
- One `transitionId` is shared across a crossing's fan-out (it identifies the crossing, not the geoset); the geoset is part of the pending-delivery key so per-geoset rows don't collide. **Backend dedup must be keyed `(transitionId, geoset_id)`.**
- The fan-out persists in one atomic store write before any send (an app kill mid-batch can't lose geosets — the cooldown is already spent), geoset ids are deduped at source, and `geosetId` is emitted type-preserving (a number when numeric, matching the server `int64`).

## Notes
- **FETCH_ALL is unused** (`active = NEARBY`); its bodyless-POST path is dead code and will be removed — along with iOS's `GET /geofences/nearby` — in a follow-up PR.
- iOS parity checked against the equivalent iOS change (endpoint, radius formula, decode, fan-out, shared transitionId, atomic persist, type-preserving emit all match).

## Testing
Unit tests updated/added: nearest POST body, numeric→string geoset decode + ordering, fan-out counts (3→3, 1→1, empty→1, duplicate→deduped), shared-transitionId + distinct-key invariants, type-preserving `geosetId` emission, radius formula, atomic batch append.

[MBL-2008](https://linear.app/customerio/issue/MBL-2008/sdk-emit-one-transition-event-per-fence-geoset-fence-as-metadata)

## PRs Stack
- **this** — Emit one transition event per geoset (`POST /geofences/nearest`)
- **next** — Remove FETCH_ALL (Android + iOS)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the geofence API contract and multiplies transition events per crossing, requiring backend dedup on (transitionId, geoset); delivery and registration paths are heavily covered by tests but rollout must stay aligned with the server.
> 
> **Overview**
> Geofence sync now calls **`POST /geofences/nearest`** with a JSON body (`latitude`, `longitude`, `radius`) instead of **`GET /geofences/nearby`**. **`radius`** is computed from cached config as **`max(monitoring cap, re-fetch radius)`** via **`remoteSearchRadiusMeters()`**. API regions gain **`geoset_ids`**, stored on **`GeofenceRegion`** and decoded from the wire.
> 
> On a real OS transition, the receiver **fans out one pending delivery (and tracked event) per distinct geoset**, sharing a single **`transitionId`** across the crossing while **`geosetId`** distinguishes rows (**pending keys**, WorkManager input, and event properties). Fences with **no geosets** still emit **one** event (no **`geosetId`**). The batch is **`appendAll`**’d atomically before scheduling sends.
> 
> **`equalsIgnoringGeosetIds`** avoids needless GMS re-registration when only geoset membership changes; the region store exposes **`getCachedRegion`** for fan-out metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec4dfed497efca8272540a9b32d3584444f9f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->