### PR TITLE
chore: reduce Maven Central publishing file count

### DIFF
--- a/docs/dev-notes/DEVELOPMENT.md
+++ b/docs/dev-notes/DEVELOPMENT.md
@@ -59,6 +59,24 @@ Create GitHub Actions secrets:
 
 This project is setup with GPG signing to sign the Maven artifacts before they are uploaded to Sonatype's servers to sync to Maven Central. GPG keys have been generated already but if you need to generate them again, [see this guide](https://gist.github.com/levibostian/ed2edcaa1ce1722d70683ce83fc429e2#sign) to do so. 
 
+#### Maven Central file count
+
+A production release publishes eight modules. Each module contains the binary, sources,
+Javadocs, Gradle module metadata, and POM, together with a PGP signature for each file.
+
+Gradle 8 normally adds MD5, SHA-1, SHA-256, and SHA-512 checksum sidecars to every artifact and
+signature during a remote Maven publication. That expands the ten publication files per module to
+fifty files, or 400 files for a complete SDK release. [Sonatype's publishing usage guidance](https://central.sonatype.org/publish/reducing-publishing-usage/)
+notes that additional generated checksum files are generally not required. The
+[Gradle compatibility flag](https://docs.gradle.org/6.0.1/release-notes.html#publication-of-sha256-and-sha512-checksums)
+in `gradle.properties` disables SHA-256 and SHA-512 sidecars while retaining MD5, SHA-1, and all
+PGP signatures. The expected remote publication is therefore thirty files per module, or 240
+files for a complete SDK release.
+
+Do not remove source jars, Javadoc jars, POMs, signatures, or Gradle module metadata solely to
+reduce this count. They are required by Maven Central or used by Gradle consumers. Review the
+calculation whenever the set of publishable modules or attached artifacts changes.
+
 ### Publish SDK locally
 
 This section explains how to publish the SDK locally to Maven Local. This could be useful in couple of scenarios:
@@ -73,6 +91,22 @@ IS_DEVELOPMENT=true ./gradlew publishToMavenLocal
 ```
 
 This will publish a local version to Maven Local called 'local', that you can use for wrapper SDKs.
+
+To validate the published artifacts as an external Android application would consume them, force
+both sample apps to resolve the `local` Maven coordinates instead of their normal project
+dependencies, then build both debug and minified release APKs:
+
+```bash
+./gradlew \
+  :samples:java_layout:assembleDebug \
+  :samples:java_layout:assembleRelease \
+  :samples:kotlin_compose:assembleDebug \
+  :samples:kotlin_compose:assembleRelease \
+  -PcioSDKVersion=local
+```
+
+This exercises dependency metadata, transitive dependencies, consumer ProGuard rules, SDK APIs,
+and Android resource packaging from the published Maven artifacts.
 
 # Troubleshooting
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,8 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Disable Gradle 8's optional SHA-256 and SHA-512 checksum sidecars. Maven Central
+# still receives every artifact and PGP signature plus MD5 and SHA-1 checksums.
+# This avoids 160 files per eight-module SDK release.
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/samples/sample-app.gradle
+++ b/samples/sample-app.gradle
@@ -4,6 +4,9 @@ if (localPropertiesFile.exists()) {
     localProperties.load(new FileInputStream(localPropertiesFile))
 }
 
+// Allow repeatable Maven consumer builds without editing the ignored samples/local.properties.
+def cioSDKVersion = project.findProperty("cioSDKVersion") ?: localProperties["sdkVersion"]
+
 // Common Compose version variables
 def compose_version = "1.4.1"
 def compose_bom_version = "2023.10.01"
@@ -53,7 +56,7 @@ android {
         String language = getConfigWithPrefix("language") ?: getLanguageFromPrefix(configKeyPrefix)
         String uiFramework = getConfigWithPrefix("uiFramework") ?: getUIFrameworkFromPrefix(configKeyPrefix)
         String sdkIntegration = "Maven"
-        String sdkVersion = localProperties["sdkVersion"]
+        String sdkVersion = cioSDKVersion?.toString()
         String branchName = localProperties["branchName"]
         String commitHash = localProperties["commitHash"]
         String commitsAheadCount = localProperties["commitsAheadCount"]
@@ -120,7 +123,6 @@ android {
 }
 
 dependencies {
-    def cioSDKVersion = localProperties["sdkVersion"]
     if (cioSDKVersion == null || cioSDKVersion.toString().isBlank()) {
         // Add local dependency for SDK modules, helpful for debugging
         implementation(project(":datapipelines"))
@@ -130,7 +132,7 @@ dependencies {
         implementation(project(":messaginginapp-compose"))
         implementation(project(":location"))
     } else {
-        // Stable releases dependency, use published versions directly
+        // Resolve published Maven artifacts instead of SDK project modules.
         implementation "io.customer.android:datapipelines:$cioSDKVersion"
         implementation "io.customer.android:messaging-push-fcm:$cioSDKVersion"
         implementation "io.customer.android:messaging-in-app:$cioSDKVersion"


### PR DESCRIPTION
## Summary

- disable Gradle 8's optional SHA-256 and SHA-512 checksum sidecars for Maven publications
- add a command-line switch that makes both sample apps consume locally published SDK coordinates
- document the file-count calculation and repeatable consumer validation workflow

## Why

A production SDK release publishes eight modules. Gradle currently expands each module's five artifacts and five PGP signatures with four checksum sidecars per file, producing 50 files per module and 400 files per release.

The compatibility flag keeps every artifact, PGP signature, MD5 checksum, and SHA-1 checksum while removing only the optional SHA-256 and SHA-512 sidecars. The expected release count is 30 files per module, or 240 files total (a 40% reduction).

## Customer impact

No AAR/JAR binaries, source archives, Javadocs, POMs, Gradle module metadata, signatures, or consumer ProGuard rules are removed. The sample apps can now be forced to resolve `io.customer.android:*:local`, which gives us a repeatable customer-style packaging check.

## Validation

- captured a signed remote Maven publication: 50 files per module before, 30 after
- `IS_DEVELOPMENT=true ./gradlew publishToMavenLocal`
- Java/XML and Compose samples resolved `io.customer.android:*:local` with no project substitutions
- both samples built in debug and R8-minified release modes
- both release APKs installed and cold-launched successfully on an emulator
- `./gradlew assembleDebug`
- Android lint for all modules covered by CI
- Compose sample Android lint
- Kotlin lint
- binary API validation through the pre-commit hook

## Existing lint issue

An additional Java sample lint run still reports three pre-existing errors in unchanged sample source files (`MissingPermission` and `MissingSuperCall`). This branch does not alter those files or introduce new Java sample lint findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect release publishing metadata and sample-app dependency wiring only; shipped AARs, signatures, and required Central artifacts are unchanged.
> 
> **Overview**
> **Publishing:** Adds `systemProp.org.gradle.internal.publish.checksums.insecure=true` in `gradle.properties` so Gradle 8 stops emitting optional SHA-256 and SHA-512 checksum sidecars on Maven publications. Artifacts, PGP signatures, MD5, and SHA-1 remain; release uploads drop from ~400 to ~240 files across eight modules.
> 
> **Sample apps:** `samples/sample-app.gradle` now resolves SDK version from `-PcioSDKVersion` (overriding `samples/local.properties` `sdkVersion`) so both samples can depend on published `io.customer.android:*` coordinates—e.g. `local` after `publishToMavenLocal`—without editing ignored local config.
> 
> **Docs:** `DEVELOPMENT.md` documents the per-module file math, what must not be stripped for Central, and the Gradle command to build Java and Compose samples in debug and release against Maven-local artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca3d5c78b51de79151c1983ea6f5d30fa74c1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->