### PR TITLE
chore(inbox): overlay bottom sheet + branding bell, position & web-parity actions

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Dependencies.kt
@@ -74,5 +74,6 @@ object Dependencies {
     const val composeUiGraphics = "androidx.compose.ui:ui-graphics"
     const val composeFoundation = "androidx.compose.foundation:foundation"
     const val composeMaterial = "androidx.compose.material:material"
+    const val composeMaterial3 = "androidx.compose.material3:material3"
     const val composeRuntime = "androidx.compose.runtime:runtime"
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/data/Branding.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/data/Branding.kt
@@ -44,11 +44,18 @@ data class Branding(
         val dark: Map<String, Any?>? = null
     )
 
-    /** The floating notification-bell icon (patterns.inbox.floatingIcon). */
+    /**
+     * The floating notification-bell icon (patterns.inbox.floatingIcon).
+     *
+     * @param svg the raw bell glyph SVG markup, rendered dynamically by the overlay so the
+     *   workspace's configured bell is honored; the overlay falls back to a bundled default
+     *   when this is absent or unparseable.
+     */
     @InternalCustomerIOApi
     data class FloatingIcon(
         val background: String? = null,
-        val color: String? = null
+        val color: String? = null,
+        val svg: String? = null
     )
 
     /**

--- a/messaginginbox/api/messaginginbox.api
+++ b/messaginginbox/api/messaginginbox.api
@@ -1,6 +1,6 @@
 public final class io/customer/messaginginbox/NotificationInboxOverlayKt {
 	public static final fun NotificationInboxBell (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun NotificationInboxOverlay (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NotificationInboxView (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NotificationInboxView (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/messaginginbox/build.gradle
+++ b/messaginginbox/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation Dependencies.composeUi
     implementation Dependencies.composeUiGraphics
     implementation Dependencies.composeFoundation
+    // Material3 provides the drop-in overlay's native ModalBottomSheet (drag handle, drag-to-dismiss,
+    // partial/expanded detents, predictive-back), the true parallel to the iOS overlay's .sheet.
+    implementation Dependencies.composeMaterial3
     implementation Dependencies.composeRuntime
     implementation Dependencies.androidxLifecycleRuntimeCompose
     implementation Dependencies.coroutinesAndroid

--- a/messaginginbox/src/main/AndroidManifest.xml
+++ b/messaginginbox/src/main/AndroidManifest.xml
@@ -2,4 +2,22 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application />
+
+    <!--
+      Package-visibility declaration (Android 11+ / API 30+): the overlay resolves openUrl/openDeeplink
+      actions via `resolveActivity`, which is filtered by package visibility. Without this, the external
+      browser fallback can resolve to null even when a browser exists. Mirrors messagingpush's manifest.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+    </queries>
 </manifest>

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellIcon.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellIcon.kt
@@ -1,0 +1,112 @@
+package io.customer.messaginginbox
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.vector.PathParser
+import kotlin.math.min
+
+/**
+ * Renders a pre-built branding bell glyph ([InboxBellSvg.BellArt]) — the workspace's configured
+ * `patterns.inbox.floatingIcon.svg`, parsed once into a combined even-odd path — scaled-to-fit the
+ * target size (aspect preserved) and filled with [tint].
+ *
+ * The art is built (and validated) up front by [InboxBellSvg.buildArt]; callers pass the result only
+ * when non-null and fall back to the bundled drawable otherwise, so a malformed SVG never reaches
+ * here. Only `<path d>` geometry + `viewBox` are honored (presentation attributes are ignored — the
+ * bell is a single tinted silhouette).
+ */
+@Composable
+internal fun InboxBellIcon(
+    art: InboxBellSvg.BellArt,
+    tint: Color,
+    modifier: Modifier = Modifier
+) {
+    Canvas(modifier = modifier) {
+        val scale = min(size.width / art.width, size.height / art.height)
+        // Center the scaled artwork in the target rect.
+        val left = (size.width - art.width * scale) / 2f
+        val top = (size.height - art.height * scale) / 2f
+        translate(left = left, top = top) {
+            scale(scaleX = scale, scaleY = scale, pivot = Offset.Zero) {
+                // Shift the viewBox origin to (0,0) before scaling so a non-zero minX/minY viewBox fits.
+                translate(left = -art.minX, top = -art.minY) {
+                    drawPath(path = art.path, color = tint)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Branding-SVG bell parsing for [InboxBellIcon]. [parse] is a pure (non-Compose) regex extraction of
+ * the `viewBox` + each `<path>`'s `d`, unit-testable on the JVM. [buildArt] turns that into a
+ * ready-to-draw [BellArt] using Compose's built-in [PathParser] (no third-party dep — unlike iOS,
+ * which vendors a parser); it is crash-safe (see below) and its result is `remember`-cached by the
+ * caller so the SVG is parsed once, not per frame.
+ */
+internal object InboxBellSvg {
+    /** A built, ready-to-draw bell glyph: the combined even-odd [Path] plus its source viewBox. */
+    data class BellArt(
+        val path: Path,
+        val minX: Float,
+        val minY: Float,
+        val width: Float,
+        val height: Float
+    )
+
+    /** Parsed geometry: viewBox origin/size + the `d` string of each `<path>`. */
+    data class Parsed(
+        val minX: Float,
+        val minY: Float,
+        val width: Float,
+        val height: Float,
+        val pathData: List<String>
+    )
+
+    private val VIEW_BOX = Regex("""viewBox\s*=\s*["']\s*([^"']+?)\s*["']""", RegexOption.IGNORE_CASE)
+    private val PATH_D = Regex("""<path\b[^>]*?\bd\s*=\s*["']([^"']+)["']""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+
+    /**
+     * Parse [svg], or return null when there is nothing renderable (no `<path d>`). A missing
+     * `viewBox` defaults to a 24×24 box so a bare `<svg><path/></svg>` still fits.
+     */
+    fun parse(svg: String): Parsed? {
+        val pathData = PATH_D.findAll(svg).map { it.groupValues[1].trim() }.filter { it.isNotEmpty() }.toList()
+        if (pathData.isEmpty()) return null
+
+        val box = VIEW_BOX.find(svg)?.groupValues?.get(1)
+            ?.split(Regex("[\\s,]+"))
+            ?.mapNotNull { it.toFloatOrNull() }
+        return if (box != null && box.size == 4 && box[2] > 0f && box[3] > 0f) {
+            Parsed(minX = box[0], minY = box[1], width = box[2], height = box[3], pathData = pathData)
+        } else {
+            Parsed(minX = 0f, minY = 0f, width = 24f, height = 24f, pathData = pathData)
+        }
+    }
+
+    /**
+     * Build a ready-to-draw [BellArt] from raw [svg], or null when it cannot be rendered (no
+     * `<path d>`, or the path data is malformed). [PathParser.parsePathString] THROWS
+     * `IllegalArgumentException` on invalid path commands (e.g. `"M0 0 X1 1"`), so the build is
+     * guarded — a malformed branding SVG falls back to the bundled bell instead of crashing.
+     */
+    fun buildArt(svg: String): BellArt? {
+        val parsed = parse(svg) ?: return null
+        return try {
+            val path = Path().apply {
+                fillType = PathFillType.EvenOdd
+                parsed.pathData.forEach { d -> addPath(PathParser().parsePathString(d).toPath()) }
+            }
+            if (path.isEmpty) null else BellArt(path, parsed.minX, parsed.minY, parsed.width, parsed.height)
+        } catch (ex: Exception) {
+            null
+        }
+    }
+}

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellPosition.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellPosition.kt
@@ -1,0 +1,34 @@
+package io.customer.messaginginbox
+
+import androidx.compose.ui.Alignment
+
+/**
+ * Where the floating inbox bell is pinned, driven by the workspace branding
+ * `patterns.inbox.position`. The raw values mirror the web SDK's `positionStyles`
+ * (gist-web `inbox-component-manager`); anything absent or unrecognized falls back
+ * to [BottomRight], matching web's `switch(position)` default.
+ */
+internal enum class InboxBellPosition(val raw: String) {
+    BottomRight("bottom-right"),
+    BottomLeft("bottom-left"),
+    TopRight("top-right"),
+    TopLeft("top-left");
+
+    /** The Compose [Alignment] this position maps to within the full-screen overlay box. */
+    val alignment: Alignment
+        get() = when (this) {
+            BottomRight -> Alignment.BottomEnd
+            BottomLeft -> Alignment.BottomStart
+            TopRight -> Alignment.TopEnd
+            TopLeft -> Alignment.TopStart
+        }
+
+    companion object {
+        /**
+         * Resolve a raw branding position string to a [InboxBellPosition]. Exact-match only (no
+         * case/format normalization), mirroring web's `switch(position)`; null / unknown → [BottomRight].
+         */
+        fun resolve(raw: String?): InboxBellPosition =
+            entries.firstOrNull { it.raw == raw } ?: BottomRight
+    }
+}

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -1,25 +1,20 @@
 package io.customer.messaginginbox
 
 import android.util.TypedValue
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,6 +28,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -80,7 +78,7 @@ import kotlinx.serialization.json.JsonObject
  *
  * Pair it with [NotificationInboxView] (which you present however you like — a sheet, a screen, a
  * popup) by toggling your own visibility state from [onClick]. For the ready-made floating bell +
- * slide-out panel, use [NotificationInboxOverlay] instead.
+ * bottom sheet, use [NotificationInboxOverlay] instead.
  *
  * @param onClick invoked when the user taps the bell (e.g. to show/hide your inbox view).
  * @param modifier Modifier applied to the bell.
@@ -100,9 +98,13 @@ fun NotificationInboxBell(
     val hasRenderableMessages = rememberHasRenderableMessages(state)
     if (!state.isVisible || !hasRenderableMessages) return
 
+    val branding = (state.visibility as? InboxVisibility.Visible)?.branding
+    val chrome = rememberInboxChrome(branding)
     InboxBellContent(
         unopenedCount = state.unopenedCount,
-        colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
+        showAlert = chrome.showAlert,
+        bellSvg = chrome.bellSvg,
+        colors = rememberInboxColors(branding),
         onClick = onClick,
         modifier = modifier
     )
@@ -113,15 +115,20 @@ fun NotificationInboxBell(
  * directly in your own screen (or present in a sheet/dialog). It fills the [modifier] you give it
  * and brings no surrounding chrome (no card/scrim), so you control the placement and container.
  *
- * Showing this view marks the currently-unread messages as opened (mirroring the panel-open
+ * Showing this view marks the currently-unread messages as opened (mirroring the sheet-open
  * behavior); tapping a message dismisses it or runs its action. For the ready-made floating bell +
- * slide-out panel, use [NotificationInboxOverlay]; to drive your own bell, use [NotificationInboxBell].
+ * bottom sheet, use [NotificationInboxOverlay]; to drive your own bell, use [NotificationInboxBell].
  *
  * @param modifier Modifier applied to the list container.
+ * @param onDismissRequest invoked when a tapped message navigates away (opens a url / deep link, or
+ *   the host listener handled a navigating action). If you present this view in your own sheet or
+ *   dialog, dismiss it here so the inbox doesn't linger over the destination. Null (default) = the
+ *   view stays put (e.g. when embedded inline in a screen).
  */
 @Composable
 fun NotificationInboxView(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onDismissRequest: (() -> Unit)? = null
 ) {
     val controller = rememberInboxController()
     // Collect state for branding-driven chrome colors (the bell/overlay do the same); InboxListContent
@@ -131,15 +138,17 @@ fun NotificationInboxView(
     InboxListContent(
         controller = controller,
         colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
+        onNavigatedAway = onDismissRequest,
         modifier = modifier.fillMaxSize()
     )
 }
 
 /**
  * Drop-in Compose overlay that shows the Customer.io Visual Notification Inbox on top of your app:
- * a floating [NotificationInboxBell] pinned bottom-end that slides out a [NotificationInboxView]
- * panel; tapping outside the panel dismisses it. The bell only appears when there is something to
- * show, and everything updates automatically as messages arrive or are read.
+ * a floating [NotificationInboxBell] pinned to the branding-configured corner (default bottom-end)
+ * that slides a [NotificationInboxView] up in a bottom sheet; tapping the scrim outside the sheet
+ * dismisses it. The bell only appears when there is something to show, and everything updates
+ * automatically as messages arrive or are read.
  *
  * Mount it once near the top of your Compose hierarchy so it overlays the rest of your content:
  * ```
@@ -163,120 +172,111 @@ fun NotificationInboxOverlay(
 
 /**
  * Internal overload that accepts the [VisualInboxController] directly so Compose UI tests can drive
- * the overlay with a fake [VisualInbox], and so the bell + panel share a single controller/state.
+ * the overlay with a fake [VisualInbox], and so the bell + sheet share a single controller/state.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun NotificationInboxOverlay(
     modifier: Modifier = Modifier,
     controller: VisualInboxController
 ) {
-    var panelExpanded by remember { mutableStateOf(false) }
+    var sheetExpanded by remember { mutableStateOf(false) }
 
     // Reactive state: re-derived automatically on every relevant store change (see uiStateFlow),
-    // so the bell/panel/badge update with no recomposition or user navigation required.
+    // so the bell/sheet/badge update with no recomposition or user navigation required.
     // Build the Flow once per controller (not on every recomposition) so collection is stable.
     // collectAsStateWithLifecycle pauses collection while the host is STOPPED (backgrounded / overlay
     // off-screen) and resumes on start, avoiding wasted work when the inbox isn't visible.
+    //
+    // Reactive-lifecycle: this collection is anchored to the always-mounted overlay composable, NOT
+    // to the conditionally-rendered bell. The empty-inbox early-return below only skips rendering; it
+    // does not remove this composable (or its subscription) from composition, so the bell reappears
+    // when a message later arrives to an empty inbox. (Keep the collection decoupled from the bell —
+    // the iOS overlay had a bug where a bell-scoped teardown cancelled the subscription permanently.)
     val state by remember(controller) { controller.uiStateFlow() }
         .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
 
-    // Auto-close the panel + hide the bell when the inbox is no longer renderable. Dismissing the
+    // Auto-close the sheet + hide the bell when the inbox is no longer renderable. Dismissing the
     // last message empties the list -> the data layer reports the inbox no longer Visible -> the
-    // panel collapses and the bell unmounts (see the guard below).
+    // sheet collapses and the bell unmounts (see the guard below).
     val hasRenderableMessages = rememberHasRenderableMessages(state)
     LaunchedEffect(state.isVisible, hasRenderableMessages) {
         if (!state.isVisible || !hasRenderableMessages) {
-            panelExpanded = false
+            sheetExpanded = false
         }
     }
 
     // The bell only appears when the inbox is renderable: enabled+Visible AND at least one message has
-    // a template. When the panel is open we keep the overlay mounted regardless so the close animation
-    // can play out.
+    // a template. When the sheet is open we keep the overlay mounted regardless.
     val canShowChrome = state.isVisible && hasRenderableMessages
-    if (!canShowChrome && !panelExpanded) {
+    if (!canShowChrome && !sheetExpanded) {
         return
     }
 
-    val colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding)
+    val branding = (state.visibility as? InboxVisibility.Visible)?.branding
+    val colors = rememberInboxColors(branding)
+    val chrome = rememberInboxChrome(branding)
 
+    // Floating bell, pinned to the branding-configured corner (default bottom-end). Tapping opens the
+    // sheet. The anchor Box fills the host so the position alignment resolves against the full area.
+    // The bell is NOT toggled off while the sheet is open: the sheet presents in its own window above
+    // this content with its own scrim, so the bell simply sits behind it — toggling it on sheet
+    // open/close would make it flicker in and out.
     Box(modifier = modifier.fillMaxSize()) {
-        AnimatedVisibility(
-            // Gate on canShowChrome too (matches iOS): if the inbox empties while the panel is open
-            // (dismissing the last message -> Hidden), hide the scrim/panel immediately rather than
-            // waiting on the panelExpanded reset, so the panel auto-dismisses with the inbox.
-            visible = panelExpanded && canShowChrome,
-            enter = fadeIn(),
-            exit = fadeOut(),
-            modifier = Modifier.fillMaxSize()
-        ) {
-            // Full-bleed scrim: dims + captures touches so nothing falls through to host content
-            // behind the open panel; a tap dismisses the panel. No ripple/indication so it doesn't
-            // flash on tap. Dim 0.32 black, matched to iOS.
-            Box(
+        if (canShowChrome) {
+            InboxBellContent(
+                unopenedCount = state.unopenedCount,
+                showAlert = chrome.showAlert,
+                bellSvg = chrome.bellSvg,
+                colors = colors,
+                onClick = { sheetExpanded = true },
                 modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.32f))
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = { panelExpanded = false }
-                    )
-                    .semantics { contentDescription = "Close inbox" }
+                    .align(chrome.position.alignment)
+                    .padding(16.dp)
             )
         }
+    }
 
-        // Slide-out hovering panel: a floating card (margins on all sides, rounded corners) wrapping
-        // the inbox list. Aligned top-end so its top margin is honored.
-        val panelShape = RoundedCornerShape(colors.cornerRadius)
-        AnimatedVisibility(
-            visible = panelExpanded && canShowChrome,
-            enter = slideInHorizontally(initialOffsetX = { it }) + fadeIn(),
-            exit = slideOutHorizontally(targetOffsetX = { it }) + fadeOut(),
-            modifier = Modifier.align(Alignment.TopEnd)
+    // Native Material3 bottom sheet: slides up from the bottom with a drag handle (grabber), a scrim
+    // + drag-to-dismiss, and partial/expanded detents (opens partially; drag up to expand) — the
+    // parallel to the iOS overlay's .sheet with medium/large detents. It presents in its own window,
+    // so it is composed outside the anchor Box. Gate on canShowChrome too: if the inbox empties while
+    // the sheet is open (dismissing the last message -> Hidden), the sheet closes with the inbox.
+    if (sheetExpanded && canShowChrome) {
+        val sheetState = rememberModalBottomSheetState()
+        ModalBottomSheet(
+            onDismissRequest = { sheetExpanded = false },
+            sheetState = sheetState,
+            shape = RoundedCornerShape(topStart = colors.cornerRadius, topEnd = colors.cornerRadius),
+            containerColor = colors.panelColor
+            // dragHandle omitted: ModalBottomSheet already uses BottomSheetDefaults.DragHandle by
+            // default. Passing it explicitly generated a public ComposableSingletons lambda in the
+            // API dump for no behavior change.
         ) {
             InboxListContent(
                 controller = controller,
                 colors = colors,
+                // Close the sheet when a tapped message navigates via a deep link, so the deep-linked
+                // screen isn't left behind the sheet (openUrl external does not close).
+                onNavigatedAway = { sheetExpanded = false },
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(
-                        start = PANEL_MARGIN,
-                        end = PANEL_MARGIN,
-                        top = PANEL_MARGIN,
-                        bottom = PANEL_BOTTOM_MARGIN
-                    )
-                    .widthIn(max = 480.dp)
-                    .shadow(8.dp, panelShape)
-                    .clip(panelShape)
-                    .background(colors.panelColor)
-                    // Absorb taps inside the card so they don't fall through to the dismiss scrim
-                    // (only the scrim closes the inbox). Tap-only absorber: unlike pointerInput,
-                    // clickable does not eat scroll/drag, so the list still scrolls.
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = {}
-                    )
+                    .fillMaxWidth()
+                    .fillMaxHeight()
             )
         }
-
-        // Floating bell, pinned bottom-end. Tapping toggles the panel.
-        InboxBellContent(
-            unopenedCount = state.unopenedCount,
-            colors = colors,
-            onClick = { panelExpanded = !panelExpanded },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-        )
     }
 }
 
-/** The bell circle + unread badge. Pure UI — no data access; callers supply [unopenedCount]. */
+/**
+ * The bell circle + unread badge. Pure UI — no data access; callers supply [unopenedCount],
+ * [showAlert] (branding `unreadIndicator.showAlert` — whether to show the badge), and [bellSvg]
+ * (branding `floatingIcon.svg` — rendered dynamically, falling back to the bundled glyph).
+ */
 @Composable
 private fun InboxBellContent(
     unopenedCount: Int,
+    showAlert: Boolean,
+    bellSvg: String?,
     colors: InboxColors,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -292,14 +292,28 @@ private fun InboxBellContent(
                 .semantics { contentDescription = "Notifications inbox" }
                 .clickable(role = Role.Button, onClick = onClick)
         ) {
-            Image(
-                painter = painterResource(id = R.drawable.cio_inbox_notifications),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(colors.bellIconColor)
-            )
+            // Prefer the workspace's configured bell SVG; fall back to the bundled glyph when it is
+            // absent or unparseable. The art is built (and validated) once per svg here — malformed
+            // path data yields null (not a crash), and the parse is cached rather than run per frame.
+            val bellArt = remember(bellSvg) { bellSvg?.let(InboxBellSvg::buildArt) }
+            if (bellArt != null) {
+                InboxBellIcon(
+                    art = bellArt,
+                    tint = colors.bellIconColor,
+                    modifier = Modifier.size(24.dp)
+                )
+            } else {
+                Image(
+                    painter = painterResource(id = R.drawable.cio_inbox_notifications),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(colors.bellIconColor)
+                )
+            }
         }
 
-        if (unopenedCount > 0) {
+        // Badge shows only when there are unread messages AND branding has not disabled the alert
+        // (default show when unset), matching web renderBadge (hidden when count===0 || !showAlert).
+        if (unopenedCount > 0 && showAlert) {
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
@@ -331,7 +345,10 @@ private fun InboxBellContent(
 private fun InboxListContent(
     controller: VisualInboxController,
     colors: InboxColors,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // Invoked when a tapped message navigates away via a deep link, so a host presenting this in a
+    // sheet/dialog can dismiss it. Null (the default) for the embeddable NotificationInboxView.
+    onNavigatedAway: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
     val state by remember(controller) { controller.uiStateFlow() }
@@ -354,9 +371,13 @@ private fun InboxListContent(
     Column(modifier = modifier) {
         when {
             state.loading -> LoadingState(color = colors.bellColor)
-            // Render the list only when fully renderable (Visible + has messages); otherwise empty,
-            // so the list is never fed null templates/theme.
-            visible == null || state.messages.isEmpty() -> EmptyState(textColor = colors.textColorPrimary)
+            // Inbox is not renderable (disabled workspace, missing templates/branding). Render
+            // nothing — matching the overlay, which hides its chrome entirely in this state, and the
+            // iOS NotificationInboxView — rather than a stale list or a misleading "empty" placeholder.
+            visible == null -> Unit
+            // Visible but genuinely caught up (no messages). The list is only rendered in `else`
+            // (Visible + has messages), so it is never fed null templates/theme.
+            state.messages.isEmpty() -> EmptyState(textColor = colors.textColorPrimary)
             else -> InboxMessageList(
                 messages = state.messages,
                 templates = templates,
@@ -367,7 +388,19 @@ private fun InboxListContent(
                     // Controller resolves the action (dismiss / track+intercept / default nav) and
                     // returns a nav instruction; we (owning the Context) run it.
                     when (val nav = controller.handleAction(state.visibility, message, event)) {
-                        is InboxNavigation.OpenUrl -> openUrlInBrowser(context, nav.url)
+                        is InboxNavigation.OpenUrl -> {
+                            // Open externally, then dismiss so the inbox doesn't linger behind the
+                            // browser / destination when the user returns.
+                            openUrlInBrowser(context, nav.url)
+                            onNavigatedAway?.invoke()
+                        }
+                        is InboxNavigation.OpenDeeplink -> {
+                            // Route through the app's deep-link handling; on success, dismiss so the
+                            // deep-linked screen isn't left behind the sheet. A failed open keeps it open.
+                            if (openDeepLink(context, nav.url)) onNavigatedAway?.invoke()
+                        }
+                        // Host handled a navigating action itself — dismiss without the SDK navigating.
+                        InboxNavigation.Dismiss -> onNavigatedAway?.invoke()
                         InboxNavigation.None -> Unit
                     }
                 }
@@ -443,6 +476,51 @@ private fun openUrlInBrowser(context: android.content.Context, url: String) {
         context.startActivity(intent)
     } catch (ex: Exception) {
         SDKComponent.logger.error("$INBOX_LOG_TAG failed to open url '$url' in browser: ${ex.message}")
+    }
+}
+
+/**
+ * Route a resolved `openDeeplink` action (item 12) through the app's deep-link handling, mirroring
+ * how push notifications and in-app messages open deep links (see messagingpush `DeepLinkUtil`):
+ * prefer an activity in the **host app** (the app's own declared intent-filters handle the link
+ * in-app), and only fall back to an **external** handler (e.g. a browser for an https deeplink) when
+ * the host app declares none. Returns true when an activity was launched (so the caller can dismiss
+ * the inbox), false when nothing could handle the link. Never throws.
+ *
+ * (Implemented here rather than via messagingpush's `DeepLinkUtil` because `messaginginbox` depends
+ * only on `messaginginapp`; this keeps the routing behavior without adding a module dependency.)
+ */
+private fun openDeepLink(context: android.content.Context, url: String): Boolean {
+    val uri = android.net.Uri.parse(url)
+    val packageManager = context.packageManager
+
+    // 1. Host app first: an ACTION_VIEW intent scoped to this package resolves only the app's own
+    //    activities/intent-filters, so the link opens in-app rather than bouncing to a browser.
+    val hostIntent = android.content.Intent(android.content.Intent.ACTION_VIEW, uri)
+        .setPackage(context.packageName)
+        .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+    if (hostIntent.resolveActivity(packageManager) != null) {
+        return startDeepLinkActivity(context, hostIntent, url)
+    }
+
+    // 2. Fall back to any app that can open the link (e.g. a browser for an https deeplink).
+    val externalIntent = android.content.Intent(android.content.Intent.ACTION_VIEW, uri)
+        .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+    if (externalIntent.resolveActivity(packageManager) != null) {
+        return startDeepLinkActivity(context, externalIntent, url)
+    }
+
+    SDKComponent.logger.info("$INBOX_LOG_TAG no activity found to handle deeplink '$url'")
+    return false
+}
+
+private fun startDeepLinkActivity(context: android.content.Context, intent: android.content.Intent, url: String): Boolean {
+    return try {
+        context.startActivity(intent)
+        true
+    } catch (ex: Exception) {
+        SDKComponent.logger.error("$INBOX_LOG_TAG failed to open deeplink '$url': ${ex.message}")
+        false
     }
 }
 
@@ -540,6 +618,29 @@ private fun rememberHasRenderableMessages(state: VisualInboxUiState): Boolean {
     return remember(state.messages, templates) {
         state.messages.any { it.type in templates }
     }
+}
+
+/**
+ * Non-color branding chrome for the bell + sheet: where the bell is pinned ([position]), whether the
+ * unread badge is shown ([showAlert]), and the raw bell glyph SVG ([bellSvg]). Kept separate from
+ * [InboxColors] so the color resolution stays focused.
+ */
+private data class InboxChromeConfig(
+    val position: InboxBellPosition,
+    val showAlert: Boolean,
+    val bellSvg: String?
+)
+
+/** Resolves [InboxChromeConfig] from branding: `patterns.inbox.position` / `unreadIndicator.showAlert` / `floatingIcon.svg`. */
+@Composable
+private fun rememberInboxChrome(branding: Branding?): InboxChromeConfig = remember(branding) {
+    val chrome = branding?.inboxChrome
+    InboxChromeConfig(
+        position = InboxBellPosition.resolve(chrome?.position),
+        // Default to showing the badge when the workspace hasn't configured showAlert.
+        showAlert = chrome?.unreadIndicator?.showAlert ?: true,
+        bellSvg = branding?.floatingIcon?.svg
+    )
 }
 
 /** Resolved chrome colors for the overlay. See [rememberInboxColors] for the resolution order. */
@@ -674,7 +775,5 @@ private fun rememberThemeColor(attrResId: Int, fallbackColor: Color): Color {
 /** Consistent, greppable prefix for visual-inbox overlay log lines (matches the data layer's). */
 private const val INBOX_LOG_TAG = "[CIO-Inbox]"
 
-/** Hovering-panel margins: 16dp top/horizontal; a larger bottom inset clears the floating bell. */
-private val PANEL_MARGIN = 16.dp
-private val PANEL_BOTTOM_MARGIN = 88.dp
+/** Fallback corner radius for the sheet's rounded top when branding does not configure one. */
 private val PANEL_CORNER_RADIUS = 12.dp

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.customer.jist.JistActionEvent
 import io.customer.jist.JistMode
@@ -475,7 +476,7 @@ private fun InboxMessageList(
  */
 private fun openUrlInBrowser(context: android.content.Context, url: String): Boolean {
     return try {
-        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
+        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, url.toUri())
             .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(intent)
         true
@@ -497,7 +498,7 @@ private fun openUrlInBrowser(context: android.content.Context, url: String): Boo
  * only on `messaginginapp`; this keeps the routing behavior without adding a module dependency.)
  */
 private fun openDeepLink(context: android.content.Context, url: String): Boolean {
-    val uri = android.net.Uri.parse(url)
+    val uri = url.toUri()
     val packageManager = context.packageManager
 
     // 1. Host app first: an ACTION_VIEW intent scoped to this package resolves only the app's own

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -389,10 +389,10 @@ private fun InboxListContent(
                     // returns a nav instruction; we (owning the Context) run it.
                     when (val nav = controller.handleAction(state.visibility, message, event)) {
                         is InboxNavigation.OpenUrl -> {
-                            // Open externally, then dismiss so the inbox doesn't linger behind the
-                            // browser / destination when the user returns.
-                            openUrlInBrowser(context, nav.url)
-                            onNavigatedAway?.invoke()
+                            // Open externally; on success dismiss so the inbox doesn't linger behind the
+                            // browser / destination. A failed open (no browser / bad url) keeps the sheet
+                            // up rather than closing onto nothing (mirrors OpenDeeplink).
+                            if (openUrlInBrowser(context, nav.url)) onNavigatedAway?.invoke()
                         }
                         is InboxNavigation.OpenDeeplink -> {
                             // Route through the app's deep-link handling; on success, dismiss so the
@@ -468,14 +468,20 @@ private fun InboxMessageList(
  * Default navigation for a resolved openUrl action (item 12): open [url] in the system browser via
  * an ACTION_VIEW intent. `FLAG_ACTIVITY_NEW_TASK` is set so it works from a non-Activity context.
  * Robust to a malformed url or a device with no browser: any failure is logged, never crashes.
+ *
+ * Returns true when the browser was launched, false on failure — so the caller only dismisses the
+ * inbox when navigation actually happened (mirroring [openDeepLink]); a failed open keeps the sheet
+ * up rather than closing onto nothing.
  */
-private fun openUrlInBrowser(context: android.content.Context, url: String) {
-    try {
+private fun openUrlInBrowser(context: android.content.Context, url: String): Boolean {
+    return try {
         val intent = android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
             .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
         context.startActivity(intent)
+        true
     } catch (ex: Exception) {
         SDKComponent.logger.error("$INBOX_LOG_TAG failed to open url '$url' in browser: ${ex.message}")
+        false
     }
 }
 

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.booleanOrNull
 
 /**
  * Read-only UI snapshot of the visual inbox, derived from the [VisualInbox] data layer. The
@@ -209,10 +209,11 @@ internal class VisualInboxController(
      *     [VisualInbox.trackMessageClicked] plumbing — no new network path) exactly once per
      *     queueId, then give the host listener (item 13) a chance to intercept. If the host returns
      *     true it fully handled the action and we return [InboxNavigation.None].
-     *  3. Otherwise the SDK applies its default navigation (item 12): an http(s) / openUrl / newTab
-     *     url opens in the system browser ([InboxNavigation.OpenUrl]); a deeplink is handed back to
-     *     the host ([InboxNavigation.None] after logging — the SDK cannot resolve app routes); a
-     *     missing/malformed url is a logged no-op.
+     *  3. Otherwise the SDK applies its default navigation (item 12): an `openUrl` (http(s)) value
+     *     opens externally in the system browser ([InboxNavigation.OpenUrl]); an `openDeeplink`
+     *     value is routed through the app's deep-link handling ([InboxNavigation.OpenDeeplink],
+     *     which the overlay resolves against the host app first, mirroring push/in-app deep links);
+     *     a `performAction` is host-only (no navigation); a missing/malformed value is a logged no-op.
      *
      * Returns a [InboxNavigation] the (Context-bearing) overlay executes, keeping this controller
      * free of Android Intent / Context dependencies so it stays unit-testable.
@@ -232,34 +233,48 @@ internal class VisualInboxController(
         // behavior (e.g. performAction), meaning "run the action AND remove the message". Captured
         // before any early-return so it applies whether or not the host intercepts the action.
         val dismissAfterAction = actionDismissFlag(event)
+        // Host-facing action name (web `data.name`, else the Jist event name) + resolved value.
+        val name = actionName(event)
         val url = resolution.url
         // Track the click against the same InboxMessage the UI renders (resolved from the visible
         // set), reusing the existing track-clicked plumbing. Deduped per queueId so a repeated tap
         // before the row updates does not double-count.
-        trackClicked(visibility, message, event.name)
+        trackClicked(visibility, message, name)
 
         // Host interception (item 13): true => host handled it, SDK runs no default nav (but still
         // honors the dismiss flag below).
-        val handledByHost = notifyHostHandled(visibility, message, event.name, url.orEmpty())
+        val handledByHost = notifyHostHandled(visibility, message, name, url.orEmpty())
 
         // SDK default navigation (item 12), unless the host handled it.
         val navigation = if (handledByHost) {
-            InboxNavigation.None
+            // The host performed the action. If it was a navigating action (openUrl / openDeeplink),
+            // still dismiss the presenting sheet so the SDK inbox doesn't linger over the host's
+            // destination (mirrors iOS). A non-navigating action (performAction / unknown) leaves the
+            // inbox open.
+            when (resolution) {
+                is InboxAction.OpenUrl, is InboxAction.Deeplink -> InboxNavigation.Dismiss
+                else -> InboxNavigation.None
+            }
         } else {
             when (resolution) {
                 is InboxAction.OpenUrl -> InboxNavigation.OpenUrl(resolution.url)
-                is InboxAction.Deeplink -> {
+                // openDeeplink: route through the app's deep-link handling (the overlay resolves the
+                // host app first, then external), mirroring push/in-app deep links.
+                is InboxAction.Deeplink -> InboxNavigation.OpenDeeplink(resolution.url)
+
+                // performAction is host-only: if no host listener handled it there is nothing for
+                // the SDK to navigate to.
+                is InboxAction.PerformAction -> {
                     logger.debug(
-                        "$INBOX_LOG_TAG deeplink '${resolution.url}' on ${message.queueId} not handled by host; " +
-                            "SDK cannot resolve app routes, no-op"
+                        "$INBOX_LOG_TAG performAction '$name' on ${message.queueId} not handled by host; no navigation"
                     )
                     InboxNavigation.None
                 }
 
                 is InboxAction.Unknown -> {
                     logger.debug(
-                        "$INBOX_LOG_TAG action '${event.name}' (behavior=${actionBehavior(event)}, url=${actionUrl(event)}) " +
-                            "on ${message.queueId}: no resolvable url/behavior, no-op"
+                        "$INBOX_LOG_TAG action '$name' (behavior=${actionBehavior(event)}, value=${actionValue(event)}) " +
+                            "on ${message.queueId}: no resolvable value/behavior, no-op"
                     )
                     InboxNavigation.None
                 }
@@ -353,98 +368,133 @@ internal class VisualInboxController(
 
 /**
  * The SDK's resolved interpretation of a Jist inbox action, derived from the action's
- * `name` / `data.behavior` / `data.url` shape. The live inbox emits the dismiss action as
- * `name = "messageAction"` with `data.behavior == "dismiss"`; other actions carry a `data.url`
- * (and/or an `openUrl` / `newTab` / `deeplink` behavior). See [resolveInboxAction].
+ * `data.behavior` / `data.action` shape (web parity — see gist-web `handleInboxAction` /
+ * `InboxActionConfig`). The live inbox emits dismiss as `data.behavior == "dismiss"`; other actions
+ * carry a `data.action` value and one of the `openUrl` / `openDeeplink` / `performAction` behaviors.
+ * See [resolveInboxAction].
  */
 internal sealed interface InboxAction {
-    /** The resolved url for the action, when present. */
+    /** The resolved action value (a url / deeplink), when present. */
     val url: String?
 
-    /** Remove (delete) the message. Web parity for a dismiss action. */
+    /** Remove (delete) the message. Web parity for a `dismiss` action. */
     object Dismiss : InboxAction {
         override val url: String? get() = null
     }
 
-    /** Open [url] in the system browser (http(s) / openUrl / newTab). */
+    /** Open [url] externally in the system browser (`openUrl`, or an http(s) value with no behavior). */
     data class OpenUrl(override val url: String) : InboxAction
 
-    /** A deeplink the host must resolve (the SDK cannot resolve app routes). */
+    /** Route [url] through the app's deep-link handling (`openDeeplink`, or a non-http scheme value). */
     data class Deeplink(override val url: String) : InboxAction
 
-    /** No resolvable url/behavior (e.g. missing/malformed url) — a no-op. */
+    /**
+     * A host-only action (`performAction`): the SDK performs no navigation, but the action [url]
+     * (value) is still handed to the host listener so it can perform the custom action.
+     */
+    data class PerformAction(override val url: String?) : InboxAction
+
+    /** No resolvable value/behavior (e.g. missing/malformed) — a no-op. */
     data class Unknown(override val url: String?) : InboxAction
 }
 
 /** Instruction the overlay (which owns an Android Context) executes after [VisualInboxController.handleAction]. */
 internal sealed interface InboxNavigation {
-    /** Nothing for the overlay to do (dismiss, host-handled, deeplink, or no-op already handled). */
+    /** Nothing for the overlay to do (a non-navigating performAction / unknown; the inbox stays open). */
     object None : InboxNavigation
 
-    /** Open [url] in the system browser via an ACTION_VIEW intent. */
+    /** Close the presenting sheet without the SDK navigating — the host already handled a nav action. */
+    object Dismiss : InboxNavigation
+
+    /** Open [url] externally in the system browser (ACTION_VIEW), then close the presenting sheet. */
     data class OpenUrl(val url: String) : InboxNavigation
+
+    /** Route [url] through the app's deep-link handling (host app first, then external), then close the sheet. */
+    data class OpenDeeplink(val url: String) : InboxNavigation
 }
 
 /**
- * Maps a Jist action event to the SDK's [InboxAction]. Determined from the action `name`,
- * `data.behavior` and `data.url`:
+ * Maps a Jist action event to the SDK's [InboxAction], matching the real gist-web `InboxActionConfig`
+ * shape (and the iOS overlay's `resolve`). STRICT `data.behavior` switch — no http/scheme guessing
+ * and no synthetic behaviors. Value is `data.action` (legacy `data.url` accepted as a fallback):
  *  - dismiss: `data.behavior == "dismiss"`, or the Jist-demo sentinels `name == "dismiss"` /
- *    `data.url == "#dismiss"`.
- *  - openUrl: `data.behavior` is `openUrl` / `newTab`, OR (absent a behavior) `data.url` is an
- *    http(s) url.
- *  - deeplink: `data.behavior == "deeplink"`, OR (absent a behavior) `data.url` is a non-http(s)
- *    scheme url (e.g. `myapp://...`).
- *  - unknown: no resolvable url/behavior (missing/malformed) — robust to nulls, never throws.
+ *    value `== "#dismiss"`.
+ *  - openUrl: `data.behavior == "openUrl"` → open the value externally in the browser. (Web's
+ *    `newTab` is a separate BOOLEAN flag on an openUrl action, not a behavior; on mobile there is no
+ *    "new tab", so we ignore it — the openUrl already opens externally.)
+ *  - openDeeplink: `data.behavior == "openDeeplink"` → route through the app's deep-link handling.
+ *  - performAction: `data.behavior == "performAction"` — host-only; the SDK performs no navigation.
+ *  - unknown: absent/unrecognized behavior (incl. the legacy demo `deeplink`, or a missing value) —
+ *    host-only no-op. The host listener still receives the action value. Robust to nulls, never throws.
  */
 internal fun resolveInboxAction(event: JistActionEvent): InboxAction {
     val behavior = actionBehavior(event)?.lowercase()
-    val url = actionUrl(event)?.takeIf { it.isNotBlank() }
+    val rawValue = actionValue(event)
+    val url = rawValue?.takeIf { it.isNotBlank() }
 
     val isDismiss = behavior == DISMISS_BEHAVIOR ||
         event.name == DISMISS_ACTION_NAME ||
-        actionUrl(event) == DISMISS_URL
+        rawValue == DISMISS_URL
     if (isDismiss) return InboxAction.Dismiss
 
     return when (behavior) {
-        OPEN_URL_BEHAVIOR, NEW_TAB_BEHAVIOR -> if (url != null) InboxAction.OpenUrl(url) else InboxAction.Unknown(null)
-        DEEPLINK_BEHAVIOR -> if (url != null) InboxAction.Deeplink(url) else InboxAction.Unknown(null)
-        else -> when {
-            url == null -> InboxAction.Unknown(null)
-            isHttpUrl(url) -> InboxAction.OpenUrl(url)
-            else -> InboxAction.Deeplink(url)
-        }
+        OPEN_URL_BEHAVIOR -> if (url != null) InboxAction.OpenUrl(url) else InboxAction.Unknown(null)
+        OPEN_DEEPLINK_BEHAVIOR -> if (url != null) InboxAction.Deeplink(url) else InboxAction.Unknown(null)
+        PERFORM_ACTION_BEHAVIOR -> InboxAction.PerformAction(url)
+        // Absent/unrecognized behavior (e.g. the legacy demo `deeplink`, or the web-only `newTab`
+        // which is a boolean flag rather than a behavior) is a host-only no-op — the SDK never
+        // guesses a browser/deeplink route from the value shape. The host still gets the value.
+        else -> InboxAction.Unknown(url)
     }
 }
 
-/** True for `http://` / `https://` urls (case-insensitive). These open in the system browser. */
-private fun isHttpUrl(url: String): Boolean =
-    url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)
+/**
+ * Reads a STRING field from a JSON object — only when the primitive is actually a string.
+ * `contentOrNull` also returns the text of numeric / boolean primitives (e.g. `true` -> "true",
+ * `5` -> "5"), which the web parser rejects, so we gate on [JsonPrimitive.isString] to keep the
+ * native contract aligned (a non-string `action` / `behavior` / `name` yields null).
+ */
+private fun JsonObject.stringField(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
 
 /**
- * Extracts the `url` string from a Jist action event's data object, or null if absent / not a
- * string. Safe casts throughout: a non-object `data` or non-primitive `url` yields null.
+ * Extracts the action value from a Jist action event's data object — the web-schema `data.action`,
+ * falling back to the legacy `data.url`. String-only (see [stringField]); a non-object `data`,
+ * missing key, or non-string value yields null.
  */
-private fun actionUrl(event: JistActionEvent): String? =
-    ((event.data as? JsonObject)?.get("url") as? JsonPrimitive)?.contentOrNull
+private fun actionValue(event: JistActionEvent): String? {
+    val data = event.data as? JsonObject ?: return null
+    return data.stringField("action") ?: data.stringField("url")
+}
 
 /**
  * Extracts the `behavior` string from a Jist action event's data object (e.g. the live inbox's
- * `messageAction = { behavior: "dismiss" }`), or null if absent / not a string. Safe casts.
+ * `messageAction = { behavior: "dismiss" }`). String-only; absent / non-string yields null.
  */
 private fun actionBehavior(event: JistActionEvent): String? =
-    ((event.data as? JsonObject)?.get("behavior") as? JsonPrimitive)?.contentOrNull
+    (event.data as? JsonObject)?.stringField("behavior")
+
+/**
+ * The host-facing action name: the web-schema `data.name` (string-only), falling back to the Jist
+ * event name. Handed to the host [InboxEventListener.messageActionTaken] and the clicked metric.
+ */
+private fun actionName(event: JistActionEvent): String =
+    (event.data as? JsonObject)?.stringField("name") ?: event.name
 
 /**
  * True when the action carries `data.dismiss == true` — "auto dismiss on click": remove the message
- * after running its (non-dismiss) action. Matches both a JSON boolean `true` and the string `"true"`.
+ * after running its (non-dismiss) action. Accepts the real JSON boolean `true` (the web shape) as
+ * well as the legacy string `"true"`.
  */
-private fun actionDismissFlag(event: JistActionEvent): Boolean =
-    ((event.data as? JsonObject)?.get("dismiss") as? JsonPrimitive)?.contentOrNull == "true"
+private fun actionDismissFlag(event: JistActionEvent): Boolean {
+    val dismiss = (event.data as? JsonObject)?.get("dismiss") as? JsonPrimitive ?: return false
+    return dismiss.booleanOrNull == true || (dismiss.isString && dismiss.content == "true")
+}
 
 /** Jist action `behavior` / sentinel constants matched by [resolveInboxAction] (compared lowercase). */
 private const val DISMISS_BEHAVIOR = "dismiss"
 private const val DISMISS_ACTION_NAME = "dismiss"
 private const val DISMISS_URL = "#dismiss"
 private const val OPEN_URL_BEHAVIOR = "openurl"
-private const val NEW_TAB_BEHAVIOR = "newtab"
-private const val DEEPLINK_BEHAVIOR = "deeplink"
+private const val OPEN_DEEPLINK_BEHAVIOR = "opendeeplink"
+private const val PERFORM_ACTION_BEHAVIOR = "performaction"

--- a/messaginginbox/src/main/res/drawable/cio_inbox_notifications.xml
+++ b/messaginginbox/src/main/res/drawable/cio_inbox_notifications.xml
@@ -6,10 +6,12 @@
   with the branding bell-icon color at runtime.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:width="24dp"
     android:height="25dp"
     android:viewportWidth="24"
-    android:viewportHeight="25">
+    android:viewportHeight="25"
+    tools:ignore="VectorPath,VectorRaster,UnusedAttribute">
     <path
         android:fillColor="@android:color/white"
         android:fillType="evenOdd"

--- a/messaginginbox/src/main/res/drawable/cio_inbox_notifications.xml
+++ b/messaginginbox/src/main/res/drawable/cio_inbox_notifications.xml
@@ -1,16 +1,25 @@
 <!--
-  Default bundled bell icon for the visual inbox floating button.
-  Lets the module render the FAB without depending on androidx.compose.material:material-icons-core
-  and without rendering the branding floatingIcon SVG (SVG rendering is deferred — no SVG dep).
-  Path is the standard Material "notifications" (filled) glyph. fillColor is white; the Compose
-  `Icon` composable tints it with the surrounding content color.
+  Default bundled bell icon for the visual inbox floating button, used as the fallback when the
+  workspace branding does not provide a renderable `patterns.inbox.floatingIcon.svg` (the overlay
+  renders that SVG dynamically via InboxBellIcon when present). Geometry matches the design bell
+  (viewBox 24x25, even-odd fill for the clapper cut-out). fillColor is white; the overlay tints it
+  with the branding bell-icon color at runtime.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
-    android:height="24dp"
+    android:height="25dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="25">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+        android:fillType="evenOdd"
+        android:pathData="M9.05889,19.1249V19.9686C9.05889,21.3666 10.1922,22.4998 11.5901,22.4998C12.9881,22.4998 14.1214,21.3666 14.1214,19.9686V19.1249H15.8088V19.9686C15.8088,22.2986 13.9201,24.1873 11.5901,24.1873C9.26019,24.1873 7.3714,22.2986 7.3714,19.9686V19.1249H9.05889Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:fillType="evenOdd"
+        android:pathData="M6.26459,6.41952C7.69491,5.17991 9.61205,4.49997 11.5901,4.49997C13.5682,4.49997 15.4853,5.17991 16.9157,6.41952C18.3498,7.66242 19.1838,9.37625 19.1838,11.1937C19.1838,14.4023 20.2353,16.4052 21.2364,17.5981C21.7423,18.201 22.2451,18.6082 22.6143,18.8616C22.7987,18.9881 22.9491,19.0757 23.0486,19.1296C23.0983,19.1565 23.1351,19.1749 23.157,19.1856L23.1784,19.1956L23.1773,19.1952C23.1772,19.1952 23.1763,19.1948 23.1748,19.1981L22.84,20.8124H0.340199L0.00547843,19.1981C0.0039515,19.1948 0.00387784,19.1948 0.00380461,19.1948L0.00166017,19.1958L0.000187376,19.1964C-0.000271145,19.1966 0.000072075,19.1965 0.00166017,19.1958L0.0232224,19.1856C0.0451327,19.1749 0.0819958,19.1565 0.131696,19.1296C0.231178,19.0757 0.381514,18.9881 0.56597,18.8616C0.935196,18.6082 1.43796,18.201 1.94386,17.5981C2.94491,16.4052 3.99642,14.4023 3.99642,11.1937C3.99642,9.37625 4.83047,7.66242 6.26459,6.41952ZM2.84048,19.1249H20.3398C20.2086,18.9878 20.0761,18.8406 19.9437,18.6829C18.6948,17.1946 17.4963,14.81 17.4963,11.1937C17.4963,9.90808 16.9081,8.64599 15.8105,7.69474C14.7091,6.74019 13.1924,6.18746 11.5901,6.18746C9.9878,6.18746 8.47118,6.74019 7.36978,7.69474C6.27218,8.64599 5.68391,9.90808 5.68391,11.1937C5.68391,14.81 4.48545,17.1946 3.23651,18.6829C3.10415,18.8406 2.97165,18.9878 2.84048,19.1249ZM23.1801,19.1964C23.1805,19.1966 23.1799,19.1964 23.1784,19.1956L23.1801,19.1964Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:fillType="evenOdd"
+        android:pathData="M11.5901,1.68749C10.5028,1.68749 9.62139,2.56892 9.62139,3.65623C9.62139,4.02656 9.72284,4.37062 9.89897,4.66499L10.3322,5.38903L8.88411,6.25546L8.4509,5.53142C8.12245,4.98249 7.9339,4.34009 7.9339,3.65623C7.9339,1.63695 9.57085,0 11.5901,0C13.6094,0 15.2464,1.63695 15.2464,3.65623C15.2464,4.34009 15.0578,4.98249 14.7294,5.53142L14.2961,6.25546L12.8481,5.38903L13.2813,4.66499C13.4574,4.37062 13.5589,4.02656 13.5589,3.65623C13.5589,2.56892 12.6774,1.68749 11.5901,1.68749Z" />
 </vector>

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -10,6 +10,7 @@ import io.customer.messaginginapp.type.InboxEventListener
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Date
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.amshove.kluent.shouldBeEqualTo
@@ -18,8 +19,9 @@ import org.junit.Test
 
 /**
  * Unit tests for inbox action mapping (items 12 + 13): [resolveInboxAction] (dismiss / openUrl /
- * deeplink / unknown) and [VisualInboxController.handleAction] (dismiss removes; non-dismiss tracks
- * clicked + offers host interception + returns the correct default navigation).
+ * openDeeplink / performAction / unknown, web-schema `data.action` value + legacy `data.url`
+ * fallback) and [VisualInboxController.handleAction] (dismiss removes; non-dismiss tracks clicked +
+ * offers host interception + returns the correct default navigation).
  */
 class InboxActionTest {
 
@@ -38,16 +40,37 @@ class InboxActionTest {
     private fun visible(messages: List<InboxMessage>): InboxVisibility.Visible =
         InboxVisibility.Visible(templatesJson = "{}", branding = Branding(), messages = messages, fromCache = false)
 
-    /** Builds a Jist action event whose `data` object carries optional `behavior` / `url`. */
-    private fun event(name: String = "messageAction", behavior: String? = null, url: String? = null): JistActionEvent {
+    /**
+     * Builds a Jist action event whose `data` object carries optional `behavior` / `action`
+     * (web-schema value) / `url` (legacy value) / `name` (web-schema action name).
+     */
+    private fun event(
+        name: String = "messageAction",
+        behavior: String? = null,
+        action: String? = null,
+        url: String? = null,
+        dataName: String? = null,
+        newTab: Boolean? = null
+    ): JistActionEvent {
         val data = JsonObject(
             buildMap {
                 if (behavior != null) put("behavior", JsonPrimitive(behavior))
+                if (action != null) put("action", JsonPrimitive(action))
                 if (url != null) put("url", JsonPrimitive(url))
+                if (dataName != null) put("name", JsonPrimitive(dataName))
+                if (newTab != null) put("newTab", JsonPrimitive(newTab))
             }
         )
         return JistActionEvent(component = "button", name = name, data = data, meta = JsonObject(emptyMap()))
     }
+
+    /** Builds an event from a raw JSON `data` object literal — for exercising non-string field shapes. */
+    private fun rawEvent(dataJson: String): JistActionEvent = JistActionEvent(
+        component = "button",
+        name = "messageAction",
+        data = Json.parseToJsonElement(dataJson),
+        meta = JsonObject(emptyMap())
+    )
 
     // --- resolveInboxAction mapping ---
 
@@ -59,47 +82,90 @@ class InboxActionTest {
     @Test
     fun resolve_givenDismissSentinels_expectDismiss() {
         resolveInboxAction(event(name = "dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
-        resolveInboxAction(event(url = "#dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
+        resolveInboxAction(event(action = "#dismiss")).shouldBeInstanceOf<InboxAction.Dismiss>()
     }
 
     @Test
     fun resolve_givenOpenUrlBehavior_expectOpenUrl() {
-        val action = resolveInboxAction(event(behavior = "openUrl", url = "https://example.com"))
+        val action = resolveInboxAction(event(behavior = "openUrl", action = "https://example.com"))
         action.shouldBeInstanceOf<InboxAction.OpenUrl>()
         action.url shouldBeEqualTo "https://example.com"
     }
 
     @Test
-    fun resolve_givenNewTabBehavior_expectOpenUrl() {
-        resolveInboxAction(event(behavior = "newTab", url = "https://x.io")).shouldBeInstanceOf<InboxAction.OpenUrl>()
+    fun resolve_givenRealOpenUrlWithNewTabFlag_expectOpenUrl() {
+        // Web emits newTab as a BOOLEAN flag alongside behavior:"openUrl", not a behavior of its own.
+        // The flag is ignored on mobile (no "new tab"); the openUrl still opens externally.
+        val action = resolveInboxAction(event(behavior = "openUrl", action = "https://x.io", newTab = true))
+        action.shouldBeInstanceOf<InboxAction.OpenUrl>()
+        action.url shouldBeEqualTo "https://x.io"
     }
 
     @Test
-    fun resolve_givenHttpUrlNoBehavior_expectOpenUrl() {
-        resolveInboxAction(event(url = "http://plain.example")).shouldBeInstanceOf<InboxAction.OpenUrl>()
-        resolveInboxAction(event(url = "https://plain.example")).shouldBeInstanceOf<InboxAction.OpenUrl>()
+    fun resolve_givenUnrecognizedBehavior_expectUnknownCarryingValue() {
+        // A behavior outside openUrl/openDeeplink/performAction/dismiss — the legacy demo `deeplink`,
+        // or the web-only `newTab` used (incorrectly) as a behavior — is a host-only no-op; no
+        // browser/deeplink guessing (mirrors iOS strict switch).
+        resolveInboxAction(event(behavior = "deeplink", action = "myapp://x")).let {
+            it.shouldBeInstanceOf<InboxAction.Unknown>()
+            it.url shouldBeEqualTo "myapp://x"
+        }
+        resolveInboxAction(event(behavior = "newTab", action = "https://x.io")).shouldBeInstanceOf<InboxAction.Unknown>()
     }
 
     @Test
-    fun resolve_givenDeeplinkBehavior_expectDeeplink() {
-        val action = resolveInboxAction(event(behavior = "deeplink", url = "myapp://home"))
+    fun resolve_givenNonStringFields_expectRejected() {
+        // contentOrNull would coerce numbers/bools to text; the web parser rejects non-strings, so a
+        // boolean/numeric action (or behavior) must not reach navigation/resolution.
+        resolveInboxAction(rawEvent("""{"behavior":"openUrl","action":true}""")).shouldBeInstanceOf<InboxAction.Unknown>()
+        resolveInboxAction(rawEvent("""{"behavior":123,"action":"https://x.io"}""")).shouldBeInstanceOf<InboxAction.Unknown>()
+    }
+
+    @Test
+    fun resolve_givenLegacyUrlValue_expectOpenUrl() {
+        // `data.action` absent but legacy `data.url` present — value falls back to url.
+        val action = resolveInboxAction(event(behavior = "openUrl", url = "https://legacy.example"))
+        action.shouldBeInstanceOf<InboxAction.OpenUrl>()
+        action.url shouldBeEqualTo "https://legacy.example"
+    }
+
+    @Test
+    fun resolve_givenBothActionAndUrl_expectActionPreferred() {
+        val action = resolveInboxAction(event(behavior = "openUrl", action = "https://new.example", url = "https://old.example"))
+        action.url shouldBeEqualTo "https://new.example"
+    }
+
+    @Test
+    fun resolve_givenValueButNoBehavior_expectUnknown() {
+        // No behavior → host-only no-op regardless of the value's scheme (mirrors iOS; the SDK never
+        // guesses browser-vs-deeplink from the URL shape).
+        resolveInboxAction(event(action = "https://plain.example")).shouldBeInstanceOf<InboxAction.Unknown>()
+        resolveInboxAction(event(action = "myapp://profile")).shouldBeInstanceOf<InboxAction.Unknown>()
+    }
+
+    @Test
+    fun resolve_givenOpenDeeplinkBehavior_expectDeeplink() {
+        val action = resolveInboxAction(event(behavior = "openDeeplink", action = "myapp://home"))
         action.shouldBeInstanceOf<InboxAction.Deeplink>()
         action.url shouldBeEqualTo "myapp://home"
     }
 
     @Test
-    fun resolve_givenNonHttpSchemeNoBehavior_expectDeeplink() {
-        resolveInboxAction(event(url = "myapp://profile")).shouldBeInstanceOf<InboxAction.Deeplink>()
+    fun resolve_givenPerformActionBehavior_expectPerformActionCarryingValue() {
+        val action = resolveInboxAction(event(behavior = "performAction", action = "customThing"))
+        action.shouldBeInstanceOf<InboxAction.PerformAction>()
+        // The action value is retained so the host listener can perform the custom action.
+        action.url shouldBeEqualTo "customThing"
     }
 
     @Test
-    fun resolve_givenNoUrlOrBehavior_expectUnknown() {
+    fun resolve_givenNoValueOrBehavior_expectUnknown() {
         resolveInboxAction(event()).shouldBeInstanceOf<InboxAction.Unknown>()
     }
 
     @Test
-    fun resolve_givenBlankUrl_expectUnknown() {
-        resolveInboxAction(event(url = "   ")).shouldBeInstanceOf<InboxAction.Unknown>()
+    fun resolve_givenBlankValue_expectUnknown() {
+        resolveInboxAction(event(action = "   ")).shouldBeInstanceOf<InboxAction.Unknown>()
     }
 
     @Test
@@ -134,7 +200,7 @@ class InboxActionTest {
         val nav = controller.handleAction(
             visible(messages),
             JistInboxAdapter.toJist(messages.first()),
-            event(name = "messageAction", url = "https://example.com")
+            event(name = "messageAction", behavior = "openUrl", action = "https://example.com")
         )
 
         nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
@@ -143,26 +209,89 @@ class InboxActionTest {
     }
 
     @Test
-    fun handleAction_givenDeeplinkNoListener_expectTrackedAndNoNav() {
+    fun handleAction_givenDeeplinkNoListener_expectTrackedAndOpenDeeplinkNav() {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
-        // Relaxed logger mock: the deeplink path logs, and the real LogcatLogger calls
-        // android.util.Log (not mocked on the JVM).
         val controller = VisualInboxController(visualInbox, logger = mockk(relaxed = true))
 
         val nav = controller.handleAction(
             visible(messages),
             JistInboxAdapter.toJist(messages.first()),
-            event(behavior = "deeplink", url = "myapp://home")
+            event(behavior = "openDeeplink", action = "myapp://home")
         )
 
-        // No listener => deeplink is logged + no-op (SDK can't resolve app routes).
-        nav shouldBeEqualTo InboxNavigation.None
+        // No host listener => the SDK routes the deeplink itself (the overlay resolves the intent).
+        nav.shouldBeInstanceOf<InboxNavigation.OpenDeeplink>()
+        (nav as InboxNavigation.OpenDeeplink).url shouldBeEqualTo "myapp://home"
         verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, any()) }
     }
 
     @Test
-    fun handleAction_givenHostHandlesAction_expectTrackedAndNoNav() {
+    fun handleAction_givenPerformActionNoListener_expectTrackedAndNoNav() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox, logger = mockk(relaxed = true))
+
+        val nav = controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(behavior = "performAction", action = "doThing")
+        )
+
+        // performAction is host-only; with no host listener there is nothing for the SDK to navigate.
+        nav shouldBeEqualTo InboxNavigation.None
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+    }
+
+    @Test
+    fun handleAction_givenPerformActionWithListener_expectListenerReceivesValue() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val captured = mutableListOf<Pair<String, String>>()
+        val listener = object : InboxEventListener {
+            override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String): Boolean {
+                captured.add(actionName to actionValue)
+                return true
+            }
+        }
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
+
+        controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(behavior = "performAction", action = "custom-action", dataName = "custom-name")
+        )
+
+        // The host must receive the performAction value (regression: it was dropped as empty before).
+        captured.single() shouldBeEqualTo ("custom-name" to "custom-action")
+    }
+
+    @Test
+    fun handleAction_givenDataName_expectListenerAndTrackUseDataName() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val captured = mutableListOf<String>()
+        val listener = object : InboxEventListener {
+            override fun messageActionTaken(message: InboxMessage, actionName: String, actionValue: String): Boolean {
+                captured.add(actionName)
+                return true
+            }
+        }
+        val controller = VisualInboxController(visualInbox, inboxEventListenerProvider = { listener })
+
+        controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            event(name = "messageAction", dataName = "cta_click", action = "https://x.io")
+        )
+
+        // The host-facing action name comes from web-schema `data.name`, not the Jist event name.
+        captured.single() shouldBeEqualTo "cta_click"
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), "cta_click") }
+    }
+
+    @Test
+    fun handleAction_givenHostHandlesNavAction_expectTrackedAndDismiss() {
         val messages = listOf(message("a"))
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val captured = mutableListOf<Triple<InboxMessage, String, String>>()
@@ -177,17 +306,34 @@ class InboxActionTest {
         val nav = controller.handleAction(
             visible(messages),
             JistInboxAdapter.toJist(messages.first()),
-            event(name = "messageAction", url = "https://example.com")
+            event(name = "messageAction", behavior = "openUrl", action = "https://example.com")
         )
 
-        // Host handled it: even though it was an http url, the SDK does not navigate.
-        nav shouldBeEqualTo InboxNavigation.None
+        // Host handled the navigating action itself: the SDK does not navigate, but the sheet still
+        // dismisses so the inbox doesn't linger over the host's destination.
+        nav shouldBeEqualTo InboxNavigation.Dismiss
         // Still tracked (a click happened) and the listener got message id + delivery + action value.
         verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
         captured.size shouldBeEqualTo 1
         captured.first().first.queueId shouldBeEqualTo "a"
         captured.first().first.deliveryId shouldBeEqualTo "d-a"
         captured.first().third shouldBeEqualTo "https://example.com"
+    }
+
+    @Test
+    fun handleAction_givenBooleanDismissFlag_expectMessageRemoved() {
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox, logger = mockk(relaxed = true))
+
+        // Real web shape: a JSON boolean `dismiss: true` chained onto a performAction.
+        controller.handleAction(
+            visible(messages),
+            JistInboxAdapter.toJist(messages.first()),
+            rawEvent("""{"behavior":"performAction","action":"do","dismiss":true}""")
+        )
+
+        verify(exactly = 1) { visualInbox.markMessageDeleted(match { it.queueId == "a" }) }
     }
 
     @Test
@@ -202,7 +348,7 @@ class InboxActionTest {
         val nav = controller.handleAction(
             visible(messages),
             JistInboxAdapter.toJist(messages.first()),
-            event(url = "https://example.com")
+            event(behavior = "openUrl", action = "https://example.com")
         )
 
         nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
@@ -222,7 +368,7 @@ class InboxActionTest {
         val nav = controller.handleAction(
             visible(messages),
             JistInboxAdapter.toJist(messages.first()),
-            event(url = "https://example.com")
+            event(behavior = "openUrl", action = "https://example.com")
         )
 
         // A throwing listener must not crash the SDK; it falls back to default navigation.
@@ -235,8 +381,8 @@ class InboxActionTest {
         val visualInbox = mockk<VisualInbox>(relaxed = true)
         val controller = VisualInboxController(visualInbox)
 
-        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(url = "https://x.io"))
-        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(url = "https://x.io"))
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://x.io"))
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://x.io"))
 
         verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
     }

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellArtTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellArtTest.kt
@@ -1,0 +1,49 @@
+package io.customer.messaginginbox
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric coverage for [InboxBellSvg.buildArt], which builds an `android.graphics.Path` and so
+ * needs an Android runtime (unlike the pure string extraction in [InboxBellSvg.parse], covered by
+ * [InboxBellSvgTest]).
+ *
+ * Regression guard for the crash-safe fallback: [PathParser][androidx.compose.ui.graphics.vector.PathParser]
+ * THROWS `IllegalArgumentException` on invalid path commands, so malformed branding SVG must fall back
+ * to the bundled bell (null) instead of crashing.
+ */
+// Robolectric SDK capped at 35 (project convention: 4.16 max is Android 15 / Java 17), matching
+// `RobolectricTest`. Not extending that base — this suite needs no DI/context harness, only a
+// runtime for `android.graphics.Path`.
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class InboxBellArtTest {
+
+    @Test
+    fun buildArt_givenValidPath_expectBuiltArtWithViewBox() {
+        val svg = """<svg viewBox="0 0 24 25"><path d="M0 0 L24 0 L24 25 Z"/></svg>"""
+        val art = InboxBellSvg.buildArt(svg)
+        art.shouldNotBeNull()
+        art.width shouldBeEqualTo 24f
+        art.height shouldBeEqualTo 25f
+    }
+
+    @Test
+    fun buildArt_givenMalformedPathCommand_expectNullNotCrash() {
+        // 'X' is not a valid SVG path command; PathParser.parsePathString throws
+        // IllegalArgumentException. buildArt must catch it and return null (→ bundled bell fallback).
+        val svg = """<svg viewBox="0 0 24 25"><path d="M0 0 X1 1"/></svg>"""
+        InboxBellSvg.buildArt(svg).shouldBeNull()
+    }
+
+    @Test
+    fun buildArt_givenNoRenderablePath_expectNull() {
+        InboxBellSvg.buildArt("""<svg viewBox="0 0 24 24"></svg>""").shouldBeNull()
+        InboxBellSvg.buildArt("not an svg").shouldBeNull()
+    }
+}

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellPositionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellPositionTest.kt
@@ -1,0 +1,36 @@
+package io.customer.messaginginbox
+
+import androidx.compose.ui.Alignment
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+/**
+ * Unit tests for [InboxBellPosition] — the branding `patterns.inbox.position` → Compose [Alignment]
+ * mapping. The raw values must match the web SDK's `positionStyles` strings exactly.
+ */
+class InboxBellPositionTest {
+
+    @Test
+    fun rawValues_matchWebStrings() {
+        InboxBellPosition.BottomRight.raw shouldBeEqualTo "bottom-right"
+        InboxBellPosition.BottomLeft.raw shouldBeEqualTo "bottom-left"
+        InboxBellPosition.TopRight.raw shouldBeEqualTo "top-right"
+        InboxBellPosition.TopLeft.raw shouldBeEqualTo "top-left"
+    }
+
+    @Test
+    fun resolve_givenBrandingStrings_mapsToAlignment() {
+        InboxBellPosition.resolve("bottom-right").alignment shouldBeEqualTo Alignment.BottomEnd
+        InboxBellPosition.resolve("bottom-left").alignment shouldBeEqualTo Alignment.BottomStart
+        InboxBellPosition.resolve("top-right").alignment shouldBeEqualTo Alignment.TopEnd
+        InboxBellPosition.resolve("top-left").alignment shouldBeEqualTo Alignment.TopStart
+    }
+
+    @Test
+    fun resolve_givenNullOrUnknown_defaultsToBottomRight() {
+        InboxBellPosition.resolve(null) shouldBeEqualTo InboxBellPosition.BottomRight
+        InboxBellPosition.resolve("somewhere") shouldBeEqualTo InboxBellPosition.BottomRight
+        // Exact-match only — no case/format normalization (matches web's switch(position)).
+        InboxBellPosition.resolve("BOTTOM-LEFT") shouldBeEqualTo InboxBellPosition.BottomRight
+    }
+}

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellSvgTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellSvgTest.kt
@@ -1,0 +1,78 @@
+package io.customer.messaginginbox
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Test
+
+/**
+ * Unit tests for [InboxBellSvg] — the pure SVG extraction (viewBox + `<path d>`) used by the
+ * branding bell glyph. Building the actual Path is Compose/`android.graphics`-bound and covered on
+ * device, so only the JVM-safe extraction is tested here.
+ */
+class InboxBellSvgTest {
+
+    @Test
+    fun parse_givenViewBoxAndPath_extractsBoxAndData() {
+        val svg = """<svg viewBox="0 0 24 25"><path d="M0 0 L24 0 L24 25 Z"/></svg>"""
+        val parsed = InboxBellSvg.parse(svg)
+        parsed.shouldNotBeNull()
+        parsed.minX shouldBeEqualTo 0f
+        parsed.minY shouldBeEqualTo 0f
+        parsed.width shouldBeEqualTo 24f
+        parsed.height shouldBeEqualTo 25f
+        parsed.pathData shouldBeEqualTo listOf("M0 0 L24 0 L24 25 Z")
+    }
+
+    @Test
+    fun parse_givenMultiplePaths_extractsAll() {
+        val svg = """<svg viewBox="0 0 24 25"><path d="M0 0 L10 0 Z"/><path fill-rule="evenodd" d="M12 12 L20 20 Z"/></svg>"""
+        val parsed = InboxBellSvg.parse(svg)
+        parsed.shouldNotBeNull()
+        parsed.pathData shouldBeEqualTo listOf("M0 0 L10 0 Z", "M12 12 L20 20 Z")
+    }
+
+    @Test
+    fun parse_givenNegativeAndDecimalViewBox_parses() {
+        // The real branding bell has a viewBox origin at 0 0 but decimal sizes are common; also verify
+        // comma-separated viewBox values parse.
+        val svg = """<svg viewBox="0,0,24,24.5"><path d="M0 0 Z"/></svg>"""
+        val parsed = InboxBellSvg.parse(svg)
+        parsed.shouldNotBeNull()
+        parsed.width shouldBeEqualTo 24f
+        parsed.height shouldBeEqualTo 24.5f
+    }
+
+    @Test
+    fun parse_givenNoViewBox_defaultsTo24x24() {
+        val parsed = InboxBellSvg.parse("""<svg><path d="M0 0 Z"/></svg>""")
+        parsed.shouldNotBeNull()
+        parsed.width shouldBeEqualTo 24f
+        parsed.height shouldBeEqualTo 24f
+    }
+
+    @Test
+    fun parse_givenNoPaths_returnsNull() {
+        InboxBellSvg.parse("<svg viewBox=\"0 0 24 24\"></svg>").shouldBeNull()
+        InboxBellSvg.parse("not an svg").shouldBeNull()
+        InboxBellSvg.parse("").shouldBeNull()
+    }
+
+    @Test
+    fun parse_reflectsRenderability() {
+        InboxBellSvg.parse("""<svg viewBox="0 0 24 25"><path d="M0 0 Z"/></svg>""").shouldNotBeNull()
+        InboxBellSvg.parse("<svg></svg>").shouldBeNull()
+    }
+
+    @Test
+    fun parse_givenRealBrandingBell_extractsThreePaths() {
+        // The actual branding floatingIcon.svg (evenodd bell with clapper cut-out) has 3 paths.
+        val svg = """<svg width="24" height="25" viewBox="0 0 24 25" fill="none">""" +
+            """<path fill-rule="evenodd" d="M9.05 19.1V19.9C9.05 21.3 10.1 22.4 11.5 22.4Z"/>""" +
+            """<path fill-rule="evenodd" d="M6.26 6.41C7.69 5.17 9.61 4.49 11.5 4.49Z"/>""" +
+            """<path fill-rule="evenodd" d="M11.5 1.68C10.5 1.68 9.62 2.56 9.62 3.65Z"/></svg>"""
+        val parsed = InboxBellSvg.parse(svg)
+        parsed.shouldNotBeNull()
+        parsed.pathData.size shouldBeEqualTo 3
+    }
+}

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
@@ -6,20 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -40,8 +34,7 @@ import io.customer.android.sample.kotlin_compose.ui.components.VersionText
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesNavigationActivity
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesTabbedActivity
 import io.customer.base.internal.InternalCustomerIOApi
-import io.customer.messaginginbox.NotificationInboxBell
-import io.customer.messaginginbox.NotificationInboxView
+import io.customer.messaginginbox.NotificationInboxOverlay
 import io.customer.sdk.CustomerIO
 import kotlinx.coroutines.launch
 
@@ -75,7 +68,7 @@ fun DashboardRoute(
     )
 }
 
-@OptIn(InternalCustomerIOApi::class, ExperimentalMaterial3Api::class)
+@OptIn(InternalCustomerIOApi::class)
 @Composable
 fun DashboardScreen(
     userState: State<User>,
@@ -116,28 +109,11 @@ fun DashboardScreen(
             hostState = snackbarHostState,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
-        // Granular Visual Notification Inbox composition (vs the drop-in NotificationInboxOverlay
-        // used by the java_layout sample): the host places the bell where it wants and presents the
-        // message list itself. This is the same composition the wrapper SDKs (React Native / Flutter)
-        // build on. Here the bell is pinned bottom-end and opens the Jist-rendered list in a modal
-        // bottom sheet. Both the bell and the list render only when the data layer reports the inbox
-        // visible (enabled + at least one renderable message).
-        var showInboxSheet by remember { mutableStateOf(false) }
-        NotificationInboxBell(
-            onClick = { showInboxSheet = true },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-        )
-        if (showInboxSheet) {
-            ModalBottomSheet(onDismissRequest = { showInboxSheet = false }) {
-                NotificationInboxView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(480.dp)
-                )
-            }
-        }
+        // Drop-in Visual Notification Inbox overlay: a floating bell (pinned to the branding-
+        // configured corner) that opens the Jist-rendered message list in a bottom sheet. The bell
+        // appears only when the data layer reports the inbox visible (enabled + a renderable
+        // message). Mounted last so it overlays the dashboard content.
+        NotificationInboxOverlay()
     }
 }
 


### PR DESCRIPTION
Reworks the Android Visual Inbox drop-in overlay to a native Material3 bottom sheet with a branding-driven bell (dynamic SVG + fallback), branding bell position, and web-parity message actions (openUrl/openDeeplink/performAction/dismiss), mirroring the iOS overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public Compose API, navigation/intents, and action-resolution semantics (stricter behavior parsing); overlay UX changes from side panel to bottom sheet may affect integrators.
> 
> **Overview**
> Reworks the Android Visual Inbox **drop-in overlay** from a custom scrim + slide-out side panel to a **Material3 `ModalBottomSheet`**, aligned with the iOS sheet experience. The floating bell now honors branding **corner position**, optional **custom bell SVG** (with crash-safe parse + bundled fallback), and **`unreadIndicator.showAlert`** for the badge.
> 
> **Public API:** `NotificationInboxView` adds an optional **`onDismissRequest`** so hosts can close their own sheet when a message navigates away; the binary API dump reflects this.
> 
> **Message actions (web/iOS parity):** Resolution is a strict **`data.behavior`** switch (`openUrl`, `openDeeplink`, `performAction`, `dismiss`) using **`data.action`** (legacy `data.url` fallback) and **`data.name`** for the host listener—no URL-scheme guessing. **`openDeeplink`** is now handled by the SDK (host app first, then external), with manifest **`queries`** for http(s) `VIEW` so `resolveActivity` works on API 30+. Successful **openUrl/openDeeplink** (and host-handled nav actions) **dismiss the sheet**; failed opens leave it open.
> 
> Adds **Material3** dependency, updates the default bell drawable, expands unit/Robolectric tests, and switches the **kotlin_compose** sample to **`NotificationInboxOverlay()`** instead of a manual bell + sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdc890fe3177583ab7b09cd6679c516d08cde4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->