### PR TITLE
chore(sample): align sample default location mode with SDK default

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/data/model/CustomerIOSDKConfig.java
@@ -50,7 +50,7 @@ public class CustomerIOSDKConfig {
                 true,
                 false,
                 true,
-                LocationTrackingMode.ON_APP_START);
+                LocationTrackingMode.MANUAL);
     }
 
     @NonNull

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -224,7 +224,6 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                 .setNegativeButton(android.R.string.cancel, null)
                 .setPositiveButton(R.string.background_location_continue, (dialog, which) ->
                         backgroundLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
-                .setNeutralButton(R.string.open_settings, (dialog, which) -> openAppDetailsSettings())
                 .show();
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -107,7 +107,8 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
 
     // Launcher behavior varies by API:
     // - API 29: shows the runtime dialog with "Allow all the time".
-    // - API 30+: OS may route to Settings (recent Pixel/Samsung) or silently no-op (others).
+    // - API 30+: OS routes to the app's location settings page rather than showing a dialog
+    //   (a few OEMs may no-op; the user enables it from system Settings in that case).
     //   Don't trust the `granted` flag — re-check actual permission state.
     private final ActivityResultLauncher<String> backgroundLocationLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
@@ -118,7 +119,7 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
                 }
                 // Not granted: respect the user's choice (API 29 dialog declined, API 30+ silent
                 // deny, or backed out of Settings). The next tap re-shows the rationale dialog,
-                // which has an explicit "Open Settings" action for recovery.
+                // whose Continue re-launches the same background-permission flow.
                 refreshGrantBackgroundLocationUI();
             });
 

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
     <string name="bg_perm_section_title">BACKGROUND LOCATION</string>
     <string name="bg_perm_rationale_title">Allow background location?</string>
     <string name="background_location_description">Geofence background delivery requires the \"Allow all the time\" location authorization. Grant foreground access first; on Android 11+ the system routes the upgrade through Settings instead of showing a dialog.</string>
-    <string name="background_location_rationale_message">Geofence transitions only fire while the app is backgrounded if you grant \"Allow all the time\". On Android 11+ the system routes this through Settings instead of showing a dialog — use \"Open Settings\" below if no prompt appears.</string>
+    <string name="background_location_rationale_message">Geofence transitions only fire while the app is backgrounded if you grant \"Allow all the time\". Tap Continue to open the location permission screen, then select \"Allow all the time\".</string>
     <string name="background_location_continue">Continue</string>
 
     <!-- Background-location permission button states -->


### PR DESCRIPTION
## What

Two sample-only alignments for the geofence/location screens:

1. **Default location mode** — the java sample defaulted to `ON_APP_START`, which differs from the SDK's own default of `MANUAL`. Align it with out-of-the-box SDK behavior. `ON_APP_START` and `OFF` remain selectable in settings — only the initial default changes.
2. **Background-location prompt** — drop the redundant "Open Settings" button from the background-location rationale dialog. On Android 11+ "Continue" already deep-links to the app's exact Location permission screen (and shows the inline dialog on API 29); "Open Settings" only reached the generic App info page — extra taps for no benefit. The separate foreground-denied and `DENIED` recovery dialogs keep their "Open Settings" (there, no in-app request can open settings).

## Changes

- `CustomerIOSDKConfig.getDefaultConfigurations()`: `LocationTrackingMode.ON_APP_START` → `LocationTrackingMode.MANUAL`.
- `LocationTestActivity.showBackgroundLocationRationale()`: remove the neutral "Open Settings" button; reword the rationale string to point at Continue.

Sample-only; no SDK code touched.

Base: `feature/geofence-on-device`.

[MBL-2148](https://linear.app/customerio/issue/MBL-2148/mobile-align-sample-app-location-mode-with-sdk-defaults)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Java sample app (config default, strings, and one dialog); no SDK or production library code is modified.
> 
> **Overview**
> **Sample-only** tweaks so the Java layout app matches SDK defaults and clarifies background-location onboarding.
> 
> The default in `CustomerIOSDKConfig.getDefaultConfigurations()` changes from `LocationTrackingMode.ON_APP_START` to **`MANUAL`**, matching the location module builder default; other modes stay selectable in settings.
> 
> On **Location Test**, the background-location rationale dialog no longer offers a neutral **Open Settings** button—**Continue** alone launches the background permission flow (app location screen on Android 11+). Copy and comments are updated to describe that flow; foreground-denied recovery still uses Open Settings on the main permission button when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7688d97a66eba3be18ffa731ebba61b94c6e27ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

