### PR TITLE
chore(live-notifications): iOS-parity SDK — contract & registration (1/2, does not compile alone)

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -144,8 +144,7 @@ internal class CustomerIOPushNotificationHandler(
             notificationManager = notificationManager
         )
 
-        // Check if this is a live notification
-        val activityId = bundle.getString(LiveNotificationHandler.ACTIVITY_ID_KEY)
+        val activityId = bundle.getString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY)
         if (activityId != null) {
             val liveChannelId = notificationChannelCreator.createLiveNotificationChannelIfNeededAndReturnChannelId(
                 context = context,
@@ -153,8 +152,7 @@ internal class CustomerIOPushNotificationHandler(
                 appMetaData = appMetaData,
                 notificationManager = notificationManager
             )
-            // onNotificationComposed is intentionally not called for live notifications —
-            // their layout is SDK-controlled and cannot be safely modified by host apps.
+            // onNotificationComposed is intentionally not called for live notifications.
             LiveNotificationHandler(bundle).handle(
                 context = context,
                 deliveryId = deliveryId,

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationData.kt
@@ -1,21 +1,14 @@
 package io.customer.messagingpush.livenotification
 
-import io.customer.messagingpush.livenotification.template.AirportFields
-import io.customer.messagingpush.livenotification.template.AuctionBidFields
 import io.customer.messagingpush.livenotification.template.CountdownTimerFields
-import io.customer.messagingpush.livenotification.template.DeliveryTrackingFields
-import io.customer.messagingpush.livenotification.template.FlightStatusFields
-import io.customer.messagingpush.livenotification.template.LiveScoreFields
-import io.customer.messagingpush.livenotification.template.TeamFields
-import org.json.JSONObject
+import io.customer.messagingpush.livenotification.template.SegmentsFields
 
 /**
  * Typed payload for starting a built-in live notification locally via
- * `ModuleMessagingPushFCM.startLiveNotification`. Each subtype knows its
- * [activityType] and flattens itself into the envelope fields the templates
- * read (the same flattened shape the backend delivers). Field names come from
- * the shared `*Fields` constants so local-start and push-render stay in sync.
+ * `ModuleMessagingPushFCM.startLiveNotification`. Each subtype exposes its
+ * [fields], plus the static [attributes] and dynamic [contentState] subsets.
  *
+ * Time fields such as `endTime` are **epoch seconds**, not milliseconds.
  * For customer-defined activity types, use the `Map` overload of
  * `startLiveNotification` instead.
  */
@@ -25,134 +18,65 @@ sealed interface LiveNotificationData {
     /** Flattened template fields; null values are omitted by the caller. */
     fun fields(): Map<String, Any?>
 
-    data class DeliveryTracking(
-        val orderId: String,
-        val statusMessage: String,
-        val recipientName: String? = null,
-        val driverName: String? = null,
-        val statusImageKey: String? = null,
-        val stepCurrent: Int? = null,
-        val stepTotal: Int? = null,
-        val estimatedArrival: Long? = null
+    /** Static fields (iOS `attributes`); null values are omitted by the caller. */
+    fun attributes(): Map<String, Any?>
+
+    /** Dynamic fields (iOS `contentState`); null values are omitted by the caller. */
+    fun contentState(): Map<String, Any?>
+
+    /**
+     * Segments template — a status headline over a discrete, multi-step progress
+     * bar (matches iOS `CIOSegmentsAttributes`). [segmentsComplete] is clamped to
+     * `0..segmentsTotal` at render time.
+     */
+    data class Segments(
+        val header: String,
+        val status: String,
+        val substatus: String? = null,
+        val segmentsTotal: Int,
+        val segmentsComplete: Int,
+        val trailingText: String? = null
     ) : LiveNotificationData {
-        override val activityType = LiveNotificationType.DELIVERY_TRACKING
-        override fun fields() = mapOf(
-            DeliveryTrackingFields.ORDER_ID to orderId,
-            DeliveryTrackingFields.STATUS_MESSAGE to statusMessage,
-            DeliveryTrackingFields.RECIPIENT_NAME to recipientName,
-            DeliveryTrackingFields.DRIVER_NAME to driverName,
-            DeliveryTrackingFields.STATUS_IMAGE_KEY to statusImageKey,
-            DeliveryTrackingFields.STEP_CURRENT to stepCurrent,
-            DeliveryTrackingFields.STEP_TOTAL to stepTotal,
-            DeliveryTrackingFields.ESTIMATED_ARRIVAL to estimatedArrival
+        override val activityType = LiveNotificationType.SEGMENTS.identifier
+
+        override fun attributes() = mapOf(
+            SegmentsFields.HEADER to header
         )
+
+        override fun contentState() = mapOf(
+            SegmentsFields.STATUS to status,
+            SegmentsFields.SUBSTATUS to substatus,
+            SegmentsFields.SEGMENTS_TOTAL to segmentsTotal,
+            SegmentsFields.SEGMENTS_COMPLETE to segmentsComplete,
+            SegmentsFields.TRAILING_TEXT to trailingText
+        )
+
+        override fun fields() = attributes() + contentState()
     }
 
-    data class FlightStatus(
-        val flightNumber: String,
-        val origin: Airport,
-        val destination: Airport,
-        val statusMessage: String,
-        val gate: String? = null,
-        val terminal: String? = null,
-        val scheduledDeparture: Long? = null,
-        val estimatedArrival: Long? = null,
-        val progressFraction: Double? = null,
-        val delayMinutes: Int? = null
-    ) : LiveNotificationData {
-        override val activityType = LiveNotificationType.FLIGHT_STATUS
-        override fun fields() = mapOf(
-            FlightStatusFields.FLIGHT_NUMBER to flightNumber,
-            FlightStatusFields.ORIGIN to origin.toJson(),
-            FlightStatusFields.DESTINATION to destination.toJson(),
-            FlightStatusFields.STATUS_MESSAGE to statusMessage,
-            FlightStatusFields.GATE to gate,
-            FlightStatusFields.TERMINAL to terminal,
-            FlightStatusFields.SCHEDULED_DEPARTURE to scheduledDeparture,
-            FlightStatusFields.ESTIMATED_ARRIVAL to estimatedArrival,
-            FlightStatusFields.PROGRESS_FRACTION to progressFraction,
-            FlightStatusFields.DELAY_MINUTES to delayMinutes
-        )
-    }
-
-    data class LiveScore(
-        val homeTeam: Team,
-        val awayTeam: Team,
-        val period: String,
-        val homeScore: Int = 0,
-        val awayScore: Int = 0,
-        val clock: String? = null,
-        val statusMessage: String? = null,
-        val sport: String? = null,
-        val leagueLogoKey: String? = null
-    ) : LiveNotificationData {
-        override val activityType = LiveNotificationType.LIVE_SCORE
-        override fun fields() = mapOf(
-            LiveScoreFields.HOME_TEAM to homeTeam.toJson(),
-            LiveScoreFields.AWAY_TEAM to awayTeam.toJson(),
-            LiveScoreFields.PERIOD to period,
-            LiveScoreFields.HOME_SCORE to homeScore,
-            LiveScoreFields.AWAY_SCORE to awayScore,
-            LiveScoreFields.CLOCK to clock,
-            LiveScoreFields.STATUS_MESSAGE to statusMessage,
-            LiveScoreFields.SPORT to sport,
-            LiveScoreFields.LEAGUE_LOGO_KEY to leagueLogoKey
-        )
-    }
-
+    /**
+     * Countdown timer template — a status headline over a live countdown to
+     * [endTime] (matches iOS `CIOCountdownTimerAttributes`). [endTime] is epoch
+     * seconds; drive the finished state by starting/updating with no [endTime].
+     */
     data class CountdownTimer(
+        val header: String,
         val title: String,
-        val targetDate: Long,
-        val statusMessage: String,
-        val expiredMessage: String? = null,
-        val heroImageKey: String? = null
+        val statusMessage: String? = null,
+        val endTime: Long? = null
     ) : LiveNotificationData {
-        override val activityType = LiveNotificationType.COUNTDOWN_TIMER
-        override fun fields() = mapOf(
+        override val activityType = LiveNotificationType.COUNTDOWN_TIMER.identifier
+
+        override fun attributes() = mapOf(
+            CountdownTimerFields.HEADER to header
+        )
+
+        override fun contentState() = mapOf(
             CountdownTimerFields.TITLE to title,
-            CountdownTimerFields.TARGET_DATE to targetDate,
             CountdownTimerFields.STATUS_MESSAGE to statusMessage,
-            CountdownTimerFields.EXPIRED_MESSAGE to expiredMessage,
-            CountdownTimerFields.HERO_IMAGE_KEY to heroImageKey
+            CountdownTimerFields.END_TIME to endTime
         )
-    }
 
-    data class AuctionBid(
-        val itemTitle: String,
-        val currentBid: String,
-        val bidCount: Int,
-        val statusMessage: String,
-        val isUserHighBidder: Boolean,
-        val endTime: Long? = null,
-        val userBidAmount: String? = null,
-        val itemImageKey: String? = null,
-        val currencySymbol: String? = null
-    ) : LiveNotificationData {
-        override val activityType = LiveNotificationType.AUCTION_BID
-        override fun fields() = mapOf(
-            AuctionBidFields.ITEM_TITLE to itemTitle,
-            AuctionBidFields.CURRENT_BID to currentBid,
-            AuctionBidFields.BID_COUNT to bidCount,
-            AuctionBidFields.STATUS_MESSAGE to statusMessage,
-            AuctionBidFields.IS_USER_HIGH_BIDDER to isUserHighBidder,
-            AuctionBidFields.END_TIME to endTime,
-            AuctionBidFields.USER_BID_AMOUNT to userBidAmount,
-            AuctionBidFields.ITEM_IMAGE_KEY to itemImageKey,
-            AuctionBidFields.CURRENCY_SYMBOL to currencySymbol
-        )
-    }
-
-    /** Airport endpoint for [FlightStatus]. */
-    data class Airport(val code: String, val city: String? = null) {
-        internal fun toJson(): JSONObject = JSONObject().put(AirportFields.CODE, code).apply {
-            city?.let { put(AirportFields.CITY, it) }
-        }
-    }
-
-    /** Team for [LiveScore]. */
-    data class Team(val name: String, val logoKey: String? = null) {
-        internal fun toJson(): JSONObject = JSONObject().put(TeamFields.NAME, name).apply {
-            logoKey?.let { put(TeamFields.LOGO_KEY, it) }
-        }
+        override fun fields() = attributes() + contentState()
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import io.customer.messagingpush.di.liveNotificationLifecycleClient
+import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
 import kotlinx.coroutines.CoroutineScope
@@ -24,6 +25,18 @@ class LiveNotificationDismissReceiver : BroadcastReceiver() {
         if (deviceId.isNullOrBlank()) {
             SDKComponent.logger.debug(
                 "No FCM token available; skipping end event for live notification '$activityId'."
+            )
+            return
+        }
+
+        // Claim the terminal transition only after confirming we can report it, so a
+        // missing token doesn't mark the id terminal (losing the end and blocking any
+        // later one). Report `end` at most once per id; if already ended (e.g.
+        // endLiveNotification ran) skip the duplicate. Marking ended also retains the
+        // store's ordering guard so a later push can't repost the dismissed notification.
+        if (!SDKComponent.liveNotificationStore.markEnded(activityId)) {
+            SDKComponent.logger.debug(
+                "Live notification '$activityId' already ended; skipping dismiss end event."
             )
             return
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
@@ -6,6 +6,8 @@ import android.content.Intent
 import io.customer.messagingpush.di.liveNotificationLifecycleClient
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Receives the delete intent fired when the user dismisses a live notification
@@ -25,11 +27,20 @@ class LiveNotificationDismissReceiver : BroadcastReceiver() {
             )
             return
         }
-        SDKComponent.liveNotificationLifecycleClient.reportEnd(
-            instanceUUID = activityId,
-            activityType = activityType,
-            deviceId = deviceId
-        )
+        // Keep the process alive past onReceive() so the async CDP pipeline can
+        // persist the end event before the receiver's process is torn down.
+        val pendingResult = goAsync()
+        CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
+            try {
+                SDKComponent.liveNotificationLifecycleClient.reportEnd(
+                    instanceUUID = activityId,
+                    activityType = activityType,
+                    deviceId = deviceId
+                )
+            } finally {
+                pendingResult.finish()
+            }
+        }
     }
 
     internal companion object {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
@@ -6,34 +6,34 @@ import android.content.Intent
 import io.customer.messagingpush.di.liveNotificationLifecycleClient
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
- * Receives the delete intent the system fires when the user dismisses a live
- * notification, and reports the dismissal to the backend.
- *
- * Programmatic [android.app.NotificationManager.cancel] does NOT trigger a
- * delete intent, so server-driven `end` events (which cancel the notification)
- * do not produce a false user-dismissal report.
+ * Receives the delete intent fired when the user dismisses a live notification
+ * and reports an `end` event to Customer.io.
  */
 class LiveNotificationDismissReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val activityId = intent.getStringExtra(EXTRA_ACTIVITY_ID) ?: return
+        val activityType = intent.getStringExtra(EXTRA_ACTIVITY_TYPE) ?: return
         SDKComponent.setupAndroidComponent(context = context)
-        // Keep the receiver alive for the short-lived network call.
-        val pendingResult = goAsync()
-        CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
-            try {
-                SDKComponent.liveNotificationLifecycleClient.reportDismissed(activityId)
-            } finally {
-                pendingResult.finish()
-            }
+
+        val deviceId = SDKComponent.android().globalPreferenceStore.getDeviceToken()
+        if (deviceId.isNullOrBlank()) {
+            SDKComponent.logger.debug(
+                "No FCM token available; skipping end event for live notification '$activityId'."
+            )
+            return
         }
+        SDKComponent.liveNotificationLifecycleClient.reportEnd(
+            instanceUUID = activityId,
+            activityType = activityType,
+            deviceId = deviceId
+        )
     }
 
-    companion object {
-        const val EXTRA_ACTIVITY_ID = "io.customer.messagingpush.EXTRA_LIVE_ACTIVITY_ID"
+    internal companion object {
+        internal const val EXTRA_ACTIVITY_ID = "io.customer.messagingpush.EXTRA_LIVE_ACTIVITY_ID"
+        internal const val EXTRA_ACTIVITY_TYPE = "io.customer.messagingpush.EXTRA_LIVE_ACTIVITY_TYPE"
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -30,12 +30,30 @@ internal interface LiveNotificationLifecycleClient {
 
     /** Reports a `register_push_to_start` event; returns true if it was emitted. */
     fun registerPushToStart(activityType: String, deviceId: String): Boolean
+
+    /**
+     * Updates the cached identified-user state used to gate lifecycle events. Fed
+     * synchronously from `Event.UserChangedEvent` (via [LiveNotificationRegistrar])
+     * rather than the pipeline's own flag, which lags a synchronous `identify()` and
+     * would otherwise drop the first start/update/end right after login.
+     */
+    fun setIdentified(identified: Boolean)
 }
 
 @OptIn(InternalCustomerIOApi::class)
 internal class LiveNotificationLifecycleClientImpl(
     private val dataPipelineProvider: () -> DataPipeline? = { SDKComponent.getOrNull<DataPipeline>() }
 ) : LiveNotificationLifecycleClient {
+
+    // Identified-user state, fed synchronously from Event.UserChangedEvent via the
+    // registrar. Used instead of pipeline.isUserIdentified, which lags a synchronous
+    // identify() and would drop the first lifecycle event right after login.
+    @Volatile
+    private var isIdentified: Boolean = false
+
+    override fun setIdentified(identified: Boolean) {
+        isIdentified = identified
+    }
 
     override fun reportStart(
         instanceUUID: String,
@@ -120,7 +138,7 @@ internal class LiveNotificationLifecycleClientImpl(
             SDKComponent.logger.debug("Data pipeline unavailable; dropping live notification event '$event'.")
             return false
         }
-        if (requireIdentifiedUser && !pipeline.isUserIdentified) {
+        if (requireIdentifiedUser && !isIdentified) {
             SDKComponent.logger.debug("Live notifications require an identified user; dropping event '$event'.")
             return false
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -1,121 +1,152 @@
 package io.customer.messagingpush.livenotification
 
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
-import io.customer.sdk.core.di.httpClient
-import io.customer.sdk.core.network.CustomerIOHttpClient
-import io.customer.sdk.core.network.HttpMethod
-import io.customer.sdk.core.network.HttpRequestException
-import io.customer.sdk.core.network.HttpRequestParams
-import kotlinx.coroutines.delay
-import org.json.JSONObject
+import io.customer.sdk.core.pipeline.DataPipeline
 
 /**
- * Reports live-notification lifecycle to the Customer.io backend.
- *
- * Android has no push-to-start token like iOS; [registerForActivityType]
- * instead registers the device's FCM token per activity type so the backend
- * can push updates for it (`os = android`, `transport = fcm`).
- * [reportDismissed] mirrors iOS's terminal-state DELETE, fired when the user
- * dismisses the notification.
+ * Reports live-notification lifecycle to Customer.io as CDP track events.
  */
 internal interface LiveNotificationLifecycleClient {
-    suspend fun registerForActivityType(activityType: String, token: String, userId: String): Result<Unit>
+    /** Reports a `start` event with the static [attributes] and dynamic [contentState]. */
+    fun reportStart(
+        instanceUUID: String,
+        activityType: String,
+        deviceId: String,
+        attributes: Map<String, Any?>,
+        contentState: Map<String, Any?>
+    )
 
-    /**
-     * Registers a specific locally-started activity instance so the backend can
-     * push updates to it.
-     */
-    suspend fun registerInstance(activityId: String, activityType: String, token: String, userId: String): Result<Unit>
+    /** Reports an `update` event carrying the new dynamic [contentState]. */
+    fun reportUpdate(instanceUUID: String, activityType: String, deviceId: String, contentState: Map<String, Any?>)
 
-    suspend fun reportDismissed(activityId: String): Result<Unit>
+    /** Reports an `end` event, optionally carrying a final dynamic [contentState]. */
+    fun reportEnd(
+        instanceUUID: String,
+        activityType: String,
+        deviceId: String,
+        contentState: Map<String, Any?> = emptyMap()
+    )
+
+    /** Reports a `register_push_to_start` event; returns true if it was emitted. */
+    fun registerPushToStart(activityType: String, deviceId: String): Boolean
 }
 
+@OptIn(InternalCustomerIOApi::class)
 internal class LiveNotificationLifecycleClientImpl(
-    private val httpClient: CustomerIOHttpClient = SDKComponent.httpClient
+    private val dataPipelineProvider: () -> DataPipeline? = { SDKComponent.getOrNull<DataPipeline>() }
 ) : LiveNotificationLifecycleClient {
 
-    override suspend fun registerForActivityType(
+    override fun reportStart(
+        instanceUUID: String,
         activityType: String,
-        token: String,
-        userId: String
-    ): Result<Unit> {
-        val body = JSONObject().apply {
-            put("token", token)
-            put("os", OS_ANDROID)
-            put("transport", TRANSPORT_FCM)
-            put("userId", userId)
-        }
-        return send(
-            HttpRequestParams(
-                path = "/v1/live_activities/registration/$activityType",
-                method = HttpMethod.PUT,
-                headers = JSON_HEADERS,
-                body = body.toString()
-            )
+        deviceId: String,
+        attributes: Map<String, Any?>,
+        contentState: Map<String, Any?>
+    ) {
+        track(
+            event = EVENT_LIVE_NOTIFICATION,
+            properties = buildMap {
+                put(PROP_EVENT_TYPE, EVENT_TYPE_START)
+                put(PROP_CIO_INSTANCE_ID, instanceUUID)
+                put(PROP_DEVICE_ID, deviceId)
+                put(PROP_PLATFORM, PLATFORM_ANDROID)
+                put(PROP_NOTIFICATION_TYPE, activityType)
+                if (attributes.isNotEmpty()) put(PROP_ATTRIBUTES, attributes)
+                if (contentState.isNotEmpty()) put(PROP_CONTENT_STATE, contentState)
+            }
         )
     }
 
-    override suspend fun registerInstance(
-        activityId: String,
+    override fun reportUpdate(
+        instanceUUID: String,
         activityType: String,
-        token: String,
-        userId: String
-    ): Result<Unit> {
-        val body = JSONObject().apply {
-            put("token", token)
-            put("activity_type", activityType)
-            put("os", OS_ANDROID)
-            put("transport", TRANSPORT_FCM)
-            put("userId", userId)
-        }
-        return send(
-            HttpRequestParams(
-                path = "/v1/live_activities/$activityId/push_token",
-                method = HttpMethod.PUT,
-                headers = JSON_HEADERS,
-                body = body.toString()
-            )
+        deviceId: String,
+        contentState: Map<String, Any?>
+    ) {
+        track(
+            event = EVENT_LIVE_NOTIFICATION,
+            properties = buildMap {
+                put(PROP_EVENT_TYPE, EVENT_TYPE_UPDATE)
+                put(PROP_CIO_INSTANCE_ID, instanceUUID)
+                put(PROP_DEVICE_ID, deviceId)
+                put(PROP_PLATFORM, PLATFORM_ANDROID)
+                put(PROP_NOTIFICATION_TYPE, activityType)
+                if (contentState.isNotEmpty()) put(PROP_CONTENT_STATE, contentState)
+            }
         )
     }
 
-    override suspend fun reportDismissed(activityId: String): Result<Unit> {
-        return send(
-            HttpRequestParams(
-                path = "/v1/live_activities/$activityId",
-                method = HttpMethod.DELETE,
-                headers = JSON_HEADERS,
-                body = "{}"
-            )
+    override fun reportEnd(
+        instanceUUID: String,
+        activityType: String,
+        deviceId: String,
+        contentState: Map<String, Any?>
+    ) {
+        track(
+            event = EVENT_LIVE_NOTIFICATION,
+            properties = buildMap {
+                put(PROP_EVENT_TYPE, EVENT_TYPE_END)
+                put(PROP_CIO_INSTANCE_ID, instanceUUID)
+                put(PROP_DEVICE_ID, deviceId)
+                put(PROP_PLATFORM, PLATFORM_ANDROID)
+                put(PROP_NOTIFICATION_TYPE, activityType)
+                if (contentState.isNotEmpty()) put(PROP_CONTENT_STATE, contentState)
+            }
         )
     }
+
+    override fun registerPushToStart(activityType: String, deviceId: String): Boolean =
+        track(
+            event = EVENT_LIVE_NOTIFICATION_TOKEN,
+            properties = mapOf(
+                PROP_REGISTRATION_TYPE to REGISTRATION_TYPE_PUSH_TO_START,
+                PROP_NOTIFICATION_TYPE to activityType,
+                PROP_PLATFORM to PLATFORM_ANDROID,
+                PROP_DEVICE_ID to deviceId,
+                PROP_PUSH_TO_START_TOKEN to deviceId
+            ),
+            // Identity is gated upstream by LiveNotificationRegistrar for registration.
+            requireIdentifiedUser = false
+        )
 
     /**
-     * Sends [params], retrying transport failures and 5xx responses up to
-     * [MAX_ATTEMPTS] with linear backoff. 4xx responses are not retried
-     * (mirrors the iOS lifecycle client policy).
+     * Emits [event]; returns true if it was sent. Requires a ready pipeline and,
+     * unless [requireIdentifiedUser] is false, an identified user.
      */
-    private suspend fun send(params: HttpRequestParams): Result<Unit> {
-        var attempt = 0
-        while (true) {
-            attempt++
-            val result = httpClient.request(params)
-            if (result.isSuccess) return Result.success(Unit)
-
-            val error = result.exceptionOrNull()
-            val statusCode = (error as? HttpRequestException)?.statusCode
-            val isClientError = statusCode != null && statusCode in 400..499
-            if (isClientError || attempt >= MAX_ATTEMPTS) {
-                return Result.failure(error ?: IllegalStateException("Live notification request failed"))
-            }
-            delay(BASE_BACKOFF_MS * attempt)
+    private fun track(event: String, properties: Map<String, Any?>, requireIdentifiedUser: Boolean = true): Boolean {
+        val pipeline = dataPipelineProvider()
+        if (pipeline == null) {
+            SDKComponent.logger.debug("Data pipeline unavailable; dropping live notification event '$event'.")
+            return false
         }
+        if (requireIdentifiedUser && !pipeline.isUserIdentified) {
+            SDKComponent.logger.debug("Live notifications require an identified user; dropping event '$event'.")
+            return false
+        }
+        pipeline.track(event, properties)
+        return true
     }
 
     companion object {
-        private const val OS_ANDROID = "android"
-        private const val TRANSPORT_FCM = "fcm"
-        private const val MAX_ATTEMPTS = 3
-        private const val BASE_BACKOFF_MS = 500L
-        private val JSON_HEADERS = mapOf("Content-Type" to "application/json; charset=utf-8")
+        const val EVENT_LIVE_NOTIFICATION = "Live Notification Event"
+        const val EVENT_LIVE_NOTIFICATION_TOKEN = "Live Notification Token"
+
+        const val PROP_EVENT_TYPE = "eventType"
+        const val PROP_REGISTRATION_TYPE = "registrationType"
+        const val PROP_CIO_INSTANCE_ID = "cioInstanceId"
+        const val PROP_DEVICE_ID = "deviceId"
+        const val PROP_PLATFORM = "platform"
+
+        const val PROP_NOTIFICATION_TYPE = "notificationType"
+        const val PROP_ATTRIBUTES = "attributes"
+        const val PROP_CONTENT_STATE = "contentState"
+        const val PROP_PUSH_TO_START_TOKEN = "pushToStartToken"
+
+        const val EVENT_TYPE_START = "start"
+        const val EVENT_TYPE_UPDATE = "update"
+        const val EVENT_TYPE_END = "end"
+        const val REGISTRATION_TYPE_PUSH_TO_START = "push_to_start"
+        const val PLATFORM_ANDROID = "android"
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -15,6 +15,8 @@ import io.customer.sdk.core.extensions.applicationMetaData
 import io.customer.sdk.core.util.DispatchersProvider
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 /**
@@ -35,6 +37,15 @@ internal class LiveNotificationManager(
     // state as a dismissible notification and resolve the activity type even if
     // the initial render never posted.
     private val lastBundles = ConcurrentHashMap<String, Bundle>()
+
+    private val renderScope: CoroutineScope by lazy {
+        CoroutineScope(SupervisorJob() + dispatchers.background)
+    }
+
+    // Renders are chained so each waits for the previous one to finish, keeping
+    // them in submission order — a slow earlier render (e.g. a RemoteUrl logo
+    // download) can't complete after, and overwrite, a later one.
+    private var renderChain: Job = Job().also { it.complete() }
 
     /** Starts a live notification locally and reports a `start` event. */
     fun start(
@@ -110,6 +121,9 @@ internal class LiveNotificationManager(
             }
         }
         store.clearAllActivities()
+        // Drop cached per-instance bundles so a post-logout end() can't reuse a
+        // previous session's payload.
+        lastBundles.clear()
     }
 
     private fun buildBundle(
@@ -135,8 +149,13 @@ internal class LiveNotificationManager(
      * blocking image download inside the handler, which must never run on the
      * caller's (possibly main) thread.
      */
+    @Synchronized
     private fun render(bundle: Bundle) {
-        CoroutineScope(dispatchers.background).launch { renderLocally(bundle) }
+        val previous = renderChain
+        renderChain = renderScope.launch {
+            previous.join()
+            renderLocally(bundle)
+        }
     }
 
     private fun renderLocally(bundle: Bundle) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -6,47 +6,96 @@ import android.os.Bundle
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import io.customer.messagingpush.LiveNotificationHandler
+import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.extensions.getColorOrNull
 import io.customer.messagingpush.extensions.getMetaDataResource
 import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
- * Starts a live notification locally on behalf of the host app: renders it
- * immediately through the normal templating path, then registers the instance
- * with the backend so Customer.io can push subsequent updates to it.
- *
- * Rendering goes straight through [LiveNotificationHandler] (not the FCM
- * delivery path), so no delivered/opened metric is fabricated for a
- * locally-started notification.
+ * Renders live notifications locally on behalf of the host app and reports the
+ * corresponding start/update/end lifecycle events to Customer.io.
  */
 internal class LiveNotificationManager(
     private val lifecycleClient: LiveNotificationLifecycleClient,
-    private val registrar: LiveNotificationRegistrar,
     private val notificationChannelCreator: NotificationChannelCreator = NotificationChannelCreator()
 ) {
     private val context: Context
         get() = SDKComponent.android().applicationContext
 
-    fun start(activityId: String, activityType: String, fields: Map<String, Any?>) {
-        renderLocally(buildBundle(activityId, activityType, fields))
-        registerInstance(activityId, activityType)
+    /** Starts a live notification locally and reports a `start` event. */
+    fun start(
+        activityId: String,
+        activityType: String,
+        attributes: Map<String, Any?>,
+        contentState: Map<String, Any?>
+    ) {
+        renderLocally(buildBundle(activityId, activityType, attributes + contentState, EVENT_START))
+        reportStart(activityId, activityType, attributes, contentState)
     }
 
-    private fun buildBundle(activityId: String, activityType: String, fields: Map<String, Any?>): Bundle =
+    /** Re-renders a previously started live notification and reports an `update` event. */
+    fun update(
+        activityId: String,
+        activityType: String,
+        attributes: Map<String, Any?>,
+        contentState: Map<String, Any?>
+    ) {
+        renderLocally(buildBundle(activityId, activityType, attributes + contentState, EVENT_UPDATE))
+        reportUpdate(activityId, activityType, contentState)
+    }
+
+    /** Removes a previously started live notification and reports an `end` event. */
+    fun end(activityId: String) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancel(activityId, LiveNotificationHandler.notificationId(activityId))
+
+        val store = SDKComponent.liveNotificationStore
+        val activityType = store.activityType(activityId)
+        if (activityType == null) {
+            SDKComponent.logger.debug(
+                "No known live notification for '$activityId'; canceled without reporting an end event."
+            )
+        } else {
+            reportEnd(activityId, activityType)
+        }
+        store.clearTimestamp(activityId)
+        store.clearActivityType(activityId)
+    }
+
+    /**
+     * Cancels every tracked live notification and clears their stored state,
+     * without reporting `end` events. Called on logout (reset).
+     */
+    fun cancelAllActivities() {
+        val store = SDKComponent.liveNotificationStore
+        val ids = store.trackedActivityIds()
+        if (ids.isNotEmpty()) {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            for (activityId in ids) {
+                notificationManager.cancel(activityId, LiveNotificationHandler.notificationId(activityId))
+            }
+        }
+        store.clearAllActivities()
+    }
+
+    private fun buildBundle(
+        activityId: String,
+        activityType: String,
+        fields: Map<String, Any?>,
+        event: String
+    ): Bundle =
         Bundle().apply {
-            // Write template fields first so the reserved envelope keys below always
-            // win if a field key collides with one (e.g. a field named "timestamp").
+            // Write template fields first so the reserved envelope keys below win on collision.
             for ((key, value) in fields) {
                 if (value != null) putString(key, value.toString())
             }
-            putString(LiveNotificationHandler.ACTIVITY_ID_KEY, activityId)
-            putString(LiveNotificationHandler.EVENT_KEY, EVENT_START)
-            putString(LiveNotificationHandler.ACTIVITY_TYPE_KEY, activityType)
-            putString(LiveNotificationHandler.TIMESTAMP_KEY, System.currentTimeMillis().toString())
+            putString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY, activityId)
+            putString(LiveNotificationHandler.EVENT_KEY, event)
+            putString(LiveNotificationHandler.NOTIFICATION_TYPE_KEY, activityType)
+            // Epoch seconds, matching the backend push wire contract.
+            putString(LiveNotificationHandler.TIMESTAMP_KEY, (System.currentTimeMillis() / 1000).toString())
         }
 
     private fun renderLocally(bundle: Bundle) {
@@ -79,23 +128,62 @@ internal class LiveNotificationManager(
         )
     }
 
-    private fun registerInstance(activityId: String, activityType: String) {
-        // Reuse the token the registrar already tracks (fetched once in ModuleMessagingPushFCM)
-        // instead of requesting it again.
-        val token = registrar.currentToken()
-        if (token == null) {
+    private fun reportStart(
+        activityId: String,
+        activityType: String,
+        attributes: Map<String, Any?>,
+        contentState: Map<String, Any?>
+    ) {
+        val deviceId = SDKComponent.android().globalPreferenceStore.getDeviceToken()
+        if (deviceId.isNullOrBlank()) {
             SDKComponent.logger.debug(
-                "No FCM token available yet; skipping instance registration for live notification '$activityId'."
+                "No FCM token available yet; skipping start event for live notification '$activityId'."
             )
             return
         }
-        CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
-            lifecycleClient.registerInstance(activityId, activityType, token, registrar.currentUserId())
+        lifecycleClient.reportStart(
+            instanceUUID = activityId,
+            activityType = activityType,
+            deviceId = deviceId,
+            attributes = attributes.toJsonSafePayload(),
+            contentState = contentState.toJsonSafePayload()
+        )
+    }
+
+    private fun reportUpdate(activityId: String, activityType: String, contentState: Map<String, Any?>) {
+        val deviceId = SDKComponent.android().globalPreferenceStore.getDeviceToken()
+        if (deviceId.isNullOrBlank()) {
+            SDKComponent.logger.debug(
+                "No FCM token available yet; skipping update event for live notification '$activityId'."
+            )
+            return
         }
+        lifecycleClient.reportUpdate(
+            instanceUUID = activityId,
+            activityType = activityType,
+            deviceId = deviceId,
+            contentState = contentState.toJsonSafePayload()
+        )
+    }
+
+    private fun reportEnd(activityId: String, activityType: String) {
+        val deviceId = SDKComponent.android().globalPreferenceStore.getDeviceToken()
+        if (deviceId.isNullOrBlank()) {
+            SDKComponent.logger.debug(
+                "No FCM token available yet; skipping end event for live notification '$activityId'."
+            )
+            return
+        }
+        lifecycleClient.reportEnd(
+            instanceUUID = activityId,
+            activityType = activityType,
+            deviceId = deviceId
+        )
     }
 
     companion object {
         private const val EVENT_START = "start"
+        private const val EVENT_UPDATE = "update"
         private const val FCM_DEFAULT_ICON = "com.google.firebase.messaging.default_notification_icon"
         private const val FCM_DEFAULT_COLOR = "com.google.firebase.messaging.default_notification_color"
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -47,6 +47,12 @@ internal class LiveNotificationManager(
     // download) can't complete after, and overwrite, a later one.
     private var renderChain: Job = Job().also { it.complete() }
 
+    // Bumped on reset. A render enqueued before a logout captures the current
+    // generation; if it changed by the time the render runs, the render is dropped
+    // so it can't re-post a previous user's activity into a just-cleared store.
+    @Volatile
+    private var renderGeneration = 0
+
     /** Starts a live notification locally and reports a `start` event. */
     fun start(
         activityId: String,
@@ -57,6 +63,12 @@ internal class LiveNotificationManager(
         val bundle = buildBundle(activityId, activityType, attributes + contentState, EVENT_START)
         lastBundles[activityId] = Bundle(bundle)
         render(bundle)
+        // Lifecycle reporting is intentionally decoupled from the local render: the
+        // app called start/update/end, so Customer.io must track the activity (and be
+        // able to push updates / remote-end it) even when the local render posts nothing
+        // — e.g. a custom type with no built-in template, or a transient render failure.
+        // The report is not blocking (token read is an in-memory pref; track() enqueues),
+        // so it stays on the caller thread; identity gating still applies in the client.
         reportStart(activityId, activityType, attributes, contentState)
     }
 
@@ -67,6 +79,16 @@ internal class LiveNotificationManager(
         attributes: Map<String, Any?>,
         contentState: Map<String, Any?>
     ) {
+        // Terminal state is governed here for local renders (they bypass the handler's
+        // server-push guard): an update after the activity ended locally or was dismissed
+        // must not repost it or report a stray update. `start` mints a fresh id, and
+        // `end` guards itself, so only `update` needs this check.
+        if (SDKComponent.liveNotificationStore.isEnded(activityId)) {
+            SDKComponent.logger.debug(
+                "Live notification '$activityId' already ended; ignoring update."
+            )
+            return
+        }
         val bundle = buildBundle(activityId, activityType, attributes + contentState, EVENT_UPDATE)
         lastBundles[activityId] = Bundle(bundle)
         render(bundle)
@@ -82,6 +104,15 @@ internal class LiveNotificationManager(
     fun end(activityId: String) {
         val store = SDKComponent.liveNotificationStore
         val lastBundle = lastBundles.remove(activityId)
+        // Already terminal (e.g. the user dismissed it, or end was already called):
+        // end is idempotent per id, so don't re-render a dismissed notification or
+        // report a second end.
+        if (store.isEnded(activityId)) {
+            SDKComponent.logger.debug(
+                "Live notification '$activityId' already ended; nothing to do."
+            )
+            return
+        }
         // Prefer the type from the last local render; fall back to the persisted
         // type (e.g. after process death) so a locally-started activity always
         // reports a matching end.
@@ -101,22 +132,31 @@ internal class LiveNotificationManager(
             notificationManager.cancel(activityId, LiveNotificationHandler.notificationId(activityId))
         }
 
+        // Claim the terminal transition so `end` is reported at most once per id
+        // (a prior user swipe-dismiss may have already reported it). The store's
+        // timestamp/type are intentionally NOT cleared: the terminal marker and the
+        // high-water mark must survive so a delayed older push can't resurrect the
+        // activity, and logout can still cancel a still-visible ended notification.
+        // Reclamation happens via the store's TTL trim / logout clear.
         if (activityType == null) {
             SDKComponent.logger.debug(
                 "No known live notification for '$activityId'; nothing to end."
             )
-        } else {
+        } else if (store.markEnded(activityId)) {
             reportEnd(activityId, activityType)
         }
-        store.clearTimestamp(activityId)
-        store.clearActivityType(activityId)
     }
 
     /**
      * Cancels every tracked live notification and clears their stored state,
      * without reporting `end` events. Called on logout (reset).
      */
+    @Synchronized
     fun cancelAllActivities() {
+        // Invalidate any render queued before this reset (see render()) so a
+        // start()'s enqueued work can't re-add a previous user's activity after the
+        // store is cleared below.
+        renderGeneration++
         val store = SDKComponent.liveNotificationStore
         val ids = store.trackedActivityIds()
         if (ids.isNotEmpty()) {
@@ -156,9 +196,13 @@ internal class LiveNotificationManager(
      */
     @Synchronized
     private fun render(bundle: Bundle) {
+        val generation = renderGeneration
         val previous = renderChain
         renderChain = renderScope.launch {
             previous.join()
+            // A logout/reset after this render was queued invalidates it, so it can't
+            // re-post a previous user's activity into a store that reset just cleared.
+            if (generation != renderGeneration) return@launch
             renderLocally(bundle)
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -12,6 +12,10 @@ import io.customer.messagingpush.extensions.getMetaDataResource
 import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
+import io.customer.sdk.core.util.DispatchersProvider
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Renders live notifications locally on behalf of the host app and reports the
@@ -24,6 +28,14 @@ internal class LiveNotificationManager(
     private val context: Context
         get() = SDKComponent.android().applicationContext
 
+    private val dispatchers: DispatchersProvider
+        get() = SDKComponent.dispatchersProvider
+
+    // Last bundle rendered per activity id, so end() can re-render the final
+    // state as a dismissible notification and resolve the activity type even if
+    // the initial render never posted.
+    private val lastBundles = ConcurrentHashMap<String, Bundle>()
+
     /** Starts a live notification locally and reports a `start` event. */
     fun start(
         activityId: String,
@@ -31,7 +43,9 @@ internal class LiveNotificationManager(
         attributes: Map<String, Any?>,
         contentState: Map<String, Any?>
     ) {
-        renderLocally(buildBundle(activityId, activityType, attributes + contentState, EVENT_START))
+        val bundle = buildBundle(activityId, activityType, attributes + contentState, EVENT_START)
+        lastBundles[activityId] = Bundle(bundle)
+        render(bundle)
         reportStart(activityId, activityType, attributes, contentState)
     }
 
@@ -42,20 +56,38 @@ internal class LiveNotificationManager(
         attributes: Map<String, Any?>,
         contentState: Map<String, Any?>
     ) {
-        renderLocally(buildBundle(activityId, activityType, attributes + contentState, EVENT_UPDATE))
+        val bundle = buildBundle(activityId, activityType, attributes + contentState, EVENT_UPDATE)
+        lastBundles[activityId] = Bundle(bundle)
+        render(bundle)
         reportUpdate(activityId, activityType, contentState)
     }
 
-    /** Removes a previously started live notification and reports an `end` event. */
+    /**
+     * Ends a live notification locally and reports an `end` event. Rather than
+     * cancelling, it re-renders the last state as a terminal (non-ongoing)
+     * notification so the final state stays in the shade and is dismissible,
+     * matching push-delivered end.
+     */
     fun end(activityId: String) {
-        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.cancel(activityId, LiveNotificationHandler.notificationId(activityId))
-
         val store = SDKComponent.liveNotificationStore
-        val activityType = store.activityType(activityId)
+        val lastBundle = lastBundles.remove(activityId)
+        // Prefer the type from the last local render; fall back to the persisted
+        // type (e.g. after process death) so a locally-started activity always
+        // reports a matching end.
+        val activityType = lastBundle?.getString(LiveNotificationHandler.NOTIFICATION_TYPE_KEY)
+            ?: store.activityType(activityId)
+
+        if (lastBundle != null) {
+            val endBundle = Bundle(lastBundle).apply {
+                putString(LiveNotificationHandler.EVENT_KEY, EVENT_END)
+                putString(LiveNotificationHandler.TIMESTAMP_KEY, (System.currentTimeMillis() / 1000).toString())
+            }
+            render(endBundle)
+        }
+
         if (activityType == null) {
             SDKComponent.logger.debug(
-                "No known live notification for '$activityId'; canceled without reporting an end event."
+                "No known live notification for '$activityId'; nothing to end."
             )
         } else {
             reportEnd(activityId, activityType)
@@ -98,6 +130,15 @@ internal class LiveNotificationManager(
             putString(LiveNotificationHandler.TIMESTAMP_KEY, (System.currentTimeMillis() / 1000).toString())
         }
 
+    /**
+     * Renders off the caller's thread: a `RemoteUrl` branding logo triggers a
+     * blocking image download inside the handler, which must never run on the
+     * caller's (possibly main) thread.
+     */
+    private fun render(bundle: Bundle) {
+        CoroutineScope(dispatchers.background).launch { renderLocally(bundle) }
+    }
+
     private fun renderLocally(bundle: Bundle) {
         val ctx = context
         val appMetaData = ctx.applicationMetaData()
@@ -124,7 +165,8 @@ internal class LiveNotificationManager(
             smallIcon = smallIcon,
             tintColor = tintColor,
             channelId = channelId,
-            notificationManager = notificationManager
+            notificationManager = notificationManager,
+            bypassOrderGuard = true
         )
     }
 
@@ -184,6 +226,7 @@ internal class LiveNotificationManager(
     companion object {
         private const val EVENT_START = "start"
         private const val EVENT_UPDATE = "update"
+        private const val EVENT_END = "end"
         private const val FCM_DEFAULT_ICON = "com.google.firebase.messaging.default_notification_icon"
         private const val FCM_DEFAULT_COLOR = "com.google.firebase.messaging.default_notification_color"
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -94,6 +94,11 @@ internal class LiveNotificationManager(
                 putString(LiveNotificationHandler.TIMESTAMP_KEY, (System.currentTimeMillis() / 1000).toString())
             }
             render(endBundle)
+        } else {
+            // No cached content to render a terminal state (e.g. after process death):
+            // cancel so a previously ongoing notification isn't left stuck and non-dismissible.
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.cancel(activityId, LiveNotificationHandler.notificationId(activityId))
         }
 
         if (activityType == null) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationPayload.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationPayload.kt
@@ -1,0 +1,26 @@
+package io.customer.messagingpush.livenotification
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Coerces live-notification template fields into values the data pipeline can
+ * serialize: `org.json` containers become plain
+ * [Map]/[List], and null entries are dropped. Used by the on-device start/update
+ * report path ([LiveNotificationManager]).
+ */
+internal fun Map<String, Any?>.toJsonSafePayload(): Map<String, Any?> =
+    buildMap {
+        for ((key, value) in this@toJsonSafePayload) {
+            if (value != null) put(key, value.toJsonSafe())
+        }
+    }
+
+private fun Any?.toJsonSafe(): Any? = when (this) {
+    null -> null
+    is JSONObject -> buildMap<String, Any?> {
+        for (key in keys()) put(key, opt(key)?.takeIf { it != JSONObject.NULL }?.toJsonSafe())
+    }
+    is JSONArray -> (0 until length()).map { opt(it)?.takeIf { v -> v != JSONObject.NULL }?.toJsonSafe() }
+    else -> this
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -51,6 +51,9 @@ internal class LiveNotificationRegistrar(
     internal fun onUserChanged(event: Event.UserChangedEvent) {
         userId = event.userId ?: event.anonymousId
         isIdentified = event.userId != null
+        // Feed identity to the lifecycle client synchronously so local start/update/end
+        // reporting isn't gated by the pipeline's laggy isUserIdentified flag.
+        client.setIdentified(isIdentified)
         registerAll()
     }
 
@@ -63,6 +66,11 @@ internal class LiveNotificationRegistrar(
     internal fun onReset() {
         SDKComponent.liveNotificationManager.cancelAllActivities()
         store.clearRegistrations()
+        // Drop identity so post-logout local start/update/end aren't reported as the
+        // previous (identified) user until a new UserChangedEvent arrives.
+        userId = ""
+        isIdentified = false
+        client.setIdentified(false)
     }
 
     private fun registerAll() {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -1,21 +1,15 @@
 package io.customer.messagingpush.livenotification
 
+import io.customer.messagingpush.di.liveNotificationManager
 import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.SDKComponent.eventBus
 
 /**
- * Registers the device's FCM token with the backend for the live-notification
- * activity types the host app enabled via
- * `MessagingPushModuleConfig.setLiveNotificationTypes` (the Android analogue of
- * iOS push-to-start registration). No types enabled ⇒ nothing is registered.
- *
- * Registration is (re)attempted whenever the device token rotates
- * ([Event.RegisterDeviceTokenEvent]) or the user changes
- * ([Event.UserChangedEvent]), and is deduped per activity type via
- * [LiveNotificationStore] (signature = `token|userId`). Token deletion / reset
- * clears the stored signatures so the next token re-registers.
+ * Emits `register_push_to_start` track events for the enabled live-notification
+ * types when the device token or user changes, deduping already-registered
+ * `token|userId` signatures. Registers only for identified users.
  */
 internal class LiveNotificationRegistrar(
     private val client: LiveNotificationLifecycleClient,
@@ -28,48 +22,62 @@ internal class LiveNotificationRegistrar(
     @Volatile
     private var userId: String = ""
 
-    /** The current FCM token, or null if not yet received. */
-    fun currentToken(): String? = token
-
-    /** The current resolved user identity (identified userId, else anonymousId). */
-    fun currentUserId(): String = userId
+    @Volatile
+    private var isIdentified: Boolean = false
 
     private val enabledTypes: Set<String>
         get() = SDKComponent.pushModuleConfig.liveNotificationTypes
 
     fun start() {
-        // Drop dedup entries for activities that ended long ago without an explicit `end`.
+        val clearedByMigration = store.migrate()
+        if (clearedByMigration > 0) {
+            SDKComponent.logger.debug(
+                "Live Notifications: migration cleared $clearedByMigration stale registration(s) from the old namespace."
+            )
+        }
         store.trimStaleTimestamps()
 
-        eventBus.subscribe(Event.RegisterDeviceTokenEvent::class) { event ->
-            token = event.token
-            registerAll()
-        }
-        eventBus.subscribe(Event.UserChangedEvent::class) { event ->
-            userId = event.userId ?: event.anonymousId
-            registerAll()
-        }
-        eventBus.subscribe(Event.DeleteDeviceTokenEvent::class) {
-            token = null
-            store.clearRegistrations()
-        }
-        eventBus.subscribe(Event.ResetEvent::class) {
-            store.clearRegistrations()
-        }
+        eventBus.subscribe(Event.RegisterDeviceTokenEvent::class) { onDeviceTokenChanged(it.token) }
+        eventBus.subscribe(Event.UserChangedEvent::class) { onUserChanged(it) }
+        eventBus.subscribe(Event.DeleteDeviceTokenEvent::class) { onDeviceTokenDeleted() }
+        eventBus.subscribe(Event.ResetEvent::class) { onReset() }
     }
 
-    private suspend fun registerAll() {
+    internal fun onDeviceTokenChanged(newToken: String) {
+        token = newToken
+        registerAll()
+    }
+
+    internal fun onUserChanged(event: Event.UserChangedEvent) {
+        userId = event.userId ?: event.anonymousId
+        isIdentified = event.userId != null
+        registerAll()
+    }
+
+    internal fun onDeviceTokenDeleted() {
+        token = null
+    }
+
+    internal fun onReset() {
+        SDKComponent.liveNotificationManager.cancelAllActivities()
+        store.clearRegistrations()
+    }
+
+    private fun registerAll() {
+        if (!isIdentified) {
+            if (token != null && enabledTypes.isNotEmpty()) {
+                SDKComponent.logger.debug(
+                    "Live Notifications: holding push-to-start registration for ${enabledTypes.size} type(s); no identified user."
+                )
+            }
+            return
+        }
         val currentToken = token ?: return
         val signature = "$currentToken|$userId"
         for (activityType in enabledTypes) {
             if (store.registrationSignature(activityType) == signature) continue
-            val result = client.registerForActivityType(activityType, currentToken, userId)
-            if (result.isSuccess) {
+            if (client.registerPushToStart(activityType, currentToken)) {
                 store.setRegistrationSignature(activityType, signature)
-            } else {
-                SDKComponent.logger.debug(
-                    "Live notification registration failed for '$activityType'; will retry on next token/user change."
-                )
             }
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -56,6 +56,8 @@ internal class LiveNotificationRegistrar(
 
     internal fun onDeviceTokenDeleted() {
         token = null
+        // Drop dedup signatures so re-registering the same token later isn't skipped.
+        store.clearRegistrations()
     }
 
     internal fun onReset() {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
@@ -5,24 +5,29 @@ import androidx.core.content.edit
 import java.util.concurrent.TimeUnit
 
 /**
- * Persistent state for live notifications, backed by a dedicated
- * SharedPreferences file:
- *
- * - **Registration dedup** (per `activity_type`): the last signature
- *   (`token|userId`) registered with the backend, so repeated app launches /
- *   unchanged tokens don't re-POST the registration.
- * - **Out-of-order / dedup guard** (per `activity_id`): the last `timestamp`
- *   seen, so a delayed or duplicate push that is older than one already
- *   rendered is dropped. Unlike iOS (where APNs/ActivityKit order updates), the
- *   Android SDK renders FCM data directly and must guard ordering itself.
- *
- * Timestamp entries are stored with their record time so stale ones (for
- * activities that ended long ago without an explicit `end`) can be trimmed on
- * app launch.
+ * Persistent live-notification state (dedicated SharedPreferences file):
+ * per-`activity_type` registration signatures, per-`activity_id` last-seen
+ * timestamps for the out-of-order guard, and per-`activity_id` activity types.
  */
 internal class LiveNotificationStore(context: Context) {
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * One-time cleanup for the namespace rename: drops registration signatures
+     * keyed under the old `io.customer.liveactivities.*` namespace. Idempotent.
+     *
+     * @return the number of stale registration signatures cleared.
+     */
+    fun migrate(): Int {
+        val stale = prefs.all.keys.filter {
+            it.startsWith(REG_PREFIX) && it.contains(LEGACY_ACTIVITY_TYPE_PREFIX)
+        }
+        if (stale.isNotEmpty()) {
+            prefs.edit { stale.forEach { remove(it) } }
+        }
+        return stale.size
+    }
 
     // --- Registration dedup (per activity_type) ---
 
@@ -54,14 +59,49 @@ internal class LiveNotificationStore(context: Context) {
         prefs.edit { remove(TS_PREFIX + activityId) }
     }
 
-    /** Removes timestamp entries recorded longer than [ttlMs] ago. Intended to run on app launch. */
+    /** Removes timestamp entries (and their paired activity types) recorded longer than [ttlMs] ago. Intended to run on app launch. */
     fun trimStaleTimestamps(ttlMs: Long = DEFAULT_TS_TTL_MS, now: Long = System.currentTimeMillis()) {
-        val staleKeys = prefs.all.entries.filter { (key, value) ->
+        val staleActivityIds = prefs.all.entries.filter { (key, value) ->
             key.startsWith(TS_PREFIX) &&
                 ((value as? String)?.substringAfter('|', "")?.toLongOrNull()?.let { now - it > ttlMs } ?: true)
-        }.map { it.key }
-        if (staleKeys.isNotEmpty()) {
-            prefs.edit { staleKeys.forEach { remove(it) } }
+        }.map { it.key.removePrefix(TS_PREFIX) }
+        if (staleActivityIds.isNotEmpty()) {
+            prefs.edit {
+                staleActivityIds.forEach {
+                    remove(TS_PREFIX + it)
+                    remove(TYPE_PREFIX + it)
+                }
+            }
+        }
+    }
+
+    // --- Activity type (per activity_id) ---
+
+    /** The activity type last rendered for [activityId], or null if unknown. */
+    fun activityType(activityId: String): String? =
+        prefs.getString(TYPE_PREFIX + activityId, null)
+
+    fun setActivityType(activityId: String, activityType: String) {
+        prefs.edit { putString(TYPE_PREFIX + activityId, activityType) }
+    }
+
+    fun clearActivityType(activityId: String) {
+        prefs.edit { remove(TYPE_PREFIX + activityId) }
+    }
+
+    /** Every activity id the SDK currently tracks (rendered and not yet ended). */
+    fun trackedActivityIds(): Set<String> =
+        prefs.all.keys
+            .filter { it.startsWith(TYPE_PREFIX) }
+            .map { it.removePrefix(TYPE_PREFIX) }
+            .toSet()
+
+    /** Clears all per-activity state (timestamps + types). Used on logout/reset. */
+    fun clearAllActivities() {
+        prefs.edit {
+            prefs.all.keys
+                .filter { it.startsWith(TS_PREFIX) || it.startsWith(TYPE_PREFIX) }
+                .forEach { remove(it) }
         }
     }
 
@@ -69,6 +109,10 @@ internal class LiveNotificationStore(context: Context) {
         private const val PREFS_NAME = "io.customer.messagingpush.live_notifications"
         private const val REG_PREFIX = "reg:"
         private const val TS_PREFIX = "ts:"
+        private const val TYPE_PREFIX = "type:"
+
+        // Old built-in namespace, replaced by `io.customer.livenotifications.` — used only by migrate().
+        private const val LEGACY_ACTIVITY_TYPE_PREFIX = "io.customer.liveactivities."
         private val DEFAULT_TS_TTL_MS = TimeUnit.DAYS.toMillis(7)
     }
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
@@ -59,7 +59,7 @@ internal class LiveNotificationStore(context: Context) {
         prefs.edit { remove(TS_PREFIX + activityId) }
     }
 
-    /** Removes timestamp entries (and their paired activity types) recorded longer than [ttlMs] ago. Intended to run on app launch. */
+    /** Removes timestamp entries (and their paired activity types + ended markers) recorded longer than [ttlMs] ago. Intended to run on app launch. */
     fun trimStaleTimestamps(ttlMs: Long = DEFAULT_TS_TTL_MS, now: Long = System.currentTimeMillis()) {
         val staleActivityIds = prefs.all.entries.filter { (key, value) ->
             key.startsWith(TS_PREFIX) &&
@@ -70,9 +70,32 @@ internal class LiveNotificationStore(context: Context) {
                 staleActivityIds.forEach {
                     remove(TS_PREFIX + it)
                     remove(TYPE_PREFIX + it)
+                    remove(END_PREFIX + it)
                 }
             }
         }
+    }
+
+    // --- Terminal state (per activity_id) ---
+
+    /**
+     * True once [activityId] has reached a terminal state (local end, remote end,
+     * or user dismissal). `activity_id`s are unique per activity and `end` is
+     * terminal, so any later event for an ended id is stale and must be dropped.
+     */
+    fun isEnded(activityId: String): Boolean =
+        prefs.contains(END_PREFIX + activityId)
+
+    /**
+     * Marks [activityId] terminal, returning `true` only if this call set it (i.e.
+     * it was not already ended). Callers use the return value to report `end` at
+     * most once per id. The marker is never cleared per-id; it is reclaimed by
+     * [trimStaleTimestamps] (TTL) and [clearAllActivities] (logout).
+     */
+    fun markEnded(activityId: String, now: Long = System.currentTimeMillis()): Boolean {
+        if (prefs.contains(END_PREFIX + activityId)) return false
+        prefs.edit { putString(END_PREFIX + activityId, now.toString()) }
+        return true
     }
 
     // --- Activity type (per activity_id) ---
@@ -96,11 +119,11 @@ internal class LiveNotificationStore(context: Context) {
             .map { it.removePrefix(TYPE_PREFIX) }
             .toSet()
 
-    /** Clears all per-activity state (timestamps + types). Used on logout/reset. */
+    /** Clears all per-activity state (timestamps + types + ended markers). Used on logout/reset. */
     fun clearAllActivities() {
         prefs.edit {
             prefs.all.keys
-                .filter { it.startsWith(TS_PREFIX) || it.startsWith(TYPE_PREFIX) }
+                .filter { it.startsWith(TS_PREFIX) || it.startsWith(TYPE_PREFIX) || it.startsWith(END_PREFIX) }
                 .forEach { remove(it) }
         }
     }
@@ -110,6 +133,7 @@ internal class LiveNotificationStore(context: Context) {
         private const val REG_PREFIX = "reg:"
         private const val TS_PREFIX = "ts:"
         private const val TYPE_PREFIX = "type:"
+        private const val END_PREFIX = "end:"
 
         // Old built-in namespace, replaced by `io.customer.livenotifications.` — used only by migrate().
         private const val LEGACY_ACTIVITY_TYPE_PREFIX = "io.customer.liveactivities."

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationType.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationType.kt
@@ -1,19 +1,13 @@
 package io.customer.messagingpush.livenotification
 
 /**
- * Built-in live-notification activity type identifiers (reverse-DNS, matching
- * the iOS Live Activity identifiers).
+ * Built-in live-notification activity types for the SDK's bundled templates.
  *
- * Pass these — and/or your own custom type strings — to
- * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.setLiveNotificationTypes]
- * to enable live notifications. The feature is a no-op until at least one type
- * is enabled: nothing is registered with the backend and pushes for
- * non-enabled types are ignored.
+ * Pass these to [io.customer.messagingpush.MessagingPushModuleConfig.Builder.enableLiveNotificationTypes].
+ * For customer-defined types use `enableCustomLiveNotificationTypes` instead.
+ * The feature is a no-op until at least one type is enabled.
  */
-object LiveNotificationType {
-    const val DELIVERY_TRACKING = "io.customer.liveactivities.deliverytracking"
-    const val FLIGHT_STATUS = "io.customer.liveactivities.flightstatus"
-    const val LIVE_SCORE = "io.customer.liveactivities.livescore"
-    const val COUNTDOWN_TIMER = "io.customer.liveactivities.countdowntimer"
-    const val AUCTION_BID = "io.customer.liveactivities.auctionbid"
+enum class LiveNotificationType(val identifier: String) {
+    SEGMENTS("io.customer.livenotifications.segments"),
+    COUNTDOWN_TIMER("io.customer.livenotifications.countdowntimer")
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/ULID.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/ULID.kt
@@ -1,0 +1,62 @@
+package io.customer.messagingpush.livenotification
+
+import java.security.SecureRandom
+
+/**
+ * Generates canonical uppercase [ULID](https://github.com/ulid/spec) identifiers
+ * (26-char Crockford Base32) for locally-started live notifications.
+ */
+internal object ULID {
+    private const val ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+    private val secureRandom = SecureRandom()
+
+    /** Generate a new 26-character uppercase Crockford Base32 ULID. */
+    fun generate(timestampMillis: Long = System.currentTimeMillis()): String =
+        encodeTimestamp(clampToRange(timestampMillis)) + encodeRandomness(randomBytes())
+
+    private fun clampToRange(millis: Long): Long {
+        if (millis <= 0L) return 0L
+        val max = (1L shl 48) - 1L
+        return if (millis > max) max else millis
+    }
+
+    private fun encodeTimestamp(timestamp: Long): String {
+        val builder = StringBuilder(10)
+        for (index in 0 until 10) {
+            val shift = (9 - index) * 5
+            val value = ((timestamp shr shift) and 0x1F).toInt()
+            builder.append(ALPHABET[value])
+        }
+        return builder.toString()
+    }
+
+    private fun randomBytes(): ByteArray = ByteArray(10).also(secureRandom::nextBytes)
+
+    private fun encodeRandomness(bytes: ByteArray): String {
+        val builder = StringBuilder(16)
+        for (group in 0 until 16) {
+            var value = 0
+            for (offset in 0 until 5) {
+                val bitIndex = group * 5 + offset
+                val byte = bytes[bitIndex / 8].toInt() and 0xFF
+                val bit = (byte shr (7 - (bitIndex % 8))) and 1
+                value = (value shl 1) or bit
+            }
+            builder.append(ALPHABET[value])
+        }
+        return builder.toString()
+    }
+
+    /** Decode the millisecond timestamp from a ULID, or `null` if malformed. */
+    fun timestampMillis(ulid: String): Long? {
+        if (ulid.length != 26) return null
+        var timestamp = 0L
+        for (character in ulid.take(10)) {
+            val index = ALPHABET.indexOf(character)
+            if (index < 0) return null
+            timestamp = (timestamp shl 5) or index.toLong()
+        }
+        return timestamp
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/JsonExtensions.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/JsonExtensions.kt
@@ -1,16 +1,36 @@
 package io.customer.messagingpush.livenotification.template
 
+import android.graphics.Color
+import androidx.annotation.ColorInt
 import org.json.JSONObject
 
 /**
  * Returns the string value for [key], or null when the key is absent, holds an
  * explicit JSON null, or is empty.
- *
- * Prefer this over `optString(key).takeIf { it.isNotEmpty() }`: `optString`
- * returns the literal string `"null"` for an explicit JSON null, which would
- * otherwise slip past an `isNotEmpty()` guard and render as visible text.
  */
 internal fun JSONObject.optStringNonEmpty(key: String): String? {
     if (isNull(key)) return null
     return optString(key).takeIf { it.isNotEmpty() }
 }
+
+/**
+ * Parses [key] as a hex/named color to an `@ColorInt`, or null when
+ * absent/blank/unparseable. A leading `#` is added when missing.
+ */
+@ColorInt
+internal fun JSONObject.optColorInt(key: String): Int? {
+    val raw = optStringNonEmpty(key) ?: return null
+    val candidate = if (raw.startsWith("#")) raw else "#$raw"
+    return try {
+        Color.parseColor(candidate)
+    } catch (e: IllegalArgumentException) {
+        null
+    }
+}
+
+/**
+ * Reads [key] as an epoch-**seconds** value and returns it as epoch
+ * **milliseconds**, or null when the key is absent or non-positive.
+ */
+internal fun JSONObject.optEpochSecondsAsMillis(key: String): Long? =
+    optLong(key).takeIf { it > 0 }?.times(1000L)

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationFields.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/template/LiveNotificationFields.kt
@@ -1,74 +1,27 @@
 package io.customer.messagingpush.livenotification.template
 
 /**
- * Single source of truth for live-notification field names. Referenced by both
- * the push-render path (each `*Template.render` reading the flattened payload)
- * and the local-start path (`LiveNotificationData.fields()`), so the two can't
- * drift apart.
+ * Single source of truth for live-notification field names, shared by the
+ * push-render and local-start paths and matching the iOS property names.
  */
-internal object DeliveryTrackingFields {
-    const val ORDER_ID = "orderId"
-    const val RECIPIENT_NAME = "recipientName"
-    const val STATUS_MESSAGE = "statusMessage"
-    const val STATUS_IMAGE_KEY = "statusImageKey"
-    const val STEP_CURRENT = "stepCurrent"
-    const val STEP_TOTAL = "stepTotal"
-    const val ESTIMATED_ARRIVAL = "estimatedArrival"
-    const val DRIVER_NAME = "driverName"
+
+/** Freeform slots shared by both templates. */
+internal object CommonFields {
+    const val HEADER = "header"
 }
 
-internal object FlightStatusFields {
-    const val FLIGHT_NUMBER = "flightNumber"
-    const val ORIGIN = "origin"
-    const val DESTINATION = "destination"
-    const val STATUS_MESSAGE = "statusMessage"
-    const val GATE = "gate"
-    const val TERMINAL = "terminal"
-    const val SCHEDULED_DEPARTURE = "scheduledDeparture"
-    const val ESTIMATED_ARRIVAL = "estimatedArrival"
-    const val PROGRESS_FRACTION = "progressFraction"
-    const val DELAY_MINUTES = "delayMinutes"
-}
-
-internal object LiveScoreFields {
-    const val HOME_TEAM = "homeTeam"
-    const val AWAY_TEAM = "awayTeam"
-    const val HOME_SCORE = "homeScore"
-    const val AWAY_SCORE = "awayScore"
-    const val PERIOD = "period"
-    const val CLOCK = "clock"
-    const val STATUS_MESSAGE = "statusMessage"
-    const val SPORT = "sport"
-    const val LEAGUE_LOGO_KEY = "leagueLogoKey"
+internal object SegmentsFields {
+    const val HEADER = CommonFields.HEADER
+    const val STATUS = "status"
+    const val SUBSTATUS = "substatus"
+    const val SEGMENTS_TOTAL = "segmentsTotal"
+    const val SEGMENTS_COMPLETE = "segmentsComplete"
+    const val TRAILING_TEXT = "trailingText"
 }
 
 internal object CountdownTimerFields {
+    const val HEADER = CommonFields.HEADER
     const val TITLE = "title"
-    const val HERO_IMAGE_KEY = "heroImageKey"
-    const val TARGET_DATE = "targetDate"
     const val STATUS_MESSAGE = "statusMessage"
-    const val EXPIRED_MESSAGE = "expiredMessage"
-}
-
-internal object AuctionBidFields {
-    const val ITEM_TITLE = "itemTitle"
-    const val ITEM_IMAGE_KEY = "itemImageKey"
-    const val CURRENCY_SYMBOL = "currencySymbol"
-    const val CURRENT_BID = "currentBid"
-    const val BID_COUNT = "bidCount"
     const val END_TIME = "endTime"
-    const val STATUS_MESSAGE = "statusMessage"
-    const val IS_USER_HIGH_BIDDER = "isUserHighBidder"
-    const val USER_BID_AMOUNT = "userBidAmount"
-}
-
-/** Nested object sub-fields shared by templates that embed them. */
-internal object AirportFields {
-    const val CODE = "code"
-    const val CITY = "city"
-}
-
-internal object TeamFields {
-    const val NAME = "name"
-    const val LOGO_KEY = "logoKey"
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDataTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDataTest.kt
@@ -5,7 +5,7 @@ import io.customer.messagingpush.testutils.core.IntegrationTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
-import org.json.JSONObject
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -14,42 +14,82 @@ import org.robolectric.RobolectricTestRunner
 internal class LiveNotificationDataTest : IntegrationTest() {
 
     @Test
-    fun deliveryTracking_mapsActivityTypeAndScalarFields() {
-        val data = LiveNotificationData.DeliveryTracking(
-            orderId = "A-1",
-            statusMessage = "On the way",
-            stepCurrent = 1,
-            stepTotal = 3
+    fun segments_mapsActivityTypeAndFlatCounts() {
+        val data = LiveNotificationData.Segments(
+            header = "Order update",
+            status = "On the way",
+            segmentsTotal = 3,
+            segmentsComplete = 1
         )
 
-        data.activityType shouldBeEqualTo TemplateRegistry.DELIVERY_TRACKING
+        data.activityType shouldBeEqualTo TemplateRegistry.SEGMENTS
         val fields = data.fields()
-        fields["orderId"] shouldBeEqualTo "A-1"
-        fields["statusMessage"] shouldBeEqualTo "On the way"
-        fields["stepCurrent"] shouldBeEqualTo 1
-        fields["stepTotal"] shouldBeEqualTo 3
+        fields["status"] shouldBeEqualTo "On the way"
+        fields["header"] shouldBeEqualTo "Order update"
+        // Flat integer segment counts (matches iOS content-state), not a nested progress object.
+        fields["segmentsTotal"] shouldBeEqualTo 3
+        fields["segmentsComplete"] shouldBeEqualTo 1
         // Unset optional fields are present as null; the manager omits them from the envelope.
-        fields["recipientName"].shouldBeNull()
+        fields["substatus"].shouldBeNull()
+        fields["trailingText"].shouldBeNull()
     }
 
     @Test
-    fun flightStatus_nestedAirportsSerializeToJson() {
-        val data = LiveNotificationData.FlightStatus(
-            flightNumber = "AA1",
-            origin = LiveNotificationData.Airport("JFK", "New York"),
-            destination = LiveNotificationData.Airport("LAX"),
-            statusMessage = "On time"
+    fun segments_splitsStaticAttributesFromDynamicContentState() {
+        val data = LiveNotificationData.Segments(
+            header = "Order update",
+            status = "On the way",
+            substatus = "For Alex",
+            segmentsTotal = 3,
+            segmentsComplete = 1,
+            trailingText = "5 min"
         )
 
-        data.activityType shouldBeEqualTo TemplateRegistry.FLIGHT_STATUS
+        // Static (attributes): header only.
+        data.attributes().containsKey("header").shouldBeTrue()
+        data.attributes().containsKey("status").shouldBeFalse()
 
-        val origin = data.fields()["origin"] as JSONObject
-        origin.getString("code") shouldBeEqualTo "JFK"
-        origin.getString("city") shouldBeEqualTo "New York"
+        // Dynamic (contentState): status, substatus, flat counts, trailingText.
+        val contentState = data.contentState()
+        contentState["status"] shouldBeEqualTo "On the way"
+        contentState["substatus"] shouldBeEqualTo "For Alex"
+        contentState["segmentsTotal"] shouldBeEqualTo 3
+        contentState["segmentsComplete"] shouldBeEqualTo 1
+        contentState["trailingText"] shouldBeEqualTo "5 min"
+        contentState.containsKey("header").shouldBeFalse()
+    }
 
-        val destination = data.fields()["destination"] as JSONObject
-        destination.getString("code") shouldBeEqualTo "LAX"
-        // city omitted when not provided.
-        destination.has("city").shouldBeFalse()
+    @Test
+    fun countdownTimer_mapsActivityTypeAndSplitsAttributes() {
+        val data = LiveNotificationData.CountdownTimer(
+            header = "Limited time",
+            title = "Flash sale ends in",
+            statusMessage = "Hurry!",
+            endTime = 1700000000L
+        )
+
+        data.activityType shouldBeEqualTo TemplateRegistry.COUNTDOWN_TIMER
+
+        // Static (attributes): header only.
+        data.attributes().containsKey("header").shouldBeTrue()
+        data.attributes().containsKey("title").shouldBeFalse()
+
+        // Dynamic (contentState): title, statusMessage, endTime.
+        val contentState = data.contentState()
+        contentState["title"] shouldBeEqualTo "Flash sale ends in"
+        contentState["statusMessage"] shouldBeEqualTo "Hurry!"
+        contentState["endTime"] shouldBeEqualTo 1700000000L
+    }
+
+    @Test
+    fun countdownTimer_optionalFieldsAreNull() {
+        val data = LiveNotificationData.CountdownTimer(
+            header = "Limited time",
+            title = "Done"
+        )
+
+        val contentState = data.contentState()
+        contentState["statusMessage"].shouldBeNull()
+        contentState["endTime"].shouldBeNull()
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiverTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiverTest.kt
@@ -1,0 +1,31 @@
+package io.customer.messagingpush.livenotification
+
+import android.content.Intent
+import io.customer.messagingpush.di.liveNotificationStore
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.di.SDKComponent
+import org.amshove.kluent.shouldBeFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationDismissReceiverTest : IntegrationTest() {
+
+    private val type = "io.customer.livenotifications.segments"
+
+    @Test
+    fun onReceive_withoutFcmToken_doesNotMarkEnded() {
+        // With no device token the receiver can't report `end`, so it must NOT mark the
+        // id terminal — doing so would lose the end and block any later one.
+        SDKComponent.android().globalPreferenceStore.removeDeviceToken()
+        val intent = Intent().apply {
+            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_ID, "act-1")
+            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_TYPE, type)
+        }
+
+        LiveNotificationDismissReceiver().onReceive(contextMock, intent)
+
+        SDKComponent.liveNotificationStore.isEnded("act-1").shouldBeFalse()
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -1,112 +1,205 @@
 package io.customer.messagingpush.livenotification
 
+import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_LIVE_NOTIFICATION
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_LIVE_NOTIFICATION_TOKEN
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_END
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_START
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_UPDATE
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PLATFORM_ANDROID
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_ATTRIBUTES
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_CIO_INSTANCE_ID
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_CONTENT_STATE
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_DEVICE_ID
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_EVENT_TYPE
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_NOTIFICATION_TYPE
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_PLATFORM
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_PUSH_TO_START_TOKEN
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_REGISTRATION_TYPE
+import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.REGISTRATION_TYPE_PUSH_TO_START
 import io.customer.messagingpush.testutils.core.IntegrationTest
-import io.customer.sdk.core.network.CustomerIOHttpClient
-import io.customer.sdk.core.network.HttpMethod
-import io.customer.sdk.core.network.HttpRequestException
-import io.customer.sdk.core.network.HttpRequestParams
-import io.mockk.coEvery
-import io.mockk.coVerify
+import io.customer.sdk.core.pipeline.DataPipeline
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.test.runTest
+import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
-import org.amshove.kluent.shouldContain
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(InternalCustomerIOApi::class)
 @RunWith(RobolectricTestRunner::class)
 internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
 
-    private val httpClient: CustomerIOHttpClient = mockk()
-    private val client = LiveNotificationLifecycleClientImpl(httpClient)
+    private val pipeline: DataPipeline = mockk(relaxed = true)
+    private val client = LiveNotificationLifecycleClientImpl(dataPipelineProvider = { pipeline })
+
+    private fun identified() {
+        every { pipeline.isUserIdentified } returns true
+    }
 
     @Test
-    fun register_buildsPutWithAndroidFcmBody() = runTest {
-        val params = slot<HttpRequestParams>()
-        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+    fun reportStart_emitsLiveNotificationWithAttributesAndContentState() {
+        identified()
+        val name = slot<String>()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(capture(name), capture(props)) } returns Unit
 
-        val result = client.registerForActivityType(
-            activityType = "io.customer.liveactivities.deliverytracking",
-            token = "tok-1",
-            userId = "user-1"
+        client.reportStart(
+            instanceUUID = "inst-1",
+            activityType = "io.customer.livenotifications.segments",
+            deviceId = "fcm-tok",
+            attributes = mapOf("header" to "Order update"),
+            contentState = mapOf("title" to "On the way")
         )
 
-        result.isSuccess.shouldBeTrue()
-        params.captured.method shouldBeEqualTo HttpMethod.PUT
-        params.captured.path shouldBeEqualTo
-            "/v1/live_activities/registration/io.customer.liveactivities.deliverytracking"
-        val body = params.captured.body!!
-        body shouldContain "tok-1"
-        body shouldContain "\"os\":\"android\""
-        body shouldContain "\"transport\":\"fcm\""
-        body shouldContain "user-1"
+        name.captured shouldBeEqualTo EVENT_LIVE_NOTIFICATION
+        props.captured[PROP_EVENT_TYPE] shouldBeEqualTo EVENT_TYPE_START
+        props.captured[PROP_CIO_INSTANCE_ID] shouldBeEqualTo "inst-1"
+        props.captured[PROP_DEVICE_ID] shouldBeEqualTo "fcm-tok"
+        props.captured[PROP_PLATFORM] shouldBeEqualTo PLATFORM_ANDROID
+        props.captured[PROP_NOTIFICATION_TYPE] shouldBeEqualTo "io.customer.livenotifications.segments"
+        @Suppress("UNCHECKED_CAST")
+        (props.captured[PROP_ATTRIBUTES] as Map<String, Any?>)["header"] shouldBeEqualTo "Order update"
+        @Suppress("UNCHECKED_CAST")
+        (props.captured[PROP_CONTENT_STATE] as Map<String, Any?>)["title"] shouldBeEqualTo "On the way"
     }
 
     @Test
-    fun registerInstance_buildsPutPushTokenWithActivityType() = runTest {
-        val params = slot<HttpRequestParams>()
-        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+    fun reportStart_omitsAttributesAndContentStateWhenEmpty() {
+        identified()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(any(), capture(props)) } returns Unit
 
-        client.registerInstance(
-            activityId = "act-9",
-            activityType = "io.customer.liveactivities.deliverytracking",
-            token = "tok",
-            userId = "user"
+        client.reportStart("inst-1", "type", "fcm-tok", attributes = emptyMap(), contentState = emptyMap())
+
+        props.captured.containsKey(PROP_ATTRIBUTES).shouldBeFalse()
+        props.captured.containsKey(PROP_CONTENT_STATE).shouldBeFalse()
+    }
+
+    @Test
+    fun reportUpdate_emitsLiveNotificationWithContentStateOnly() {
+        identified()
+        val name = slot<String>()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(capture(name), capture(props)) } returns Unit
+
+        client.reportUpdate(
+            instanceUUID = "inst-2",
+            activityType = "io.customer.livenotifications.segments",
+            deviceId = "fcm-tok",
+            contentState = mapOf("title" to "Arriving")
         )
 
-        params.captured.method shouldBeEqualTo HttpMethod.PUT
-        params.captured.path shouldBeEqualTo "/v1/live_activities/act-9/push_token"
-        val body = params.captured.body!!
-        body shouldContain "\"activity_type\":\"io.customer.liveactivities.deliverytracking\""
-        body shouldContain "\"os\":\"android\""
-        body shouldContain "\"transport\":\"fcm\""
+        name.captured shouldBeEqualTo EVENT_LIVE_NOTIFICATION
+        props.captured[PROP_EVENT_TYPE] shouldBeEqualTo EVENT_TYPE_UPDATE
+        props.captured[PROP_CIO_INSTANCE_ID] shouldBeEqualTo "inst-2"
+        props.captured[PROP_DEVICE_ID] shouldBeEqualTo "fcm-tok"
+        props.captured[PROP_PLATFORM] shouldBeEqualTo PLATFORM_ANDROID
+        props.captured[PROP_NOTIFICATION_TYPE] shouldBeEqualTo "io.customer.livenotifications.segments"
+        // Update never carries static attributes.
+        props.captured.containsKey(PROP_ATTRIBUTES).shouldBeFalse()
+        @Suppress("UNCHECKED_CAST")
+        (props.captured[PROP_CONTENT_STATE] as Map<String, Any?>)["title"] shouldBeEqualTo "Arriving"
     }
 
     @Test
-    fun reportDismissed_buildsDeleteWithEmptyBody() = runTest {
-        val params = slot<HttpRequestParams>()
-        coEvery { httpClient.request(capture(params)) } returns Result.success("")
+    fun reportUpdate_omitsContentStateWhenEmpty() {
+        identified()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(any(), capture(props)) } returns Unit
 
-        client.reportDismissed("act-123")
+        client.reportUpdate("inst-2", "type", "fcm-tok", contentState = emptyMap())
 
-        params.captured.method shouldBeEqualTo HttpMethod.DELETE
-        params.captured.path shouldBeEqualTo "/v1/live_activities/act-123"
-        params.captured.body shouldBeEqualTo "{}"
+        props.captured.containsKey(PROP_CONTENT_STATE).shouldBeFalse()
     }
 
     @Test
-    fun send_retriesOn5xxUpToThreeAttempts() = runTest {
-        coEvery { httpClient.request(any()) } returns Result.failure(HttpRequestException(503, "boom"))
+    fun reportEnd_emitsLiveNotificationWithEndProperties() {
+        identified()
+        val name = slot<String>()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(capture(name), capture(props)) } returns Unit
 
-        val result = client.reportDismissed("act-1")
+        client.reportEnd(instanceUUID = "inst-9", activityType = "type-x", deviceId = "fcm-tok")
 
-        result.isFailure.shouldBeTrue()
-        coVerify(exactly = 3) { httpClient.request(any()) }
+        name.captured shouldBeEqualTo EVENT_LIVE_NOTIFICATION
+        props.captured[PROP_EVENT_TYPE] shouldBeEqualTo EVENT_TYPE_END
+        props.captured[PROP_CIO_INSTANCE_ID] shouldBeEqualTo "inst-9"
+        props.captured[PROP_NOTIFICATION_TYPE] shouldBeEqualTo "type-x"
+        props.captured[PROP_DEVICE_ID] shouldBeEqualTo "fcm-tok"
+        // No final content-state supplied: neither attributes nor contentState are sent.
+        props.captured.containsKey(PROP_ATTRIBUTES).shouldBeFalse()
+        props.captured.containsKey(PROP_CONTENT_STATE).shouldBeFalse()
     }
 
     @Test
-    fun send_doesNotRetryOn4xx() = runTest {
-        coEvery { httpClient.request(any()) } returns Result.failure(HttpRequestException(400, "bad request"))
+    fun reportEnd_withFinalContentState_carriesIt() {
+        identified()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(any(), capture(props)) } returns Unit
 
-        val result = client.reportDismissed("act-1")
-
-        result.isFailure.shouldBeTrue()
-        coVerify(exactly = 1) { httpClient.request(any()) }
-    }
-
-    @Test
-    fun send_succeedsAfterTransientFailure() = runTest {
-        coEvery { httpClient.request(any()) } returnsMany listOf(
-            Result.failure(HttpRequestException(500, "x")),
-            Result.success("")
+        client.reportEnd(
+            instanceUUID = "inst-9",
+            activityType = "type-x",
+            deviceId = "fcm-tok",
+            contentState = mapOf("title" to "Delivered")
         )
 
-        val result = client.reportDismissed("act-1")
+        @Suppress("UNCHECKED_CAST")
+        (props.captured[PROP_CONTENT_STATE] as Map<String, Any?>)["title"] shouldBeEqualTo "Delivered"
+    }
 
-        result.isSuccess.shouldBeTrue()
-        coVerify(exactly = 2) { httpClient.request(any()) }
+    @Test
+    fun registerPushToStart_emitsTokenEventWithFcmAsBothIds() {
+        identified()
+        val name = slot<String>()
+        val props = slot<Map<String, Any?>>()
+        every { pipeline.track(capture(name), capture(props)) } returns Unit
+
+        val emitted = client.registerPushToStart(activityType = "type-x", deviceId = "fcm-tok")
+
+        emitted.shouldBeTrue()
+        name.captured shouldBeEqualTo EVENT_LIVE_NOTIFICATION_TOKEN
+        props.captured[PROP_REGISTRATION_TYPE] shouldBeEqualTo REGISTRATION_TYPE_PUSH_TO_START
+        props.captured[PROP_PLATFORM] shouldBeEqualTo PLATFORM_ANDROID
+        props.captured[PROP_DEVICE_ID] shouldBeEqualTo "fcm-tok"
+        props.captured[PROP_PUSH_TO_START_TOKEN] shouldBeEqualTo "fcm-tok"
+    }
+
+    @Test
+    fun lifecycleEvents_areDroppedForAnonymousUser() {
+        every { pipeline.isUserIdentified } returns false
+
+        client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
+        client.reportUpdate("inst-1", "type", "fcm-tok", emptyMap())
+        client.reportEnd("inst-1", "type", "fcm-tok")
+
+        verify(exactly = 0) { pipeline.track(any(), any()) }
+    }
+
+    @Test
+    fun registerPushToStart_isNotGatedByPipelineIdentity() {
+        // Identity is gated upstream by LiveNotificationRegistrar; the client must NOT re-check the
+        // laggy isUserIdentified flag for the registration event (that re-introduced the login race).
+        every { pipeline.isUserIdentified } returns false
+        every { pipeline.track(any(), any()) } returns Unit
+
+        val emitted = client.registerPushToStart("type", "fcm-tok")
+
+        emitted.shouldBeTrue()
+        verify(exactly = 1) { pipeline.track(EVENT_LIVE_NOTIFICATION_TOKEN, any()) }
+    }
+
+    @Test
+    fun events_areDroppedWhenPipelineUnavailable() {
+        val noPipeline = LiveNotificationLifecycleClientImpl(dataPipelineProvider = { null })
+
+        val emitted = noPipeline.registerPushToStart("type", "fcm-tok")
+
+        emitted.shouldBeFalse()
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -38,7 +38,9 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     private val client = LiveNotificationLifecycleClientImpl(dataPipelineProvider = { pipeline })
 
     private fun identified() {
-        every { pipeline.isUserIdentified } returns true
+        // Identity is fed synchronously via setIdentified (from UserChangedEvent), not
+        // read from the pipeline's laggy isUserIdentified flag.
+        client.setIdentified(true)
     }
 
     @Test
@@ -172,7 +174,7 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
 
     @Test
     fun lifecycleEvents_areDroppedForAnonymousUser() {
-        every { pipeline.isUserIdentified } returns false
+        client.setIdentified(false)
 
         client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
         client.reportUpdate("inst-1", "type", "fcm-tok", emptyMap())
@@ -182,10 +184,24 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     }
 
     @Test
-    fun registerPushToStart_isNotGatedByPipelineIdentity() {
-        // Identity is gated upstream by LiveNotificationRegistrar; the client must NOT re-check the
-        // laggy isUserIdentified flag for the registration event (that re-introduced the login race).
+    fun lifecycleEvents_gateOnSyncIdentityNotPipelineFlag() {
+        // The pipeline's own flag lags a synchronous identify(); the client must gate on
+        // the identity fed via setIdentified (from UserChangedEvent) so the first event
+        // right after login isn't dropped.
         every { pipeline.isUserIdentified } returns false
+        every { pipeline.track(any(), any()) } returns Unit
+        client.setIdentified(true)
+
+        client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
+
+        verify(exactly = 1) { pipeline.track(EVENT_LIVE_NOTIFICATION, any()) }
+    }
+
+    @Test
+    fun registerPushToStart_isNotGatedByIdentity() {
+        // Identity is gated upstream by LiveNotificationRegistrar; the client must NOT
+        // re-check identity for the registration event (that re-introduced the login race).
+        client.setIdentified(false)
         every { pipeline.track(any(), any()) } returns Unit
 
         val emitted = client.registerPushToStart("type", "fcm-tok")

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
@@ -1,8 +1,12 @@
 package io.customer.messagingpush.livenotification
 
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
 import io.mockk.mockk
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEmpty
@@ -27,6 +31,19 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
     private val manager = LiveNotificationManager(lifecycleClient)
 
     private val type = "io.customer.livenotifications.segments"
+
+    override fun setup(testConfig: TestConfig) {
+        // Render runs on the background dispatcher; the stub makes it inline+synchronous.
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
+                    }
+                }
+            } + testConfig
+        )
+    }
 
     private fun saveToken() = SDKComponent.android().globalPreferenceStore.saveDeviceToken("fcm-tok")
 
@@ -92,6 +109,19 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
         manager.end("act-1")
 
         store.activityType("act-1").shouldBeNull()
+    }
+
+    @Test
+    fun end_afterLocalStart_reportsEndEvenWhenTypeNotPersisted() {
+        // A local start remembers the type for its id, so end() reports a matching
+        // end even if the render never persisted the activity type.
+        saveToken()
+        manager.start("act-1", type, attributes = emptyMap(), contentState = mapOf("title" to "Preparing"))
+        SDKComponent.liveNotificationStore.clearActivityType("act-1")
+
+        manager.end("act-1")
+
+        verify { lifecycleClient.reportEnd("act-1", type, "fcm-tok") }
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
@@ -1,0 +1,120 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.messagingpush.di.liveNotificationStore
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.di.SDKComponent
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [LiveNotificationManager], the on-device (client-initiated) path.
+ *
+ * Local start/update are reported to Customer.io; push-delivered start/update
+ * are backend-initiated and reported by neither the manager nor the handler
+ * (see [io.customer.messagingpush.LiveNotificationHandler]). Reporting happens
+ * after rendering regardless of whether the type is enabled, so these tests do
+ * not need a module config attached.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationManagerTest : IntegrationTest() {
+
+    private val lifecycleClient: LiveNotificationLifecycleClient = mockk(relaxed = true)
+    private val manager = LiveNotificationManager(lifecycleClient)
+
+    private val type = "io.customer.livenotifications.segments"
+
+    private fun saveToken() = SDKComponent.android().globalPreferenceStore.saveDeviceToken("fcm-tok")
+
+    @Test
+    fun start_reportsStartEventWithAttributesAndContentState() {
+        saveToken()
+
+        manager.start(
+            "act-1",
+            type,
+            attributes = mapOf("header" to "Order update"),
+            contentState = mapOf("title" to "Preparing")
+        )
+
+        verify { lifecycleClient.reportStart("act-1", type, "fcm-tok", any(), any()) }
+    }
+
+    @Test
+    fun update_reportsUpdateEventWithContentState() {
+        saveToken()
+
+        manager.update(
+            "act-1",
+            type,
+            attributes = emptyMap(),
+            contentState = mapOf("title" to "Arriving")
+        )
+
+        verify { lifecycleClient.reportUpdate("act-1", type, "fcm-tok", any()) }
+    }
+
+    @Test
+    fun update_withoutFcmToken_doesNotReport() {
+        SDKComponent.android().globalPreferenceStore.removeDeviceToken()
+
+        manager.update(
+            "act-1",
+            type,
+            attributes = emptyMap(),
+            contentState = mapOf("title" to "Arriving")
+        )
+
+        verify(exactly = 0) { lifecycleClient.reportUpdate(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun end_reportsEndUsingStoredType() {
+        saveToken()
+        // The SDK records the type when it renders the activity; the host ends with just the id.
+        SDKComponent.liveNotificationStore.setActivityType("act-1", type)
+
+        manager.end("act-1")
+
+        verify { lifecycleClient.reportEnd("act-1", type, "fcm-tok") }
+    }
+
+    @Test
+    fun end_clearsStoredActivityType() {
+        saveToken()
+        val store = SDKComponent.liveNotificationStore
+        store.setActivityType("act-1", type)
+
+        manager.end("act-1")
+
+        store.activityType("act-1").shouldBeNull()
+    }
+
+    @Test
+    fun end_unknownActivity_doesNotReport() {
+        saveToken()
+        SDKComponent.liveNotificationStore.clearActivityType("act-unknown")
+
+        manager.end("act-unknown")
+
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any()) }
+    }
+
+    @Test
+    fun cancelAllActivities_clearsTrackedStateWithoutReporting() {
+        saveToken()
+        val store = SDKComponent.liveNotificationStore
+        store.setActivityType("act-1", type)
+        store.setActivityType("act-2", type)
+
+        manager.cancelAllActivities()
+
+        store.trackedActivityIds().shouldBeEmpty()
+        // Logout must NOT emit end events.
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any()) }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
@@ -135,6 +135,19 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
     }
 
     @Test
+    fun end_afterCancelAllActivities_reportsNothing() {
+        // Logout must drop cached bundles too, so a later end() for a recycled id
+        // can't resurrect a previous session's activity.
+        saveToken()
+        manager.start("act-1", type, attributes = emptyMap(), contentState = mapOf("title" to "Preparing"))
+
+        manager.cancelAllActivities()
+        manager.end("act-1")
+
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any()) }
+    }
+
+    @Test
     fun cancelAllActivities_clearsTrackedStateWithoutReporting() {
         saveToken()
         val store = SDKComponent.liveNotificationStore

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
@@ -1,0 +1,80 @@
+package io.customer.messagingpush.livenotification
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.extensions.attachToSDKComponent
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.communication.Event
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [LiveNotificationRegistrar]'s identity gate.
+ *
+ * The registrar registers push-to-start tokens only for identified users, deriving identity from
+ * [Event.UserChangedEvent] (which carries the userId synchronously) rather than the data pipeline's
+ * asynchronously-updated `isUserIdentified` flag — that flag can still read false on the login turn,
+ * which used to drop the registration with no retry (the G5 race).
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationRegistrarTest : IntegrationTest() {
+
+    private val client: LiveNotificationLifecycleClient = mockk(relaxed = true)
+    private val store: LiveNotificationStore = mockk(relaxed = true)
+    private val type = "io.customer.livenotifications.segments"
+
+    private lateinit var registrar: LiveNotificationRegistrar
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder()
+                .enableLiveNotificationTypes(LiveNotificationType.SEGMENTS)
+                .build()
+        ).attachToSDKComponent()
+        every { store.registrationSignature(any()) } returns null
+        every { client.registerPushToStart(any(), any()) } returns true
+        registrar = LiveNotificationRegistrar(client, store)
+    }
+
+    @Test
+    fun register_firesForIdentifiedUser_evenIfPipelineFlagWouldLag() {
+        registrar.onDeviceTokenChanged("fcm-tok")
+        // Identify: the event carries the userId synchronously even though the pipeline's
+        // isUserIdentified flag may still read false at this instant. Registration must fire.
+        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
+
+        verify(exactly = 1) { client.registerPushToStart(type, "fcm-tok") }
+        verify { store.setRegistrationSignature(type, "fcm-tok|u1") }
+    }
+
+    @Test
+    fun register_skippedForAnonymousUser() {
+        registrar.onDeviceTokenChanged("fcm-tok")
+        registrar.onUserChanged(Event.UserChangedEvent(userId = null, anonymousId = "anon"))
+
+        verify(exactly = 0) { client.registerPushToStart(any(), any()) }
+    }
+
+    @Test
+    fun register_defersUntilIdentified_whenTokenArrivesFirstWhileAnonymous() {
+        // Token before any identify → nothing registered yet (still anonymous).
+        registrar.onDeviceTokenChanged("fcm-tok")
+        verify(exactly = 0) { client.registerPushToStart(any(), any()) }
+
+        // Later identify → the held token registers.
+        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
+        verify(exactly = 1) { client.registerPushToStart(type, "fcm-tok") }
+    }
+
+    @Test
+    fun register_skipped_whenNoTokenYet() {
+        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
+        verify(exactly = 0) { client.registerPushToStart(any(), any()) }
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
@@ -62,6 +62,28 @@ internal class LiveNotificationRegistrarTest : IntegrationTest() {
     }
 
     @Test
+    fun onUserChanged_feedsIdentityToLifecycleClient() {
+        // The client gates local lifecycle events on this synchronous signal instead of
+        // the pipeline's laggy isUserIdentified flag (avoids dropping the first event after login).
+        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
+        verify { client.setIdentified(true) }
+
+        registrar.onUserChanged(Event.UserChangedEvent(userId = null, anonymousId = "anon"))
+        verify { client.setIdentified(false) }
+    }
+
+    @Test
+    fun onReset_clearsLifecycleIdentity() {
+        // Logout must gate off local lifecycle reporting until a new identify, so the
+        // client's identity is reset to false on reset.
+        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
+
+        registrar.onReset()
+
+        verify { client.setIdentified(false) }
+    }
+
+    @Test
     fun register_defersUntilIdentified_whenTokenArrivesFirstWhileAnonymous() {
         // Token before any identify → nothing registered yet (still anonymous).
         registrar.onDeviceTokenChanged("fcm-tok")

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
@@ -77,4 +77,12 @@ internal class LiveNotificationRegistrarTest : IntegrationTest() {
         registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
         verify(exactly = 0) { client.registerPushToStart(any(), any()) }
     }
+
+    @Test
+    fun tokenDeleted_clearsRegistrationSignatures() {
+        // Otherwise re-registering the same token later would be deduped away.
+        registrar.onDeviceTokenDeleted()
+
+        verify { store.clearRegistrations() }
+    }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
@@ -3,7 +3,9 @@ package io.customer.messagingpush.livenotification
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -93,6 +95,40 @@ internal class LiveNotificationStoreTest : IntegrationTest() {
         store.trimStaleTimestamps(ttlMs = ttl, now = now)
 
         store.activityType("old").shouldBeNull()
+    }
+
+    @Test
+    fun markEnded_claimsOnceAndReportsTerminalState() {
+        store.isEnded("act-1").shouldBeFalse()
+
+        // First mark wins (claims the terminal transition); repeats return false.
+        store.markEnded("act-1").shouldBeTrue()
+        store.isEnded("act-1").shouldBeTrue()
+        store.markEnded("act-1").shouldBeFalse()
+        store.markEnded("act-1").shouldBeFalse()
+    }
+
+    @Test
+    fun clearAllActivities_removesEndedMarker() {
+        store.markEnded("a1")
+        store.setActivityType("a1", "type.a")
+
+        store.clearAllActivities()
+
+        store.isEnded("a1").shouldBeFalse()
+    }
+
+    @Test
+    fun trimStaleTimestamps_alsoRemovesEndedMarker() {
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        store.setLastTimestamp("old", 1L, now = now - ttl - 1)
+        store.markEnded("old")
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.isEnded("old").shouldBeFalse()
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
@@ -1,8 +1,10 @@
 package io.customer.messagingpush.livenotification
 
 import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContainSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -52,5 +54,71 @@ internal class LiveNotificationStoreTest : IntegrationTest() {
 
         store.lastTimestamp("old").shouldBeNull()
         store.lastTimestamp("fresh") shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun activityType_setGetClear() {
+        store.activityType("act-1").shouldBeNull()
+
+        store.setActivityType("act-1", "io.customer.livenotifications.segments")
+        store.activityType("act-1") shouldBeEqualTo "io.customer.livenotifications.segments"
+
+        store.clearActivityType("act-1")
+        store.activityType("act-1").shouldBeNull()
+    }
+
+    @Test
+    fun trackedActivityIds_andClearAllActivities() {
+        store.setActivityType("a1", "type.a")
+        store.setActivityType("a2", "type.b")
+        store.setLastTimestamp("a1", 5L)
+
+        store.trackedActivityIds() shouldContainSame setOf("a1", "a2")
+
+        store.clearAllActivities()
+
+        store.trackedActivityIds().shouldBeEmpty()
+        store.activityType("a1").shouldBeNull()
+        store.lastTimestamp("a1").shouldBeNull()
+    }
+
+    @Test
+    fun trimStaleTimestamps_alsoRemovesPairedActivityType() {
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        store.setLastTimestamp("old", 1L, now = now - ttl - 1)
+        store.setActivityType("old", "io.customer.livenotifications.segments")
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.activityType("old").shouldBeNull()
+    }
+
+    @Test
+    fun migrate_clearsOldNamespaceRegistrationsAndKeepsNewOnes() {
+        // Legacy registrations recorded under the old `io.customer.liveactivities.*` namespace...
+        store.setRegistrationSignature("io.customer.liveactivities.deliverytracking", "tok|user")
+        store.setRegistrationSignature("io.customer.liveactivities.auctionbid", "tok|user")
+        // ...alongside new-namespace and custom-type registrations that must survive.
+        store.setRegistrationSignature("io.customer.livenotifications.segments", "tok|user")
+        store.setRegistrationSignature("com.acme.custom", "tok|user")
+
+        store.migrate()
+
+        store.registrationSignature("io.customer.liveactivities.deliverytracking").shouldBeNull()
+        store.registrationSignature("io.customer.liveactivities.auctionbid").shouldBeNull()
+        store.registrationSignature("io.customer.livenotifications.segments") shouldBeEqualTo "tok|user"
+        store.registrationSignature("com.acme.custom") shouldBeEqualTo "tok|user"
+    }
+
+    @Test
+    fun migrate_isIdempotentAndSafeWhenNothingStale() {
+        store.setRegistrationSignature("io.customer.livenotifications.segments", "tok|user")
+
+        store.migrate()
+        store.migrate()
+
+        store.registrationSignature("io.customer.livenotifications.segments") shouldBeEqualTo "tok|user"
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/ULIDTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/ULIDTest.kt
@@ -1,0 +1,87 @@
+package io.customer.messagingpush.livenotification
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeIn
+import org.amshove.kluent.shouldBeLessThan
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+
+internal class ULIDTest {
+    private val crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ".toSet()
+
+    @Test
+    fun generate_givenAnyTimestamp_isExactly26Characters() {
+        repeat(1000) { ULID.generate().length shouldBeEqualTo 26 }
+    }
+
+    @Test
+    fun generate_givenAnyTimestamp_usesOnlyCrockfordAlphabet() {
+        repeat(1000) {
+            ULID.generate().all { it in crockfordAlphabet }.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun generate_givenAnyTimestamp_isUppercase() {
+        repeat(1000) {
+            val ulid = ULID.generate()
+            ulid shouldBeEqualTo ulid.uppercase()
+        }
+    }
+
+    @Test
+    fun generate_givenAnyTimestamp_leadingCharacterIsAtMost7() {
+        // 26 * 5 = 130 bits but the value is 128 bits, so the first character carries just
+        // 3 significant timestamp bits and can never exceed '7'.
+        repeat(1000) { ULID.generate().first() shouldBeIn "01234567".toList() }
+    }
+
+    @Test
+    fun generate_givenCanonicalSpecTimestamp_encodesKnownPrefix() {
+        // Canonical ULID spec example: 1469918176385 ms -> timestamp prefix "01ARYZ6S41"
+        // (full spec ULID 01ARYZ6S41QJQECH4KPG6SEF3Y).
+        ULID.generate(timestampMillis = 1_469_918_176_385L).take(10) shouldBeEqualTo "01ARYZ6S41"
+    }
+
+    @Test
+    fun generate_givenEpoch_encodesAllZeroPrefix() {
+        ULID.generate(timestampMillis = 0L).take(10) shouldBeEqualTo "0000000000"
+    }
+
+    @Test
+    fun generate_givenManyIterations_producesUniqueValues() {
+        val seen = HashSet<String>()
+        repeat(10_000) { seen.add(ULID.generate()).shouldBeTrue() }
+    }
+
+    @Test
+    fun generate_givenSameTimestamp_randomnessDiffers() {
+        val a = ULID.generate(timestampMillis = 1_700_000_000_000L)
+        val b = ULID.generate(timestampMillis = 1_700_000_000_000L)
+        a.take(10) shouldBeEqualTo b.take(10)
+        (a.takeLast(16) != b.takeLast(16)).shouldBeTrue()
+    }
+
+    @Test
+    fun generate_givenIncreasingTimestamps_sortsLexicographically() {
+        val earlier = ULID.generate(timestampMillis = 1_000L)
+        val middle = ULID.generate(timestampMillis = 1_700_000_000_000L)
+        val later = ULID.generate(timestampMillis = 4_000_000_000_000L)
+        earlier shouldBeLessThan middle
+        middle shouldBeLessThan later
+    }
+
+    @Test
+    fun timestampMillis_givenGeneratedULID_roundTripsValue() {
+        val expected = 1_700_000_000_000L
+        ULID.timestampMillis(ULID.generate(timestampMillis = expected)) shouldBeEqualTo expected
+    }
+
+    @Test
+    fun timestampMillis_givenMalformedInput_returnsNull() {
+        ULID.timestampMillis("TOOSHORT").shouldBeNull()
+        // 'I' is excluded from the Crockford alphabet.
+        ULID.timestampMillis("I" + "0".repeat(25)).shouldBeNull()
+    }
+}


### PR DESCRIPTION
Part **1 of 2** of the iOS-parity SDK refactor (splitting #779).

Contains the first two concern-commits:
- `CDP contract & field model` (event names/keys, `cioInstanceId`, epoch-seconds, 2-type field model)
- `registration, store & local lifecycle`

⚠️ **This PR does not compile on its own — that's expected.** It's the first half of an atomic refactor: the contract + registration land before their branding/templates/rendering consumers, which are in **part 2 (#779)**. Review it for the contract + registration/lifecycle design; CI red here is intentional. Merges together with part 2 into `feature/live-notifications`.

Split from #765.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public contract (activity types, field model, lifecycle transport) and complex state machines (terminal dedup, identity gating, logout races) in push/messaging core; intended to merge atomically with part 2.
> 
> **Overview**
> **Part 1 of 2** realigns Android live notifications with iOS: new wire keys (`cioInstanceId`), epoch-second timestamps, and a two-template built-in model (**Segments**, **CountdownTimer**) with separate **attributes** vs **contentState** on local start payloads. The five legacy built-in types (`io.customer.liveactivities.*`) are removed in favor of `io.customer.livenotifications.*`.
> 
> **Backend integration** moves off REST (`/v1/live_activities/...`) onto the CDP **`DataPipeline`**: `Live Notification Event` (`start` / `update` / `end`) and `Live Notification Token` (`register_push_to_start`), with FCM token as `deviceId` / `pushToStartToken`. Push routing now keys off `LiveNotificationHandler.CIO_INSTANCE_ID_KEY` instead of `activity_id`.
> 
> **Local lifecycle** expands: `LiveNotificationManager` handles **start / update / end** (terminal re-render vs cancel), chained background renders, logout invalidation, and lifecycle reporting even when render fails. `LiveNotificationStore` adds **ended** markers, per-id activity types, legacy registration **migration**, and TTL cleanup. User dismissals emit **`end`** once via `markEnded` (skipped if no FCM token). Registration runs only for **identified** users, with identity fed synchronously from `UserChangedEvent` to avoid post-login drops.
> 
> Adds **ULID** generation for local instance IDs and `toJsonSafePayload()` for track properties. Extensive unit tests cover the new client, manager, registrar, store, and dismiss behavior. **Does not compile alone** until part 2 lands handler/templates/API renames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c8358c9a966bc1f90be0d83e22b872906dd019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->