### PR TITLE
fix(live-notifications): identify→start race + logout-during-render writeback

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/pipeline/DataPipeline.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/pipeline/DataPipeline.kt
@@ -12,6 +12,11 @@ import io.customer.base.internal.InternalCustomerIOApi
  */
 @InternalCustomerIOApi
 interface DataPipeline {
+    /**
+     * Whether a user is currently identified. Updated synchronously on the caller's thread
+     * during identify()/clearIdentify(), so it is accurate the instant those calls return —
+     * a consumer may gate on it immediately after identify() without racing async propagation.
+     */
     val isUserIdentified: Boolean
     fun track(name: String, properties: Map<String, Any?>)
 }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -117,6 +117,16 @@ class CustomerIO private constructor(
     // Reset on clearIdentify so a subsequent identify of the same userId is not deduped.
     private var lastIdentifiedUserIdThisSession: String? = null
 
+    // Caller-thread mirror of whether a user is currently identified, backing the synchronous
+    // [isUserIdentified]. analytics.userId() is updated asynchronously and lags a synchronous
+    // identify(), so a consumer that gates on it right after login (e.g. a live-notification
+    // start() on the next line) would otherwise read stale state and drop the event. Set on the
+    // caller's thread during identify()/clearIdentify() so it is accurate the instant they return.
+    // null = no identify/reset has happened this process yet, so fall back to the (possibly
+    // restored-from-persistence) analytics userId; true = identified; false = anonymous.
+    @Volatile
+    private var syncUserIdentified: Boolean? = null
+
     init {
         // Set analytics logger and debug logs based on SDK logger configuration
         Analytics.debugLogsEnabled = logger.logLevel == CioLogLevel.DEBUG
@@ -299,6 +309,9 @@ class CustomerIO private constructor(
         // Update the per-session marker after a successful identify (with or without traits)
         // so that a subsequent no-traits identify of the same userId can be deduped.
         lastIdentifiedUserIdThisSession = userId
+        // Reflect identity synchronously on the caller's thread so isUserIdentified is correct
+        // immediately, before analytics.userId() catches up (see syncUserIdentified).
+        syncUserIdentified = true
     }
 
     /**
@@ -330,6 +343,9 @@ class CustomerIO private constructor(
 
         // Reset the dedup marker so a subsequent identify of the same userId is not deduped.
         lastIdentifiedUserIdThisSession = null
+        // Reflect logout synchronously so isUserIdentified reads false immediately, before
+        // analytics.reset() propagates (see syncUserIdentified).
+        syncUserIdentified = false
 
         logger.debug("deleting device token to remove device from user profile")
 
@@ -359,7 +375,10 @@ class CustomerIO private constructor(
         get() = analytics.userId()
 
     override val isUserIdentified: Boolean
-        get() = !analytics.userId().isNullOrEmpty()
+        // Prefer the caller-thread mirror so this is correct synchronously right after
+        // identify()/clearIdentify(); fall back to analytics for a session restored from
+        // persistence, where neither was called this process. See [syncUserIdentified].
+        get() = syncUserIdentified ?: !analytics.userId().isNullOrEmpty()
 
     @Deprecated("Use setDeviceAttributes() function instead")
     @set:JvmName("setDeviceAttributesDeprecated")

--- a/datapipelines/src/test/java/io/customer/datapipelines/IsUserIdentifiedSyncTests.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/IsUserIdentifiedSyncTests.kt
@@ -1,0 +1,47 @@
+package io.customer.datapipelines
+
+import io.customer.commontest.extensions.random
+import io.customer.datapipelines.testutils.core.JUnitTest
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Direct coverage for the synchronous `CustomerIO.isUserIdentified` mirror at the layer that owns
+ * it. The messagingpush live-notification tests mock `isUserIdentified`, so they don't prove the
+ * contract itself: it must flip true on the caller thread the instant `identify()` returns (before
+ * the async `analytics.userId()` catches up), flip false the instant `clearIdentify()` returns, and
+ * still reflect a session restored from persistence where neither was called this process.
+ */
+class IsUserIdentifiedSyncTests : JUnitTest() {
+
+    @Test
+    fun isUserIdentified_isTrueSynchronouslyAfterIdentify() {
+        sdkInstance.isUserIdentified.shouldBeFalse()
+
+        sdkInstance.identify(String.random)
+
+        // No async wait: the mirror is set on the caller thread inside identify(), so a consumer
+        // gating on it immediately after login (e.g. a live-notification start()) is not dropped.
+        sdkInstance.isUserIdentified.shouldBeTrue()
+    }
+
+    @Test
+    fun isUserIdentified_isFalseSynchronouslyAfterClearIdentify() {
+        sdkInstance.identify(String.random)
+        sdkInstance.isUserIdentified.shouldBeTrue()
+
+        sdkInstance.clearIdentify()
+
+        sdkInstance.isUserIdentified.shouldBeFalse()
+    }
+
+    @Test
+    fun isUserIdentified_fallsBackToAnalyticsForRestoredSession() {
+        // Cold launch: no identify() this process (the mirror stays unset), but analytics restored a
+        // userId from persistence. isUserIdentified must reflect the restored user via the fallback.
+        analytics.identify(String.random)
+
+        sdkInstance.isUserIdentified.shouldBeTrue()
+    }
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -71,7 +71,12 @@ internal class LiveNotificationHandler(
         // out-of-order timestamp dedupe and the terminal ended check/claim). They are
         // governed by LiveNotificationManager instead, which enforces terminal state on
         // the local start/update/end paths before rendering.
-        bypassOrderGuard: Boolean = false
+        bypassOrderGuard: Boolean = false,
+        // Re-checked after the (potentially slow) render work and immediately before the
+        // notification is posted and the activity type is written back. Returns true when a
+        // logout/reset landed during rendering, in which case the render is dropped so it
+        // can't post or re-store a previous user's activity. Local renders only.
+        isSuperseded: () -> Boolean = { false }
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS)
@@ -193,6 +198,16 @@ internal class LiveNotificationHandler(
             ?.createLiveNotification(parsedPayload, context)
         val notification = appNotification ?: result?.let {
             buildSdkNotification(context, channelId, effectiveSmallIcon, it, pendingIntent, deletePendingIntent, ongoing = !isEnd)
+        }
+
+        // A logout/reset may have landed while the branding logo downloaded or the app
+        // renderer ran above. If so, drop this render: don't post the notification and don't
+        // write the activity type back into the store that reset just cleared.
+        if (isSuperseded()) {
+            SDKComponent.logger.debug(
+                "Live notification render for '$activityId' was superseded by a reset; dropping."
+            )
+            return
         }
 
         when {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -30,30 +30,12 @@ internal interface LiveNotificationLifecycleClient {
 
     /** Reports a `register_push_to_start` event; returns true if it was emitted. */
     fun registerPushToStart(activityType: String, deviceId: String): Boolean
-
-    /**
-     * Updates the cached identified-user state used to gate lifecycle events. Fed
-     * synchronously from `Event.UserChangedEvent` (via [LiveNotificationRegistrar])
-     * rather than the pipeline's own flag, which lags a synchronous `identify()` and
-     * would otherwise drop the first start/update/end right after login.
-     */
-    fun setIdentified(identified: Boolean)
 }
 
 @OptIn(InternalCustomerIOApi::class)
 internal class LiveNotificationLifecycleClientImpl(
     private val dataPipelineProvider: () -> DataPipeline? = { SDKComponent.getOrNull<DataPipeline>() }
 ) : LiveNotificationLifecycleClient {
-
-    // Identified-user state, fed synchronously from Event.UserChangedEvent via the
-    // registrar. Used instead of pipeline.isUserIdentified, which lags a synchronous
-    // identify() and would drop the first lifecycle event right after login.
-    @Volatile
-    private var isIdentified: Boolean = false
-
-    override fun setIdentified(identified: Boolean) {
-        isIdentified = identified
-    }
 
     override fun reportStart(
         instanceUUID: String,
@@ -138,7 +120,9 @@ internal class LiveNotificationLifecycleClientImpl(
             SDKComponent.logger.debug("Data pipeline unavailable; dropping live notification event '$event'.")
             return false
         }
-        if (requireIdentifiedUser && !isIdentified) {
+        // pipeline.isUserIdentified is updated synchronously during identify()/clearIdentify(),
+        // so an identify() immediately followed by start() is not dropped by a stale flag.
+        if (requireIdentifiedUser && !pipeline.isUserIdentified) {
             SDKComponent.logger.debug("Live notifications require an identified user; dropping event '$event'.")
             return false
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -203,11 +203,15 @@ internal class LiveNotificationManager(
             // A logout/reset after this render was queued invalidates it, so it can't
             // re-post a previous user's activity into a store that reset just cleared.
             if (generation != renderGeneration) return@launch
-            renderLocally(bundle)
+            // The render below performs a blocking branding-logo download (up to ~20s) and
+            // may invoke a slow app renderer. A logout can land during that window — after
+            // this pre-check passed — so the handler re-checks the generation immediately
+            // before it posts the notification and writes the activity type back.
+            renderLocally(bundle, isSuperseded = { generation != renderGeneration })
         }
     }
 
-    private fun renderLocally(bundle: Bundle) {
+    private fun renderLocally(bundle: Bundle, isSuperseded: () -> Boolean) {
         val ctx = context
         val appMetaData = ctx.applicationMetaData()
         val applicationName = ctx.applicationInfo.loadLabel(ctx.packageManager).toString()
@@ -234,7 +238,8 @@ internal class LiveNotificationManager(
             tintColor = tintColor,
             channelId = channelId,
             notificationManager = notificationManager,
-            bypassOrderGuard = true
+            bypassOrderGuard = true,
+            isSuperseded = isSuperseded
         )
     }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -51,9 +51,6 @@ internal class LiveNotificationRegistrar(
     internal fun onUserChanged(event: Event.UserChangedEvent) {
         userId = event.userId ?: event.anonymousId
         isIdentified = event.userId != null
-        // Feed identity to the lifecycle client synchronously so local start/update/end
-        // reporting isn't gated by the pipeline's laggy isUserIdentified flag.
-        client.setIdentified(isIdentified)
         registerAll()
     }
 
@@ -66,11 +63,12 @@ internal class LiveNotificationRegistrar(
     internal fun onReset() {
         SDKComponent.liveNotificationManager.cancelAllActivities()
         store.clearRegistrations()
-        // Drop identity so post-logout local start/update/end aren't reported as the
-        // previous (identified) user until a new UserChangedEvent arrives.
+        // Drop identity so a post-logout push-to-start registration isn't sent for the
+        // previous (identified) user until a new UserChangedEvent arrives. Local
+        // start/update/end gating uses pipeline.isUserIdentified, cleared synchronously by
+        // clearIdentify().
         userId = ""
         isIdentified = false
-        client.setIdentified(false)
     }
 
     private fun registerAll() {

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -82,7 +82,11 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
 
     private fun handlerFor(bundle: Bundle): LiveNotificationHandler = LiveNotificationHandler(bundle)
 
-    private fun invoke(handler: LiveNotificationHandler, bypassOrderGuard: Boolean = false) {
+    private fun invoke(
+        handler: LiveNotificationHandler,
+        bypassOrderGuard: Boolean = false,
+        isSuperseded: () -> Boolean = { false }
+    ) {
         handler.handle(
             context = contextMock,
             deliveryId = "delivery-id-1",
@@ -91,7 +95,8 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
             tintColor = null,
             channelId = channelId,
             notificationManager = notificationManager,
-            bypassOrderGuard = bypassOrderGuard
+            bypassOrderGuard = bypassOrderGuard,
+            isSuperseded = isSuperseded
         )
     }
 
@@ -276,6 +281,36 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
     }
 
     // --- Missing required fields short-circuit ---
+
+    // --- Superseded-by-reset guard (logout during a slow render) ---
+
+    @Test
+    fun handle_givenSupersededByReset_dropsRenderWithoutNotifyingOrStoring() {
+        // A logout can land while the branding logo downloads or the app renderer runs. When it
+        // does, the render must be dropped after that work completes: it must not post the
+        // notification nor write the activity type back into the store the reset just cleared.
+        val activityId = "live-act-1"
+
+        invoke(handlerFor(newBundle(activityId = activityId)), bypassOrderGuard = true, isSuperseded = { true })
+
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+        SDKComponent.liveNotificationStore.activityType(activityId).shouldBeNull()
+    }
+
+    @Test
+    fun handle_givenNotSuperseded_postsAndStoresActivityType() {
+        // The complement of the guard above: a render that is still current posts and writes back.
+        val activityId = "live-act-1"
+
+        invoke(handlerFor(newBundle(activityId = activityId)), bypassOrderGuard = true, isSuperseded = { false })
+
+        verify {
+            notificationManager.notify(activityId, any<Int>(), any<Notification>())
+        }
+        SDKComponent.liveNotificationStore.activityType(activityId).shouldNotBeNull()
+    }
 
     @Test
     fun handle_givenMissingActivityId_returnsEarlyWithoutNotifying() {

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -38,9 +38,9 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     private val client = LiveNotificationLifecycleClientImpl(dataPipelineProvider = { pipeline })
 
     private fun identified() {
-        // Identity is fed synchronously via setIdentified (from UserChangedEvent), not
-        // read from the pipeline's laggy isUserIdentified flag.
-        client.setIdentified(true)
+        // The client gates on pipeline.isUserIdentified, which the data pipeline updates
+        // synchronously during identify()/clearIdentify() (so it doesn't lag a login).
+        every { pipeline.isUserIdentified } returns true
     }
 
     @Test
@@ -174,7 +174,7 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
 
     @Test
     fun lifecycleEvents_areDroppedForAnonymousUser() {
-        client.setIdentified(false)
+        every { pipeline.isUserIdentified } returns false
 
         client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
         client.reportUpdate("inst-1", "type", "fcm-tok", emptyMap())
@@ -184,13 +184,12 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     }
 
     @Test
-    fun lifecycleEvents_gateOnSyncIdentityNotPipelineFlag() {
-        // The pipeline's own flag lags a synchronous identify(); the client must gate on
-        // the identity fed via setIdentified (from UserChangedEvent) so the first event
-        // right after login isn't dropped.
-        every { pipeline.isUserIdentified } returns false
+    fun lifecycleEvents_gateOnPipelineIsUserIdentified() {
+        // The gate reads pipeline.isUserIdentified directly. The pipeline updates it
+        // synchronously during identify(), so an identify() immediately followed by start()
+        // is reported rather than dropped by a stale flag.
+        every { pipeline.isUserIdentified } returns true
         every { pipeline.track(any(), any()) } returns Unit
-        client.setIdentified(true)
 
         client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
 
@@ -201,7 +200,7 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     fun registerPushToStart_isNotGatedByIdentity() {
         // Identity is gated upstream by LiveNotificationRegistrar; the client must NOT
         // re-check identity for the registration event (that re-introduced the login race).
-        client.setIdentified(false)
+        every { pipeline.isUserIdentified } returns false
         every { pipeline.track(any(), any()) } returns Unit
 
         val emitted = client.registerPushToStart("type", "fcm-tok")

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrarTest.kt
@@ -62,25 +62,18 @@ internal class LiveNotificationRegistrarTest : IntegrationTest() {
     }
 
     @Test
-    fun onUserChanged_feedsIdentityToLifecycleClient() {
-        // The client gates local lifecycle events on this synchronous signal instead of
-        // the pipeline's laggy isUserIdentified flag (avoids dropping the first event after login).
-        registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
-        verify { client.setIdentified(true) }
-
-        registrar.onUserChanged(Event.UserChangedEvent(userId = null, anonymousId = "anon"))
-        verify { client.setIdentified(false) }
-    }
-
-    @Test
-    fun onReset_clearsLifecycleIdentity() {
-        // Logout must gate off local lifecycle reporting until a new identify, so the
-        // client's identity is reset to false on reset.
+    fun onReset_skipsRegistrationUntilNextIdentify() {
+        // Local lifecycle events gate on pipeline.isUserIdentified (cleared synchronously by
+        // clearIdentify), so the registrar no longer feeds identity to the client. It still
+        // drops its own identity on reset so a held token isn't re-registered while anonymous.
+        registrar.onDeviceTokenChanged("fcm-tok")
         registrar.onUserChanged(Event.UserChangedEvent(userId = "u1", anonymousId = "anon"))
 
         registrar.onReset()
+        registrar.onDeviceTokenChanged("fcm-tok-2")
 
-        verify { client.setIdentified(false) }
+        // The token arriving after reset (while anonymous) must not register.
+        verify(exactly = 0) { client.registerPushToStart(type, "fcm-tok-2") }
     }
 
     @Test


### PR DESCRIPTION
Fixes two live-notification races on the local path.

- **identify()→start() drop:** `DataPipeline.isUserIdentified` is now updated synchronously on the caller thread during identify()/clearIdentify(), so a start/update/end issued immediately after identify() is reported instead of dropped by an async-lagging identity flag. The lifecycle client gates on `pipeline.isUserIdentified` instead of an EventBus-fed cached flag.
- **logout during a slow render:** the handler re-checks the render generation immediately before posting the notification and writing the activity type back, so a logout landing during the branding-logo download / app renderer can't resurface the previous user's activity.

Unit tests updated/added; `:messagingpush` and `:datapipelines` unit suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches identity semantics used across the data pipeline and live-notification lifecycle; behavior change is intentional but affects login/logout timing-sensitive paths.
> 
> **Overview**
> Fixes two **local live-notification races**.
> 
> **identify() → start() drop:** `CustomerIO` now keeps a caller-thread `syncUserIdentified` mirror set in `identify()` / `clearIdentify()`, so `DataPipeline.isUserIdentified` is correct as soon as those calls return (instead of lagging behind async `analytics.userId()`). `LiveNotificationLifecycleClient` gates start/update/end on `pipeline.isUserIdentified` and drops the separate `setIdentified` / EventBus-fed cache.
> 
> **Logout during slow render:** `LiveNotificationHandler` accepts an `isSuperseded` callback checked right before `notify` and `setActivityType`, so a reset during branding download or custom rendering cannot repost or write back into a cleared store. `LiveNotificationManager` wires this to its `renderGeneration` bump on logout.
> 
> Adds `IsUserIdentifiedSyncTests` and updates handler/registrar/lifecycle tests for the new contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41d2d171f8496b013970d5b88f2edec03b7e83d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->