### PR TITLE
fix(inbox): overlay QA fixes, custom fonts + dedicated CDP metric events

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -229,7 +229,8 @@ public final class io/customer/messaginginapp/inbox/NotificationInbox {
 	public final fun removeChangeListener (Lio/customer/messaginginapp/inbox/NotificationInboxChangeListener;)V
 	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
 	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;)V
-	public static synthetic fun trackMessageClicked$default (Lio/customer/messaginginapp/inbox/NotificationInbox;Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun trackMessageClicked$default (Lio/customer/messaginginapp/inbox/NotificationInbox;Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/customer/messaginginapp/inbox/NotificationInboxChangeListener {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -230,7 +230,7 @@ public final class io/customer/messaginginapp/inbox/NotificationInbox {
 	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
 	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;)V
 	public final fun trackMessageClicked (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun trackMessageClicked$default (Lio/customer/messaginginapp/inbox/NotificationInbox;Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun trackMessageClicked$default (Lio/customer/messaginginapp/inbox/NotificationInbox;Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/customer/messaginginapp/inbox/NotificationInboxChangeListener {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/NotificationInbox.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/NotificationInbox.kt
@@ -239,13 +239,16 @@ class NotificationInbox internal constructor(
      *
      * @param message The inbox message that was clicked
      * @param actionName Optional name of the action clicked (e.g., "view_details", "dismiss")
+     * @param actionValue Optional value of the action clicked (e.g., the deep link / URL). Included
+     *   in the `Report Delivery Event` (metric: clicked) alongside the name, matching web.
      */
     @JvmOverloads
-    fun trackMessageClicked(message: InboxMessage, actionName: String? = null) {
+    fun trackMessageClicked(message: InboxMessage, actionName: String? = null, actionValue: String? = null) {
         inAppMessagingManager.dispatch(
             InAppMessagingAction.InboxAction.TrackClicked(
                 message = message,
-                actionName = actionName
+                actionName = actionName,
+                actionValue = actionValue
             )
         )
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/NotificationInbox.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/NotificationInbox.kt
@@ -239,11 +239,27 @@ class NotificationInbox internal constructor(
      *
      * @param message The inbox message that was clicked
      * @param actionName Optional name of the action clicked (e.g., "view_details", "dismiss")
-     * @param actionValue Optional value of the action clicked (e.g., the deep link / URL). Included
-     *   in the `Report Delivery Event` (metric: clicked) alongside the name, matching web.
      */
     @JvmOverloads
-    fun trackMessageClicked(message: InboxMessage, actionName: String? = null, actionValue: String? = null) {
+    fun trackMessageClicked(message: InboxMessage, actionName: String? = null) {
+        trackMessageClicked(message, actionName, actionValue = null)
+    }
+
+    /**
+     * Tracks a click event for an inbox message, including the clicked action's value.
+     * Sends metric event to data pipelines to track message interaction.
+     *
+     * This is a separate overload rather than a third defaulted parameter on the two-arg method
+     * above: adding a default to that method would change its generated `$default` synthetic
+     * signature and break precompiled Kotlin integrations that call `trackMessageClicked(message)`
+     * / `trackMessageClicked(message, actionName)` against a released SDK (`NoSuchMethodError`).
+     *
+     * @param message The inbox message that was clicked
+     * @param actionName Name of the action clicked (e.g., "view_details", "dismiss")
+     * @param actionValue Value of the action clicked (e.g., the deep link / URL). Included in the
+     *   `Report Delivery Event` (metric: clicked) alongside the name, matching web.
+     */
+    fun trackMessageClicked(message: InboxMessage, actionName: String?, actionValue: String?) {
         inAppMessagingManager.dispatch(
             InAppMessagingAction.InboxAction.TrackClicked(
                 message = message,

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/VisualInbox.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/VisualInbox.kt
@@ -83,9 +83,13 @@ class VisualInbox internal constructor(
 
     fun markMessageDeleted(message: InboxMessage) = notificationInbox.markMessageDeleted(message)
 
+    // Inbox click reporting goes through the existing generic "Report Delivery Event" metric (the
+    // in-app middleware publishes it for opened/clicked via TrackInAppMetricEvent), carrying both the
+    // action name AND value so it matches web — the CDP backend renders it as "Clicked Inbox Message"
+    // for an inbox delivery. No separate named CDP event is emitted (web doesn't send one either).
     @JvmOverloads
-    fun trackMessageClicked(message: InboxMessage, actionName: String? = null) =
-        notificationInbox.trackMessageClicked(message, actionName)
+    fun trackMessageClicked(message: InboxMessage, actionName: String? = null, actionValue: String? = null) =
+        notificationInbox.trackMessageClicked(message, actionName, actionValue)
 }
 
 /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
@@ -31,7 +31,7 @@ internal sealed class InAppMessagingAction {
     sealed class InboxAction(open val message: InboxMessage) : InAppMessagingAction() {
         data class UpdateOpened(override val message: InboxMessage, val opened: Boolean) : InboxAction(message)
         data class DeleteMessage(override val message: InboxMessage) : InboxAction(message)
-        data class TrackClicked(override val message: InboxMessage, val actionName: String?) : InboxAction(message)
+        data class TrackClicked(override val message: InboxMessage, val actionName: String?, val actionValue: String? = null) : InboxAction(message)
     }
 
     data class ClearMessageQueue(val isContentEmpty: Boolean) : InAppMessagingAction()

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -285,8 +285,15 @@ internal fun processInboxMessages() = middleware<InAppMessagingState> { store, n
                     }
 
                     is InAppMessagingAction.InboxAction.TrackClicked -> {
-                        // Track click metric for analytics
-                        val params = action.actionName?.let { mapOf("actionName" to it) } ?: emptyMap()
+                        // Track click metric for analytics via the generic "Report Delivery Event"
+                        // (metric: clicked), carrying the action name AND value to match web — the CDP
+                        // backend renders it as "Clicked Inbox Message" for an inbox delivery.
+                        // Omit empty name/value so a value-less action doesn't emit `actionValue: ""`
+                        // — web omits the field entirely when there is no value.
+                        val params = buildMap {
+                            action.actionName?.takeIf { it.isNotEmpty() }?.let { put("actionName", it) }
+                            action.actionValue?.takeIf { it.isNotEmpty() }?.let { put("actionValue", it) }
+                        }
 
                         logger.debug("Inbox message clicked: ${currentMessage.toLogString()}")
                         currentMessage.deliveryId?.let { deliveryId ->

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/inbox/NotificationInboxTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/inbox/NotificationInboxTest.kt
@@ -243,6 +243,29 @@ class NotificationInboxTest : IntegrationTest() {
     }
 
     @Test
+    fun trackMessageClicked_givenActionNameAndValue_expectMetricEventPublishedWithBoth() = runTest {
+        val deliveryId = "inbox1"
+        val message = createInboxMessage(deliveryId = deliveryId, queueId = "queue-123", opened = false)
+
+        initializeAndSetUser()
+        manager.dispatch(InAppMessagingAction.ProcessInboxMessages(listOf(message)))
+
+        // The three-arg overload (kept separate from the two-arg method for binary compatibility)
+        // carries actionValue through to the metric params alongside actionName.
+        notificationInbox.trackMessageClicked(message, "view_details", "https://example.com")
+
+        verify {
+            mockEventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = deliveryId,
+                    event = Metric.Clicked,
+                    params = mapOf("actionName" to "view_details", "actionValue" to "https://example.com")
+                )
+            )
+        }
+    }
+
+    @Test
     fun addChangeListener_givenNoTopicFilter_expectListenerReceivesAllMessages() = runTest {
         initializeAndSetUser()
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
@@ -680,6 +680,42 @@ class InAppMessagingMiddlewaresTest : JUnitTest() {
     }
 
     @Test
+    fun processInboxMessages_givenTrackClickedWithActionValue_shouldPublishMetricWithNameAndValue() {
+        // Given an inbox message in state
+        val deliveryId = String.random
+        val queueId = String.random
+        val inboxMessage = createInboxMessage(deliveryId = deliveryId, queueId = queueId, opened = false)
+
+        val state = InAppMessagingState(
+            siteId = String.random,
+            dataCenter = String.random,
+            inboxMessages = setOf(inboxMessage)
+        )
+        every { store.state } returns state
+
+        val actionName = "view_details"
+        val actionValue = "https://example.com"
+        val action = InAppMessagingAction.InboxAction.TrackClicked(inboxMessage, actionName, actionValue)
+
+        // When the middleware processes the action
+        val middleware = processInboxMessages()
+        middleware(store)(nextFn)(action)
+
+        // Then it should publish a generic "Report Delivery Event" (Metric.Clicked) carrying BOTH the
+        // action name and value (web parity) — no separate named inbox event.
+        verify {
+            mockEventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = deliveryId,
+                    event = Metric.Clicked,
+                    params = mapOf("actionName" to actionName, "actionValue" to actionValue)
+                )
+            )
+        }
+        verify { nextFn(action) }
+    }
+
+    @Test
     fun processInboxMessages_givenTrackClickedWithoutActionName_shouldPublishMetricWithoutParams() {
         // Given an inbox message in state
         val deliveryId = String.random
@@ -712,6 +748,38 @@ class InAppMessagingMiddlewaresTest : JUnitTest() {
         }
 
         // And it should pass the action to the next middleware/reducer
+        verify { nextFn(action) }
+    }
+
+    @Test
+    fun processInboxMessages_givenTrackClickedWithEmptyActionValue_shouldOmitEmptyParams() {
+        val deliveryId = String.random
+        val queueId = String.random
+        val inboxMessage = createInboxMessage(deliveryId = deliveryId, queueId = queueId, opened = false)
+
+        val state = InAppMessagingState(
+            siteId = String.random,
+            dataCenter = String.random,
+            inboxMessages = setOf(inboxMessage)
+        )
+        every { store.state } returns state
+
+        // A value-less action arrives with empty strings, not null.
+        val action = InAppMessagingAction.InboxAction.TrackClicked(inboxMessage, actionName = "", actionValue = "")
+
+        val middleware = processInboxMessages()
+        middleware(store)(nextFn)(action)
+
+        // Empty name/value are omitted entirely (web parity) — no `actionValue: ""`.
+        verify {
+            mockEventBus.publish(
+                Event.TrackInAppMetricEvent(
+                    deliveryID = deliveryId,
+                    event = Metric.Clicked,
+                    params = emptyMap()
+                )
+            )
+        }
         verify { nextFn(action) }
     }
 

--- a/messaginginbox/api/messaginginbox.api
+++ b/messaginginbox/api/messaginginbox.api
@@ -1,6 +1,6 @@
 public final class io/customer/messaginginbox/NotificationInboxOverlayKt {
 	public static final fun NotificationInboxBell (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NotificationInboxOverlay (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun NotificationInboxView (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NotificationInboxOverlay (Landroidx/compose/ui/Modifier;Ljava/util/Map;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NotificationInboxView (Landroidx/compose/ui/Modifier;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellIcon.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/InboxBellIcon.kt
@@ -14,7 +14,7 @@ import kotlin.math.min
 
 /**
  * Renders a pre-built branding bell glyph ([InboxBellSvg.BellArt]) — the workspace's configured
- * `patterns.inbox.floatingIcon.svg`, parsed once into a combined even-odd path — scaled-to-fit the
+ * `patterns.inbox.floatingIcon.svg`, parsed once into one path per `<path>` (each with its own fill rule) — scaled-to-fit the
  * target size (aspect preserved) and filled with [tint].
  *
  * The art is built (and validated) up front by [InboxBellSvg.buildArt]; callers pass the result only
@@ -37,7 +37,9 @@ internal fun InboxBellIcon(
             scale(scaleX = scale, scaleY = scale, pivot = Offset.Zero) {
                 // Shift the viewBox origin to (0,0) before scaling so a non-zero minX/minY viewBox fits.
                 translate(left = -art.minX, top = -art.minY) {
-                    drawPath(path = art.path, color = tint)
+                    // Fill each <path> INDEPENDENTLY (each with its own fill rule) so overlapping paths don't flip
+                    // each other's winding parity (MBL-2123). Uniform tint → the union reads as one glyph.
+                    art.paths.forEach { path -> drawPath(path = path, color = tint) }
                 }
             }
         }
@@ -52,44 +54,68 @@ internal fun InboxBellIcon(
  * caller so the SVG is parsed once, not per frame.
  */
 internal object InboxBellSvg {
-    /** A built, ready-to-draw bell glyph: the combined even-odd [Path] plus its source viewBox. */
+    /**
+     * A built, ready-to-draw bell glyph: one [Path] per source `<path>` element (each with its own fill rule, filled
+     * independently — see [InboxBellIcon]) plus its source viewBox.
+     */
     data class BellArt(
-        val path: Path,
+        val paths: List<Path>,
         val minX: Float,
         val minY: Float,
         val width: Float,
         val height: Float
     )
 
-    /** Parsed geometry: viewBox origin/size + the `d` string of each `<path>`. */
+    /** One `<path>` element: its `d` geometry + whether it fills even-odd (else nonzero). */
+    data class PathSpec(val d: String, val evenOdd: Boolean)
+
+    /** Parsed geometry: viewBox origin/size + the per-`<path>` specs. */
     data class Parsed(
         val minX: Float,
         val minY: Float,
         val width: Float,
         val height: Float,
-        val pathData: List<String>
+        val paths: List<PathSpec>
     )
 
     private val VIEW_BOX = Regex("""viewBox\s*=\s*["']\s*([^"']+?)\s*["']""", RegexOption.IGNORE_CASE)
-    private val PATH_D = Regex("""<path\b[^>]*?\bd\s*=\s*["']([^"']+)["']""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+    private val PATH_TAG = Regex("""<path\b[^>]*>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+    private val SVG_TAG = Regex("""<svg\b[^>]*>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+    private val D_ATTR = Regex("""\bd\s*=\s*["']([^"']+)["']""", RegexOption.IGNORE_CASE)
+
+    // `fill-rule="evenodd"` (attribute) or `fill-rule: evenodd` (CSS style), either rule, any quoting.
+    private val FILL_RULE = Regex("""fill-rule\s*[=:]\s*["']?\s*(evenodd|nonzero)""", RegexOption.IGNORE_CASE)
 
     /**
      * Parse [svg], or return null when there is nothing renderable (no `<path d>`). A missing
-     * `viewBox` defaults to a 24×24 box so a bare `<svg><path/></svg>` still fits.
+     * `viewBox` defaults to a 24×24 box so a bare `<svg><path/></svg>` still fits. Each `<path>`
+     * carries its OWN fill rule — the path's declared `fill-rule`, else the root `<svg>`'s, else
+     * nonzero (the SVG/CSS default) — matching how a browser fills each path (MBL-2123), and matching
+     * iOS which likewise honors the declared rule per path.
      */
     fun parse(svg: String): Parsed? {
-        val pathData = PATH_D.findAll(svg).map { it.groupValues[1].trim() }.filter { it.isNotEmpty() }.toList()
-        if (pathData.isEmpty()) return null
+        val rootEvenOdd = SVG_TAG.find(svg)?.value?.let { fillRuleEvenOdd(it) }
+        val paths = PATH_TAG.findAll(svg).mapNotNull { match ->
+            val tag = match.value
+            val d = D_ATTR.find(tag)?.groupValues?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+                ?: return@mapNotNull null
+            PathSpec(d = d, evenOdd = fillRuleEvenOdd(tag) ?: rootEvenOdd ?: false)
+        }.toList()
+        if (paths.isEmpty()) return null
 
         val box = VIEW_BOX.find(svg)?.groupValues?.get(1)
             ?.split(Regex("[\\s,]+"))
             ?.mapNotNull { it.toFloatOrNull() }
         return if (box != null && box.size == 4 && box[2] > 0f && box[3] > 0f) {
-            Parsed(minX = box[0], minY = box[1], width = box[2], height = box[3], pathData = pathData)
+            Parsed(minX = box[0], minY = box[1], width = box[2], height = box[3], paths = paths)
         } else {
-            Parsed(minX = 0f, minY = 0f, width = 24f, height = 24f, pathData = pathData)
+            Parsed(minX = 0f, minY = 0f, width = 24f, height = 24f, paths = paths)
         }
     }
+
+    /** true if [tag] declares `fill-rule` evenodd, false if nonzero, null if it declares neither. */
+    private fun fillRuleEvenOdd(tag: String): Boolean? =
+        FILL_RULE.find(tag)?.groupValues?.get(1)?.equals("evenodd", ignoreCase = true)
 
     /**
      * Build a ready-to-draw [BellArt] from raw [svg], or null when it cannot be rendered (no
@@ -100,11 +126,16 @@ internal object InboxBellSvg {
     fun buildArt(svg: String): BellArt? {
         val parsed = parse(svg) ?: return null
         return try {
-            val path = Path().apply {
-                fillType = PathFillType.EvenOdd
-                parsed.pathData.forEach { d -> addPath(PathParser().parsePathString(d).toPath()) }
+            // Build each <path> as its OWN path with its declared fill rule (nonzero default), filled
+            // independently by InboxBellIcon. Merging them into one path + a single fill rule flips
+            // parity where paths overlap, producing a malformed glyph (MBL-2123); browsers fill each
+            // <path> on its own with that path's own rule.
+            val paths = parsed.paths.mapNotNull { spec ->
+                PathParser().parsePathString(spec.d).toPath()
+                    .apply { fillType = if (spec.evenOdd) PathFillType.EvenOdd else PathFillType.NonZero }
+                    .takeIf { !it.isEmpty }
             }
-            if (path.isEmpty) null else BellArt(path, parsed.minX, parsed.minY, parsed.width, parsed.height)
+            if (paths.isEmpty()) null else BellArt(paths, parsed.minX, parsed.minY, parsed.width, parsed.height)
         } catch (ex: Exception) {
             null
         }

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -54,8 +56,10 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -63,6 +67,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.customer.jist.JistActionEvent
 import io.customer.jist.JistMode
+import io.customer.jist.JistTheme
 import io.customer.jist.JistView
 import io.customer.messaginginapp.ModuleMessagingInApp
 import io.customer.messaginginapp.inbox.VisualInbox
@@ -101,13 +106,15 @@ fun NotificationInboxBell(
 
     val branding = (state.visibility as? InboxVisibility.Visible)?.branding
     val chrome = rememberInboxChrome(branding)
+    val colors = rememberInboxColors(branding)
     InboxBellContent(
         unopenedCount = state.unopenedCount,
         showAlert = chrome.showAlert,
         bellSvg = chrome.bellSvg,
-        colors = rememberInboxColors(branding),
+        colors = colors,
         onClick = onClick,
-        modifier = modifier
+        modifier = modifier,
+        badgeTextSize = colors.badgeTextSize
     )
 }
 
@@ -121,6 +128,8 @@ fun NotificationInboxBell(
  * bottom sheet, use [NotificationInboxOverlay]; to drive your own bell, use [NotificationInboxBell].
  *
  * @param modifier Modifier applied to the list container.
+ * @param fonts optional custom-font registry forwarded to the Jist renderer — see
+ *   [NotificationInboxOverlay] for details. Empty (the default) = system fonts only.
  * @param onDismissRequest invoked when a tapped message navigates away (opens a url / deep link, or
  *   the host listener handled a navigating action). If you present this view in your own sheet or
  *   dialog, dismiss it here so the inbox doesn't linger over the destination. Null (default) = the
@@ -129,6 +138,7 @@ fun NotificationInboxBell(
 @Composable
 fun NotificationInboxView(
     modifier: Modifier = Modifier,
+    fonts: Map<String, FontFamily> = emptyMap(),
     onDismissRequest: (() -> Unit)? = null
 ) {
     val controller = rememberInboxController()
@@ -139,6 +149,7 @@ fun NotificationInboxView(
     InboxListContent(
         controller = controller,
         colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
+        fonts = fonts,
         onNavigatedAway = onDismissRequest,
         modifier = modifier.fillMaxSize()
     )
@@ -162,13 +173,19 @@ fun NotificationInboxView(
  * [NotificationInboxBell] and [NotificationInboxView] directly instead.
  *
  * @param modifier Modifier applied to the root overlay container.
+ * @param fonts optional custom-font registry forwarded to the Jist renderer: a map from the font
+ *   family name a message/branding theme references (e.g. `"Abril Fatface"`) to the loaded Compose
+ *   [FontFamily] (e.g. `FontFamily(Font(R.font.abril_fatface))`). Jist resolves a theme's
+ *   `fontFamily` token ONLY from this map, so a workspace theme that sets a custom font falls back to
+ *   the system font unless the host supplies it here. Empty (the default) = system fonts only.
  */
 @Composable
 fun NotificationInboxOverlay(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    fonts: Map<String, FontFamily> = emptyMap()
 ) {
     val controller = rememberInboxController()
-    NotificationInboxOverlay(modifier = modifier, controller = controller)
+    NotificationInboxOverlay(modifier = modifier, controller = controller, fonts = fonts)
 }
 
 /**
@@ -179,7 +196,8 @@ fun NotificationInboxOverlay(
 @Composable
 internal fun NotificationInboxOverlay(
     modifier: Modifier = Modifier,
-    controller: VisualInboxController
+    controller: VisualInboxController,
+    fonts: Map<String, FontFamily> = emptyMap()
 ) {
     var sheetExpanded by remember { mutableStateOf(false) }
 
@@ -233,7 +251,8 @@ internal fun NotificationInboxOverlay(
                 onClick = { sheetExpanded = true },
                 modifier = Modifier
                     .align(chrome.position.alignment)
-                    .padding(16.dp)
+                    .padding(16.dp),
+                badgeTextSize = colors.badgeTextSize
             )
         }
     }
@@ -249,14 +268,16 @@ internal fun NotificationInboxOverlay(
             onDismissRequest = { sheetExpanded = false },
             sheetState = sheetState,
             shape = RoundedCornerShape(topStart = colors.cornerRadius, topEnd = colors.cornerRadius),
-            containerColor = colors.panelColor
-            // dragHandle omitted: ModalBottomSheet already uses BottomSheetDefaults.DragHandle by
-            // default. Passing it explicitly generated a public ComposableSingletons lambda in the
-            // API dump for no behavior change.
+            containerColor = colors.panelColor,
+            // MBL-2124: a compact grabber replaces the tall default BottomSheetDefaults.DragHandle
+            // (~24dp of vertical padding), which — stacked on the first message's own padding — left
+            // an excessive gap above the first message vs web. Keeps a drag-to-dismiss affordance.
+            dragHandle = { CompactDragHandle(colors.textColorPrimary) }
         ) {
             InboxListContent(
                 controller = controller,
                 colors = colors,
+                fonts = fonts,
                 // Close the sheet when a tapped message navigates via a deep link, so the deep-linked
                 // screen isn't left behind the sheet (openUrl external does not close).
                 onNavigatedAway = { sheetExpanded = false },
@@ -280,7 +301,9 @@ private fun InboxBellContent(
     bellSvg: String?,
     colors: InboxColors,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // MBL-2126/2127: branding-driven unread-badge text size (`unreadIndicator.text.size`).
+    badgeTextSize: TextUnit = BADGE_TEXT_SIZE
 ) {
     Box(modifier = modifier) {
         Box(
@@ -301,13 +324,16 @@ private fun InboxBellContent(
                 InboxBellIcon(
                     art = bellArt,
                     tint = colors.bellIconColor,
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier.size(BELL_GLYPH_SIZE)
                 )
             } else {
                 Image(
                     painter = painterResource(id = R.drawable.cio_inbox_notifications),
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(colors.bellIconColor)
+                    colorFilter = ColorFilter.tint(colors.bellIconColor),
+                    // MBL-2123: pin the default bell to the same size as the branded glyph. Without an
+                    // explicit size it rendered at the drawable's intrinsic size (parity mismatch).
+                    modifier = Modifier.size(BELL_GLYPH_SIZE)
                 )
             }
         }
@@ -329,7 +355,13 @@ private fun InboxBellContent(
             ) {
                 BasicText(
                     text = unopenedCount.toString(),
-                    style = TextStyle(color = Color.White, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                    // MBL-2126: color + size come from branding (`unreadIndicator.text`) rather than
+                    // being hardcoded white/10sp.
+                    style = TextStyle(
+                        color = colors.badgeTextColor,
+                        fontSize = badgeTextSize,
+                        fontWeight = FontWeight.Bold
+                    )
                 )
             }
         }
@@ -347,6 +379,8 @@ private fun InboxListContent(
     controller: VisualInboxController,
     colors: InboxColors,
     modifier: Modifier = Modifier,
+    // Custom-font registry forwarded to the Jist renderer (see NotificationInboxOverlay); empty = none.
+    fonts: Map<String, FontFamily> = emptyMap(),
     // Invoked when a tapped message navigates away via a deep link, so a host presenting this in a
     // sheet/dialog can dismiss it. Null (the default) for the embeddable NotificationInboxView.
     onNavigatedAway: (() -> Unit)? = null
@@ -383,6 +417,7 @@ private fun InboxListContent(
                 messages = state.messages,
                 templates = templates,
                 theme = theme,
+                fonts = fonts,
                 dividerColor = colors.dividerColor,
                 onMessageShown = { message -> controller.notifyMessageShown(state.visibility, message) },
                 onMessageAction = { message, event ->
@@ -418,7 +453,9 @@ private fun InboxMessageList(
     dividerColor: Color,
     onMessageShown: (JistInboxMessage) -> Unit,
     onMessageAction: (JistInboxMessage, JistActionEvent) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // Host-supplied custom fonts; provided to Jist via JistTheme so theme `fontFamily` tokens resolve.
+    fonts: Map<String, FontFamily> = emptyMap()
 ) {
     // No-template fallback (item 16): a message whose `type` has no decoded template can't be
     // rendered — skip it (do NOT render a blank row) and log so it's diagnosable.
@@ -434,34 +471,89 @@ private fun InboxMessageList(
             }
         }
     }
-    LazyColumn(modifier = modifier.fillMaxWidth()) {
-        items(renderable, key = { it.queueId }) { message ->
-            // Report "shown" once when the row enters composition (controller dedupes per session).
-            LaunchedEffect(message.queueId) { onMessageShown(message) }
-            // Decode the per-row Jist data once per message (not on every recomposition).
-            val data = remember(message) { InboxJistDecoder.decodeData(message) }
-            // Render with Jist: `name` selects the template by message type, `data` is the typed
-            // properties, `templates`/`theme` come from the data layer, `mode = Auto` follows the
-            // system light/dark setting, `formatDate` renders web-aligned relative time.
-            JistView(
-                name = message.type,
-                templates = templates,
-                data = data,
-                theme = theme,
-                mode = JistMode.Auto,
-                formatDate = { iso, name -> InboxJistDecoder.formatRelativeDate(iso, name) },
-                onAction = { event -> onMessageAction(message, event) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            )
-            Box(
-                Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)
-                    .background(dividerColor)
-            )
+    // Wrap the list in JistTheme so the injected font map is visible to every JistView composed
+    // lazily below (CUSTOM-FONTS). Only wrap when the host actually supplied fonts — an empty map
+    // would otherwise clobber Jist's own default font registry with nothing.
+    JistFontScope(fonts) {
+        LazyColumn(
+            modifier = modifier.fillMaxWidth(),
+            // MBL-2124: a small top/bottom inset instead of relying on the first item's full padding,
+            // keeping the top margin comfortable-but-tight under the compact drag handle (web parity).
+            contentPadding = PaddingValues(vertical = LIST_VERTICAL_PADDING)
+        ) {
+            items(renderable, key = { it.queueId }) { message ->
+                // Report "shown" once when the row enters composition (controller dedupes per session).
+                LaunchedEffect(message.queueId) { onMessageShown(message) }
+                // Decode the per-row Jist data once per message (not on every recomposition).
+                val data = remember(message) { InboxJistDecoder.decodeData(message) }
+                // Render with Jist: `name` selects the template by message type, `data` is the typed
+                // properties, `templates`/`theme` come from the data layer, `mode = Auto` follows the
+                // system light/dark setting, `formatDate` renders web-aligned relative time.
+                JistView(
+                    name = message.type,
+                    templates = templates,
+                    data = data,
+                    theme = theme,
+                    mode = JistMode.Auto,
+                    formatDate = { iso, name -> InboxJistDecoder.formatRelativeDate(iso, name) },
+                    onAction = { event -> onMessageAction(message, event) },
+                    // MBL-2124: horizontal + modest vertical padding (was a flat 16dp all sides), so the
+                    // first row no longer stacks a tall top inset on top of the drag handle.
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = ITEM_VERTICAL_PADDING)
+                )
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(dividerColor)
+                )
+            }
         }
+    }
+}
+
+/**
+ * Provides [fonts] to Jist via [JistTheme] so theme `fontFamily` tokens resolve to the host's loaded
+ * [FontFamily]s (CUSTOM-FONTS). A no-op passthrough when [fonts] is empty (JistTheme's own default is
+ * also an empty map, so wrapping then would add a redundant CompositionLocalProvider for no effect).
+ */
+@Composable
+private fun JistFontScope(
+    fonts: Map<String, FontFamily>,
+    content: @Composable () -> Unit
+) {
+    if (fonts.isEmpty()) {
+        content()
+    } else {
+        JistTheme(fonts = fonts, content = content)
+    }
+}
+
+/**
+ * A compact bottom-sheet grabber (MBL-2124): a small rounded bar with tight vertical padding, in
+ * place of the tall default [androidx.compose.material3.BottomSheetDefaults.DragHandle]. Keeps a
+ * drag-to-dismiss affordance while bringing the top margin in line with the web inbox.
+ */
+@Composable
+private fun CompactDragHandle(
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .width(32.dp)
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(color.copy(alpha = 0.4f))
+        )
     }
 }
 
@@ -650,6 +742,22 @@ private fun rememberInboxChrome(branding: Branding?): InboxChromeConfig = rememb
     )
 }
 
+/**
+ * Resolves the unread-badge text size (sp) from the raw `unreadIndicator.text` token map, or null
+ * when absent/unparseable so callers can fall back (dark override → light → [BADGE_TEXT_SIZE]). Reads
+ * the confirmed contract key `fontSize` (matching iOS), accepting a number or a string like `"12"` /
+ * `"12px"` / `"12sp"`.
+ */
+private fun badgeTextSizeFrom(text: Map<*, *>?): TextUnit? {
+    val raw = text?.get("fontSize") ?: return null
+    val value = when (raw) {
+        is Number -> raw.toFloat()
+        is String -> raw.trim().removeSuffix("px").removeSuffix("sp").toFloatOrNull()
+        else -> null
+    } ?: return null
+    return if (value > 0f) value.sp else null
+}
+
 /** Resolved chrome colors for the overlay. See [rememberInboxColors] for the resolution order. */
 private data class InboxColors(
     val bellColor: Color,
@@ -658,6 +766,11 @@ private data class InboxColors(
     val textColorPrimary: Color,
     val dividerColor: Color,
     val badgeColor: Color,
+    // MBL-2126: unread-badge label color from `unreadIndicator.text.color` (was hardcoded white).
+    val badgeTextColor: Color,
+    // MBL-2126/2127: unread-badge text size from `unreadIndicator.text.fontSize`. Resolved here (not
+    // in InboxChromeConfig) so it honors the dark-mode override like the color does.
+    val badgeTextSize: TextUnit,
     val cornerRadius: Dp
 )
 
@@ -710,9 +823,24 @@ private fun rememberInboxColors(branding: Branding? = null): InboxColors {
         val dividerColor = (dark.str("dividerColor") ?: dark.str("borderColor")).toColorOrNull()
             ?: (light?.dividerColor ?: light?.borderColor).toColorOrNull()
             ?: textColorSecondary.copy(alpha = 0.12f)
+        // MBL-2126: resolve the branded badge background; when the workspace does not configure
+        // `unreadIndicator.background`, fall back to the (branded) bell color rather than an
+        // off-brand literal red, so the badge stays on-brand. (If the branded value is a token
+        // reference string rather than a hex color, it can't be dereferenced here — see fix report.)
         val badgeColor = dark.childStr("unreadIndicator", "background").toColorOrNull()
             ?: light?.unreadIndicator?.background.toColorOrNull()
-            ?: Color(0xFFE53935)
+            ?: bellColor
+        // MBL-2126: badge label color from `unreadIndicator.text.color`. Final fallback contrasts
+        // against the resolved badge background (which itself can fall back to a light bell color),
+        // so the count never renders white-on-light — mirrors the bell icon's luminance fallback.
+        val badgeTextColor = dark.grandChildStr("unreadIndicator", "text", "color").toColorOrNull()
+            ?: (light?.unreadIndicator?.text?.get("color") as? String).toColorOrNull()
+            ?: if (badgeColor.luminance() > 0.5f) Color.Black else Color.White
+        // MBL-2126/2127: badge text size — dark override → light → compact default, mirroring the
+        // badge color's dark-awareness (and iOS, which resolves both from the dark override).
+        val badgeTextSize = badgeTextSizeFrom(dark.grandChildMap("unreadIndicator", "text"))
+            ?: badgeTextSizeFrom(light?.unreadIndicator?.text)
+            ?: BADGE_TEXT_SIZE
         val cornerRadius = light?.cornerRadius?.dp ?: PANEL_CORNER_RADIUS
 
         InboxColors(
@@ -722,6 +850,8 @@ private fun rememberInboxColors(branding: Branding? = null): InboxColors {
             textColorPrimary = textPrimary,
             dividerColor = dividerColor,
             badgeColor = badgeColor,
+            badgeTextColor = badgeTextColor,
+            badgeTextSize = badgeTextSize,
             cornerRadius = cornerRadius
         )
     }
@@ -733,6 +863,14 @@ private fun Map<*, *>?.str(key: String): String? = this?.get(key) as? String
 /** Reads a String from a nested child object of a raw branding (dark-mode override) map, or null. */
 private fun Map<*, *>?.childStr(child: String, key: String): String? =
     (this?.get(child) as? Map<*, *>)?.get(key) as? String
+
+/** Reads a String two objects deep in a raw branding (dark-mode override) map, or null. */
+private fun Map<*, *>?.grandChildStr(child: String, grandChild: String, key: String): String? =
+    ((this?.get(child) as? Map<*, *>)?.get(grandChild) as? Map<*, *>)?.get(key) as? String
+
+/** Reads a nested object two levels deep (e.g. `unreadIndicator.text`) from a raw branding map, or null. */
+private fun Map<*, *>?.grandChildMap(child: String, grandChild: String): Map<*, *>? =
+    (this?.get(child) as? Map<*, *>)?.get(grandChild) as? Map<*, *>
 
 /**
  * Parses a branding hex color string (`#RRGGBB` or `#RRGGBBAA`, CSS byte order) into a Compose
@@ -784,3 +922,15 @@ private const val INBOX_LOG_TAG = "[CIO-Inbox]"
 
 /** Fallback corner radius for the sheet's rounded top when branding does not configure one. */
 private val PANEL_CORNER_RADIUS = 12.dp
+
+/** MBL-2124: top/bottom inset for the message list content (paired with the compact drag handle). */
+private val LIST_VERTICAL_PADDING = 4.dp
+
+/** MBL-2124: per-message vertical padding (was a flat 16dp all sides on each row). */
+private val ITEM_VERTICAL_PADDING = 12.dp
+
+/** Bell glyph size, shared by the branded SVG and the bundled default so they render identically. */
+private val BELL_GLYPH_SIZE = 26.dp
+
+/** MBL-2127: default unread-badge text size when branding does not configure `unreadIndicator.text.size`. */
+private val BADGE_TEXT_SIZE = 10.sp

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -168,6 +168,9 @@ internal class VisualInboxController(
                 .filter { !it.opened && it.queueId !in markedOpenedQueueIds }
                 .forEach { message ->
                     markedOpenedQueueIds.add(message.queueId)
+                    // markMessageOpened dispatches UpdateOpened, whose middleware reports the opened
+                    // metric via the generic `Report Delivery Event` (metric: opened) — matching web
+                    // (rendered as "Opened Inbox Message" for an inbox delivery). No named CDP event.
                     visualInbox.markMessageOpened(message)
                     // Observational host callback (item 14): a message was marked opened.
                     notifyListener { messageOpened(message) }
@@ -239,7 +242,7 @@ internal class VisualInboxController(
         // Track the click against the same InboxMessage the UI renders (resolved from the visible
         // set), reusing the existing track-clicked plumbing. Deduped per queueId so a repeated tap
         // before the row updates does not double-count.
-        trackClicked(visibility, message, name)
+        trackClicked(visibility, message, name, url)
 
         // Host interception (item 13): true => host handled it, SDK runs no default nav (but still
         // honors the dismiss flag below).
@@ -302,17 +305,29 @@ internal class VisualInboxController(
         val inboxMessage = (visibility as? InboxVisibility.Visible)
             ?.messages?.firstOrNull { it.queueId == message.queueId } ?: return
         if (!shownQueueIds.add(message.queueId)) return
+        // No "delivered" CDP event is emitted from the client — web doesn't send one; the backend
+        // synthesizes `Delivered Inbox Message` when the message is delivered to the inbox.
         notifyListener { messageShown(inboxMessage) }
     }
 
-    /** Track a clicked metric for [message], once per queueId. Reuses [VisualInbox.trackMessageClicked]. */
-    private fun trackClicked(visibility: InboxVisibility, message: JistInboxMessage, actionName: String?) {
+    /**
+     * Track a click for [message], once per queueId, via the existing generic delivery metric
+     * ([VisualInbox.trackMessageClicked]) — carrying both [actionName] and [actionValue] so the
+     * `Report Delivery Event` (metric: clicked) matches web (MBL-2125). The CDP backend renders it
+     * as "Clicked Inbox Message" for an inbox delivery; no separate named event is emitted.
+     */
+    private fun trackClicked(
+        visibility: InboxVisibility,
+        message: JistInboxMessage,
+        actionName: String?,
+        actionValue: String?
+    ) {
         val visible = visibility as? InboxVisibility.Visible ?: return
         val tracked = visible.messages.firstOrNull { it.queueId == message.queueId } ?: return
         // Reserve only AFTER confirming the message exists, so a failed lookup never permanently
         // dedupes (blocks) the click metric for later taps on the same message.
         if (!clickedQueueIds.add(message.queueId)) return
-        visualInbox.trackMessageClicked(tracked, actionName)
+        visualInbox.trackMessageClicked(tracked, actionName, actionValue)
     }
 
     /** Invoke the host listener (if any), returning true if the host handled the action. */

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -324,9 +324,13 @@ internal class VisualInboxController(
     ) {
         val visible = visibility as? InboxVisibility.Visible ?: return
         val tracked = visible.messages.firstOrNull { it.queueId == message.queueId } ?: return
-        // Reserve only AFTER confirming the message exists, so a failed lookup never permanently
-        // dedupes (blocks) the click metric for later taps on the same message.
-        if (!clickedQueueIds.add(message.queueId)) return
+        // Dedupe per DISTINCT action (queueId + action name + value), NOT per message: a single
+        // message can carry multiple CTAs and web reports a click for each, so two different actions
+        // on the same message must each report. Only a repeat of the SAME action (e.g. a rapid
+        // double-tap of one CTA) is suppressed here; the backend deduplicates the delivery's
+        // first-click metric regardless. Reserve only AFTER confirming the message exists, so a
+        // failed lookup never permanently blocks later clicks.
+        if (!clickedActions.add(Triple(message.queueId, actionName, actionValue))) return
         visualInbox.trackMessageClicked(tracked, actionName, actionValue)
     }
 
@@ -374,8 +378,10 @@ internal class VisualInboxController(
         const val INBOX_LOG_TAG = "[CIO-Inbox]"
     }
 
-    // Dedupe guard for click tracking: a message clicked in this session is tracked once.
-    private val clickedQueueIds = HashSet<String>()
+    // Dedupe guard for click tracking, keyed by DISTINCT action (queueId + action name + value) so a
+    // message with multiple CTAs reports a click for each (web parity); only a repeat of the same
+    // action is suppressed.
+    private val clickedActions = HashSet<Triple<String, String?, String?>>()
 
     // Dedupe guard for the observational messageShown callback: notified once per queueId.
     private val shownQueueIds = HashSet<String>()

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -387,6 +387,21 @@ class InboxActionTest {
         verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "https://x.io") }
     }
 
+    @Test
+    fun handleAction_givenTwoDifferentCtasSameMessage_expectEachTracked() {
+        // A message can carry multiple CTAs; web reports a click for each, so two DIFFERENT actions
+        // on the same message must both track (the same-action repeat above is what's deduped).
+        val messages = listOf(message("a"))
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        val controller = VisualInboxController(visualInbox)
+
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://one.io"))
+        controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://two.io"))
+
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "https://one.io") }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "https://two.io") }
+    }
+
     // --- observe callbacks (item 14): shown / opened / dismissed ---
 
     private class RecordingListener : InboxEventListener {

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxActionTest.kt
@@ -188,7 +188,7 @@ class InboxActionTest {
         nav shouldBeEqualTo InboxNavigation.None
         verify(exactly = 1) { visualInbox.markMessageDeleted(match { it.queueId == "a" }) }
         // Dismiss is not a click — no clicked metric.
-        verify(exactly = 0) { visualInbox.trackMessageClicked(any(), any()) }
+        verify(exactly = 0) { visualInbox.trackMessageClicked(any(), any(), any()) }
     }
 
     @Test
@@ -205,7 +205,7 @@ class InboxActionTest {
 
         nav.shouldBeInstanceOf<InboxNavigation.OpenUrl>()
         (nav as InboxNavigation.OpenUrl).url shouldBeEqualTo "https://example.com"
-        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, "messageAction") }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, "messageAction", "https://example.com") }
     }
 
     @Test
@@ -223,7 +223,7 @@ class InboxActionTest {
         // No host listener => the SDK routes the deeplink itself (the overlay resolves the intent).
         nav.shouldBeInstanceOf<InboxNavigation.OpenDeeplink>()
         (nav as InboxNavigation.OpenDeeplink).url shouldBeEqualTo "myapp://home"
-        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, any()) }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(match { it.queueId == "a" }, any(), "myapp://home") }
     }
 
     @Test
@@ -240,7 +240,7 @@ class InboxActionTest {
 
         // performAction is host-only; with no host listener there is nothing for the SDK to navigate.
         nav shouldBeEqualTo InboxNavigation.None
-        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "doThing") }
     }
 
     @Test
@@ -287,7 +287,7 @@ class InboxActionTest {
 
         // The host-facing action name comes from web-schema `data.name`, not the Jist event name.
         captured.single() shouldBeEqualTo "cta_click"
-        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), "cta_click") }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), "cta_click", "https://x.io") }
     }
 
     @Test
@@ -313,7 +313,7 @@ class InboxActionTest {
         // dismisses so the inbox doesn't linger over the host's destination.
         nav shouldBeEqualTo InboxNavigation.Dismiss
         // Still tracked (a click happened) and the listener got message id + delivery + action value.
-        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "https://example.com") }
         captured.size shouldBeEqualTo 1
         captured.first().first.queueId shouldBeEqualTo "a"
         captured.first().first.deliveryId shouldBeEqualTo "d-a"
@@ -384,7 +384,7 @@ class InboxActionTest {
         controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://x.io"))
         controller.handleAction(visible(messages), JistInboxAdapter.toJist(messages.first()), event(behavior = "openUrl", action = "https://x.io"))
 
-        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any()) }
+        verify(exactly = 1) { visualInbox.trackMessageClicked(any(), any(), "https://x.io") }
     }
 
     // --- observe callbacks (item 14): shown / opened / dismissed ---

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellSvgTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxBellSvgTest.kt
@@ -21,7 +21,9 @@ class InboxBellSvgTest {
         parsed.minY shouldBeEqualTo 0f
         parsed.width shouldBeEqualTo 24f
         parsed.height shouldBeEqualTo 25f
-        parsed.pathData shouldBeEqualTo listOf("M0 0 L24 0 L24 25 Z")
+        parsed.paths.map { it.d } shouldBeEqualTo listOf("M0 0 L24 0 L24 25 Z")
+        // No declared fill-rule → nonzero (the SVG/CSS default), matching iOS.
+        parsed.paths.single().evenOdd shouldBeEqualTo false
     }
 
     @Test
@@ -29,7 +31,22 @@ class InboxBellSvgTest {
         val svg = """<svg viewBox="0 0 24 25"><path d="M0 0 L10 0 Z"/><path fill-rule="evenodd" d="M12 12 L20 20 Z"/></svg>"""
         val parsed = InboxBellSvg.parse(svg)
         parsed.shouldNotBeNull()
-        parsed.pathData shouldBeEqualTo listOf("M0 0 L10 0 Z", "M12 12 L20 20 Z")
+        parsed.paths.map { it.d } shouldBeEqualTo listOf("M0 0 L10 0 Z", "M12 12 L20 20 Z")
+        // Per-path fill rule: first has none (nonzero default), second declares evenodd.
+        parsed.paths.map { it.evenOdd } shouldBeEqualTo listOf(false, true)
+    }
+
+    @Test
+    fun parse_fillRule_resolvesPerPath() {
+        // Explicit nonzero → false.
+        InboxBellSvg.parse("""<svg viewBox="0 0 24 25"><path fill-rule="nonzero" d="M0 0 Z"/></svg>""")!!
+            .paths.single().evenOdd shouldBeEqualTo false
+        // CSS-style spelling inside style="" → true.
+        InboxBellSvg.parse("""<svg viewBox="0 0 24 25"><path style="fill-rule: evenodd" d="M0 0 Z"/></svg>""")!!
+            .paths.single().evenOdd shouldBeEqualTo true
+        // A path with no rule inherits the root <svg>'s declared rule.
+        InboxBellSvg.parse("""<svg fill-rule="evenodd" viewBox="0 0 24 25"><path d="M0 0 Z"/></svg>""")!!
+            .paths.single().evenOdd shouldBeEqualTo true
     }
 
     @Test
@@ -73,6 +90,8 @@ class InboxBellSvgTest {
             """<path fill-rule="evenodd" d="M11.5 1.68C10.5 1.68 9.62 2.56 9.62 3.65Z"/></svg>"""
         val parsed = InboxBellSvg.parse(svg)
         parsed.shouldNotBeNull()
-        parsed.pathData.size shouldBeEqualTo 3
+        parsed.paths.size shouldBeEqualTo 3
+        // The real glyph declares fill-rule="evenodd" on every path.
+        parsed.paths.all { it.evenOdd } shouldBeEqualTo true
     }
 }


### PR DESCRIPTION
Visual Inbox overlay QA fixes surfaced during device testing, plus web-parity inbox metric reporting and host-supplied custom fonts.

- **MBL-2123** — render the branding bell by filling each `<path>` independently (even-odd per path) so overlapping subpaths don't flip winding parity.
- **MBL-2124** — compact drag handle / top margin on the sheet.
- **MBL-2126** — badge background + text color driven by branding.
- **MBL-2127** — badge proportions/offset.
- **MBL-2125** — report inbox opened/clicked via the generic `Report Delivery Event` (`metric: opened|clicked`), matching the web SDK (`cdp-analytics-js`). The CDP backend renders these as "Opened/Clicked Inbox Message" for an inbox delivery. Click carries `actionName` + `actionValue` (web parity). **No** separate named CDP events and **no** client-side "delivered" — the backend synthesizes delivered.
- Expose a public `fonts` map on `NotificationInboxOverlay` so hosts can supply custom font families for Jist theme resolution (regenerated public API dump).

Pre-flight: `:messaginginbox:assembleDebug`, `:messaginginapp:assembleDebug`, `:messaginginbox:testDebugUnitTest`, `:messaginginapp:testDebugUnitTest`, `apiDump`, `ktlint --android` all green locally.

> Custom fonts render end-to-end only once the Jist quote-stripping fix (#43) lands and republishes; sample-app font scaffolding is held for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public SDK/Compose APIs and changes inbox click-metric payload and dedupe semantics, which can affect analytics parity and integrators; UI/branding changes are localized to the inbox overlay.
> 
> **Overview**
> Visual inbox overlay fixes from device QA, plus **web-aligned inbox analytics** and an optional **custom-font** hook for Jist.
> 
> **Analytics (MBL-2125):** Inbox clicks now flow through the existing generic delivery metric (`Metric.Clicked`) with both `actionName` and `actionValue` when present; empty strings are omitted. A new **three-argument** `trackMessageClicked` overload carries the URL/deeplink without changing the two-arg `$default` synthetic (binary compatibility). The overlay controller forwards the resolved action value and **dedupes per distinct action** (queue + name + value) so multiple CTAs on one message each report, while identical taps stay deduped.
> 
> **Overlay UI:** Branding bell SVGs render **one Compose path per `<path>`** with per-path fill rules (MBL-2123). Sheet uses a **compact drag handle** and tighter list/message padding (MBL-2124). Unread badge **color, text color, and `fontSize`** come from `unreadIndicator` branding, with dark-mode overrides and sensible contrast fallbacks (MBL-2126/2127). Default and branded bells share a fixed glyph size.
> 
> **Public API:** `NotificationInboxOverlay` / `NotificationInboxView` accept an optional `fonts: Map<String, FontFamily>` wired through `JistTheme` for theme `fontFamily` resolution (API dump updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f023a767e0d04770ea045fe2a7022164d7345701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->