### PR TITLE
chore(geofence): harden transition delivery and sign-out reset

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -13,17 +13,11 @@ import kotlinx.coroutines.launch
  * (typically an app-foreground handoff), coordinating with the durable
  * WorkManager channel that also consumes the same store.
  *
- * For each pending entry it: cancels that entry's WorkManager unique work — so
- * the worker can't also deliver — then atomically
- * [claims][PendingDeliveryStore.claim] it and hands it to the caller's
- * [publish] block. Cancel happens before the claim on purpose: an `ENQUEUED`
- * or running worker flips to `CANCELLED` immediately, narrowing the window in
- * which both channels could race. Cancellation is best-effort and can lose
- * across process death, so the claim is what makes this flush deliver each
- * entry at most once. Whether the *system* is exactly- or at-least-once depends
- * on the paired worker: one that also claims before sending (push) is
- * exactly-once; one that sends-then-removes (geofence) is at-least-once and
- * relies on a stable id in the payload for downstream dedupe.
+ * For each pending entry it cancels that entry's WorkManager unique work — so the worker can't
+ * also deliver — then spends it against the store per the caller's [DeliveryGuarantee] and hands
+ * it to [publish]. Cancel is best-effort (can lose across process death), so the store op is what
+ * actually bounds duplicates; match the guarantee to the paired worker (push claims →
+ * [DeliveryGuarantee.AT_MOST_ONCE]; geofence sends-then-removes → [DeliveryGuarantee.AT_LEAST_ONCE]).
  *
  * Entries are processed in isolation: one failed cancel/publish does not abort
  * the batch, and an unclaimed or failed entry survives for the next flush. The
