### PR TITLE
chore(core): fail pending-delivery claim when its removing write fails

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
@@ -34,8 +34,12 @@ sealed interface PendingDeliveryResult {
  * Atomically [claims][PendingDeliveryStore.claim] the entry before sending —
  * a read-only check is not enough, since a slow [send] would let both channels
  * act on the same still-present entry. If the claim is lost, [send] is never
- * invoked. On failure the entry is [restored][PendingDeliveryStore.append] so
- * a retry or the flush can deliver it later; on success it stays removed.
+ * invoked: a claim can fail because another channel already took the entry
+ * ([AlreadyClaimed][PendingDeliveryResult.AlreadyClaimed]) or because its
+ * removing write didn't land — the latter leaves the entry present and
+ * undelivered, so it's reported [Retryable][PendingDeliveryResult.Retryable].
+ * On failure the entry is [restored][PendingDeliveryStore.append] so a retry or
+ * the flush can deliver it later; on success it stays removed.
  *
  * Both the push and geofence workers share this so the claim/send/restore
  * logic lives in one place — only the per-channel [send] call differs.
@@ -46,7 +50,16 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
     isRetryable: (Throwable?) -> Boolean = { it is IOException },
     send: suspend () -> Result<Unit>
 ): PendingDeliveryResult {
-    if (!claim(entry.key)) return PendingDeliveryResult.AlreadyClaimed
+    if (!claim(entry.key)) {
+        // A false claim is either another channel taking the entry (now gone) or the removing write
+        // failing (still present). Only the former was delivered elsewhere; a still-present entry was
+        // claimed by no one, so retry rather than reporting success.
+        return if (get(entry.key) == null) {
+            PendingDeliveryResult.AlreadyClaimed
+        } else {
+            PendingDeliveryResult.Retryable(null)
+        }
+    }
 
     val result = send()
     return when {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -115,11 +115,17 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                                 publish(entry)
                             }
                             DeliveryGuarantee.AT_LEAST_ONCE -> {
-                                // Cancel after publish succeeds: a throw skips cancel+remove, keeping the worker
-                                // as the durable fallback. Overlap is deduped by payload id.
+                                // Publish first so a throw keeps the worker as the durable fallback; once it
+                                // returns the entry is delivered, so remove commits it and the cancel is
+                                // best-effort cleanup whose failure can't un-deliver it (deduped by payload id).
                                 publish(entry)
-                                cancelWorker()
                                 store.remove(entry.key)
+                                try {
+                                    cancelWorker()
+                                } catch (ce: CancellationException) {
+                                    throw ce
+                                } catch (ignored: Exception) {
+                                }
                             }
                         }
                         callbacks.onPublished(entry)

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -13,11 +13,12 @@ import kotlinx.coroutines.launch
  * (typically an app-foreground handoff), coordinating with the durable
  * WorkManager channel that also consumes the same store.
  *
- * For each pending entry it cancels that entry's WorkManager unique work — so the worker can't
- * also deliver — then spends it against the store per the caller's [DeliveryGuarantee] and hands
- * it to [publish]. Cancel is best-effort (can lose across process death), so the store op is what
- * actually bounds duplicates; match the guarantee to the paired worker (push claims →
- * [DeliveryGuarantee.AT_MOST_ONCE]; geofence sends-then-removes → [DeliveryGuarantee.AT_LEAST_ONCE]).
+ * For each pending entry it cancels that entry's WorkManager unique work — so the two channels don't
+ * both deliver — and spends it against the store per the caller's [DeliveryGuarantee], which also
+ * decides when the cancel runs relative to the claim/publish (see the branches). Cancel is
+ * best-effort (can lose across process death), so the store op is what actually bounds duplicates;
+ * match the guarantee to the paired worker (push claims → [DeliveryGuarantee.AT_MOST_ONCE]; geofence
+ * sends-then-removes → [DeliveryGuarantee.AT_LEAST_ONCE]).
  *
  * Entries are processed in isolation: one failed cancel/publish does not abort
  * the batch, and an unclaimed or failed entry survives for the next flush. The
