### PR TITLE
chore(geofence): drop regions the OS would reject instead of crashing the sync

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -48,6 +48,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId': device already inside a newly-registered fence — synthesizing ENTER (GMS INITIAL_TRIGGER_ENTER is unreliable)", tag = TAG)
     }
 
+    fun logInvalidRegionDropped(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' dropped — invalid coordinates or radius, not registerable with the OS", tag = TAG)
+    }
+
     fun logTransitionDroppedUnknownId(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -52,6 +52,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' dropped — invalid coordinates or radius, not registerable with the OS", tag = TAG)
     }
 
+    fun logRegionMappingFailed(geofenceId: String, message: String?) {
+        logger.error("Geofence '$geofenceId' dropped — mapping failed unexpectedly: $message", tag = TAG)
+    }
+
     fun logTransitionDroppedUnknownId(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
@@ -128,10 +128,16 @@ internal class GeofenceManager(
         regions: List<GeofenceRegion>,
         initialTrigger: Int
     ): Result<Unit> {
-        val request = GeofencingRequest.Builder()
-            .setInitialTrigger(initialTrigger)
-            .addGeofences(regions.map { it.toGmsGeofence() })
-            .build()
+        // Defense in depth: a GMS rejection must fail the sync, never crash the host.
+        val request = try {
+            GeofencingRequest.Builder()
+                .setInitialTrigger(initialTrigger)
+                .addGeofences(regions.map { it.toGmsGeofence() })
+                .build()
+        } catch (e: IllegalArgumentException) {
+            logger.logRegistrationFailed(e.message)
+            return Result.failure(e)
+        }
 
         return suspendCancellableCoroutine { cont ->
             try {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -238,9 +238,16 @@ internal class GeofenceRepositoryImpl(
         val fetchResult = apiService.fetchGeofences(fetchLocation)
         return fetchResult.fold(
             onSuccess = { response ->
-                val regions = response.toDomainRegions()
+                // An unusable response throws (see toDomainRegions) — fail the refresh and
+                // keep current registrations; never let it escape the handler-less scope.
+                val mapped = runCatching {
+                    response.toDomainRegions() to response.toDomainConfig()
+                }.getOrElse { e ->
+                    logger.logSyncFailed("response mapping failed: ${e.message}")
+                    return@fold Result.failure(e)
+                }
+                val (regions, parsedConfig) = mapped
                 // Config preference: server-shipped > last cached > constants.
-                val parsedConfig = response.toDomainConfig()
                 val config = parsedConfig ?: store.getCachedConfigOrFallback()
                 registerNearestAndPersist(
                     userId = userId,

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -84,14 +84,26 @@ internal data class GeofenceApiRegion(
 internal fun GeofenceApiResponse.toDomainConfig(): GeofenceConfig? =
     config?.toDomain()
 
-internal fun GeofenceApiResponse.toDomainRegions(): List<GeofenceRegion> =
-    geofences.mapNotNull { region ->
-        // Unknown-unknowns net: an escaping throw would crash the host (scope has no exception handler).
-        runCatching { region.toDomain() }.getOrNull() ?: run {
-            SDKComponent.geofenceLogger.logInvalidRegionDropped(region.id)
+// One bad region costs itself (dropped + logged). A non-empty response whose regions ALL drop
+// is unusable — throw so the caller fails the refresh instead of clearing live state.
+internal fun GeofenceApiResponse.toDomainRegions(): List<GeofenceRegion> {
+    if (geofences.isEmpty()) return emptyList()
+
+    val mapped = geofences.mapNotNull { region ->
+        try {
+            region.toDomain() ?: run {
+                SDKComponent.geofenceLogger.logInvalidRegionDropped(region.id)
+                null
+            }
+        } catch (e: Exception) {
+            SDKComponent.geofenceLogger.logRegionMappingFailed(region.id, e.message)
             null
         }
     }
+
+    if (mapped.isEmpty()) error("all ${geofences.size} regions dropped")
+    return mapped
+}
 
 // Coerces raw server values into sane bounds so a misconfigured backend can't push the SDK into a
 // pathological state: non-positive values fall back; positive out-of-range values clamp.
@@ -136,7 +148,7 @@ private fun GeofenceApiConfig.toDomain(): GeofenceConfig {
 }
 
 // Null when the region violates Geofence.Builder preconditions; one bad region must not cost the whole sync.
-private fun GeofenceApiRegion.toDomain(): GeofenceRegion? {
+internal fun GeofenceApiRegion.toDomain(): GeofenceRegion? {
     if (radius <= 0 || !LocationCoordinates.isValid(latitude, longitude)) return null
     return GeofenceRegion(
         id = id,

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -5,6 +5,7 @@ import io.customer.geofence.GeofenceConstants
 import io.customer.geofence.GeofenceRegion
 import io.customer.geofence.GeofenceTransitionType
 import io.customer.geofence.di.geofenceLogger
+import io.customer.location.LocationCoordinates
 import io.customer.sdk.core.di.SDKComponent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -84,7 +85,13 @@ internal fun GeofenceApiResponse.toDomainConfig(): GeofenceConfig? =
     config?.toDomain()
 
 internal fun GeofenceApiResponse.toDomainRegions(): List<GeofenceRegion> =
-    geofences.map { it.toDomain() }
+    geofences.mapNotNull { region ->
+        // Unknown-unknowns net: an escaping throw would crash the host (scope has no exception handler).
+        runCatching { region.toDomain() }.getOrNull() ?: run {
+            SDKComponent.geofenceLogger.logInvalidRegionDropped(region.id)
+            null
+        }
+    }
 
 // Coerces raw server values into sane bounds so a misconfigured backend can't push the SDK into a
 // pathological state: non-positive values fall back; positive out-of-range values clamp.
@@ -128,18 +135,22 @@ private fun GeofenceApiConfig.toDomain(): GeofenceConfig {
     )
 }
 
-private fun GeofenceApiRegion.toDomain(): GeofenceRegion = GeofenceRegion(
-    id = id,
-    name = name,
-    externalId = externalId,
-    latitude = latitude,
-    longitude = longitude,
-    radius = radius.toFloat(),
-    transitionTypes = resolveTransitionTypes(transitionTypes),
-    lastUpdated = lastUpdated ?: 0L,
-    geosetIds = geosetIds,
-    metadata = sanitizeMetadata(metadata)
-)
+// Null when the region violates Geofence.Builder preconditions; one bad region must not cost the whole sync.
+private fun GeofenceApiRegion.toDomain(): GeofenceRegion? {
+    if (radius <= 0 || !LocationCoordinates.isValid(latitude, longitude)) return null
+    return GeofenceRegion(
+        id = id,
+        name = name,
+        externalId = externalId,
+        latitude = latitude,
+        longitude = longitude,
+        radius = radius.toFloat(),
+        transitionTypes = resolveTransitionTypes(transitionTypes),
+        lastUpdated = lastUpdated ?: 0L,
+        geosetIds = geosetIds,
+        metadata = sanitizeMetadata(metadata)
+    )
+}
 
 /**
  * Reduces the raw wire value to the scalar map the event can carry: anything that isn't a JSON object

--- a/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
@@ -101,6 +101,19 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
+    fun replaceGeofences_givenRegionGmsRejects_expectFailureNotCrash() = runTest {
+        // Defense in depth behind parse-time validation: GMS throws IllegalArgumentException
+        // at request build for a non-positive radius — the sync must fail, never throw (the
+        // geofence scope has no exception handler, so an escape would crash the host).
+        grantAllPermissions()
+
+        val result = manager.replaceGeofences(listOf(buildRegion(radius = 0f)))
+
+        result.isFailure.shouldBeTrue()
+        verify(exactly = 0) { client.addGeofences(any<GeofencingRequest>(), any()) }
+    }
+
+    @Test
     fun replaceGeofences_givenBusinessGeofences_expectInitialTriggerEnter() = runTest {
         grantAllPermissions()
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
@@ -102,9 +102,7 @@ class GeofenceManagerTest : RobolectricTest() {
 
     @Test
     fun replaceGeofences_givenRegionGmsRejects_expectFailureNotCrash() = runTest {
-        // Defense in depth behind parse-time validation: GMS throws IllegalArgumentException
-        // at request build for a non-positive radius — the sync must fail, never throw (the
-        // geofence scope has no exception handler, so an escape would crash the host).
+        // GMS rejects the request at build (radius 0) — the sync must fail, never throw.
         grantAllPermissions()
 
         val result = manager.replaceGeofences(listOf(buildRegion(radius = 0f)))

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -5,6 +5,7 @@ import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
 import io.customer.geofence.api.GeofenceApiResponse
 import io.customer.geofence.api.GeofenceApiService
+import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
@@ -14,7 +15,9 @@ import io.mockk.coVerify
 import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
@@ -387,6 +390,30 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenResponseMappingThrows_expectFailureNotEmptySuccess() = runTest {
+        // Unusable response fails the refresh; nothing registered, removed, or persisted.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        try {
+            every { any<GeofenceApiResponse>().toDomainRegions() } throws IllegalStateException("mapper defect")
+
+            val result = repository.refresh(latitude = 12.34, longitude = 56.78)
+
+            result.isFailure shouldBeEqualTo true
+            verify { logger.logSyncFailed(match { it?.contains("mapper defect") == true }) }
+            coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+            coVerify(exactly = 0) { manager.removeGeofencesByIds(any()) }
+            verify(exactly = 0) { store.saveCachedRegions(any()) }
+            verify(exactly = 0) { store.saveRegisteredIds(any()) }
+        } finally {
+            unmockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -86,6 +86,46 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parseAndMap_givenInvalidRegions_expectDroppedAndValidKept() {
+        // GMS throws IllegalArgumentException for these at registration — one bad region
+        // must never fail the sync (or crash the host). Each is dropped with a log.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                { "id": "zero-radius", "latitude": 0.0, "longitude": 0.0, "radius": 0 },
+                { "id": "negative-radius", "latitude": 0.0, "longitude": 0.0, "radius": -5 },
+                { "id": "bad-lat", "latitude": 91.0, "longitude": 0.0, "radius": 100 },
+                { "id": "bad-lng", "latitude": 0.0, "longitude": 181.0, "radius": 100 },
+                { "id": "valid", "latitude": 40.7, "longitude": -74.0, "radius": 100 }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        regions.map { it.id } shouldBeEqualTo listOf("valid")
+        verify(exactly = 4) { mockLogger.logInvalidRegionDropped(any()) }
+        verify { mockLogger.logInvalidRegionDropped("zero-radius") }
+    }
+
+    @Test
+    fun parseAndMap_givenBoundaryCoordinates_expectKept() {
+        // Poles and the antimeridian are valid registerable values — the validation is
+        // inclusive at the boundaries.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                { "id": "pole", "latitude": -90.0, "longitude": 180.0, "radius": 0.5 }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        regions.map { it.id } shouldBeEqualTo listOf("pole")
+    }
+
+    @Test
     fun parseAndMap_givenNoGeosetIds_expectEmpty() {
         val regions = parseRegions(
             """{ "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": 100 } ] }"""

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -164,6 +164,18 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parse_givenNaNOrInfinityValues_expectDecodeFails() {
+        // Pins the assumption that lets toDomain skip isFinite checks: the serializer has
+        // no allowSpecialFloatingPointValues, so NaN/Infinity can never reach mapping —
+        // even via lenient-mode quoted strings. Decode failure -> Result.failure upstream.
+        val nanRadius = """{ "geofences": [ { "id": 1, "latitude": 0.0, "longitude": 0.0, "radius": "NaN" } ] }"""
+        val infLatitude = """{ "geofences": [ { "id": 1, "latitude": "Infinity", "longitude": 0.0, "radius": 100 } ] }"""
+
+        invoking { parseResponse(nanRadius) } shouldThrow Exception::class
+        invoking { parseResponse(infLatitude) } shouldThrow Exception::class
+    }
+
+    @Test
     fun parseAndMap_givenBoundaryCoordinates_expectKept() {
         // Poles and the antimeridian are valid registerable values — the validation is
         // inclusive at the boundaries.

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -9,13 +9,18 @@ import io.customer.geofence.GeofenceJsonSerializer
 import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.GeofenceRegion
 import io.customer.geofence.GeofenceTransitionType
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.serialization.json.JsonPrimitive
+import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldContainSame
+import org.amshove.kluent.shouldThrow
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -87,8 +92,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
 
     @Test
     fun parseAndMap_givenInvalidRegions_expectDroppedAndValidKept() {
-        // GMS throws IllegalArgumentException for these at registration — one bad region
-        // must never fail the sync (or crash the host). Each is dropped with a log.
+        // GMS would throw for these at registration — each drops alone, with a log.
         val regions = parseRegions(
             """
             {
@@ -106,6 +110,57 @@ class GeofenceApiResponseTest : RobolectricTest() {
         regions.map { it.id } shouldBeEqualTo listOf("valid")
         verify(exactly = 4) { mockLogger.logInvalidRegionDropped(any()) }
         verify { mockLogger.logInvalidRegionDropped("zero-radius") }
+    }
+
+    @Test
+    fun parseAndMap_givenOneRegionMappingThrows_expectOthersKept() {
+        // One region's unexpected mapper throw must cost only itself.
+        val response = parseResponse(twoValidRegionsJson())
+        mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        try {
+            every { any<GeofenceApiRegion>().toDomain() } answers {
+                val region = invocation.self as GeofenceApiRegion
+                if (region.id == "1") throw IllegalStateException("metadata defect") else callOriginal()
+            }
+
+            val regions = response.toDomainRegions()
+
+            regions.map { it.id } shouldBeEqualTo listOf("2")
+            verify { mockLogger.logRegionMappingFailed("1", "metadata defect") }
+        } finally {
+            unmockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        }
+    }
+
+    @Test
+    fun parseAndMap_givenAllRegionsMappingThrow_expectThrowsNotEmptyList() {
+        // All regions dropping = unusable response; an empty "success" would wipe live registrations.
+        val response = parseResponse(twoValidRegionsJson())
+        mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        try {
+            every { any<GeofenceApiRegion>().toDomain() } throws IllegalStateException("mapper defect")
+
+            invoking { response.toDomainRegions() } shouldThrow IllegalStateException::class
+        } finally {
+            unmockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        }
+    }
+
+    @Test
+    fun parseAndMap_givenAllRegionsInvalid_expectThrowsNotEmptyList() {
+        // Same guard for all-invalid values (no exceptions involved) — only a genuinely
+        // empty response may produce an empty result.
+        val raw = """
+            {
+              "geofences": [
+                { "id": "zero-radius", "latitude": 0.0, "longitude": 0.0, "radius": 0 },
+                { "id": "bad-lat", "latitude": 91.0, "longitude": 0.0, "radius": 100 }
+              ]
+            }
+        """.trimIndent()
+
+        invoking { parseRegions(raw) } shouldThrow IllegalStateException::class
+        verify(exactly = 2) { mockLogger.logInvalidRegionDropped(any()) }
     }
 
     @Test
@@ -572,6 +627,15 @@ class GeofenceApiResponseTest : RobolectricTest() {
 
     private fun parseRegions(raw: String): List<GeofenceRegion> =
         parseResponse(raw).toDomainRegions()
+
+    private fun twoValidRegionsJson(): String = """
+        {
+          "geofences": [
+            { "id": 1, "latitude": 10.0, "longitude": 10.0, "radius": 100 },
+            { "id": 2, "latitude": 20.0, "longitude": 20.0, "radius": 100 }
+          ]
+        }
+    """.trimIndent()
 
     private fun regionJsonWith(transitionTypes: String): String = """
         {

--- a/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
@@ -29,7 +29,7 @@ internal class LocationServicesImpl(
             return
         }
 
-        if (!isValidCoordinate(latitude, longitude)) {
+        if (!LocationCoordinates.isValid(latitude, longitude)) {
             logger.error("Invalid coordinates: lat=$latitude, lng=$longitude. Latitude must be [-90, 90] and longitude [-180, 180].")
             return
         }
@@ -83,17 +83,5 @@ internal class LocationServicesImpl(
         currentLocationJob = null
         job.cancel()
         return true
-    }
-
-    companion object {
-        /**
-         * Validates that latitude is within [-90, 90] and longitude is within [-180, 180].
-         * Also rejects NaN and Infinity values.
-         */
-        internal fun isValidCoordinate(latitude: Double, longitude: Double): Boolean {
-            if (latitude.isNaN() || latitude.isInfinite()) return false
-            if (longitude.isNaN() || longitude.isInfinite()) return false
-            return latitude in -90.0..90.0 && longitude in -180.0..180.0
-        }
     }
 }

--- a/location/src/main/kotlin/io/customer/location/LocationTracker.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationTracker.kt
@@ -178,4 +178,18 @@ internal class LocationTracker(
 data class LocationCoordinates(
     val latitude: Double,
     val longitude: Double
-)
+) {
+    // The API validator checks nested classes individually — the companion doesn't inherit the marker.
+    @InternalCustomerIOApi
+    companion object {
+        /**
+         * Validates that latitude is within [-90, 90] and longitude is within [-180, 180].
+         * Also rejects NaN and Infinity values.
+         */
+        fun isValid(latitude: Double, longitude: Double): Boolean {
+            if (latitude.isNaN() || latitude.isInfinite()) return false
+            if (longitude.isNaN() || longitude.isInfinite()) return false
+            return latitude in -90.0..90.0 && longitude in -180.0..180.0
+        }
+    }
+}

--- a/location/src/test/java/io/customer/location/LocationCoordinatesTest.kt
+++ b/location/src/test/java/io/customer/location/LocationCoordinatesTest.kt
@@ -1,0 +1,44 @@
+package io.customer.location
+
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class LocationCoordinatesTest {
+
+    @Test
+    fun isValid_givenValidCoordinates_expectTrue() {
+        LocationCoordinates.isValid(37.7749, -122.4194).shouldBeTrue()
+    }
+
+    @Test
+    fun isValid_givenBoundaryValues_expectTrue() {
+        LocationCoordinates.isValid(90.0, 180.0).shouldBeTrue()
+        LocationCoordinates.isValid(-90.0, -180.0).shouldBeTrue()
+        LocationCoordinates.isValid(0.0, 0.0).shouldBeTrue()
+    }
+
+    @Test
+    fun isValid_givenLatitudeOutOfRange_expectFalse() {
+        LocationCoordinates.isValid(91.0, 0.0).shouldBeFalse()
+        LocationCoordinates.isValid(-91.0, 0.0).shouldBeFalse()
+    }
+
+    @Test
+    fun isValid_givenLongitudeOutOfRange_expectFalse() {
+        LocationCoordinates.isValid(0.0, 181.0).shouldBeFalse()
+        LocationCoordinates.isValid(0.0, -181.0).shouldBeFalse()
+    }
+
+    @Test
+    fun isValid_givenNaN_expectFalse() {
+        LocationCoordinates.isValid(Double.NaN, 0.0).shouldBeFalse()
+        LocationCoordinates.isValid(0.0, Double.NaN).shouldBeFalse()
+    }
+
+    @Test
+    fun isValid_givenInfinity_expectFalse() {
+        LocationCoordinates.isValid(Double.POSITIVE_INFINITY, 0.0).shouldBeFalse()
+        LocationCoordinates.isValid(0.0, Double.NEGATIVE_INFINITY).shouldBeFalse()
+    }
+}

--- a/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
+++ b/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
@@ -7,8 +7,6 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class, InternalCustomerIOApi::class)
@@ -81,43 +79,5 @@ class LocationServicesImplTest {
 
         coVerify { orchestrator.requestLocationUpdateSilently() }
         coVerify(exactly = 0) { orchestrator.requestLocationUpdate() }
-    }
-
-    // -- Coordinate validation tests --
-
-    @Test
-    fun isValidCoordinate_givenValidCoordinates_expectTrue() {
-        LocationServicesImpl.isValidCoordinate(37.7749, -122.4194).shouldBeTrue()
-    }
-
-    @Test
-    fun isValidCoordinate_givenBoundaryValues_expectTrue() {
-        LocationServicesImpl.isValidCoordinate(90.0, 180.0).shouldBeTrue()
-        LocationServicesImpl.isValidCoordinate(-90.0, -180.0).shouldBeTrue()
-        LocationServicesImpl.isValidCoordinate(0.0, 0.0).shouldBeTrue()
-    }
-
-    @Test
-    fun isValidCoordinate_givenLatitudeOutOfRange_expectFalse() {
-        LocationServicesImpl.isValidCoordinate(91.0, 0.0).shouldBeFalse()
-        LocationServicesImpl.isValidCoordinate(-91.0, 0.0).shouldBeFalse()
-    }
-
-    @Test
-    fun isValidCoordinate_givenLongitudeOutOfRange_expectFalse() {
-        LocationServicesImpl.isValidCoordinate(0.0, 181.0).shouldBeFalse()
-        LocationServicesImpl.isValidCoordinate(0.0, -181.0).shouldBeFalse()
-    }
-
-    @Test
-    fun isValidCoordinate_givenNaN_expectFalse() {
-        LocationServicesImpl.isValidCoordinate(Double.NaN, 0.0).shouldBeFalse()
-        LocationServicesImpl.isValidCoordinate(0.0, Double.NaN).shouldBeFalse()
-    }
-
-    @Test
-    fun isValidCoordinate_givenInfinity_expectFalse() {
-        LocationServicesImpl.isValidCoordinate(Double.POSITIVE_INFINITY, 0.0).shouldBeFalse()
-        LocationServicesImpl.isValidCoordinate(0.0, Double.NEGATIVE_INFINITY).shouldBeFalse()
     }
 }


### PR DESCRIPTION
## Summary

A single malformed region in the `/geofences/nearest` response could crash the host app: `Geofence.Builder.build()` throws `IllegalArgumentException` for `radius <= 0`, `|lat| > 90`, or `|lng| > 180`, the whole batch was built outside any try/catch, and the geofence coroutine scope has no exception handler. Since the region cache only saves on success, every retry re-fetched the same bad region — a crash loop until the backend data changes.

Linear: [MBL-2157](https://linear.app/customerio/issue/MBL-2157/mobile-validate-geofence-data-before-registering-with-the-os)

## Changes

- **Parse-time validation**: `toDomain()` returns null for regions violating `Geofence.Builder` preconditions — dropped with a log, so one bad region costs itself, not the whole sync. Parse time is the only safe layer for per-region drops: dropping after the registration diff would mark regions as registered that never reached the OS.
- **Unusable-response guard**: an unexpected mapper throw drops only the affected region (logged distinctly from invalid values); a non-empty response whose regions *all* drop — by throw or by validation — fails the refresh instead of succeeding empty, preserving live registrations and cache. A legitimately empty response still clears normally, keeping the kill-switch semantics.
- **Batch-build guard**: `GeofencingRequest` construction is wrapped so a GMS rejection fails the sync as a normal `Result.failure` instead of throwing.
- **Validator reuse**: `isValidCoordinate` moved from `LocationServicesImpl`'s companion to `LocationCoordinates.isValid()` (already a public `@InternalCustomerIOApi` type), shared by `:location` manual input validation and geofence parse validation. No API-dump change — the marker is in `nonPublicMarkers` (the companion needs its own annotation; the validator checks nested classes individually).

Malformed JSON was already safe (decoded inside `mapCatching` → `Result.failure`).

## Stack

```
main ← feature/geofence-on-device ← this PR
```

## Tests

- Invalid regions (zero/negative radius, out-of-range lat/lng) dropped with a log while valid ones are kept; boundary values (poles, antimeridian, sub-meter radius) kept.
- GMS batch rejection returns failure without a client call (region built directly, bypassing parse validation, so the guard is pinned genuinely).
- `LocationCoordinates.isValid()` unit tests moved from `LocationServicesImplTest` to `LocationCoordinatesTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence refresh and OS registration paths; behavior is intentionally defensive but incorrect guards could leave stale registrations or block sync until backend data fixes.
> 
> **Overview**
> **Hardens geofence sync** so malformed `/geofences/nearest` data cannot crash the host app or wipe live OS registrations.
> 
> **API → domain mapping** now drops individual regions that violate GMS preconditions (non-positive radius, out-of-range lat/lng) via shared `LocationCoordinates.isValid()`, with new debug/error logs. A non-empty response where *every* region is dropped or mapping throws is treated as unusable: mapping throws, `GeofenceRepository` catches it and returns `Result.failure` without registering or persisting—so existing fences stay in place. Legitimately empty `geofences: []` still clears as before.
> 
> **GMS batch build** in `GeofenceManager.registerBatch` is wrapped in `try/catch` so `IllegalArgumentException` from `GeofencingRequest` construction becomes `Result.failure` instead of an uncaught throw in the geofence coroutine scope.
> 
> **Location module** moves coordinate validation from `LocationServicesImpl` to `LocationCoordinates.isValid()` for reuse by geofence parsing; tests move to `LocationCoordinatesTest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415bf49d2f20397d6fa9c6a481fe9b0e65311192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

