### PR TITLE
chore(geofence): emit ENTER when already inside a geofence at registration

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -6,19 +6,15 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
-import io.customer.geofence.di.geofenceCooldownFilter
-import io.customer.geofence.di.geofenceEventScheduler
 import io.customer.geofence.di.geofenceLogger
 import io.customer.geofence.di.geofenceManager
 import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
-import io.customer.geofence.di.pendingGeofenceDeliveryStore
-import io.customer.geofence.store.PendingGeofenceDelivery
+import io.customer.geofence.di.geofenceTransitionEmitter
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
-import java.util.UUID
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -98,8 +94,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val timestamp = SDKComponent.clock.currentTimeSeconds()
         val dispatchStartUptimeMs = SDKComponent.clock.elapsedRealtime()
         val androidComponent = SDKComponent.android()
-        val scheduler = androidComponent.geofenceEventScheduler
-        val cooldownFilter = androidComponent.geofenceCooldownFilter
+        val transitionEmitter = androidComponent.geofenceTransitionEmitter
         // Defense-in-depth against orphans (failed clearAll, app-data wipe, SDK
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
@@ -144,54 +139,16 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 return@forEach
             }
 
-            if (!cooldownFilter.tryAcquire(userId, geofenceId, transition)) {
-                logger.logTransitionSuppressed(geofenceId, transition.name)
-                return@forEach
-            }
-            logger.logTransitionEmitting(geofenceId, transition.name)
-
-            // One transitionId for the whole crossing, shared across the per-geoset fan-out below.
-            val transitionId = UUID.randomUUID().toString()
             val cachedRegion = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
-            val geofenceName = cachedRegion?.name?.takeIf { it.isNotEmpty() }
-            val metadata = cachedRegion?.metadata ?: emptyMap()
-            // One event per geoset; a fence with no geosets still emits one (null geoset) so a real
-            // OS transition is never dropped. Distinct so a fence listing the same geoset twice
-            // doesn't fan out to duplicate events.
-            val geosetIds: List<String?> = cachedRegion?.geosetIds?.distinct()?.takeIf { it.isNotEmpty() } ?: listOf(null)
-            val entries = geosetIds.map { geosetId ->
-                PendingGeofenceDelivery(
-                    geofenceId = geofenceId,
-                    transition = transition,
-                    timestamp = timestamp,
-                    userId = userId,
-                    transitionId = transitionId,
-                    geofenceName = geofenceName,
-                    geosetId = geosetId,
-                    metadata = metadata
-                )
-            }
-
-            // Persist the whole fan-out atomically before any send, so an app kill mid-batch can't
-            // save some geosets and lose the rest. Both delivery channels (WorkManager worker +
-            // foreground flush) read the row back from this store, deduped by (transitionId, geoset).
-            // If the write fails there's nothing to deliver, so roll back the cooldown to allow a
-            // later retry and skip scheduling a worker that would find no row.
-            if (!androidComponent.pendingGeofenceDeliveryStore.appendAll(entries)) {
-                logger.logPersistFailed(geofenceId, transition.name)
-                cooldownFilter.release(userId, geofenceId, transition)
-                return@forEach
-            }
-            entries.forEach { entry ->
-                // Isolate the scheduler so one failure can't abandon the rest of the batch.
-                try {
-                    scheduler.schedule(entry)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logger.logSchedulerFailed(geofenceId, transition.name, e.message)
-                }
-            }
+            transitionEmitter.emit(
+                geofenceId = geofenceId,
+                transition = transition,
+                userId = userId,
+                timestampSeconds = timestamp,
+                geofenceName = cachedRegion?.name,
+                metadata = cachedRegion?.metadata ?: emptyMap(),
+                geosetIds = cachedRegion?.geosetIds ?: emptyList()
+            )
         }
 
         // Hold the goAsync window open until the refresh lands so the OS doesn't kill a

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -44,6 +44,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' $transitionName: suppressed — same transition fired within the cooldown window", tag = TAG)
     }
 