@@ -99,18 +100,25 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                 var publishedCount = 0
                 pending.forEach { entry ->
                     try {
-                        if (workManager != null) {
-                            workManager.cancelUniqueWork(entry.key).await()
-                            callbacks.onWorkCancelled(entry)
+                        suspend fun cancelWorker() {
+                            if (workManager != null) {
+                                workManager.cancelUniqueWork(entry.key).await()
+                                callbacks.onWorkCancelled(entry)
+                            }
                         }
-                        // Order claim vs. publish per the caller's crash-safety guarantee (see [DeliveryGuarantee]).
                         when (guarantee) {
                             DeliveryGuarantee.AT_MOST_ONCE -> {
+                                // A false claim (already gone, or the removing write failed) means we don't own
+                                // the send — back off; the row is retried on the next flush.
+                                cancelWorker()
                                 if (!store.claim(entry.key)) return@forEach
                                 publish(entry)
                             }
                             DeliveryGuarantee.AT_LEAST_ONCE -> {
+                                // Cancel after publish succeeds: a throw skips cancel+remove, keeping the worker
+                                // as the durable fallback. Overlap is deduped by payload id.
                                 publish(entry)
+                                cancelWorker()
                                 store.remove(entry.key)
                             }
                         }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -52,9 +52,9 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
         /**
          * Remove the row only after [publish] returns, so a crash before publish keeps it for the
          * next flush. On its own this only *narrows* the loss window — [publish] is an in-process
-         * hand-off and the removal is not crash-atomic, so a crash after publish but before the
-         * event is durably queued can still drop it. At-least-once holds end-to-end via the paired
-         * send-then-remove worker (the durable channel) plus a stable payload id for dedupe.
+         * hand-off (not durably queued), so a crash after publish but before the event is persisted
+         * can still drop it. At-least-once holds end-to-end via the paired send-then-remove worker
+         * (the durable channel) plus a stable payload id for dedupe.
          */
         AT_LEAST_ONCE
     }

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -108,14 +108,16 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * channel whose [claim] returns true owns the send, the other backs off.
      * A read-only check is not enough — claim-then-send must be atomic, or a
      * slow send lets both channels act on the same still-present entry.
-     * Returns true if this call removed the entry, false if it was already gone.
+     * Returns true only if this call actually removed the entry from storage:
+     * false when it was already gone, and also false when the removing write
+     * failed, so the caller backs off and leaves the still-present entry for
+     * the other channel rather than sending a duplicate.
      */
     fun claim(key: String): Boolean = lock.withLock {
         val entries = readAll()
         val filtered = entries.filterNot { it.key == key }
         if (filtered.size == entries.size) return@withLock false
         writeAll(filtered)
-        true
     }
 
     /**

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -108,10 +108,11 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * channel whose [claim] returns true owns the send, the other backs off.
      * A read-only check is not enough — claim-then-send must be atomic, or a
      * slow send lets both channels act on the same still-present entry.
-     * Returns true only if this call actually removed the entry from storage:
-     * false when it was already gone, and also false when the removing write
-     * failed, so the caller backs off and leaves the still-present entry for
-     * the other channel rather than sending a duplicate.
+     * Returns true only when the removing write completed and this call owns
+     * the send; false when the entry was already gone or the write failed. A
+     * false return means "you did not claim it — back off", not that the entry
+     * definitely survived: [writeAll] isn't crash-atomic, so a mid-write failure
+     * can still leave the file blank or partial.
      */
     fun claim(key: String): Boolean = lock.withLock {
         val entries = readAll()

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.util.Logger
 import java.io.File
+import java.io.IOException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlinx.serialization.KSerializer
@@ -23,7 +24,9 @@ import kotlinx.serialization.json.Json
  *
  * Storage is a single JSON file in [Context.filesDir]. All read-modify-write
  * sequences are guarded by an in-process [ReentrantLock] so concurrent appends
- * cannot corrupt the file. Capacity is capped at [maxEntries]; on overflow
+ * cannot corrupt the file, and each write is atomic — staged to a temp file
+ * then renamed over the target — so a failed or interrupted write leaves the
+ * previous file intact rather than a partial one. Capacity is capped at [maxEntries]; on overflow
  * the entry with the smallest [PendingDeliveryEntry.timestamp] is dropped so
  * the queue never grows without bound when the primary delivery path is
  * failing.
@@ -109,10 +112,10 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * A read-only check is not enough — claim-then-send must be atomic, or a
      * slow send lets both channels act on the same still-present entry.
      * Returns true only when the removing write completed and this call owns
-     * the send; false when the entry was already gone or the write failed. A
-     * false return means "you did not claim it — back off", not that the entry
-     * definitely survived: [writeAll] isn't crash-atomic, so a mid-write failure
-     * can still leave the file blank or partial.
+     * the send; false when the entry was already gone or the write failed.
+     * [writeAll] is atomic, so a failed write leaves the prior file intact — a
+     * false return from a write failure therefore means the entry is still
+     * present for the other channel to claim.
      */
     fun claim(key: String): Boolean = lock.withLock {
         val entries = readAll()
@@ -161,10 +164,18 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     }
 
     private fun writeAll(entries: List<T>): Boolean {
+        val tmp = File(file.parentFile, "${file.name}.tmp")
         return try {
-            file.writeText(Json.encodeToString(listSerializer, entries))
+            tmp.writeText(Json.encodeToString(listSerializer, entries))
+            // Atomic swap: rename the fully-written temp over the target. A failed or interrupted
+            // write leaves the prior file intact rather than a truncated/partial one, so readers and
+            // claimers never see corrupt JSON.
+            if (!tmp.renameTo(file)) {
+                throw IOException("atomic rename failed for ${file.name}")
+            }
             true
         } catch (ex: Exception) {
+            tmp.delete()
             logger.error(
                 "Failed to write pending delivery store ${file.name}",
                 tag = TAG,

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -3,6 +3,7 @@ package io.customer.sdk.data.store
 import io.customer.commontest.core.RobolectricTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.mockk
+import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -22,12 +23,16 @@ class PendingDeliveryClaimTest : RobolectricTest() {
         override val key: String get() = id
     }
 
+    private val fileName = "cio_test_claim_send_restore.json"
+
     private fun newStore() = PendingDeliveryStore(
         context = contextMock,
-        fileName = "cio_test_claim_send_restore.json",
+        fileName = fileName,
         elementSerializer = TestEntry.serializer(),
         logger = mockLogger
     ).also { it.removeAll() }
+
+    private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
 
     @Test
     fun claimSendRestore_givenEntryNotPresent_expectAlreadyClaimedAndSendNotInvoked() = runBlocking<Unit> {
@@ -42,6 +47,30 @@ class PendingDeliveryClaimTest : RobolectricTest() {
 
         result shouldBeEqualTo PendingDeliveryResult.AlreadyClaimed
         sendInvoked shouldBeEqualTo false
+    }
+
+    @Test
+    fun claimSendRestore_givenClaimWriteFailsWithEntryPresent_expectRetryableAndSendNotInvoked() = runBlocking<Unit> {
+        val store = newStore()
+        val entry = TestEntry("stuck")
+        store.append(entry)
+        var sendInvoked = false
+
+        // Entry is readable but the claiming write can't land: claim returns false while the row is
+        // still present. That is not "delivered elsewhere", so it must retry and must not send.
+        storeFile().setReadOnly()
+        val result = try {
+            store.claimSendRestore(entry) {
+                sendInvoked = true
+                Result.success(Unit)
+            }
+        } finally {
+            storeFile().setWritable(true)
+        }
+
+        result shouldBeInstanceOf PendingDeliveryResult.Retryable::class
+        sendInvoked shouldBeEqualTo false
+        store.loadAll() shouldBeEqualTo listOf(entry)
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -3,7 +3,6 @@ package io.customer.sdk.data.store
 import io.customer.commontest.core.RobolectricTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.mockk
-import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
@@ -23,16 +22,12 @@ class PendingDeliveryClaimTest : RobolectricTest() {
         override val key: String get() = id
     }
 
-    private val fileName = "cio_test_claim_send_restore.json"
-
     private fun newStore() = PendingDeliveryStore(
         context = contextMock,
-        fileName = fileName,
+        fileName = "cio_test_claim_send_restore.json",
         elementSerializer = TestEntry.serializer(),
         logger = mockLogger
     ).also { it.removeAll() }
-
-    private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
 
     @Test
     fun claimSendRestore_givenEntryNotPresent_expectAlreadyClaimedAndSendNotInvoked() = runBlocking<Unit> {
@@ -56,16 +51,18 @@ class PendingDeliveryClaimTest : RobolectricTest() {
         store.append(entry)
         var sendInvoked = false
 
-        // Entry is readable but the claiming write can't land: claim returns false while the row is
-        // still present. That is not "delivered elsewhere", so it must retry and must not send.
-        storeFile().setReadOnly()
+        // Entry is readable, but the atomic write can't stage its temp file while the store's
+        // directory is read-only: claim returns false while the row is still present. That is not
+        // "delivered elsewhere", so it must retry and must not send.
+        val dir = contextMock.applicationContext.filesDir
+        dir.setReadOnly()
         val result = try {
             store.claimSendRestore(entry) {
                 sendInvoked = true
                 Result.success(Unit)
             }
         } finally {
-            storeFile().setWritable(true)
+            dir.setWritable(true)
         }
 
         result shouldBeInstanceOf PendingDeliveryResult.Retryable::class

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -10,6 +10,7 @@ import io.customer.sdk.core.util.Logger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyOrder
+import java.io.File
 import kotlinx.serialization.Serializable
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -35,12 +36,16 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         override val key: String get() = id
     }
 
+    private val fileName = "cio_test_flusher.json"
+
     private fun newStore() = PendingDeliveryStore(
         context = contextMock,
-        fileName = "cio_test_flusher.json",
+        fileName = fileName,
         elementSerializer = TestEntry.serializer(),
         logger = mockLogger
     ).also { it.removeAll() }
+
+    private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
 
     private fun newFlusher(store: PendingDeliveryStore<TestEntry>) =
         PendingDeliveryFlusher(store, workManagerProvider, dispatchers)
@@ -136,6 +141,28 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.failed shouldBeEqualTo listOf("bad")
         callbacks.completeCount shouldBeEqualTo 2
         store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun flush_givenAtMostOnceAndClaimWriteFails_expectNotPublishedAndEntryRetained() {
+        val store = newStore()
+        listOf("a", "b").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        // Entries stay readable but the claiming write can't land, so claim reports failure and the
+        // flush must back off — leaving the rows for the worker rather than publishing a duplicate.
+        storeFile().setReadOnly()
+        try {
+            newFlusher(store).flush(callbacks) { publishedKeys += it.key }
+        } finally {
+            storeFile().setWritable(true)
+        }
+
+        publishedKeys shouldBeEqualTo emptyList()
+        callbacks.published shouldBeEqualTo emptyList()
+        callbacks.completeCount shouldBeEqualTo 0
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("a", "b")
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -9,6 +9,7 @@ import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.core.util.Logger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.mockk.verifyOrder
 import java.io.File
 import kotlinx.serialization.Serializable
@@ -144,14 +145,19 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
     }
 
     @Test
-    fun flush_givenAtMostOnceAndClaimWriteFails_expectNotPublishedAndEntryRetained() {
+    fun flush_givenAtMostOnceClaimWriteFails_expectNotPublishedAndRowRetainedForNextFlush() {
         val store = newStore()
-        listOf("a", "b").forEach { store.append(TestEntry(it)) }
+        store.append(TestEntry("a"))
+        val workManager: WorkManager = mockk(relaxed = true) {
+            every { cancelUniqueWork(any()) } returns immediateSuccessfulOperation()
+        }
+        every { workManagerProvider.getWorkManager() } returns workManager
         val callbacks = RecordingCallbacks()
         val publishedKeys = mutableListOf<String>()
 
-        // Entries stay readable but the claiming write can't land, so claim reports failure and the
-        // flush must back off — leaving the rows for the worker rather than publishing a duplicate.
+        // Entry stays readable but the claiming write can't land, so claim reports failure and the
+        // flush backs off without publishing (no duplicate). The worker is already cancelled by then,
+        // so the retained row is retried on the next foreground flush — not by the worker.
         storeFile().setReadOnly()
         try {
             newFlusher(store).flush(callbacks) { publishedKeys += it.key }
@@ -159,10 +165,11 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
             storeFile().setWritable(true)
         }
 
+        verify { workManager.cancelUniqueWork("a") }
         publishedKeys shouldBeEqualTo emptyList()
         callbacks.published shouldBeEqualTo emptyList()
         callbacks.completeCount shouldBeEqualTo 0
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("a", "b")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("a")
     }
 
     @Test
@@ -199,6 +206,28 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         publishedKeys shouldBeEqualTo listOf("a", "c")
         callbacks.failed shouldBeEqualTo listOf("bad")
         callbacks.completeCount shouldBeEqualTo 2
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("bad")
+    }
+
+    @Test
+    fun flush_givenAtLeastOncePublishThrowsWithWorkManager_expectFailedEntryWorkerNotCancelled() {
+        val store = newStore()
+        listOf("bad", "ok").forEach { store.append(TestEntry(it)) }
+        val workManager: WorkManager = mockk(relaxed = true) {
+            every { cancelUniqueWork(any()) } returns immediateSuccessfulOperation()
+        }
+        every { workManagerProvider.getWorkManager() } returns workManager
+        val callbacks = RecordingCallbacks()
+
+        newFlusher(store).flush(callbacks, PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE) { entry ->
+            if (entry.key == "bad") throw IllegalStateException("publish failed")
+        }
+
+        // Cancel runs only after a successful publish, so a failed entry keeps its worker as the
+        // durable fallback (and the row is retained); a delivered entry has its worker cancelled.
+        verify(exactly = 0) { workManager.cancelUniqueWork("bad") }
+        verify { workManager.cancelUniqueWork("ok") }
+        callbacks.failed shouldBeEqualTo listOf("bad")
         store.loadAll().map { it.key } shouldBeEqualTo listOf("bad")
     }
 }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -11,7 +11,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
-import java.io.File
 import kotlinx.serialization.Serializable
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -37,16 +36,12 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         override val key: String get() = id
     }
 
-    private val fileName = "cio_test_flusher.json"
-
     private fun newStore() = PendingDeliveryStore(
         context = contextMock,
-        fileName = fileName,
+        fileName = "cio_test_flusher.json",
         elementSerializer = TestEntry.serializer(),
         logger = mockLogger
     ).also { it.removeAll() }
-
-    private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
 
     private fun newFlusher(store: PendingDeliveryStore<TestEntry>) =
         PendingDeliveryFlusher(store, workManagerProvider, dispatchers)
@@ -155,14 +150,16 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         val callbacks = RecordingCallbacks()
         val publishedKeys = mutableListOf<String>()
 
-        // Entry stays readable but the claiming write can't land, so claim reports failure and the
-        // flush backs off without publishing (no duplicate). The worker is already cancelled by then,
-        // so the retained row is retried on the next foreground flush — not by the worker.
-        storeFile().setReadOnly()
+        // Entry stays readable, but the atomic write can't stage its temp file while the store's
+        // directory is read-only, so claim reports failure and the flush backs off without publishing
+        // (no duplicate). The worker is already cancelled by then, so the retained row is retried on
+        // the next foreground flush — not by the worker.
+        val dir = contextMock.applicationContext.filesDir
+        dir.setReadOnly()
         try {
             newFlusher(store).flush(callbacks) { publishedKeys += it.key }
         } finally {
-            storeFile().setWritable(true)
+            dir.setWritable(true)
         }
 
         verify { workManager.cancelUniqueWork("a") }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -230,4 +230,30 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.failed shouldBeEqualTo listOf("bad")
         store.loadAll().map { it.key } shouldBeEqualTo listOf("bad")
     }
+
+    @Test
+    fun flush_givenAtLeastOnceCancelThrowsAfterPublish_expectEntryStillPublishedAndRemoved() {
+        val store = newStore()
+        store.append(TestEntry("a"))
+        val failingCancel: Operation = mockk(relaxed = true) {
+            every { result } returns Futures.immediateFailedFuture(RuntimeException("cancel failed"))
+        }
+        val workManager: WorkManager = mockk(relaxed = true) {
+            every { cancelUniqueWork("a") } returns failingCancel
+        }
+        every { workManagerProvider.getWorkManager() } returns workManager
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store).flush(callbacks, PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE) {
+            publishedKeys += it.key
+        }
+
+        // Publish already delivered, so a best-effort cancel failure must not re-mark the entry
+        // failed or leave the row behind.
+        publishedKeys shouldBeEqualTo listOf("a")
+        callbacks.published shouldBeEqualTo listOf("a")
+        callbacks.failed shouldBeEqualTo emptyList()
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
 }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -181,13 +181,14 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         val store = newStore()
         val target = entry("target")
         store.append(target)
-        // Entry is readable but the removing write can't land, so the claim must
-        // not report success — the row stays for the other delivery channel.
-        storeFile().setReadOnly()
+        // Entry is readable, but the atomic write can't stage its temp file while the store's
+        // directory is read-only, so the claim must fail and leave the row for the other channel.
+        val dir = contextMock.applicationContext.filesDir
+        dir.setReadOnly()
         try {
             store.claim(target.key) shouldBeEqualTo false
         } finally {
-            storeFile().setWritable(true)
+            dir.setWritable(true)
         }
 
         store.loadAll() shouldBeEqualTo listOf(target)

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -177,6 +177,23 @@ class PendingDeliveryStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun claim_givenRemovingWriteFails_expectFalseAndEntryPreserved() {
+        val store = newStore()
+        val target = entry("target")
+        store.append(target)
+        // Entry is readable but the removing write can't land, so the claim must
+        // not report success — the row stays for the other delivery channel.
+        storeFile().setReadOnly()
+        try {
+            store.claim(target.key) shouldBeEqualTo false
+        } finally {
+            storeFile().setWritable(true)
+        }
+
+        store.loadAll() shouldBeEqualTo listOf(target)
+    }
+
+    @Test
     fun remove_givenUnknownKey_expectNoOp() {
         val store = newStore()
         val keep = entry("keep")

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -439,8 +439,9 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         val deliveryToken = String.random
         val inputData = createInputData(deliveryId, deliveryToken)
 
-        // Foreground handoff already claimed (delivered + removed) this entry.
+        // Foreground handoff already claimed (delivered + removed) this entry, so it's gone.
         every { mockPendingStore.claim(deliveryId) } returns false
+        every { mockPendingStore.get(deliveryId) } returns null
 
         val worker = createWorker(inputData)
         val result = worker.doWork()


### PR DESCRIPTION
## What

Addresses a Bugbot comment on #763 ("Claim ignores failed store write"). No Linear ticket — this is PR-review-comment handling for the geofence feature branch.

`PendingDeliveryStore.claim()` returned `true` even when the underlying `writeAll()` failed. On a write failure the entry is still on disk, so an `AT_MOST_ONCE` foreground flush (push) would treat the row as claimed and publish it while the WorkManager worker — which also sees the still-present row — could deliver it too. That breaks at-most-once coordination.

Fix: `claim()` returns the write result. A failed claim now makes the caller back off and leave the still-present entry for the other channel, so exactly one channel delivers.

## Scope

- One-line source change in `:core` (`PendingDeliveryStore.claim`) + return-contract KDoc.
- Affects the push at-most-once path too, not just geofence.
- No public API change (`claim` already returned `Boolean`; `apiCheck` clean).

## Tests

- `claim_givenRemovingWriteFails_expectFalseAndEntryPreserved` — store returns `false` and keeps the row on write failure.
- `flush_givenAtMostOnceAndClaimWriteFails_expectNotPublishedAndEntryRetained` — the flusher backs off (no publish, rows retained) end-to-end. This back-off branch was previously untested at any layer.
- Both verified to fail without the fix. `:core`, `:datapipelines`, `:messagingpush` suites green.

## Deferred (not in this PR)

Bugbot's companion comment ("Null userId rows never drain") is unreachable: the receiver drops null/empty-userId transitions before persisting, and the feature is unreleased so there are no legacy rows — the worker/flush null-userId branches are dead defensive code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery deduplication and disk persistence for push/geofence pending metrics; behavior shifts on IO failures but reduces duplicate-delivery risk rather than expanding attack surface.
> 
> **Overview**
> Fixes **at-most-once** coordination when a foreground flush and WorkManager both use the pending-delivery store: `PendingDeliveryStore.claim()` now returns **`false` unless the removing persist succeeds**, so a failed claim no longer implies ownership while the row is still on disk.
> 
> **`writeAll`** persists via a **temp file + atomic rename**, so interrupted writes keep the previous JSON intact and align with “failed claim ⇒ entry still present.”
> 
> **`claimSendRestore`** treats a failed claim as **`AlreadyClaimed` only if the entry is gone**; if it is still present (e.g. write failed), it returns **`Retryable`** and does not call `send`.
> 
> **`PendingDeliveryFlusher`** adjusts ordering: **AT_MOST_ONCE** cancels the worker then **backs off without publishing** when claim fails; **AT_LEAST_ONCE** **publishes before remove**, cancels the worker only after a successful publish, and **ignores cancel failures** so a delivered row is not left behind or marked failed.
> 
> New **core** and **messagingpush** tests cover failed claim writes and the updated flush/worker paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d0d34d34cd6073b1a9400e367b79983aa80476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->