### PR TITLE
feat(live-notifications): stop reporting locally-triggered updates

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -68,7 +68,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
      * registers the instance with Customer.io so the backend can push updates.
      *
      * The notification renders regardless of identity, but its lifecycle events
-     * (start/update/end) are only reported to Customer.io for an **identified
+     * (start/end) are only reported to Customer.io for an **identified
      * user** — call `identify` first if you need the backend to track this
      * activity and push updates/remote end (matches iOS Live Activities).
      *
@@ -111,8 +111,8 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
 
     /**
      * Updates a live notification previously started via [startLiveNotification]
-     * for a built-in template type: re-renders it in place and reports an
-     * `update` event to Customer.io.
+     * for a built-in template type: re-renders it in place. The update is
+     * intentionally not reported to Customer.io — only start/end emit CDP events.
      *
      * @param activityId the id returned by [startLiveNotification].
      */

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClient.kt
@@ -17,9 +17,6 @@ internal interface LiveNotificationLifecycleClient {
         contentState: Map<String, Any?>
     )
 
-    /** Reports an `update` event carrying the new dynamic [contentState]. */
-    fun reportUpdate(instanceUUID: String, activityType: String, deviceId: String, contentState: Map<String, Any?>)
-
     /** Reports an `end` event, optionally carrying a final dynamic [contentState]. */
     fun reportEnd(
         instanceUUID: String,
@@ -53,25 +50,6 @@ internal class LiveNotificationLifecycleClientImpl(
                 put(PROP_PLATFORM, PLATFORM_ANDROID)
                 put(PROP_NOTIFICATION_TYPE, activityType)
                 if (attributes.isNotEmpty()) put(PROP_ATTRIBUTES, attributes)
-                if (contentState.isNotEmpty()) put(PROP_CONTENT_STATE, contentState)
-            }
-        )
-    }
-
-    override fun reportUpdate(
-        instanceUUID: String,
-        activityType: String,
-        deviceId: String,
-        contentState: Map<String, Any?>
-    ) {
-        track(
-            event = EVENT_LIVE_NOTIFICATION,
-            properties = buildMap {
-                put(PROP_EVENT_TYPE, EVENT_TYPE_UPDATE)
-                put(PROP_CIO_INSTANCE_ID, instanceUUID)
-                put(PROP_DEVICE_ID, deviceId)
-                put(PROP_PLATFORM, PLATFORM_ANDROID)
-                put(PROP_NOTIFICATION_TYPE, activityType)
                 if (contentState.isNotEmpty()) put(PROP_CONTENT_STATE, contentState)
             }
         )
@@ -146,7 +124,6 @@ internal class LiveNotificationLifecycleClientImpl(
         const val PROP_PUSH_TO_START_TOKEN = "pushToStartToken"
 
         const val EVENT_TYPE_START = "start"
-        const val EVENT_TYPE_UPDATE = "update"
         const val EVENT_TYPE_END = "end"
         const val REGISTRATION_TYPE_PUSH_TO_START = "push_to_start"
         const val PLATFORM_ANDROID = "android"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -21,7 +21,8 @@ import kotlinx.coroutines.launch
 
 /**
  * Renders live notifications locally on behalf of the host app and reports the
- * corresponding start/update/end lifecycle events to Customer.io.
+ * corresponding start/end lifecycle events to Customer.io. Local updates are
+ * rendered but intentionally not reported — only start/end emit CDP events.
  */
 internal class LiveNotificationManager(
     private val lifecycleClient: LiveNotificationLifecycleClient,
@@ -72,7 +73,10 @@ internal class LiveNotificationManager(
         reportStart(activityId, activityType, attributes, contentState)
     }
 
-    /** Re-renders a previously started live notification and reports an `update` event. */
+    /**
+     * Re-renders a previously started live notification locally. The update is
+     * intentionally not reported to Customer.io — only start/end emit CDP events.
+     */
     fun update(
         activityId: String,
         activityType: String,
@@ -81,8 +85,8 @@ internal class LiveNotificationManager(
     ) {
         // Terminal state is governed here for local renders (they bypass the handler's
         // server-push guard): an update after the activity ended locally or was dismissed
-        // must not repost it or report a stray update. `start` mints a fresh id, and
-        // `end` guards itself, so only `update` needs this check.
+        // must not repost it. `start` mints a fresh id, and `end` guards itself, so only
+        // `update` needs this check.
         if (SDKComponent.liveNotificationStore.isEnded(activityId)) {
             SDKComponent.logger.debug(
                 "Live notification '$activityId' already ended; ignoring update."
@@ -92,7 +96,6 @@ internal class LiveNotificationManager(
         val bundle = buildBundle(activityId, activityType, attributes + contentState, EVENT_UPDATE)
         lastBundles[activityId] = Bundle(bundle)
         render(bundle)
-        reportUpdate(activityId, activityType, contentState)
     }
 
     /**
@@ -261,22 +264,6 @@ internal class LiveNotificationManager(
             activityType = activityType,
             deviceId = deviceId,
             attributes = attributes.toJsonSafePayload(),
-            contentState = contentState.toJsonSafePayload()
-        )
-    }
-
-    private fun reportUpdate(activityId: String, activityType: String, contentState: Map<String, Any?>) {
-        val deviceId = SDKComponent.android().globalPreferenceStore.getDeviceToken()
-        if (deviceId.isNullOrBlank()) {
-            SDKComponent.logger.debug(
-                "No FCM token available yet; skipping update event for live notification '$activityId'."
-            )
-            return
-        }
-        lifecycleClient.reportUpdate(
-            instanceUUID = activityId,
-            activityType = activityType,
-            deviceId = deviceId,
             contentState = contentState.toJsonSafePayload()
         )
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -65,7 +65,7 @@ internal class LiveNotificationManager(
         lastBundles[activityId] = Bundle(bundle)
         render(bundle)
         // Lifecycle reporting is intentionally decoupled from the local render: the
-        // app called start/update/end, so Customer.io must track the activity (and be
+        // app called start/end, so Customer.io must track the activity (and be
         // able to push updates / remote-end it) even when the local render posts nothing
         // — e.g. a custom type with no built-in template, or a transient render failure.
         // The report is not blocking (token read is an in-memory pref; track() enqueues),

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -65,7 +65,7 @@ internal class LiveNotificationRegistrar(
         store.clearRegistrations()
         // Drop identity so a post-logout push-to-start registration isn't sent for the
         // previous (identified) user until a new UserChangedEvent arrives. Local
-        // start/update/end gating uses pipeline.isUserIdentified, cleared synchronously by
+        // start/end gating uses pipeline.isUserIdentified, cleared synchronously by
         // clearIdentify().
         userId = ""
         isIdentified = false

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationLifecycleClientTest.kt
@@ -5,7 +5,6 @@ import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClien
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_LIVE_NOTIFICATION_TOKEN
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_END
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_START
-import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.EVENT_TYPE_UPDATE
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PLATFORM_ANDROID
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_ATTRIBUTES
 import io.customer.messagingpush.livenotification.LiveNotificationLifecycleClientImpl.Companion.PROP_CIO_INSTANCE_ID
@@ -83,43 +82,6 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
     }
 
     @Test
-    fun reportUpdate_emitsLiveNotificationWithContentStateOnly() {
-        identified()
-        val name = slot<String>()
-        val props = slot<Map<String, Any?>>()
-        every { pipeline.track(capture(name), capture(props)) } returns Unit
-
-        client.reportUpdate(
-            instanceUUID = "inst-2",
-            activityType = "io.customer.livenotifications.segments",
-            deviceId = "fcm-tok",
-            contentState = mapOf("title" to "Arriving")
-        )
-
-        name.captured shouldBeEqualTo EVENT_LIVE_NOTIFICATION
-        props.captured[PROP_EVENT_TYPE] shouldBeEqualTo EVENT_TYPE_UPDATE
-        props.captured[PROP_CIO_INSTANCE_ID] shouldBeEqualTo "inst-2"
-        props.captured[PROP_DEVICE_ID] shouldBeEqualTo "fcm-tok"
-        props.captured[PROP_PLATFORM] shouldBeEqualTo PLATFORM_ANDROID
-        props.captured[PROP_NOTIFICATION_TYPE] shouldBeEqualTo "io.customer.livenotifications.segments"
-        // Update never carries static attributes.
-        props.captured.containsKey(PROP_ATTRIBUTES).shouldBeFalse()
-        @Suppress("UNCHECKED_CAST")
-        (props.captured[PROP_CONTENT_STATE] as Map<String, Any?>)["title"] shouldBeEqualTo "Arriving"
-    }
-
-    @Test
-    fun reportUpdate_omitsContentStateWhenEmpty() {
-        identified()
-        val props = slot<Map<String, Any?>>()
-        every { pipeline.track(any(), capture(props)) } returns Unit
-
-        client.reportUpdate("inst-2", "type", "fcm-tok", contentState = emptyMap())
-
-        props.captured.containsKey(PROP_CONTENT_STATE).shouldBeFalse()
-    }
-
-    @Test
     fun reportEnd_emitsLiveNotificationWithEndProperties() {
         identified()
         val name = slot<String>()
@@ -177,7 +139,6 @@ internal class LiveNotificationLifecycleClientTest : IntegrationTest() {
         every { pipeline.isUserIdentified } returns false
 
         client.reportStart("inst-1", "type", "fcm-tok", emptyMap(), emptyMap())
-        client.reportUpdate("inst-1", "type", "fcm-tok", emptyMap())
         client.reportEnd("inst-1", "type", "fcm-tok")
 
         verify(exactly = 0) { pipeline.track(any(), any()) }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
@@ -68,7 +68,9 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
     }
 
     @Test
-    fun update_reportsUpdateEventWithContentState() {
+    fun update_reportsNoLifecycleEvent() {
+        // A locally-triggered update re-renders the activity but must NOT emit a CDP
+        // "Live Notification Event": only start/end are reported.
         saveToken()
 
         manager.update(
@@ -78,33 +80,21 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
             contentState = mapOf("title" to "Arriving")
         )
 
-        verify { lifecycleClient.reportUpdate("act-1", type, "fcm-tok", any()) }
+        verify(exactly = 0) { lifecycleClient.reportStart(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any()) }
     }
 
     @Test
     fun update_afterEnded_isIgnored() {
         // The activity ended locally or was dismissed (marked terminal): a later update
-        // must not repost it or report a stray update event.
+        // must not repost it. (Updates are never reported regardless; this covers the guard.)
         saveToken()
         SDKComponent.liveNotificationStore.markEnded("act-1")
 
         manager.update("act-1", type, attributes = emptyMap(), contentState = mapOf("title" to "Late"))
 
-        verify(exactly = 0) { lifecycleClient.reportUpdate(any(), any(), any(), any()) }
-    }
-
-    @Test
-    fun update_withoutFcmToken_doesNotReport() {
-        SDKComponent.android().globalPreferenceStore.removeDeviceToken()
-
-        manager.update(
-            "act-1",
-            type,
-            attributes = emptyMap(),
-            contentState = mapOf("title" to "Arriving")
-        )
-
-        verify(exactly = 0) { lifecycleClient.reportUpdate(any(), any(), any(), any()) }
+        verify(exactly = 0) { lifecycleClient.reportStart(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
Local live-notification updates driven by the host app now re-render locally but no longer emit a `Live Notification Event` (`eventType=update`) to CDP — only `start` and `end` are reported. Removes the dead `reportUpdate` path and the `update` eventType from the wire contract. Public `updateLiveNotification` API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the CDP analytics contract for live notifications; anything that relied on locally-triggered `update` events will stop receiving them, though on-device UI updates still work.
> 
> **Overview**
> Host-driven **`updateLiveNotification`** still re-renders on device, but it **no longer sends** a CDP **`Live Notification Event`** with **`eventType=update`**. Lifecycle reporting is limited to **`start`** and **`end`**, aligned with iOS Live Activities.
> 
> The **`reportUpdate`** path is removed from **`LiveNotificationLifecycleClient`** / **`LiveNotificationManager`**, along with **`EVENT_TYPE_UPDATE`** on the wire. Public APIs and local render behavior (including the ended-activity guard on update) are unchanged; docs and tests reflect that only start/end emit events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b746821d47685daa869499ece9d1bb4376370633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->