@@ -39,6 +33,22 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
     private val workManagerProvider: CustomerIOWorkManagerProvider,
     private val dispatchersProvider: DispatchersProvider
 ) {
+
+    /** How the foreground flush spends a pending entry against a possible mid-publish crash. */
+    enum class DeliveryGuarantee {
+        /**
+         * Claim (remove) before publishing. If the process dies after the claim the entry is gone,
+         * so it delivers at most once. Pair with a worker that also claims — together exactly-once.
+         */
+        AT_MOST_ONCE,
+
+        /**
+         * Publish, then remove only after it returns. A crash between the two leaves the entry for
+         * the next flush to re-publish, so it delivers at least once; requires a stable payload id
+         * for downstream dedupe. Pair with a send-then-remove worker.
+         */
+        AT_LEAST_ONCE
+    }
 
     /**
      * Per-feature observation hooks. All default to no-ops so callers only
@@ -66,7 +76,11 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * on [DispatchersProvider.background]. Safe to call on every foreground
      * transition — an empty store is a cheap no-op.
      */
-    fun flush(callbacks: Callbacks<T> = Callbacks(), publish: (T) -> Unit) {
+    fun flush(
+        callbacks: Callbacks<T> = Callbacks(),
+        guarantee: DeliveryGuarantee = DeliveryGuarantee.AT_MOST_ONCE,
+        publish: (T) -> Unit
+    ) {
         CoroutineScope(dispatchersProvider.background).launch {
             runCatching {
                 val pending = store.loadAll()
@@ -81,14 +95,17 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                             workManager.cancelUniqueWork(entry.key).await()
                             callbacks.onWorkCancelled(entry)
                         }
-                        // Atomically claim before publishing so this flush delivers
-                        // each entry at most once (and a worker that also claims —
-                        // push — can't deliver the same entry). Claiming per-entry
-                        // here, rather than batching a remove at the end, also means a
-                        // mid-loop CancellationException can't strand an already-
-                        // published entry for re-publish next flush.
-                        if (!store.claim(entry.key)) return@forEach
-                        publish(entry)
+                        // Order claim vs. publish per the caller's crash-safety guarantee (see [DeliveryGuarantee]).
+                        when (guarantee) {
+                            DeliveryGuarantee.AT_MOST_ONCE -> {
+                                if (!store.claim(entry.key)) return@forEach
+                                publish(entry)
+                            }
+                            DeliveryGuarantee.AT_LEAST_ONCE -> {
+                                publish(entry)
+                                store.remove(entry.key)
+                            }
+                        }
                         callbacks.onPublished(entry)
                         publishedCount++
                     } catch (ce: CancellationException) {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -34,18 +34,26 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
     private val dispatchersProvider: DispatchersProvider
 ) {
 
-    /** How the foreground flush spends a pending entry against a possible mid-publish crash. */
+    /**
+     * When the flush removes the store row relative to [publish] — the flush's half of a feature's
+     * overall delivery guarantee. The guarantee names describe the *system* (this flush paired with
+     * its worker + backend dedupe), not this step in isolation; see each value for what the flush
+     * alone actually provides.
+     */
     enum class DeliveryGuarantee {
         /**
-         * Claim (remove) before publishing. If the process dies after the claim the entry is gone,
-         * so it delivers at most once. Pair with a worker that also claims — together exactly-once.
+         * Claim (remove) the row before publishing. A crash after the claim drops the entry, so
+         * paired with a worker that also claims this is at-most-once (push): no duplicates, possible
+         * loss.
          */
         AT_MOST_ONCE,
 
         /**
-         * Publish, then remove only after it returns. A crash between the two leaves the entry for
-         * the next flush to re-publish, so it delivers at least once; requires a stable payload id
-         * for downstream dedupe. Pair with a send-then-remove worker.
+         * Remove the row only after [publish] returns, so a crash before publish keeps it for the
+         * next flush. On its own this only *narrows* the loss window — [publish] is an in-process
+         * hand-off and the removal is not crash-atomic, so a crash after publish but before the
+         * event is durably queued can still drop it. At-least-once holds end-to-end via the paired
+         * send-then-remove worker (the durable channel) plus a stable payload id for dedupe.
          */
         AT_LEAST_ONCE
     }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -137,4 +137,41 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.completeCount shouldBeEqualTo 2
         store.loadAll().isEmpty().shouldBeTrue()
     }
+
+    @Test
+    fun flush_givenAtLeastOnce_expectPublishedThenStoreEmptied() {
+        val store = newStore()
+        listOf("a", "b").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks, PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE) {
+            publishedKeys += it.key
+        }
+
+        publishedKeys shouldBeEqualTo listOf("a", "b")
+        callbacks.published shouldBeEqualTo listOf("a", "b")
+        callbacks.completeCount shouldBeEqualTo 2
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun flush_givenAtLeastOnceAndPublishThrows_expectEntryRetainedForRetry() {
+        val store = newStore()
+        listOf("a", "bad", "c").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks, PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE) { entry ->
+            if (entry.key == "bad") throw IllegalStateException("publish failed")
+            publishedKeys += entry.key
+        }
+
+        // Publish precedes removal, so a throw keeps "bad" for the next flush to retry;
+        // successfully published entries are removed.
+        publishedKeys shouldBeEqualTo listOf("a", "c")
+        callbacks.failed shouldBeEqualTo listOf("bad")
+        callbacks.completeCount shouldBeEqualTo 2
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("bad")
+    }
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -166,9 +166,6 @@ class CustomerIO private constructor(
         eventBus.subscribe<Event.RegisterDeviceTokenEvent> {
             registerDeviceToken(deviceToken = it.token)
         }
-        eventBus.subscribe<Event.ResetEvent> {
-            secureUserStore.clearAll()
-        }
         eventBus.subscribe<Event.GeofenceTransitionEvent> { geofenceEvent ->
             // Snapshotted userId (if any) overrides current SDK identity for this one event so a
             // sign-out + sign-in between queue and flush cannot reattribute. Null snapshot → no
@@ -358,6 +355,10 @@ class CustomerIO private constructor(
         }
 
         logger.debug("resetting user profile")
+        // Clear the persisted userId synchronously BEFORE publishing ResetEvent. Subscribers run
+        // asynchronously, so a live `secureUserStore` read inside one (e.g. geofence deciding whether
+        // to wipe) must observe the signed-out state here, not a stale value or a fast re-identify.
+        secureUserStore.clearAll()
         // publish event to EventBus for other modules to consume
         eventBus.publish(Event.ResetEvent)
         analytics.reset()

--- a/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/DataPipelineEventBusInteractionTest.kt
@@ -54,4 +54,16 @@ class DataPipelineEventBusInteractionTest : JUnitTest() {
 
         verify(exactly = 1) { mockSecureUserStore.saveUserId("user-sync") }
     }
+
+    @Test
+    fun givenClearIdentify_expectSecureUserStoreClearedSynchronously() {
+        // clearIdentify() must clear secureUserStore synchronously (before ResetEvent is delivered)
+        // so a reset subscriber gating on it (geofence deciding whether to wipe) observes the
+        // signed-out state, not a stale value. EventBus is mocked, so this passes only if the clear
+        // happens in clearIdentify() itself, not via event dispatch.
+        sdkInstance.identify("user-sync")
+        sdkInstance.clearIdentify()
+
+        verify(exactly = 1) { mockSecureUserStore.clearAll() }
+    }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -129,15 +129,23 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
+            // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
+            // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
+            val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+            // Geofencing is identified-only: the backend rejects anonymous geofence tracks, so an
+            // anonymous transition has no deliverable path. Drop it before spending a cooldown slot
+            // or persisting a row neither channel could ever send.
+            if (userId == null) {
+                logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
+                return@forEach
+            }
+
             if (!cooldownFilter.tryAcquire(geofenceId, transition)) {
                 logger.logTransitionSuppressed(geofenceId, transition.name)
                 return@forEach
             }
             logger.logTransitionEmitting(geofenceId, transition.name)
 
-            // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
-            // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
-            val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
             // One transitionId for the whole crossing, shared across the per-geoset fan-out below.
             val transitionId = UUID.randomUUID().toString()
             val cachedRegion = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
@@ -171,17 +179,13 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 return@forEach
             }
             entries.forEach { entry ->
-                // Anonymous entries can only be delivered via the foreground flush —
-                // skip the WorkManager schedule that would just no-op on null userId.
                 // Isolate the scheduler so one failure can't abandon the rest of the batch.
-                if (entry.userId != null) {
-                    try {
-                        scheduler.schedule(entry)
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        logger.logSchedulerFailed(geofenceId, transition.name, e.message)
-                    }
+                try {
+                    scheduler.schedule(entry)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.logSchedulerFailed(geofenceId, transition.name, e.message)
                 }
             }
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -17,10 +17,11 @@ import io.customer.sdk.data.store.PendingDeliveryFlusher
  * transitions delivered.
  *
  * The shared [PendingDeliveryFlusher] cancels each transition's WorkManager
- * delivery and atomically claims it before publishing here, so this path stays
- * the primary deliverer; the worker (send-then-remove) can still race a
- * duplicate via direct HTTP, deduped downstream by transitionId. The entry's
- * snapshotted userId rides through on [io.customer.sdk.communication.Event.GeofenceTransitionEvent]
+ * delivery, then publishes and only then removes the row
+ * ([PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE]) so a crash between
+ * publish and removal re-delivers rather than drops; the worker (send-then-remove)
+ * can likewise race a duplicate via direct HTTP, deduped downstream by transitionId.
+ * The entry's snapshotted userId rides through on [io.customer.sdk.communication.Event.GeofenceTransitionEvent]
  * so the pipeline subscriber attributes the track event to it.
  *
  * Thread safety: all lifecycle callbacks are delivered on the main thread
@@ -48,7 +49,8 @@ internal class GeofenceLifecycleObserver(
                 override fun onEntryFailed(entry: PendingGeofenceDelivery, cause: Throwable) =
                     logger.logForegroundFlushEntryFailed(entry.geofenceId, entry.transition.name, cause.message)
                 override fun onComplete(count: Int) = logger.logForegroundFlushComplete(count)
-            }
+            },
+            guarantee = PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE
         ) { entry ->
             eventBus.publish(
                 entry.withFreshestEventData(regionStore.getCachedRegion(entry.geofenceId)).toGeofenceTransitionEvent()

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -18,11 +18,12 @@ import io.customer.sdk.data.store.PendingDeliveryFlusher
  *
  * The shared [PendingDeliveryFlusher] cancels each transition's WorkManager
  * delivery, then publishes and only then removes the row
- * ([PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE]) so a crash between
- * publish and removal re-delivers rather than drops; the worker (send-then-remove)
- * can likewise race a duplicate via direct HTTP, deduped downstream by transitionId.
- * The entry's snapshotted userId rides through on [io.customer.sdk.communication.Event.GeofenceTransitionEvent]
- * so the pipeline subscriber attributes the track event to it.
+ * ([PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE]), which keeps the row
+ * for a retry if the process dies before publish. It's the worker (send-then-remove
+ * via direct HTTP) that is the durable channel; duplicates across the two are deduped
+ * downstream by transitionId. The entry's snapshotted userId rides through on
+ * [io.customer.sdk.communication.Event.GeofenceTransitionEvent] so the pipeline
+ * subscriber attributes the track event to it.
  *
  * Thread safety: all lifecycle callbacks are delivered on the main thread
  * by `ProcessLifecycleOwner`, so no synchronization is needed.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -48,6 +48,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logTransitionDroppedAnonymous(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: dropped — no identified user (geofencing is identified-only)", tag = TAG)
+    }
+
     fun logUnknownTransition(transitionType: Int) {
         logger.debug("Ignoring geofence transition type=$transitionType (only ENTER and EXIT are tracked)", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -23,7 +23,7 @@ internal data class GeofenceRegion(
     @SerialName("radius")
     val radius: Float,
     @SerialName("name")
-    val name: String = "",
+    val name: String? = null,
     @SerialName("externalId")
     val externalId: String? = null,
     @SerialName("transitionTypes")

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -43,13 +43,13 @@ internal interface GeofenceRepository {
      * Drops OS-registered geofences + wipes user-specific store state on
      * sign-out. Workspace cache (regions, config, last-sync) is preserved.
      *
-     * [signedOutUserId] is the user being signed out, captured synchronously
-     * at the call site. Used to distinguish a normal sign-out (current user
-     * still matches because `secureUserStore` hasn't been cleared yet by its
-     * own ResetEvent subscriber) from a true re-login (different user signed
-     * in during the reset window, skip wipe).
+     * Wipes unless the user signed in *now* already owns the live registration —
+     * i.e. a switch-account where the new user re-synced before this ran, whose
+     * state we must not clobber. `secureUserStore` is cleared synchronously in
+     * `clearIdentify` before the ResetEvent, so a null current user here reliably
+     * means a plain sign-out (wipe).
      */
-    suspend fun reset(signedOutUserId: String?): Result<Unit>
+    suspend fun reset(): Result<Unit>
 }
 
 internal class GeofenceRepositoryImpl(
@@ -70,6 +70,12 @@ internal class GeofenceRepositoryImpl(
     // Serializes state-mutation against reset() (sign-out). Held only around the
     // write block — the long-running API call happens outside the lock.
     private val stateMutex = Mutex()
+
+    // User who owns the current OS registration, set on each successful register and read by
+    // reset() to tell a switch-account (new user already re-synced → keep) from a plain sign-out
+    // (→ wipe). In-memory only: sign-out never kills the process, and a reset only fires from an
+    // in-session clearIdentify, so this is always populated when it matters. Guarded by stateMutex.
+    private var registeredOwnerUserId: String? = null
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
@@ -353,6 +359,9 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // Record who this registration belongs to so a later sign-out can tell a plain
+                    // sign-out from a switch-account this user already re-synced (see reset()).
+                    registeredOwnerUserId = userId
                     // Stamp device uptime so the next refresh can detect a reboot (which wipes OS
                     // geofences) and force a full re-register instead of trusting registeredIds.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
@@ -371,10 +380,14 @@ internal class GeofenceRepositoryImpl(
         }
     }
 
-    override suspend fun reset(signedOutUserId: String?): Result<Unit> = stateMutex.withLock {
-        // Skip only when a DIFFERENT user is signed in — see KDoc on [reset].
-        val currentUserId = secureUserStore.getUserId()
-        if (!currentUserId.isNullOrBlank() && currentUserId != signedOutUserId) {
+    override suspend fun reset(): Result<Unit> = stateMutex.withLock {
+        // Skip only when the user signed in *now* already owns the live registration — a
+        // switch-account where the new user re-synced first (registeredOwnerUserId is set under
+        // this same lock). Current user is read after clearIdentify cleared it, so null here means
+        // a plain sign-out → wipe. A different current user with a stale owner → wipe (the new
+        // user's sync re-registers).
+        val currentUserId = secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+        if (currentUserId != null && currentUserId == registeredOwnerUserId) {
             logger.logSyncSkipped("reset superseded by signed-in user")
             return@withLock Result.success(Unit)
         }
@@ -386,6 +399,7 @@ internal class GeofenceRepositoryImpl(
         // so the next login re-fetches.
         manager.clearAll().also { result ->
             if (result.isSuccess) {
+                registeredOwnerUserId = null
                 store.clearUserScopedState()
             }
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -40,14 +40,14 @@ internal interface GeofenceRepository {
     suspend fun restoreFromCache(): Result<Unit>
 
     /**
-     * Drops OS-registered geofences + wipes user-specific store state on
-     * sign-out. Workspace cache (regions, config, last-sync) is preserved.
+     * Drops OS-registered geofences + wipes user-specific store state on a genuine
+     * sign-out. Workspace cache (regions, config) is preserved.
      *
-     * Wipes unless the user signed in *now* already owns the live registration —
-     * i.e. a switch-account where the new user re-synced before this ran, whose
-     * state we must not clobber. `secureUserStore` is cleared synchronously in
-     * `clearIdentify` before the ResetEvent, so a null current user here reliably
-     * means a plain sign-out (wipe).
+     * No-op while a user is signed in: geofences are workspace-scoped, so the active
+     * user reuses the existing registration and their identify-sync reconciles it —
+     * tearing it down here would only race that sync. `secureUserStore` is cleared
+     * synchronously in `clearIdentify` before the ResetEvent, so a null current user
+     * here reliably means a plain sign-out.
      */
     suspend fun reset(): Result<Unit>
 }
@@ -71,12 +71,6 @@ internal class GeofenceRepositoryImpl(
     // write block — the long-running API call happens outside the lock.
     private val stateMutex = Mutex()
 
-    // User who owns the current OS registration, set on each successful register and read by
-    // reset() to tell a switch-account (new user already re-synced → keep) from a plain sign-out
-    // (→ wipe). In-memory only: sign-out never kills the process, and a reset only fires from an
-    // in-session clearIdentify, so this is always populated when it matters. Guarded by stateMutex.
-    private var registeredOwnerUserId: String? = null
-
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
         if (!refreshInProgress.compareAndSet(false, true)) {
@@ -95,16 +89,6 @@ internal class GeofenceRepositoryImpl(
                 RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
                 RefreshAction.SKIP -> {
-                    // The live registration is fresh and valid for this user (cache is
-                    // workspace-scoped), so claim ownership without re-registering — otherwise a
-                    // concurrent sign-out reset() could see a stale owner and wipe a registration
-                    // this user legitimately relies on. Re-check the user in case it changed while
-                    // we were deciding; guarded by the same lock reset() reads the owner under.
-                    stateMutex.withLock {
-                        if (secureUserStore.getUserId() == userId) {
-                            registeredOwnerUserId = userId
-                        }
-                    }
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
                 }
@@ -369,9 +353,6 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Record who this registration belongs to so a later sign-out can tell a plain
-                    // sign-out from a switch-account this user already re-synced (see reset()).
-                    registeredOwnerUserId = userId
                     // Stamp device uptime so the next refresh can detect a reboot (which wipes OS
                     // geofences) and force a full re-register instead of trusting registeredIds.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
@@ -391,13 +372,12 @@ internal class GeofenceRepositoryImpl(
     }
 
     override suspend fun reset(): Result<Unit> = stateMutex.withLock {
-        // Skip only when the user signed in *now* already owns the live registration — a
-        // switch-account where the new user re-synced first (registeredOwnerUserId is set under
-        // this same lock). Current user is read after clearIdentify cleared it, so null here means
-        // a plain sign-out → wipe. A different current user with a stale owner → wipe (the new
-        // user's sync re-registers).
+        // Skip the wipe while a user is signed in now: geofences are workspace-scoped, so the
+        // active user reuses the existing registration and their identify-sync reconciles it —
+        // tearing it down here would only race that sync. clearIdentify clears the user store
+        // synchronously before ResetEvent, so a null current user reliably means a plain sign-out.
         val currentUserId = secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
-        if (currentUserId != null && currentUserId == registeredOwnerUserId) {
+        if (currentUserId != null) {
             logger.logSyncSkipped("reset superseded by signed-in user")
             return@withLock Result.success(Unit)
         }
@@ -409,7 +389,6 @@ internal class GeofenceRepositoryImpl(
         // so the next login re-fetches.
         manager.clearAll().also { result ->
             if (result.isSuccess) {
-                registeredOwnerUserId = null
                 store.clearUserScopedState()
             }
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -95,6 +95,16 @@ internal class GeofenceRepositoryImpl(
                 RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
                 RefreshAction.SKIP -> {
+                    // The live registration is fresh and valid for this user (cache is
+                    // workspace-scoped), so claim ownership without re-registering — otherwise a
+                    // concurrent sign-out reset() could see a stale owner and wipe a registration
+                    // this user legitimately relies on. Re-check the user in case it changed while
+                    // we were deciding; guarded by the same lock reset() reads the owner under.
+                    stateMutex.withLock {
+                        if (secureUserStore.getUserId() == userId) {
+                            registeredOwnerUserId = userId
+                        }
+                    }
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
                 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -32,8 +32,10 @@ internal interface GeofenceServices {
     fun onAppLaunch(latitude: Double?, longitude: Double?)
 
     /**
-     * Clears all geofence state so a subsequent user doesn't inherit the previous
-     * user's geofences. Fired when [Event.UserChangedEvent] arrives with a null userId.
+     * Clears all geofence state so a subsequent user doesn't inherit the previous user's geofences.
+     * Fired from the [Event.ResetEvent] subscriber. Whether to actually wipe is decided in
+     * [GeofenceRepository.reset], which compares the now-signed-out identity against the user that
+     * owns the live registration.
      */
     fun onUserSignedOut()
 
@@ -128,14 +130,9 @@ internal class GeofenceServicesImpl(
         // user's geofences around it. Clearing it now makes the next identify fall
         // back to a no-location skip and acquire a fresh fix instead.
         regionStore.clearLastMovementTriggerLocation()
-        // Snapshot the userId synchronously — the datapipelines `ResetEvent`
-        // subscriber races to clear `secureUserStore`, so a deferred read
-        // inside `reset()` could see null and misclassify a normal sign-out
-        // as a re-login.
-        val signedOutUserId = secureUserStore.getUserId()
         logger.logGeofenceStateResetOnSignOut()
         scope.launch {
-            repository.reset(signedOutUserId)
+            repository.reset()
         }
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -56,7 +56,7 @@ internal data class GeofenceApiRegion(
     @SerialName("id")
     val id: String,
     @SerialName("name")
-    val name: String = "",
+    val name: String? = null,
     @SerialName("latitude")
     val latitude: Double,
     @SerialName("longitude")

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -90,8 +90,7 @@ internal fun PendingGeofenceDelivery.withFreshestEventData(cachedRegion: Geofenc
     }
 
     return copy(
-        // Keep the snapshot name if the cached one is now empty — don't drop a name we once had.
-        geofenceName = cachedRegion.name.takeIf { it.isNotEmpty() } ?: geofenceName,
+        geofenceName = cachedRegion.name?.takeIf { it.isNotEmpty() },
         metadata = cachedRegion.metadata
     )
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -25,6 +25,7 @@ import io.mockk.verify
 import java.io.File
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeBlank
@@ -201,9 +202,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
-    fun dispatchTransition_givenAnonymousSession_expectEntryQueuedAndNoWorkerScheduled() = runTest {
-        // Worker can't HTTP without a userId, so for anonymous entries we skip
-        // WorkManager entirely — the foreground flush is the only delivery path.
+    fun dispatchTransition_givenAnonymousSession_expectDroppedNothingPersistedNorScheduled() = runTest {
+        // Geofencing is identified-only (backend rejects anonymous tracks), so an anonymous
+        // transition is dropped outright — nothing persisted, no worker scheduled.
         every { mockSecureUserStore.getUserId() } returns null
 
         receiver.dispatchTransition(
@@ -213,13 +214,14 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 2.0
         )
 
-        pendingStore.loadAll().single().userId.shouldBeNull()
+        pendingStore.loadAll().shouldBeEmpty()
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
     }
 
     @Test
-    fun dispatchTransition_givenEmptyUserId_expectTreatedAsAnonymous() = runTest {
-        // Matches the SDK's `isUserIdentified` semantics — empty = not identified.
+    fun dispatchTransition_givenEmptyUserId_expectTreatedAsAnonymousAndDropped() = runTest {
+        // Matches the SDK's `isUserIdentified` semantics — empty = not identified — so it's
+        // dropped like a null user: nothing persisted, no worker scheduled.
         every { mockSecureUserStore.getUserId() } returns ""
 
         receiver.dispatchTransition(
@@ -229,7 +231,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 2.0
         )
 
-        pendingStore.loadAll().single().userId.shouldBeNull()
+        pendingStore.loadAll().shouldBeEmpty()
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
@@ -34,7 +34,10 @@ class GeofenceLifecycleObserverTest {
         observer.onStart(owner)
         observer.onStart(owner)
 
-        verify(exactly = 2) { mockDeliveryFlusher.flush(any(), any()) }
+        // At-least-once so a crash between publish and row-removal re-delivers rather than drops.
+        verify(exactly = 2) {
+            mockDeliveryFlusher.flush(any(), PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE, any())
+        }
     }
 
     @Test
@@ -50,7 +53,7 @@ class GeofenceLifecycleObserverTest {
             metadata = mapOf("k" to JsonPrimitive("fresh"))
         )
         val publishSlot = slot<(PendingGeofenceDelivery) -> Unit>()
-        every { mockDeliveryFlusher.flush(any(), capture(publishSlot)) } returns Unit
+        every { mockDeliveryFlusher.flush(any(), any(), capture(publishSlot)) } returns Unit
         val eventSlot = slot<Event>()
         every { mockEventBus.publish(capture(eventSlot)) } returns Unit
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -983,18 +983,13 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun reset_givenCurrentUserOwnsRegistration_expectSkipWipe() = runTest {
-        // Switch-account where the new user (B) already re-synced before this reset ran:
-        // B owns the live registration, so skip the wipe rather than clobber B's state.
+    fun reset_givenUserSignedInAtResetTime_expectSkipWipe() = runTest {
+        // A user is signed in when reset() runs — a fast account switch (A→B) or a same-user
+        // clearIdentify+identify. Geofences are workspace-scoped, so the active user reuses the
+        // existing registration and their identify-sync reconciles it; reset must NOT tear it
+        // down (that would race the sync and drop coverage). Holds regardless of what the racing
+        // refresh decided (REMOTE/LOCAL/SKIP), since reset keys only off the current user.
         every { secureUserStore.getUserId() } returns "user-B"
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
-            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
-        // Registration records owner = user-B.
-        repository.refresh(latitude = 1.0, longitude = 2.0)
 
         val result = repository.reset()
 
@@ -1005,21 +1000,11 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun reset_givenDifferentUserOwnsRegistration_expectWipeProceeds() = runTest {
-        // Switch-account where B is signed in but hasn't re-synced yet: the live
-        // registration still belongs to A, so wipe it — B's own sync re-registers.
-        every { secureUserStore.getUserId() } returns "user-A"
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
-            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+    fun reset_givenEmptyCurrentUser_expectWipeProceeds() = runTest {
+        // Empty userId is "not identified" (matches isUserIdentified), so it's a genuine sign-out
+        // and must wipe — same as a null user.
+        every { secureUserStore.getUserId() } returns ""
         coEvery { manager.clearAll() } returns Result.success(Unit)
-        // Registration records owner = user-A...
-        repository.refresh(latitude = 1.0, longitude = 2.0)
-        // ...then user-B becomes the current user without re-syncing.
-        every { secureUserStore.getUserId() } returns "user-B"
 
         val result = repository.reset()
 
@@ -1028,52 +1013,6 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager.clearAll()
             store.clearUserScopedState()
         }
-    }
-
-    @Test
-    fun reset_givenSameUserReidentifiedBeforeReset_expectSkipWipe() = runTest {
-        // clearIdentify() then identify() with the SAME user before reset() runs: the user still
-        // owns the live registration, so skip the teardown. Wiping + their re-sync would just
-        // re-register the same fences and fire a spurious INITIAL_TRIGGER_ENTER; their re-identify
-        // refresh keeps the registration current instead.
-        every { secureUserStore.getUserId() } returns "user-A"
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(sampleResponse(maxBusinessGeofences = 3))
-        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
-            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
-        // Registration records owner = user-A, who is still the current user at reset time.
-        repository.refresh(latitude = 1.0, longitude = 2.0)
-
-        val result = repository.reset()
-
-        result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.clearAll() }
-        verify(exactly = 0) { store.clearUserScopedState() }
-        verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
-    }
-
-    @Test
-    fun reset_givenNewUserRefreshSkippedBeforeReset_expectSkipWipe() = runTest {
-        // Fast switch-account: user B identifies and their refresh takes the fresh-cache SKIP path
-        // (no re-registration) before reset() runs. SKIP must claim ownership for B so the sign-out
-        // reset doesn't wipe the still-valid registration B now relies on.
-        every { secureUserStore.getUserId() } returns "user-B"
-        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() // fresh → SKIP
-
-        val refreshResult = repository.refresh(latitude = 1.0, longitude = 2.0)
-
-        refreshResult.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { apiService.fetchGeofences(any()) } // SKIP took no remote fetch
-        verify { logger.logSyncSkippedFresh() }
-
-        val result = repository.reset()
-
-        result.isSuccess shouldBeEqualTo true
-        coVerify(exactly = 0) { manager.clearAll() }
-        verify(exactly = 0) { store.clearUserScopedState() }
-        verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -972,7 +972,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns null
         coEvery { manager.clearAll() } returns Result.success(Unit)
 
-        val result = repository.reset(signedOutUserId = "user-A")
+        val result = repository.reset()
 
         result.isSuccess shouldBeEqualTo true
         coVerifyOrder {
@@ -983,38 +983,75 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun reset_givenNewUserSignedInDuringWait_expectSkipWipe() = runTest {
-        // True re-login race: User A signed out, User B signed in before our
-        // reset ran. Current user differs from the one being reset → skip wipe
-        // so we don't clobber User B's freshly-written state.
+    fun reset_givenCurrentUserOwnsRegistration_expectSkipWipe() = runTest {
+        // Switch-account where the new user (B) already re-synced before this reset ran:
+        // B owns the live registration, so skip the wipe rather than clobber B's state.
         every { secureUserStore.getUserId() } returns "user-B"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        // Registration records owner = user-B.
+        repository.refresh(latitude = 1.0, longitude = 2.0)
 
-        val result = repository.reset(signedOutUserId = "user-A")
+        val result = repository.reset()
 
         result.isSuccess shouldBeEqualTo true
         coVerify(exactly = 0) { manager.clearAll() }
         verify(exactly = 0) { store.clearUserScopedState() }
-        verify(exactly = 0) { store.clearAll() }
         verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
     }
 
     @Test
-    fun reset_givenSecureUserStoreNotYetCleared_expectWipeProceeds() = runTest {
-        // The two ResetEvent subscribers (datapipelines clearing
-        // secureUserStore, location running reset) race. If our reset runs
-        // first, secureUserStore.getUserId() still returns the signed-out
-        // user — but it's the SAME id, not a different user signed in. Must
-        // proceed with wipe; this is the regression Cursor flagged on #706.
+    fun reset_givenDifferentUserOwnsRegistration_expectWipeProceeds() = runTest {
+        // Switch-account where B is signed in but hasn't re-synced yet: the live
+        // registration still belongs to A, so wipe it — B's own sync re-registers.
         every { secureUserStore.getUserId() } returns "user-A"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
         coEvery { manager.clearAll() } returns Result.success(Unit)
+        // Registration records owner = user-A...
+        repository.refresh(latitude = 1.0, longitude = 2.0)
+        // ...then user-B becomes the current user without re-syncing.
+        every { secureUserStore.getUserId() } returns "user-B"
 
-        val result = repository.reset(signedOutUserId = "user-A")
+        val result = repository.reset()
 
         result.isSuccess shouldBeEqualTo true
         coVerifyOrder {
             manager.clearAll()
             store.clearUserScopedState()
         }
+    }
+
+    @Test
+    fun reset_givenSameUserReidentifiedBeforeReset_expectSkipWipe() = runTest {
+        // clearIdentify() then identify() with the SAME user before reset() runs: the user still
+        // owns the live registration, so skip the teardown. Wiping + their re-sync would just
+        // re-register the same fences and fire a spurious INITIAL_TRIGGER_ENTER; their re-identify
+        // refresh keeps the registration current instead.
+        every { secureUserStore.getUserId() } returns "user-A"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        // Registration records owner = user-A, who is still the current user at reset time.
+        repository.refresh(latitude = 1.0, longitude = 2.0)
+
+        val result = repository.reset()
+
+        result.isSuccess shouldBeEqualTo true
+        coVerify(exactly = 0) { manager.clearAll() }
+        verify(exactly = 0) { store.clearUserScopedState() }
+        verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
     }
 
     @Test
@@ -1027,7 +1064,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val error = RuntimeException("gms clear boom")
         coEvery { manager.clearAll() } returns Result.failure(error)
 
-        val result = repository.reset(signedOutUserId = "user-A")
+        val result = repository.reset()
 
         result.isFailure shouldBeEqualTo true
         result.exceptionOrNull() shouldBeEqualTo error

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1055,6 +1055,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun reset_givenNewUserRefreshSkippedBeforeReset_expectSkipWipe() = runTest {
+        // Fast switch-account: user B identifies and their refresh takes the fresh-cache SKIP path
+        // (no re-registration) before reset() runs. SKIP must claim ownership for B so the sign-out
+        // reset doesn't wipe the still-valid registration B now relies on.
+        every { secureUserStore.getUserId() } returns "user-B"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() // fresh → SKIP
+
+        val refreshResult = repository.refresh(latitude = 1.0, longitude = 2.0)
+
+        refreshResult.isSuccess shouldBeEqualTo true
+        coVerify(exactly = 0) { apiService.fetchGeofences(any()) } // SKIP took no remote fetch
+        verify { logger.logSyncSkippedFresh() }
+
+        val result = repository.reset()
+
+        result.isSuccess shouldBeEqualTo true
+        coVerify(exactly = 0) { manager.clearAll() }
+        verify(exactly = 0) { store.clearUserScopedState() }
+        verify { logger.logSyncSkipped(match { it.contains("reset superseded") }) }
+    }
+
+    @Test
     fun reset_givenManagerFails_expectStorePreservedForSelfHeal() = runTest {
         // If manager.clearAll fails (transient GMS error), the store MUST be
         // preserved — otherwise OS-side registrations orphan with no record to

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -212,7 +212,7 @@ class GeofenceServicesTest : RobolectricTest() {
         // drive a sync for the next user's first fix.
         every { secureUserStore.getUserId() } returns "user-1"
         coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
-        coEvery { repository.reset(any()) } returns Result.success(Unit)
+        coEvery { repository.reset() } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onRefreshRequested()
@@ -230,7 +230,7 @@ class GeofenceServicesTest : RobolectricTest() {
         // synchronously on sign-out — before repository.reset() runs on the scope —
         // so an in-process re-login can't rank the next user's geofences around the
         // previous user's location.
-        coEvery { repository.reset(any()) } returns Result.success(Unit)
+        coEvery { repository.reset() } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onUserSignedOut()
@@ -239,18 +239,16 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
-    fun onUserSignedOut_expectSignedOutUserIdCapturedSynchronouslyAndPassedToReset() = runTest(StandardTestDispatcher()) {
-        // The capture has to happen BEFORE scope.launch — otherwise a racing
-        // ResetEvent subscriber (datapipelines clears secureUserStore) could
-        // null it out by the time reset() reads it.
-        every { secureUserStore.getUserId() } returns "user-42"
-        coEvery { repository.reset(any()) } returns Result.success(Unit)
+    fun onUserSignedOut_expectRepositoryResetInvoked() = runTest(StandardTestDispatcher()) {
+        // Sign-out delegates the wipe decision to repository.reset(); the services layer
+        // just drops the anchor synchronously and kicks reset off the scope.
+        coEvery { repository.reset() } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onUserSignedOut()
         advanceUntilIdle()
 
-        coVerify { repository.reset("user-42") }
+        coVerify { repository.reset() }
         verify { logger.logGeofenceStateResetOnSignOut() }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -199,7 +199,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
         )
 
         regions[0].id shouldBeEqualTo "9"
-        regions[0].name shouldBeEqualTo ""
+        regions[0].name.shouldBeNull()
         regions[0].externalId.shouldBeNull()
         regions[0].lastUpdated shouldBeEqualTo 0L
         regions[0].transitionTypes shouldContainSame listOf(

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotContain
 import org.junit.Test
@@ -194,9 +195,9 @@ class PendingGeofenceDeliveryTest {
     }
 
     @Test
-    fun withFreshestEventData_givenCachedRegionWithEmptyName_expectSnapshotNameKept() {
-        // A cached region whose name is now empty keeps the crossing-time snapshot name rather than
-        // dropping a name we once had; metadata still comes fresh from the cache.
+    fun withFreshestEventData_givenCachedRegionWithNoName_expectNameClearedFromCache() {
+        // Region is still cached but its name is now gone → take the fresh (absent) name, not the
+        // stale snapshot. The snapshot is a fallback only for a region that has left the cache.
         val entry = PendingGeofenceDelivery(
             "biz-h",
             Event.GeofenceTransition.ENTER,
@@ -211,13 +212,13 @@ class PendingGeofenceDeliveryTest {
             latitude = 1.0,
             longitude = 2.0,
             radius = 100f,
-            name = "",
+            name = null,
             metadata = mapOf("k" to JsonPrimitive("fresh"))
         )
 
         val resolved = entry.withFreshestEventData(cached)
 
-        resolved.geofenceName shouldBeEqualTo "Snapshot Name"
+        resolved.geofenceName.shouldBeNull()
         resolved.metadata shouldBeEqualTo mapOf("k" to JsonPrimitive("fresh"))
     }
 


### PR DESCRIPTION
### Summary

Addresses review feedback on the geofence integration PR (#763) — three delivery/attribution durability fixes plus two small cleanups. Base is `feature/geofence-on-device`, not `main`.

**Foreground flush is now at-least-once (was at-most-once).** `PendingDeliveryFlusher` gained a `DeliveryGuarantee`; the geofence foreground flush now publishes **then** removes, so a crash between the two re-delivers instead of dropping the only durable copy. Duplicates are deduped downstream by `transitionId`. Push delivery is unchanged (`AT_MOST_ONCE`).

**Sign-out reset no longer clobbers a fast switch-account.** `clearIdentify` now clears `secureUserStore` **synchronously before** publishing `ResetEvent`, so a reset subscriber reading identity sees the signed-out state (not a stale value or a fast re-identify). The geofence repo tracks the user that owns the live registration (in-memory, under the existing lock) and `reset()` skips the wipe only when the current user already owns it — wiping on a plain sign-out and when a different user hasn't re-synced yet. No public API change.

**Anonymous transitions are dropped at the receiver.** Geofencing is identified-only (Edge rejects anonymous geofence tracks), so a null/empty-user transition has no deliverable path — we drop it before spending a cooldown slot or persisting a row no channel could send, instead of queuing an undeliverable row.

**Cleanups:** `GeofenceRegion.name` is now optional (`String? = null`, iOS parity); `withFreshestEventData` takes the freshest cached name at send.

### Reviewer mapping (#763)
- Foreground flush claims before durable hand-off (HIGH, Shahroz + Bugbot) → at-least-once flush.
- Identify-before-reset snapshot (HIGH, Shahroz + Bugbot) → clear-before-publish + registered-owner check.
- Anonymous flush hits rejected track (MEDIUM, Shahroz + Bugbot) → drop at receiver.

### Stack
```
main
└─ feature/geofence-on-device
   └─ geofence-delivery-durability-fixes  ← this PR
```

### Testing
- Unit tests added/updated: flusher at-least-once (happy path + throw-retains-entry), repo `reset` owner classification (plain wipe / skip-when-owned / wipe-when-different-owner / manager-fail-preserve), `clearIdentify` synchronous store clear, anonymous-drop at receiver, `name` optional parse + send.
- Green: `core`, `geofence`, `datapipelines`, `messaginginapp`, `messagingpush` unit tests, lint, `apiCheck` (no surface change), ktlint.

Linear: https://linear.app/customerio/issue/MBL-2087/mobile-address-geosets-prs-review-feedback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity timing on reset, pending-delivery ordering, and geofence wipe vs. fast account switch—behavioral changes in event delivery and sign-out paths, mitigated by focused unit tests and unchanged public API.
> 
> **Overview**
> Hardens geofence **transition delivery** and **sign-out / identity** behavior without public API changes.
> 
> **Foreground flush (at-least-once).** `PendingDeliveryFlusher` adds a `DeliveryGuarantee` parameter: geofence foreground drain uses **publish then remove** (`AT_LEAST_ONCE`) instead of claim-before-publish, so a crash after hand-off can retry; push stays **claim then publish** (`AT_MOST_ONCE`). End-to-end dedupe still relies on `transitionId` plus the send-then-remove worker.
> 
> **Sign-out reset.** `clearIdentify` now clears `secureUserStore` **synchronously before** `ResetEvent` (the async subscriber that cleared it was removed). `GeofenceRepository.reset()` no longer takes a signed-out user snapshot: it **skips the wipe only when someone is still signed in** (fast re-identify / account switch), and wipes when the store reads unsigned-out after that synchronous clear.
> 
> **Anonymous transitions.** The broadcast receiver drops null/empty `userId` transitions **before** cooldown or persistence (identified-only; no undeliverable rows or foreground-only worker skips).
> 
> **Small model cleanup.** `GeofenceRegion.name` is optional (`String?`); `withFreshestEventData` uses the cached name when present (including clearing a stale snapshot when the cache has no name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f8f0e752750a3fef3d218531a90f8d2bd96ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

