### PR TITLE
chore(sample): align sample default location mode with SDK default

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -50,7 +50,7 @@ public class CustomerIOSDKConfig {
                 true,
                 false,
                 true,
-                LocationTrackingMode.ON_APP_START);
+                LocationTrackingMode.MANUAL);
     }
 
     @NonNull


### PR DESCRIPTION
## What

The java sample defaulted its location tracking mode to `ON_APP_START`, which differs from the SDK's own default of `MANUAL`. This aligns the sample's default with out-of-the-box SDK behavior.

`ON_APP_START` and `OFF` remain selectable in the sample's settings — only the initial default changes.

## Change

- `CustomerIOSDKConfig.getDefaultConfigurations()`: `LocationTrackingMode.ON_APP_START` → `LocationTrackingMode.MANUAL` (one line).

Sample-only; no SDK code touched.

Base: `feature/geofence-on-device`.

[MBL-2148](https://linear.app/customerio/issue/MBL-2148/mobile-align-sample-app-location-mode-with-sdk-defaults)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app configuration default only; no SDK or production runtime logic is modified.
> 
> **Overview**
> Updates the Java sample’s **default** location tracking mode so fresh installs match SDK out-of-the-box behavior.
> 
> `CustomerIOSDKConfig.getDefaultConfigurations()` now uses **`LocationTrackingMode.MANUAL`** instead of **`ON_APP_START`**. Settings can still pick `ON_APP_START` or `OFF`; only the initial default when no saved preference exists changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52eca60a325b090926afd6999b7ec6cddc28663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->