### PR TITLE
chore(location): preserve tracked intent when requests race the single-request gate

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -6,11 +6,13 @@ internal object GeofenceConstants {
     // business geofences when applying separate INITIAL_TRIGGER strategies.
     const val MOVEMENT_TRIGGER_ID = "cio_movement_trigger"
 
-    // Fallback for `localRefreshTriggerRadius` when the API config omits it.
-    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 3_000f
+    // Fallback for `localRefreshTriggerRadius` when the API config omits it. Matches the
+    // server default and iOS.
+    const val FALLBACK_LOCAL_REFRESH_RADIUS_METERS = 1_000f
 
-    // Fallback for `remoteFetchRefreshTriggerRadius` when the API config omits it.
-    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 20_000f
+    // Fallback for `remoteFetchRefreshTriggerRadius` when the API config omits it. Matches the
+    // server default and iOS.
+    const val FALLBACK_REMOTE_FETCH_RADIUS_METERS = 5_000f
 
     // Fallback for `maxBusinessGeofences`. Matches the historical cap so customers
     // aren't punished by a misconfigured backend.

--- a/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
@@ -4,7 +4,7 @@ import io.customer.location.provider.LocationProvider
 import io.customer.location.provider.LocationRequestException
 import io.customer.location.type.LocationGranularity
 import io.customer.sdk.core.util.Logger
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -19,6 +19,16 @@ internal class LocationOrchestrator(
 ) {
 
     suspend fun requestLocation(intent: LocationRequestIntent) {
+        // Closed on every exit path, so a tracked request can never upgrade onto this one once it
+        // can no longer deliver.
+        try {
+            acquireLocation(intent)
+        } finally {
+            intent.finish()
+        }
+    }
+
+    private suspend fun acquireLocation(intent: LocationRequestIntent) {
         // A request that starts tracked respects the OFF gate; silent ones fetch regardless —
         // geofencing needs a fix even when location tracking is OFF.
         if (intent.isTracked && !config.isEnabled) {
@@ -37,9 +47,10 @@ internal class LocationOrchestrator(
                 granularity = LocationGranularity.DEFAULT
             )
             logger.debug("Tracking location: lat=${snapshot.latitude}, lng=${snapshot.longitude}")
-            // Read at delivery so a mid-flight upgrade routes the same fix tracked. The OFF gate
-            // re-applies — an upgrade must never make a disabled tracking mode emit analytics.
-            if (intent.isTracked && config.isEnabled) {
+            // Claimed at delivery so a mid-flight upgrade routes this same fix, and a later one is
+            // rejected rather than lost. The OFF re-check keeps an upgrade from emitting analytics
+            // for a disabled tracking mode.
+            if (intent.claimTrackedDelivery() && config.isEnabled) {
                 locationTracker.onLocationReceived(snapshot.latitude, snapshot.longitude)
             } else {
                 locationTracker.onLocationReceivedWithoutTracking(snapshot.latitude, snapshot.longitude)
@@ -59,9 +70,32 @@ internal class LocationOrchestrator(
  * Mutable intent of one in-flight location request. Starts tracked (analytics) or silent
  * (geofence-only) and can only be upgraded: a tracked request arriving while a silent
  * fetch is in flight consumes the same fix instead of being dropped.
+ *
+ * Closed once the request can no longer deliver, so a late upgrade is rejected instead of
+ * swallowed and the caller knows to fetch its own fix.
  */
 internal class LocationRequestIntent(tracked: Boolean) {
-    private val tracked = AtomicBoolean(tracked)
-    val isTracked: Boolean get() = tracked.get()
-    fun upgradeToTracked() = tracked.set(true)
+    private val state = AtomicReference(if (tracked) State.TRACKED else State.SILENT)
+
+    /** Peek for the pre-fetch tracking-mode gate; does not close the intent. */
+    val isTracked: Boolean get() = state.get() == State.TRACKED
+
+    /** Reports whether the fix routes tracked, closing the intent so no later upgrade is lost. */
+    fun claimTrackedDelivery(): Boolean = state.getAndSet(State.DONE) == State.TRACKED
+
+    /** Closes a request that ended without delivering. */
+    fun finish() = state.set(State.DONE)
+
+    /** Upgrades a silent request to tracked. False once closed: the caller must fetch its own. */
+    fun upgradeToTracked(): Boolean {
+        while (true) {
+            when (state.get()) {
+                State.DONE -> return false
+                State.TRACKED -> return true
+                State.SILENT -> if (state.compareAndSet(State.SILENT, State.TRACKED)) return true
+            }
+        }
+    }
+
+    private enum class State { SILENT, TRACKED, DONE }
 }

--- a/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationOrchestrator.kt
@@ -4,6 +4,7 @@ import io.customer.location.provider.LocationProvider
 import io.customer.location.provider.LocationRequestException
 import io.customer.location.type.LocationGranularity
 import io.customer.sdk.core.util.Logger
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -17,27 +18,10 @@ internal class LocationOrchestrator(
     private val locationProvider: LocationProvider
 ) {
 
-    suspend fun requestLocationUpdate() {
-        acquireLocation(forceFetch = false, onAcquired = locationTracker::onLocationReceived)
-    }
-
-    /**
-     * Like [requestLocationUpdate] but skips the "CIO Location Update" track event and fetches
-     * regardless of tracking mode: geofencing needs a fix even when location tracking is OFF.
-     */
-    suspend fun requestLocationUpdateSilently() {
-        acquireLocation(forceFetch = true, onAcquired = locationTracker::onLocationReceivedWithoutTracking)
-    }
-
-    /**
-     * @param forceFetch when true, bypasses the tracking-mode (OFF) gate so an internal caller
-     *   can still get a fix; the location permission check below always applies.
-     */
-    private suspend fun acquireLocation(
-        forceFetch: Boolean,
-        onAcquired: (Double, Double) -> Unit
-    ) {
-        if (!forceFetch && !config.isEnabled) {
+    suspend fun requestLocation(intent: LocationRequestIntent) {
+        // A request that starts tracked respects the OFF gate; silent ones fetch regardless —
+        // geofencing needs a fix even when location tracking is OFF.
+        if (intent.isTracked && !config.isEnabled) {
             logger.debug("Location tracking is disabled, ignoring requestLocationUpdate.")
             return
         }
@@ -53,7 +37,13 @@ internal class LocationOrchestrator(
                 granularity = LocationGranularity.DEFAULT
             )
             logger.debug("Tracking location: lat=${snapshot.latitude}, lng=${snapshot.longitude}")
-            onAcquired(snapshot.latitude, snapshot.longitude)
+            // Read at delivery so a mid-flight upgrade routes the same fix tracked. The OFF gate
+            // re-applies — an upgrade must never make a disabled tracking mode emit analytics.
+            if (intent.isTracked && config.isEnabled) {
+                locationTracker.onLocationReceived(snapshot.latitude, snapshot.longitude)
+            } else {
+                locationTracker.onLocationReceivedWithoutTracking(snapshot.latitude, snapshot.longitude)
+            }
         } catch (e: CancellationException) {
             logger.debug("Location request was cancelled.")
             throw e
@@ -63,4 +53,15 @@ internal class LocationOrchestrator(
             logger.error("Location request failed with unexpected error: ${e.message}")
         }
     }
+}
+
+/**
+ * Mutable intent of one in-flight location request. Starts tracked (analytics) or silent
+ * (geofence-only) and can only be upgraded: a tracked request arriving while a silent
+ * fetch is in flight consumes the same fix instead of being dropped.
+ */
+internal class LocationRequestIntent(tracked: Boolean) {
+    private val tracked = AtomicBoolean(tracked)
+    val isTracked: Boolean get() = tracked.get()
+    fun upgradeToTracked() = tracked.set(true)
 }

--- a/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
@@ -59,11 +59,10 @@ internal class LocationServicesImpl(
         if (currentLocationJob?.isActive == true) {
             if (!tracked) return
             // Tracked intent must survive the gate (ON_APP_START and the geofence bootstrap
-            // race for this slot on first identify) — upgrade the in-flight request instead.
-            currentRequestIntent?.upgradeToTracked()
-            // If the request finished before the upgrade applied, fall through to a fresh
-            // one — a duplicate fix is deduped by the sync filter; a lost one isn't recoverable.
-            if (currentLocationJob?.isActive == true) return
+            // race for this slot on first identify) — upgrade the in-flight request instead. If it
+            // can no longer deliver, fall through to a fresh fetch: a duplicate fix is dropped by
+            // the sync filter, a lost one isn't recoverable.
+            if (currentRequestIntent?.upgradeToTracked() == true) return
         }
 
         val intent = LocationRequestIntent(tracked)

--- a/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
+++ b/location/src/main/kotlin/io/customer/location/LocationServicesImpl.kt
@@ -23,6 +23,9 @@ internal class LocationServicesImpl(
     @Volatile
     private var currentLocationJob: Job? = null
 
+    @Volatile
+    private var currentRequestIntent: LocationRequestIntent? = null
+
     override fun setLastKnownLocation(latitude: Double, longitude: Double) {
         if (!config.isEnabled) {
             logger.debug("Location tracking is disabled, ignoring setLastKnownLocation.")
@@ -44,21 +47,30 @@ internal class LocationServicesImpl(
     }
 
     override fun requestLocationUpdate() {
-        launchLocationRequest(orchestrator::requestLocationUpdate)
+        launchLocationRequest(tracked = true)
     }
 
     @OptIn(InternalCustomerIOApi::class)
     override fun requestLocationUpdateSilently() {
-        launchLocationRequest(orchestrator::requestLocationUpdateSilently)
+        launchLocationRequest(tracked = false)
     }
 
-    private fun launchLocationRequest(request: suspend () -> Unit) {
-        // If a request is already in flight, ignore the new call
-        if (currentLocationJob?.isActive == true) return
+    private fun launchLocationRequest(tracked: Boolean) {
+        if (currentLocationJob?.isActive == true) {
+            if (!tracked) return
+            // Tracked intent must survive the gate (ON_APP_START and the geofence bootstrap
+            // race for this slot on first identify) — upgrade the in-flight request instead.
+            currentRequestIntent?.upgradeToTracked()
+            // If the request finished before the upgrade applied, fall through to a fresh
+            // one — a duplicate fix is deduped by the sync filter; a lost one isn't recoverable.
+            if (currentLocationJob?.isActive == true) return
+        }
 
+        val intent = LocationRequestIntent(tracked)
+        currentRequestIntent = intent
         currentLocationJob = scope.launch {
             try {
-                request()
+                orchestrator.requestLocation(intent)
             } finally {
                 // Only clear if this is still the current job — prevents
                 // a cancelled job's finally from nulling a newer job's reference

--- a/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
+++ b/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
@@ -7,11 +7,14 @@ import io.customer.location.type.LocationSnapshot
 import io.customer.sdk.core.util.Logger
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Date
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -75,6 +78,34 @@ class LocationOrchestratorTest {
 
         coVerify(exactly = 0) { provider.requestLocation(any()) }
         verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
+    }
+
+    @Test
+    fun requestLocation_givenUpgradeRacesTheHandoff_expectRejected() = runTest {
+        // Upgrading at the moment the fix is handed off must fail, or the tracked caller is dropped
+        // while its fix goes out silently. Observed from inside the delivery callback.
+        givenAuthorizedFix()
+        val intent = LocationRequestIntent(tracked = false)
+        var upgradeAccepted: Boolean? = null
+        every { tracker.onLocationReceivedWithoutTracking(any(), any()) } answers {
+            upgradeAccepted = intent.upgradeToTracked()
+        }
+
+        orchestrator(LocationTrackingMode.MANUAL).requestLocation(intent)
+
+        upgradeAccepted shouldBeEqualTo false
+    }
+
+    @Test
+    fun requestLocation_givenRequestEndedWithoutDelivering_expectIntentClosed() = runTest {
+        // A closed intent is what tells a later tracked caller to fetch its own fix instead of
+        // waiting on a request that can no longer deliver.
+        coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.DENIED
+        val intent = LocationRequestIntent(tracked = false)
+
+        orchestrator(LocationTrackingMode.MANUAL).requestLocation(intent)
+
+        intent.upgradeToTracked().shouldBeFalse()
     }
 
     @Test

--- a/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
+++ b/location/src/test/java/io/customer/location/LocationOrchestratorTest.kt
@@ -39,28 +39,28 @@ class LocationOrchestratorTest {
     }
 
     @Test
-    fun requestLocationUpdate_givenModeOff_expectNoFix() = runTest {
-        orchestrator(LocationTrackingMode.OFF).requestLocationUpdate()
+    fun requestLocation_givenTrackedAndModeOff_expectNoFix() = runTest {
+        orchestrator(LocationTrackingMode.OFF).requestLocation(LocationRequestIntent(tracked = true))
 
         coVerify(exactly = 0) { provider.requestLocation(any()) }
         verify(exactly = 0) { tracker.onLocationReceived(any(), any()) }
     }
 
     @Test
-    fun requestLocationUpdate_givenModeEnabledAndAuthorized_expectTrackedFix() = runTest {
+    fun requestLocation_givenTrackedAndModeEnabledAndAuthorized_expectTrackedFix() = runTest {
         givenAuthorizedFix()
 
-        orchestrator(LocationTrackingMode.MANUAL).requestLocationUpdate()
+        orchestrator(LocationTrackingMode.MANUAL).requestLocation(LocationRequestIntent(tracked = true))
 
         verify { tracker.onLocationReceived(37.7749, -122.4194) }
         verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
     }
 
     @Test
-    fun requestLocationUpdateSilently_givenModeOff_expectFixWithoutTracking() = runTest {
+    fun requestLocation_givenSilentAndModeOff_expectFixWithoutTracking() = runTest {
         givenAuthorizedFix()
 
-        orchestrator(LocationTrackingMode.OFF).requestLocationUpdateSilently()
+        orchestrator(LocationTrackingMode.OFF).requestLocation(LocationRequestIntent(tracked = false))
 
         coVerify { provider.requestLocation(LocationGranularity.DEFAULT) }
         verify { tracker.onLocationReceivedWithoutTracking(37.7749, -122.4194) }
@@ -68,12 +68,45 @@ class LocationOrchestratorTest {
     }
 
     @Test
-    fun requestLocationUpdateSilently_givenPermissionDenied_expectNoFix() = runTest {
+    fun requestLocation_givenSilentAndPermissionDenied_expectNoFix() = runTest {
         coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.DENIED
 
-        orchestrator(LocationTrackingMode.OFF).requestLocationUpdateSilently()
+        orchestrator(LocationTrackingMode.OFF).requestLocation(LocationRequestIntent(tracked = false))
 
         coVerify(exactly = 0) { provider.requestLocation(any()) }
         verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
+    }
+
+    @Test
+    fun requestLocation_givenSilentUpgradedMidFetch_expectTrackedDelivery() = runTest {
+        // Tracked request arrives while the silent fetch is in flight: the same
+        // fix must reach the tracked path (trackedLocation, persistence, track event).
+        coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.AUTHORIZED_FOREGROUND
+        val intent = LocationRequestIntent(tracked = false)
+        coEvery { provider.requestLocation(LocationGranularity.DEFAULT) } answers {
+            intent.upgradeToTracked()
+            LocationSnapshot(latitude = 37.7749, longitude = -122.4194, timestamp = Date(), horizontalAccuracy = 10.0)
+        }
+
+        orchestrator(LocationTrackingMode.ON_APP_START).requestLocation(intent)
+
+        verify { tracker.onLocationReceived(37.7749, -122.4194) }
+        verify(exactly = 0) { tracker.onLocationReceivedWithoutTracking(any(), any()) }
+    }
+
+    @Test
+    fun requestLocation_givenSilentUpgradedButModeOff_expectSilentDelivery() = runTest {
+        // An upgrade must never make a disabled tracking mode emit analytics.
+        coEvery { provider.currentAuthorizationStatus() } returns AuthorizationStatus.AUTHORIZED_FOREGROUND
+        val intent = LocationRequestIntent(tracked = false)
+        coEvery { provider.requestLocation(LocationGranularity.DEFAULT) } answers {
+            intent.upgradeToTracked()
+            LocationSnapshot(latitude = 37.7749, longitude = -122.4194, timestamp = Date(), horizontalAccuracy = 10.0)
+        }
+
+        orchestrator(LocationTrackingMode.OFF).requestLocation(intent)
+
+        verify { tracker.onLocationReceivedWithoutTracking(37.7749, -122.4194) }
+        verify(exactly = 0) { tracker.onLocationReceived(any(), any()) }
     }
 }

--- a/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
+++ b/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
@@ -1,12 +1,19 @@
 package io.customer.location
 
 import io.customer.base.internal.InternalCustomerIOApi
+import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class, InternalCustomerIOApi::class)
@@ -62,10 +69,10 @@ class LocationServicesImplTest {
         verify { tracker.onLocationReceived(37.7749, -122.4194) }
     }
 
-    // -- requestLocationUpdateSilently --
+    // -- request intent routing --
 
     @Test
-    fun requestLocationUpdateSilently_expectSilentOrchestratorCall() {
+    fun requestLocationUpdateSilently_expectSilentIntent() {
         val config = LocationModuleConfig.Builder()
             .setLocationTrackingMode(LocationTrackingMode.MANUAL)
             .build()
@@ -73,11 +80,83 @@ class LocationServicesImplTest {
         val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
         val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
         val scope = TestScope(UnconfinedTestDispatcher())
+        val intentSlot = slot<LocationRequestIntent>()
+        coEvery { orchestrator.requestLocation(capture(intentSlot)) } just runs
 
         val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
         services.requestLocationUpdateSilently()
 
-        coVerify { orchestrator.requestLocationUpdateSilently() }
-        coVerify(exactly = 0) { orchestrator.requestLocationUpdate() }
+        coVerify(exactly = 1) { orchestrator.requestLocation(any()) }
+        intentSlot.captured.isTracked.shouldBeFalse()
+    }
+
+    @Test
+    fun requestLocationUpdate_givenSilentRequestInFlight_expectUpgradeNotSecondFetch() {
+        val config = LocationModuleConfig.Builder()
+            .setLocationTrackingMode(LocationTrackingMode.ON_APP_START)
+            .build()
+        val tracker: LocationTracker = mockk(relaxUnitFun = true)
+        val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
+        val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val gate = CompletableDeferred<Unit>()
+        val intentSlot = slot<LocationRequestIntent>()
+        coEvery { orchestrator.requestLocation(capture(intentSlot)) } coAnswers { gate.await() }
+
+        val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
+        services.requestLocationUpdateSilently()
+        intentSlot.captured.isTracked.shouldBeFalse()
+
+        services.requestLocationUpdate()
+
+        // The tracked request upgrades the in-flight silent one instead of being dropped
+        // or starting a second fetch.
+        intentSlot.captured.isTracked.shouldBeTrue()
+        coVerify(exactly = 1) { orchestrator.requestLocation(any()) }
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun requestLocationUpdateSilently_givenTrackedRequestInFlight_expectDropped() {
+        val config = LocationModuleConfig.Builder()
+            .setLocationTrackingMode(LocationTrackingMode.ON_APP_START)
+            .build()
+        val tracker: LocationTracker = mockk(relaxUnitFun = true)
+        val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
+        val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val gate = CompletableDeferred<Unit>()
+        val intentSlot = slot<LocationRequestIntent>()
+        coEvery { orchestrator.requestLocation(capture(intentSlot)) } coAnswers { gate.await() }
+
+        val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
+        services.requestLocationUpdate()
+
+        services.requestLocationUpdateSilently()
+
+        // Tracked delivery is a superset of silent (both update lastKnownLocation and
+        // publish LocationAcquired), so the silent request needs nothing extra.
+        intentSlot.captured.isTracked.shouldBeTrue()
+        coVerify(exactly = 1) { orchestrator.requestLocation(any()) }
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun requestLocationUpdate_givenPreviousRequestCompleted_expectFreshFetch() {
+        val config = LocationModuleConfig.Builder()
+            .setLocationTrackingMode(LocationTrackingMode.ON_APP_START)
+            .build()
+        val tracker: LocationTracker = mockk(relaxUnitFun = true)
+        val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
+        val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
+        val scope = TestScope(UnconfinedTestDispatcher())
+        coEvery { orchestrator.requestLocation(any()) } just runs
+
+        val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
+        services.requestLocationUpdateSilently()
+
+        services.requestLocationUpdate()
+
+        coVerify(exactly = 2) { orchestrator.requestLocation(any()) }
     }
 }

--- a/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
+++ b/location/src/test/java/io/customer/location/LocationServicesImplTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -113,6 +114,37 @@ class LocationServicesImplTest {
         // or starting a second fetch.
         intentSlot.captured.isTracked.shouldBeTrue()
         coVerify(exactly = 1) { orchestrator.requestLocation(any()) }
+        gate.complete(Unit)
+    }
+
+    @Test
+    fun requestLocationUpdate_givenInFlightRequestAlreadyDelivered_expectFreshFetch() {
+        // The in-flight request has handed its fix off but its job is still alive, so upgrading
+        // would be swallowed — the tracked caller needs its own fetch.
+        val config = LocationModuleConfig.Builder()
+            .setLocationTrackingMode(LocationTrackingMode.ON_APP_START)
+            .build()
+        val tracker: LocationTracker = mockk(relaxUnitFun = true)
+        val orchestrator: LocationOrchestrator = mockk(relaxUnitFun = true)
+        val logger = mockk<io.customer.sdk.core.util.Logger>(relaxUnitFun = true)
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val gate = CompletableDeferred<Unit>()
+        val intents = mutableListOf<LocationRequestIntent>()
+        val routedTracked = mutableListOf<Boolean>()
+        coEvery { orchestrator.requestLocation(capture(intents)) } coAnswers {
+            // Deliver, then keep the job alive so the second call still sees it as in flight.
+            routedTracked += intents.last().claimTrackedDelivery()
+            gate.await()
+        }
+
+        val services = LocationServicesImpl(config, logger, tracker, orchestrator, scope)
+        services.requestLocationUpdateSilently()
+
+        services.requestLocationUpdate()
+
+        // The second fetch is the one that routes tracked.
+        coVerify(exactly = 2) { orchestrator.requestLocation(any()) }
+        routedTracked shouldBeEqualTo listOf(false, true)
         gate.complete(Unit)
     }
 


### PR DESCRIPTION
## Summary

On a first identified session, the `ON_APP_START` tracked location request and geofence's silent auto-acquire both reach `launchLocationRequest`'s single-request gate within milliseconds (independent `UserChangedEvent` collectors — no ordering guarantee). The loser was silently dropped. When the silent request won (~coin flip), the tracked intent was lost for the whole process: no "CIO Location Update" event and no persisted location for identify enrichment until the next cold launch. At launch, every session is a first session, so this hits exactly when customers evaluate the feature.

Reported by Shahroz on #763 ([thread](https://github.com/customerio/customerio-android/pull/763#discussion_r3626300020)) and independently by Bugbot.

Linear: [MBL-2191](https://linear.app/customerio/issue/MBL-2191/mobile-prevent-location-request-race-during-app-launch)

## Changes

- **Intent upgrade instead of drop**: a tracked request arriving while a request is in flight upgrades the shared `LocationRequestIntent` (atomic, upgrade-only), so the same GPS fix serves both consumers — no second fetch. The reverse overlap needs nothing: tracked delivery is a superset of silent (both update `lastKnownLocation` and publish `LocationAcquired`).
- **Routing decided at delivery**: the orchestrator's two entry points merge into `requestLocation(intent)`; tracked-vs-silent is read after the fix arrives, with the OFF-mode gate re-applied there so an upgrade can never make a disabled tracking mode emit analytics.
- **Claim-once intent**: the intent is closed rather than flagged. Delivery claims it atomically with the routing decision, and the request closes it on every other exit path (mode gate, permission denied, failure, cancellation), so an upgrade reports whether it landed in time. Without this the fix's own window stayed open: a `Job` is active until its body finishes, so a tracked call arriving after the hand-off would upgrade an intent that could no longer route anything and then be dropped by the is-active check. That window spans the whole delivery body — a prefs write, a track call, an event-bus publish — and on `ON_APP_START` both requests fire in the same burst, so a cached fix makes it reachable.
- **Fallthrough on a rejected upgrade**: when the upgrade can't land, the tracked call starts a fresh fetch — a duplicate fix is deduped by the 24h/1km sync filter; a lost tracked delivery isn't recoverable.
- **Rider — fallback config alignment**: geofence fallback refresh radii updated to match the server defaults and iOS constants (`localRefreshTriggerRadius` 3 km → 1 km, `remoteFetchRefreshTriggerRadius` 20 km → 5 km). Fallbacks only apply when the server config omits the field, so behavior is unchanged whenever the API responds.

No public API changes; `:location` and `:geofence` internals only.

## iOS parity

Same semantics as [customerio-ios#1173](https://github.com/customerio/customerio-ios/pull/1173): single fix serves both callers, upgrade-only latch, OFF gate re-checked at delivery, failed fetch drops the latched intent. That last part is what the claim-once commit adds — iOS already dropped its latch on a failed fetch, Android didn't.

## Stack

```
main ← feature/geofence-on-device ← this PR
```

## Tests

- Silent in-flight + tracked call → intent upgraded, exactly one fetch (the reported race).
- Tracked in-flight + silent call → dropped safely (superset delivery).
- Mid-fetch upgrade routes the fix through the tracked path; upgrade while mode is OFF stays silent.
- Upgrade racing the hand-off is rejected (observed from inside the delivery callback), and the tracked caller gets its own fetch instead of being dropped.
- A request that ends without delivering leaves the intent closed, so a later upgrade can't attach to it.
- Each of the three parts is mutation-verified: reverting the claim, the close, or the upgrade-result gate fails exactly one test.
- Completed job → fresh fetch; OFF/permission-denied gates unchanged; orchestrator suite migrated to the single entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent location routing and first-launch analytics/identify behavior; logic is well-tested and mirrors iOS, but mistakes could still drop or duplicate tracked events.
> 
> **Overview**
> Fixes a launch race where **tracked** (`ON_APP_START`) and **silent** (geofence) location requests hit the single in-flight gate together and the loser was dropped—often losing the first-session **CIO Location Update** and persisted location for identify.
> 
> **Location** now routes both paths through a shared **`LocationRequestIntent`**: a tracked call while a silent fetch is active **upgrades** the intent so one GPS fix can deliver tracked analytics; if upgrade is too late (intent already closed at delivery), the tracked caller **starts a fresh fetch**. Tracked-vs-silent is decided **at delivery**, with tracking mode **OFF** re-checked so upgrades never emit tracked events when disabled. Silent-over-tracked overlap still drops the extra call because tracked delivery is a superset.
> 
> **Geofence** fallback refresh radii when API omits config are aligned with server/iOS defaults (**1 km** local, **5 km** remote; was 3 km / 20 km).
> 
> Tests cover upgrade, reject-on-handoff, fresh fetch after close, and OFF-at-delivery behavior. No public API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a3aecb09f2100134acafb38668ce5720d2eafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