+    fun logInitialEnterInside(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId': device already inside a newly-registered fence — synthesizing ENTER (GMS INITIAL_TRIGGER_ENTER is unreliable)", tag = TAG)
+    }
+
     fun logTransitionDroppedUnknownId(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -8,6 +8,7 @@ import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.store.getCachedConfigOrFallback
 import io.customer.location.LocationCoordinates
+import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
@@ -56,6 +57,7 @@ internal class GeofenceRepositoryImpl(
     private val manager: GeofenceManager,
     private val secureUserStore: SecureUserStore,
     private val cooldownFilter: GeofenceCooldownFilter,
+    private val transitionEmitter: GeofenceTransitionEmitter,
     private val clock: Clock,
     private val logger: GeofenceLogger
 ) : GeofenceRepository {
@@ -211,7 +213,10 @@ internal class GeofenceRepositoryImpl(
             latitude = effectiveLocation.latitude,
             longitude = effectiveLocation.longitude,
             cachedConfig = cachedConfig,
-            register = manager::replaceGeofencesForBootRestore
+            register = manager::replaceGeofencesForBootRestore,
+            // No initial-enter on boot restore: the cached anchor may be stale if the device moved
+            // while off, so containment can't be trusted.
+            emitInitialEnter = false
         )
     }
 
@@ -261,14 +266,16 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
+        emitInitialEnter: Boolean = true
     ): Result<Unit> = registerNearestAndPersist(
         userId = userId,
         latitude = latitude,
         longitude = longitude,
         regions = store.getCachedRegions(),
         config = cachedConfig,
-        register = register
+        register = register,
+        emitInitialEnter = emitInitialEnter
     )
 
     /**
@@ -308,7 +315,8 @@ internal class GeofenceRepositoryImpl(
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
-        onRegistered: () -> Unit = {}
+        onRegistered: () -> Unit = {},
+        emitInitialEnter: Boolean = true
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
         val nearest = distanceFilter.nearest(
@@ -336,7 +344,14 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
-            register(regionsToRegister).also { result ->
+            // Snapshot already-monitored fences before register overwrites the set — initial-enter
+            // fires only for newly-monitored ones. A reboot wipes OS state, so treat all as new.
+            val previouslyRegisteredBusinessIds = if (osStateWipedByReboot()) {
+                emptySet()
+            } else {
+                store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+            }
+            val registrationResult = register(regionsToRegister).also { result ->
                 if (result.isSuccess) {
                     // Stale cleanup — Manager added new−existing, we remove
                     // existing−new. Runs only on add success; on failure leave
@@ -370,6 +385,44 @@ internal class GeofenceRepositoryImpl(
                     logger.logSyncSucceeded(nearest.size)
                 }
             }
+            if (registrationResult.isSuccess && emitInitialEnter) {
+                emitInitialEnters(nearest, previouslyRegisteredBusinessIds, userId, latitude, longitude)
+            }
+            registrationResult
+        }
+    }
+
+    /**
+     * Synthesizes an ENTER for each newly-registered fence the device is already inside — GMS's
+     * `INITIAL_TRIGGER_ENTER` unreliably drops this for a region added around a stationary device.
+     * Scoped to fences not in [previouslyRegisteredBusinessIds] (a re-register of the same set stays
+     * silent; sign-out clears the set, so the next sign-in re-fires). Cooldown-deduped, so a real GMS
+     * ENTER and this one collapse to one event. Runs under [stateMutex] with [userId] rechecked.
+     */
+    private suspend fun emitInitialEnters(
+        candidates: List<GeofenceRegion>,
+        previouslyRegisteredBusinessIds: Set<String>,
+        userId: String,
+        latitude: Double,
+        longitude: Double
+    ) {
+        val timestamp = clock.currentTimeSeconds()
+        candidates.forEach { region ->
+            val newlyRegistered = region.id !in previouslyRegisteredBusinessIds
+            val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
+            // Compare against the full radius: GMS has no per-region monitored-radius cap.
+            val inside = region.distanceTo(latitude, longitude) <= region.radius
+            if (!newlyRegistered || !monitorsEnter || !inside) return@forEach
+            logger.logInitialEnterInside(region.id)
+            transitionEmitter.emit(
+                geofenceId = region.id,
+                transition = Event.GeofenceTransition.ENTER,
+                userId = userId,
+                timestampSeconds = timestamp,
+                geofenceName = region.name,
+                metadata = region.metadata,
+                geosetIds = region.geosetIds
+            )
         }
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -291,20 +291,25 @@ internal class GeofenceRepositoryImpl(
         val existingBusinessIds = if (osStateWipedByReboot()) {
             emptySet()
         } else {
-            val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
-            val cachedById = store.getCachedRegions().associateBy { it.id }
-            regions
-                .filter { region ->
-                    val cached = cachedById[region.id]
-                    region.id in registeredBusinessIds && cached?.equalsForRegistration(region) == true
-                }
-                .map { it.id }
-                .toSet()
+            unchangedRegisteredIds(regions)
         }
         return manager.replaceGeofences(
             regions = regions,
             existingBusinessIds = existingBusinessIds
         )
+    }
+
+    /** Business IDs already registered whose GMS-relevant params match the cache — safe to skip re-adding. */
+    private fun unchangedRegisteredIds(regions: List<GeofenceRegion>): Set<String> {
+        val registeredBusinessIds = store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
+        val cachedById = store.getCachedRegions().associateBy { it.id }
+        return regions
+            .filter { region ->
+                val cached = cachedById[region.id]
+                region.id in registeredBusinessIds && cached?.equalsForRegistration(region) == true
+            }
+            .map { it.id }
+            .toSet()
     }
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -344,13 +349,10 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
-            // Snapshot already-monitored fences before register overwrites the set — initial-enter
-            // fires only for newly-monitored ones. A reboot wipes OS state, so treat all as new.
-            val previouslyRegisteredBusinessIds = if (osStateWipedByReboot()) {
-                emptySet()
-            } else {
-                store.getRegisteredIds() - GeofenceConstants.MOVEMENT_TRIGGER_ID
-            }
+            // Synthesis baseline, snapshotted before register/persist mutate the store. Unlike the
+            // registration diff, no reboot override: the post-reboot anchor can predate the reboot,
+            // so containment can't be trusted (same reason boot restore skips synthesis).
+            val unchangedRegistered = unchangedRegisteredIds(nearest)
             val registrationResult = register(regionsToRegister).also { result ->
                 if (result.isSuccess) {
                     // Stale cleanup — Manager added new−existing, we remove
@@ -386,7 +388,13 @@ internal class GeofenceRepositoryImpl(
                 }
             }
             if (registrationResult.isSuccess && emitInitialEnter) {
-                emitInitialEnters(nearest, previouslyRegisteredBusinessIds, userId, latitude, longitude)
+                // Identity can change during the awaited GMS call, and reset doesn't clear pending
+                // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
+                if (secureUserStore.getUserId() == userId) {
+                    emitInitialEnters(nearest, unchangedRegistered, userId, latitude, longitude)
+                } else {
+                    logger.logSyncSkipped("user changed during refresh — initial-enter synthesis skipped")
+                }
             }
             registrationResult
         }
@@ -395,20 +403,20 @@ internal class GeofenceRepositoryImpl(
     /**
      * Synthesizes an ENTER for each newly-registered fence the device is already inside — GMS's
      * `INITIAL_TRIGGER_ENTER` unreliably drops this for a region added around a stationary device.
-     * Scoped to fences not in [previouslyRegisteredBusinessIds] (a re-register of the same set stays
-     * silent; sign-out clears the set, so the next sign-in re-fires). Cooldown-deduped, so a real GMS
-     * ENTER and this one collapse to one event. Runs under [stateMutex] with [userId] rechecked.
+     * "New" = not in [unchangedRegisteredIds]: brand-new fences and re-added param changes fire,
+     * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
+     * collapse to one event.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
-        previouslyRegisteredBusinessIds: Set<String>,
+        unchangedRegisteredIds: Set<String>,
         userId: String,
         latitude: Double,
         longitude: Double
     ) {
         val timestamp = clock.currentTimeSeconds()
         candidates.forEach { region ->
-            val newlyRegistered = region.id !in previouslyRegisteredBusinessIds
+            val newlyRegistered = region.id !in unchangedRegisteredIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
             // Compare against the full radius: GMS has no per-region monitored-radius cap.
             val inside = region.distanceTo(latitude, longitude) <= region.radius

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -89,9 +89,14 @@ internal class GeofenceRepositoryImpl(
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
             val action = stateMutex.withLock { refreshAction(LocationCoordinates(latitude, longitude), config) }
+            // A launch/identify refresh runs with the persisted anchor, which a reboot can leave
+            // pointing at a pre-reboot position — containment can't be trusted, so no synthesis
+            // this pass (mirrors restoreFromCache). The flag drops once registration re-stamps
+            // uptime. Sign-in is unaffected: sign-out clears the stamp with the anchor.
+            val emitInitialEnter = !osStateWipedByReboot()
             return when (action) {
-                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude)
-                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config)
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, emitInitialEnter)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, emitInitialEnter = emitInitialEnter)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
@@ -224,7 +229,8 @@ internal class GeofenceRepositoryImpl(
     private suspend fun performRemoteRefresh(
         userId: String,
         latitude: Double,
-        longitude: Double
+        longitude: Double,
+        emitInitialEnter: Boolean = true
     ): Result<Unit> {
         // The device location lets the backend return the nearby set; the request carries no user
         // identity, so it isn't attributable to a user.
@@ -242,6 +248,7 @@ internal class GeofenceRepositoryImpl(
                     longitude = longitude,
                     regions = regions,
                     config = config,
+                    emitInitialEnter = emitInitialEnter,
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
                     // a null parse must not clobber a previously cached value.
@@ -349,9 +356,9 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
-            // Synthesis baseline, snapshotted before register/persist mutate the store. Unlike the
-            // registration diff, no reboot override: the post-reboot anchor can predate the reboot,
-            // so containment can't be trusted (same reason boot restore skips synthesis).
+            // Synthesis baseline, snapshotted before register/persist mutate the store. No reboot
+            // override here (unlike the registration diff): callers disable synthesis outright
+            // while the reboot flag is up — the anchor can predate the reboot.
             val unchangedRegistered = unchangedRegisteredIds(nearest)
             val registrationResult = register(regionsToRegister).also { result ->
                 if (result.isSuccess) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -1,0 +1,76 @@
+package io.customer.geofence
+
+import io.customer.geofence.store.PendingGeofenceDelivery
+import io.customer.geofence.worker.GeofenceEventScheduler
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.PendingDeliveryStore
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Cooldown-gated, per-geoset fan-out for one crossing: persist the batch, then schedule delivery.
+ * Shared by the OS broadcast path ([GeofenceBroadcastReceiver]) and the synthesized initial-enter
+ * path ([GeofenceRepository]) so both produce identical rows and dedupe via the cooldown filter.
+ */
+internal class GeofenceTransitionEmitter(
+    private val cooldownFilter: GeofenceCooldownFilter,
+    private val pendingStore: PendingDeliveryStore<PendingGeofenceDelivery>,
+    private val scheduler: GeofenceEventScheduler,
+    private val logger: GeofenceLogger
+) {
+    /** @return false when the cooldown suppressed it or the persist failed (cooldown rolled back). */
+    suspend fun emit(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        userId: String,
+        timestampSeconds: Long,
+        geofenceName: String?,
+        metadata: Map<String, JsonElement>,
+        geosetIds: List<String>
+    ): Boolean {
+        if (!cooldownFilter.tryAcquire(userId, geofenceId, transition)) {
+            logger.logTransitionSuppressed(geofenceId, transition.name)
+            return false
+        }
+        logger.logTransitionEmitting(geofenceId, transition.name)
+
+        // One transitionId shared across the per-geoset fan-out.
+        val transitionId = UUID.randomUUID().toString()
+        val name = geofenceName?.takeIf { it.isNotEmpty() }
+        // One event per geoset; no geosets → one null-geoset event. Distinct so a repeated geoset
+        // doesn't duplicate.
+        val geosets: List<String?> = geosetIds.distinct().takeIf { it.isNotEmpty() } ?: listOf(null)
+        val entries = geosets.map { geosetId ->
+            PendingGeofenceDelivery(
+                geofenceId = geofenceId,
+                transition = transition,
+                timestamp = timestampSeconds,
+                userId = userId,
+                transitionId = transitionId,
+                geofenceName = name,
+                geosetId = geosetId,
+                metadata = metadata
+            )
+        }
+
+        // Persist atomically before any send so an app kill mid-batch can't lose part of the fan-out.
+        // On write failure there's nothing to deliver: roll back the cooldown so the crossing retries.
+        if (!pendingStore.appendAll(entries)) {
+            logger.logPersistFailed(geofenceId, transition.name)
+            cooldownFilter.release(userId, geofenceId, transition)
+            return false
+        }
+        entries.forEach { entry ->
+            // Isolate the scheduler so one failure can't abandon the rest of the batch.
+            try {
+                scheduler.schedule(entry)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.logSchedulerFailed(geofenceId, transition.name, e.message)
+            }
+        }
+        return true
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -13,6 +13,7 @@ import io.customer.geofence.GeofenceRepository
 import io.customer.geofence.GeofenceRepositoryImpl
 import io.customer.geofence.GeofenceServices
 import io.customer.geofence.GeofenceServicesImpl
+import io.customer.geofence.GeofenceTransitionEmitter
 import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.api.GeofenceApiServiceImpl
 import io.customer.geofence.store.GeofenceCooldownStore
@@ -92,6 +93,16 @@ internal val AndroidSDKComponent.asyncGeofenceEventTracker: AsyncGeofenceEventTr
 internal val AndroidSDKComponent.geofenceEventScheduler: GeofenceEventScheduler
     get() = singleton { GeofenceEventScheduler(SDKComponent.workManagerProvider, asyncGeofenceEventTracker) }
 
+internal val AndroidSDKComponent.geofenceTransitionEmitter: GeofenceTransitionEmitter
+    get() = singleton {
+        GeofenceTransitionEmitter(
+            cooldownFilter = geofenceCooldownFilter,
+            pendingStore = pendingGeofenceDeliveryStore,
+            scheduler = geofenceEventScheduler,
+            logger = SDKComponent.geofenceLogger
+        )
+    }
+
 internal val SDKComponent.geofenceDistanceFilter: GeofenceDistanceFilter
     get() = newInstance<GeofenceDistanceFilter> { GeofenceDistanceFilter() }
 
@@ -127,6 +138,7 @@ internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
             manager = geofenceManager,
             secureUserStore = secureUserStore,
             cooldownFilter = geofenceCooldownFilter,
+            transitionEmitter = geofenceTransitionEmitter,
             clock = SDKComponent.clock,
             logger = SDKComponent.geofenceLogger
         )

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1412,9 +1412,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
     @Test
     fun refresh_givenRebootWipedOsState_expectReRegistrationButNoInitialEnter() = runTest {
         // Uptime regressed → reboot wiped GMS, so everything is re-added (empty existing set). But
-        // the launch anchor can predate the reboot, so containment can't be trusted — a fence whose
-        // params didn't change stays silent (mirrors restoreFromCache).
-        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        // the launch anchor can predate the reboot, so containment can't be trusted — no synthesis
+        // for any fence, registered (biz-1) or never-registered (biz-2), mirroring restoreFromCache.
+        val cached = listOf(
+            GeofenceRegion("biz-1", 0.0, 0.0, 100f),
+            GeofenceRegion("biz-2", 0.0, 0.0, 100f)
+        )
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
         every { store.getCachedRegions() } returns cached
@@ -1428,6 +1431,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify { manager.replaceGeofences(any(), emptySet()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenRebootAndStaleCache_expectRemoteFetchButNoInitialEnter() = runTest {
+        // Reboot + expired cache → remote re-fetch, still anchored at the untrusted persisted
+        // point — a newly fetched fence containing it must not synthesize either.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns emptyList()
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getLastRegistrationUptime() } returns 500_000L
+        every { clock.elapsedRealtime() } returns 1_000L // rebooted
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
         coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.customer.commontest.core.RobolectricTest
 import io.customer.geofence.api.GeofenceApiResponse
 import io.customer.geofence.api.GeofenceApiService
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
@@ -42,6 +43,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     private val manager: GeofenceManager = mockk(relaxed = true)
     private val secureUserStore: SecureUserStore = mockk(relaxed = true)
     private val cooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
+    private val transitionEmitter: GeofenceTransitionEmitter = mockk(relaxed = true)
     private val clock: Clock = mockk(relaxed = true)
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val jsonSerializer = GeofenceJsonSerializer()
@@ -63,6 +65,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         manager = manager,
         secureUserStore = secureUserStore,
         cooldownFilter = cooldownFilter,
+        transitionEmitter = transitionEmitter,
         clock = clock,
         logger = logger
     )
@@ -1374,6 +1377,160 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         verify { distanceFilter.nearest(any(), any(), any(), max = 3, maxDistanceMeters = 50_000f) }
+    }
+
+    // ---------- initial enter-when-inside (synthesized; GMS INITIAL_TRIGGER_ENTER is unreliable) ----------
+
+    @Test
+    fun refresh_givenNewlyRegisteredFenceDeviceInside_expectInitialEnterEmitted() = runTest {
+        // Fresh cache but OS regs wiped → local re-register; the fence is newly registered and the
+        // device sits inside it → synthesize the ENTER GMS may have dropped.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet() // newly registered
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any()
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenRebootWipedOsState_expectInitialEnterForAlreadyRegisteredFence() = runTest {
+        // Uptime regressed since the last registration → reboot wiped GMS state, so a fence still
+        // in registeredIds counts as newly monitored and the enter is synthesized.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastRegistrationUptime() } returns 500_000L
+        every { clock.elapsedRealtime() } returns 1_000L // below last registration uptime → rebooted
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any()
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenAlreadyRegisteredFenceDeviceInside_expectNoInitialEnter() = runTest {
+        // Device is inside, but the fence was already monitored (regs intact, no reboot) → no
+        // re-emit; only a genuinely-new registration synthesizes an enter.
+        val cached = listOf(GeofenceRegion("biz-1", 0.02, 0.0, 300f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns setOf("biz-1") // already registered, regs intact
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // ~2.2 km move → local re-rank runs, and the device is inside biz-1 (radius 300 m at 0.02,0.0).
+        repository.refresh(latitude = 0.02, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenNewlyRegisteredFenceDeviceOutside_expectNoInitialEnter() = runTest {
+        // Newly registered but the device isn't within the fence radius → no synthesized enter.
+        // Fence ~111 km from the (0,0) anchor; local re-register (fresh cache, regs wiped).
+        val cached = listOf(GeofenceRegion("biz-1", 1.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenExitOnlyFenceDeviceInside_expectNoInitialEnter() = runTest {
+        // A fence that doesn't monitor ENTER gets no synthesized enter, even sitting inside it.
+        val cached = listOf(
+            GeofenceRegion("biz-1", 0.0, 0.0, 100f, transitionTypes = listOf(GeofenceTransitionType.EXIT))
+        )
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationFails_expectNoInitialEnter() = runTest {
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(RuntimeException("gms boom"))
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun restoreFromCache_givenDeviceInside_expectNoInitialEnter() = runTest {
+        // Boot restore never synthesizes an enter — its anchor may be stale after the device moved
+        // while off, so containment can't be trusted (matches iOS).
+        val movementLoc = GeofenceLocation(latitude = 50.0, longitude = 60.0)
+        val cached = listOf(GeofenceRegion("biz-1", 50.0, 60.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastMovementTriggerLocation() } returns movementLoc
+        every { store.getLastApiFetchLocation() } returns null
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(cached, 50.0, 60.0, any(), any()) } returns cached
+        coEvery { manager.replaceGeofencesForBootRestore(any()) } returns Result.success(Unit)
+
+        repository.restoreFromCache()
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     private fun sampleConfig(

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1410,9 +1410,10 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenRebootWipedOsState_expectInitialEnterForAlreadyRegisteredFence() = runTest {
-        // Uptime regressed since the last registration → reboot wiped GMS state, so a fence still
-        // in registeredIds counts as newly monitored and the enter is synthesized.
+    fun refresh_givenRebootWipedOsState_expectReRegistrationButNoInitialEnter() = runTest {
+        // Uptime regressed → reboot wiped GMS, so everything is re-added (empty existing set). But
+        // the launch anchor can predate the reboot, so containment can't be trusted — a fence whose
+        // params didn't change stays silent (mirrors restoreFromCache).
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
@@ -1426,9 +1427,29 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
+        coVerify { manager.replaceGeofences(any(), emptySet()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenRegisteredFenceParamsChangedDeviceInside_expectInitialEnter() = runTest {
+        // Server grew g-1's radius (50 → 100 m): the fence is re-added to GMS, so it synthesizes
+        // like a new fence when the device is inside the new geometry.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
         coVerify(exactly = 1) {
             transitionEmitter.emit(
-                geofenceId = "biz-1",
+                geofenceId = "g-1",
                 transition = Event.GeofenceTransition.ENTER,
                 userId = "user-42",
                 timestampSeconds = any(),
@@ -1437,6 +1458,32 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 geosetIds = any()
             )
         }
+    }
+
+    @Test
+    fun refresh_givenUserChangesDuringRegistration_expectNoInitialEnter() = runTest {
+        // clearIdentify rewrites the user store without taking stateMutex, so identity can change
+        // while the GMS call is awaited; synthesis must recheck before queueing a delivery row.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val gmsGate = CompletableDeferred<Unit>()
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            gmsGate.await()
+            Result.success(Unit)
+        }
+
+        val refreshJob = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent() // pre-register identity check passed; now suspended in the GMS call
+        every { secureUserStore.getUserId() } returns null // signed out mid-await
+        gmsGate.complete(Unit)
+        refreshJob.join()
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -1,0 +1,107 @@
+package io.customer.geofence
+
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.PendingGeofenceDelivery
+import io.customer.geofence.worker.GeofenceEventScheduler
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.PendingDeliveryStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GeofenceTransitionEmitterTest : RobolectricTest() {
+
+    private val mockCooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
+    private val mockPendingStore: PendingDeliveryStore<PendingGeofenceDelivery> = mockk(relaxed = true)
+    private val mockScheduler: GeofenceEventScheduler = mockk(relaxed = true)
+    private val mockLogger: GeofenceLogger = mockk(relaxed = true)
+
+    private val emitter = GeofenceTransitionEmitter(
+        cooldownFilter = mockCooldownFilter,
+        pendingStore = mockPendingStore,
+        scheduler = mockScheduler,
+        logger = mockLogger
+    )
+
+    @Test
+    fun emit_givenCooldownSuppresses_expectFalseAndNoPersist() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+
+        emitted.shouldBeFalse()
+        verify(exactly = 0) { mockPendingStore.appendAll(any()) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenNoGeosets_expectSingleNullGeosetEntryPersistedAndScheduled() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+        val entries = slot<List<PendingGeofenceDelivery>>()
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, "Cafe", emptyMap(), emptyList())
+
+        emitted.shouldBeTrue()
+        verify { mockPendingStore.appendAll(capture(entries)) }
+        entries.captured.size shouldBeEqualTo 1
+        entries.captured[0].geosetId.shouldBeNull()
+        entries.captured[0].userId shouldBeEqualTo "user-1"
+        entries.captured[0].geofenceName shouldBeEqualTo "Cafe"
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenMultipleGeosets_expectPerGeosetFanoutWithSharedTransitionId() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+        val entries = slot<List<PendingGeofenceDelivery>>()
+
+        // "g1" listed twice → deduped to one entry.
+        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2", "g1"))
+
+        verify { mockPendingStore.appendAll(capture(entries)) }
+        entries.captured.map { it.geosetId } shouldBeEqualTo listOf("g1", "g2")
+        entries.captured.map { it.transitionId }.distinct().size shouldBeEqualTo 1
+        coVerify(exactly = 2) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenSchedulerThrowsForOneGeoset_expectRemainingStillScheduled() = runTest {
+        // A scheduler failure for one geoset must not abandon the rest of the batch; the row is
+        // already persisted, so the foreground flush still delivers the un-scheduled one.
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+        coEvery { mockScheduler.schedule(match { it.geosetId == "g1" }) } throws RuntimeException("boom")
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2"))
+
+        emitted.shouldBeTrue()
+        coVerify(exactly = 1) { mockScheduler.schedule(match { it.geosetId == "g2" }) }
+        verify { mockLogger.logSchedulerFailed("biz-1", "ENTER", any()) }
+    }
+
+    @Test
+    fun emit_givenPersistFails_expectCooldownReleasedAndFalse() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns false
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+
+        emitted.shouldBeFalse()
+        verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+}


### PR DESCRIPTION
## What & why

Android relied on GMS `INITIAL_TRIGGER_ENTER` to report a geofence the user is already inside when it's registered. GMS drops this unreliably — confirmed on-device: a fresh install standing inside a business fence registered 6 fences but fired **no** ENTER (only the movement trigger's did). So a user who logs in / opens the app already inside a fence never got the ENTER.

This synthesizes the ENTER ourselves, matching iOS's `emitInitialEnters`.

## How

After a successful registration, for each business fence that is:
- **newly monitored** (not already registered with unchanged params — a re-register of an unchanged set stays silent; a re-added param change counts as new),
- **monitors ENTER**, and
- **contains the device** (point-in-circle against the sync anchor),

emit an ENTER through the normal delivery path.

- **Cooldown-deduped**: if GMS *does* fire its own ENTER, the two collapse to a single event (no doubles).
- **Login parity**: sign-out clears the registered-id set, so the next sign-in re-fires.
- **Boot restore & reboot excluded**: the anchor may predate the reboot / moving-while-off, so containment can't be trusted (post-reboot registration still re-adds everything).
- **Identity rechecked** after the awaited GMS call — a sign-out/switch mid-registration never queues a synthetic ENTER.
- **Refactor**: extracted the transition fan-out (cooldown → per-geoset persist → schedule) into a shared `GeofenceTransitionEmitter` used by both the broadcast receiver and this new path, so both emit identical event rows.

Derived from an iOS↔Android parity sweep — this was the one substantive iOS-only construct; everything else (event shape, cooldown, delivery, reset, config) was already aligned.

## Scope / safety

- No public API change (`apiCheck` green); no DB/schema change; `:geofence` only.
- Behavior change: **more ENTER events** when identifying/opening while already inside a fence — the intended fix.
- Extraction is behavior-preserving: existing receiver/repo tests pass unedited.
- Threading: `emitInitialEnters` runs under the existing `stateMutex` (coroutine mutex), with identity rechecked after the GMS await. No new locks, deadlocks, or scopes; the receiver's hot path takes no `stateMutex`.

## Testing

Unit: 10 repository initial-enter cases (new+inside→emit, params-changed→emit, reboot-wiped→re-registers but none, reboot+stale-cache remote→none, already-registered→none, outside→none, EXIT-only→none, register-fail→none, user-changed-mid-register→none, boot-restore→none) + 5 `GeofenceTransitionEmitter` cases (suppress / single / multi-geoset shared transitionId / scheduler-throw isolation / persist-fail rollback). `:geofence` + `:core` tests, `apiCheck`, ktlint all green.

**On-device (pre-merge):** fresh install inside a fence → expect exactly one `Geofence Transition` (`enter`) per geoset + log `device already inside a newly-registered fence — synthesizing ENTER`; verify no double when GMS also fires; verify sign-out→sign-in re-fires; verify outside→none and boot-restore→no spam.

## Ticket
https://linear.app/customerio/issue/MBL-2152/android-address-geofencing-improvements

## Stack
```
main
 └─ feature/geofence-on-device
     └─ mbl-2152-geofence-initial-enter  ← this PR
```
Base: `feature/geofence-on-device`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentionally increases ENTER analytics when identifying inside fences; delivery logic is refactored but shared via one emitter with extensive tests—wrong containment or guard bugs could duplicate or miss events.
> 
> **Overview**
> Fixes missing **ENTER** events when the user is already inside a business geofence at registration time—GMS `INITIAL_TRIGGER_ENTER` is unreliable, so the SDK now emits ENTER itself after a successful sync registration (iOS parity).
> 
> **Shared delivery path:** Transition fan-out (cooldown → atomic per-geoset persist → WorkManager schedule) moves into **`GeofenceTransitionEmitter`**. The broadcast receiver delegates OS transitions to it; the repository uses the same emitter so synthetic and real crossings produce identical pending rows and share cooldown dedupe.
> 
> **When synthesis runs:** After registration succeeds, for each nearest business fence that is newly monitored (not unchanged re-register), monitors ENTER, and contains the sync anchor. Skipped on reboot-detected refresh (untrusted anchor), boot restore, failed registration, EXIT-only fences, device outside radius, or user identity change after the GMS await.
> 
> Adds **`logInitialEnterInside`** and broad unit coverage for emitter behavior and repository guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673a481dabbf1b85771f060b917151dee794bfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

