### PR TITLE
chore(geofence): keep monitoring alive through empty areas and app updates, add OFF mode

### DIFF
--- a/geofence/api/geofence.api
+++ b/geofence/api/geofence.api
@@ -11,6 +11,7 @@ public final class io/customer/geofence/GeofenceBroadcastReceiver : android/cont
 public final class io/customer/geofence/GeofenceLocationMode : java/lang/Enum {
 	public static final field AUTOMATIC Lio/customer/geofence/GeofenceLocationMode;
 	public static final field MANUAL Lio/customer/geofence/GeofenceLocationMode;
+	public static final field OFF Lio/customer/geofence/GeofenceLocationMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/customer/geofence/GeofenceLocationMode;
 	public static fun values ()[Lio/customer/geofence/GeofenceLocationMode;

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
@@ -21,7 +21,8 @@ internal data class GeofenceConfig(
     // Window (ms) for suppressing duplicate transition events for the same geofence.
     @SerialName("duplicateEventsExpiry")
     val duplicateEventsExpiry: Long,
-    // Max business geofences registered at once (the movement trigger is extra).
+    // Max business geofences registered at once (the movement trigger is extra). 0 is the
+    // server-driven kill switch: nothing registers, not even the movement trigger.
     @SerialName("maxBusinessGeofences")
     val maxBusinessGeofences: Int,
     // Cap (m) on how far a business geofence can be from the device to be registered.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -29,26 +29,36 @@ internal class GeofenceLifecycleObserver(
 ) : DefaultLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
-        flushPendingGeofenceDeliveries()
+        flushPendingGeofenceDeliveries(deliveryFlusher, eventBus, regionStore, logger)
     }
+}
 
-    private fun flushPendingGeofenceDeliveries() {
-        deliveryFlusher.flush(
-            callbacks = object : PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>() {
-                override fun onSnapshot(count: Int) = logger.logForegroundFlushSnapshot(count)
-                override fun onWorkCancelled(entry: PendingGeofenceDelivery) =
-                    logger.logForegroundFlushCancelledWorkManager(entry.geofenceId, entry.transition.name)
-                override fun onPublished(entry: PendingGeofenceDelivery) =
-                    logger.logForegroundFlushPublished(entry.geofenceId, entry.transition.name)
-                override fun onEntryFailed(entry: PendingGeofenceDelivery, cause: Throwable) =
-                    logger.logForegroundFlushEntryFailed(entry.geofenceId, entry.transition.name, cause.message)
-                override fun onComplete(count: Int) = logger.logForegroundFlushComplete(count)
-            },
-            guarantee = PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE
-        ) { entry ->
-            eventBus.publish(
-                entry.withFreshestEventData(regionStore.getCachedRegion(entry.geofenceId)).toGeofenceTransitionEvent()
-            )
-        }
+/**
+ * Drains the pending-delivery store through the analytics pipeline. Returns immediately; the drain
+ * runs in the background. Also called once at init in [GeofenceLocationMode.OFF], where a row whose
+ * WorkManager enqueue failed would otherwise have no drain path left.
+ */
+internal fun flushPendingGeofenceDeliveries(
+    deliveryFlusher: PendingDeliveryFlusher<PendingGeofenceDelivery>,
+    eventBus: EventBus,
+    regionStore: GeofenceRegionStore,
+    logger: GeofenceLogger
+) {
+    deliveryFlusher.flush(
+        callbacks = object : PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>() {
+            override fun onSnapshot(count: Int) = logger.logForegroundFlushSnapshot(count)
+            override fun onWorkCancelled(entry: PendingGeofenceDelivery) =
+                logger.logForegroundFlushCancelledWorkManager(entry.geofenceId, entry.transition.name)
+            override fun onPublished(entry: PendingGeofenceDelivery) =
+                logger.logForegroundFlushPublished(entry.geofenceId, entry.transition.name)
+            override fun onEntryFailed(entry: PendingGeofenceDelivery, cause: Throwable) =
+                logger.logForegroundFlushEntryFailed(entry.geofenceId, entry.transition.name, cause.message)
+            override fun onComplete(count: Int) = logger.logForegroundFlushComplete(count)
+        },
+        guarantee = PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE
+    ) { entry ->
+        eventBus.publish(
+            entry.withFreshestEventData(regionStore.getCachedRegion(entry.geofenceId)).toGeofenceTransitionEvent()
+        )
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLocationMode.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLocationMode.kt
@@ -1,10 +1,13 @@
 package io.customer.geofence
 
 /**
- * How the geofence module acquires the location it needs. Location acquired for
- * geofencing is never sent to analytics.
+ * How the geofence module operates. Location acquired for geofencing is never
+ * sent to analytics.
  */
 enum class GeofenceLocationMode {
+    /** Geofencing is disabled: applied at initialization, removing any prior OS registrations. */
+    OFF,
+
     /** The SDK acquires a fix itself when it needs one and none is available. Default. */
     AUTOMATIC,
 

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -185,6 +185,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; left in pending store for the foreground flush — $message", tag = TAG)
     }
 
+    fun logGeofencingDisabled() {
+        logger.info("Geofencing is disabled (GeofenceLocationMode.OFF); removing any existing OS registrations and skipping setup", tag = TAG)
+    }
+
     fun logMissingLocationModule() {
         logger.error(
             "ModuleGeofence requires ModuleLocation to be registered alongside it. Add ModuleLocation to CustomerIOConfigBuilder; geofencing will not function until then.",

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -112,8 +112,13 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Geofence sync failed: $message", tag = TAG)
     }
 
-    fun logSyncSucceeded(count: Int) {
-        logger.debug("Geofence sync succeeded: $count regions registered", tag = TAG)
+    fun logSyncSucceeded(count: Int, movementTriggerRegistered: Boolean) {
+        val trigger = if (movementTriggerRegistered) {
+            " + 1 movement trigger"
+        } else {
+            "; monitoring disabled (max business geofences is 0)"
+        }
+        logger.debug("Geofence sync succeeded: $count regions registered$trigger", tag = TAG)
     }
 
     fun logSyncSkipped(reason: String) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceModuleConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceModuleConfig.kt
@@ -6,12 +6,14 @@ import io.customer.sdk.core.module.CustomerIOModuleConfig
  * Geofence module configuration.
  */
 class GeofenceModuleConfig private constructor(
-    /**
-     * How the module acquires the device location it needs for geofencing.
-     * Default is [GeofenceLocationMode.AUTOMATIC].
-     */
+    /** How the module operates. Default is [GeofenceLocationMode.AUTOMATIC]. */
     val locationMode: GeofenceLocationMode
 ) : CustomerIOModuleConfig {
+
+    /** Whether geofencing is enabled (any mode other than [GeofenceLocationMode.OFF]). */
+    internal val isEnabled: Boolean
+        get() = locationMode != GeofenceLocationMode.OFF
+
     class Builder : CustomerIOModuleConfig.Builder<GeofenceModuleConfig> {
         private var locationMode: GeofenceLocationMode = GeofenceLocationMode.AUTOMATIC
 

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofencePackageInfo.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofencePackageInfo.kt
@@ -1,0 +1,14 @@
+package io.customer.geofence
+
+import android.content.Context
+
+/**
+ * Reads the host package's last-update timestamp. An app update can wipe GMS
+ * geofence registrations (like a reboot does), so a change in this value since
+ * the last registration means OS state can't be trusted.
+ */
+internal class GeofencePackageInfo(private val context: Context) {
+    fun lastUpdateTimeMs(): Long? = runCatching {
+        context.packageManager.getPackageInfo(context.packageName, 0).lastUpdateTime
+    }.getOrNull()
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -59,6 +59,7 @@ internal class GeofenceRepositoryImpl(
     private val cooldownFilter: GeofenceCooldownFilter,
     private val transitionEmitter: GeofenceTransitionEmitter,
     private val clock: Clock,
+    private val packageInfo: GeofencePackageInfo,
     private val logger: GeofenceLogger
 ) : GeofenceRepository {
 
@@ -89,11 +90,10 @@ internal class GeofenceRepositoryImpl(
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
             val action = stateMutex.withLock { refreshAction(LocationCoordinates(latitude, longitude), config) }
-            // A launch/identify refresh runs with the persisted anchor, which a reboot can leave
-            // pointing at a pre-reboot position — containment can't be trusted, so no synthesis
-            // this pass (mirrors restoreFromCache). The flag drops once registration re-stamps
-            // uptime. Sign-in is unaffected: sign-out clears the stamp with the anchor.
-            val emitInitialEnter = !osStateWipedByReboot()
+            // A launch/identify refresh runs with the persisted anchor, which a reboot or app update
+            // can leave pointing at a stale position — containment can't be trusted, so no synthesis
+            // this pass (mirrors restoreFromCache). Drops once registration re-stamps.
+            val emitInitialEnter = !osStateWiped()
             return when (action) {
                 RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, emitInitialEnter)
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, emitInitialEnter = emitInitialEnter)
@@ -121,9 +121,9 @@ internal class GeofenceRepositoryImpl(
             movedBeyondFetchRadius(distanceFromLastFetch, config) -> RefreshAction.REMOTE
             isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
             hasUnregisteredCache() -> RefreshAction.LOCAL
-            // Without this a fresh-cache launch after a reboot would SKIP — registeredIds survive the
-            // reboot but GMS doesn't, leaving nothing monitored. Re-rank locally to re-register.
-            osStateWipedByReboot() -> RefreshAction.LOCAL
+            // Without this a fresh-cache launch after a reboot or app update would SKIP —
+            // registeredIds survive but GMS state doesn't, leaving nothing monitored.
+            osStateWiped() -> RefreshAction.LOCAL
             else -> RefreshAction.SKIP
         }
     }
@@ -157,6 +157,22 @@ internal class GeofenceRepositoryImpl(
      */
     private fun osStateWipedByReboot(): Boolean =
         store.getLastRegistrationUptime()?.let { clock.elapsedRealtime() < it } ?: false
+
+    /**
+     * Package replaced since the last registration — an app update can cancel the geofence
+     * PendingIntent, silently dropping OS registrations while registeredIds survive.
+     * Same consequences and call sites as [osStateWipedByReboot].
+     */
+    private fun osStateWipedByAppUpdate(): Boolean {
+        val current = packageInfo.lastUpdateTimeMs() ?: return false
+        // No stamp but live registrations = they predate stamping (this upgrade is itself an
+        // app update) — treat as wiped.
+        val stamped = store.getLastRegistrationPackageUpdateTime()
+            ?: return store.getRegisteredIds().isNotEmpty()
+        return current != stamped
+    }
+
+    private fun osStateWiped(): Boolean = osStateWipedByReboot() || osStateWipedByAppUpdate()
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
@@ -300,9 +316,9 @@ internal class GeofenceRepositoryImpl(
      */
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun registerWithBusinessDiff(regions: List<GeofenceRegion>): Result<Unit> {
-        // After a reboot GMS is empty, so re-register everything rather than trust the surviving
-        // registeredIds (which would otherwise be skipped as "unchanged").
-        val existingBusinessIds = if (osStateWipedByReboot()) {
+        // After a reboot or app update GMS state is gone, so re-register everything rather than
+        // trust the surviving registeredIds (which would otherwise be skipped as "unchanged").
+        val existingBusinessIds = if (osStateWiped()) {
             emptySet()
         } else {
             unchangedRegisteredIds(regions)
@@ -345,11 +361,11 @@ internal class GeofenceRepositoryImpl(
             max = config.maxBusinessGeofences,
             maxDistanceMeters = config.maxMonitoringDistance
         )
-        // Keep the movement trigger registered whenever the user has registerable geofences — even
-        // if none are near enough now (all beyond maxMonitoringDistance) — so an EXIT re-ranks them
-        // in as the device approaches. A truly empty set (no geofences / kill switch) registers nothing.
-        val hasRegisterableGeofences = regions.isNotEmpty() && config.maxBusinessGeofences > 0
-        val regionsToRegister = if (!hasRegisterableGeofences) {
+        // Keep the movement trigger registered even when no regions qualify right now — all beyond
+        // maxMonitoringDistance, or the distance-capped /nearest returned none here — so an EXIT
+        // re-ranks/re-fetches as the device travels. Only maxBusinessGeofences = 0 means "feature off".
+        val monitoringEnabled = config.maxBusinessGeofences > 0
+        val regionsToRegister = if (!monitoringEnabled) {
             emptyList()
         } else {
             listOf(buildMovementTrigger(latitude, longitude, config.localRefreshTriggerRadius)) + nearest
@@ -386,19 +402,20 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Stamp device uptime so the next refresh can detect a reboot (which wipes OS
-                    // geofences) and force a full re-register instead of trusting registeredIds.
+                    // Stamp uptime and package update time so the next refresh detects a reboot or
+                    // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
+                    packageInfo.lastUpdateTimeMs()?.let { store.setLastRegistrationPackageUpdateTime(it) }
                     // Track the user's location at each successful registration so boot restore can
                     // re-center close to their real position. Clear only when nothing is registered
-                    // (no geofences / kill switch) — the trigger, and thus its location, is gone.
-                    if (hasRegisterableGeofences) {
+                    // (kill switch) — the trigger, and thus its location, is gone.
+                    if (monitoringEnabled) {
                         store.saveLastMovementTriggerLocation(GeofenceLocation(latitude, longitude))
                     } else {
                         store.clearLastMovementTriggerLocation()
                     }
                     onRegistered()
-                    logger.logSyncSucceeded(nearest.size)
+                    logger.logSyncSucceeded(nearest.size, movementTriggerRegistered = monitoringEnabled)
                 }
             }
             if (registrationResult.isSuccess && emitInitialEnter) {

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -3,8 +3,10 @@ package io.customer.geofence
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.geofence.di.geofenceCooldownFilter
 import io.customer.geofence.di.geofenceDeliveryFlusher
 import io.customer.geofence.di.geofenceLogger
+import io.customer.geofence.di.geofenceManager
 import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
 import io.customer.location.LocationCoordinates
@@ -17,6 +19,7 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.util.HandlerMainThreadPoster
 import io.customer.sdk.core.util.MainThreadPoster
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
@@ -33,7 +36,8 @@ private const val MODULE_NAME = "Geofence"
  * location provider regardless of the location tracking mode, and works even when
  * location tracking is OFF (geofence fixes never emit analytics). With the default
  * [GeofenceLocationMode.AUTOMATIC] the SDK acquires the location it needs on its own;
- * with [GeofenceLocationMode.MANUAL] the host drives it via [refreshFromCurrentLocation].
+ * with [GeofenceLocationMode.MANUAL] the host drives it via [refreshFromCurrentLocation];
+ * with [GeofenceLocationMode.OFF] geofencing is disabled.
  *
  * Usage:
  * ```
@@ -51,6 +55,12 @@ class ModuleGeofence @JvmOverloads constructor(
 
     override fun initialize() {
         val logger = SDKComponent.geofenceLogger
+
+        if (!moduleConfig.isEnabled) {
+            logger.logGeofencingDisabled()
+            tearDownForDisabledMode(logger)
+            return
+        }
 
         // Geofencing is meaningless without the location module: there is no path
         // for fixes to reach the SDK, so nearby-sync and movement triggers would
@@ -79,6 +89,7 @@ class ModuleGeofence @JvmOverloads constructor(
      */
     @OptIn(InternalCustomerIOApi::class)
     fun refreshFromCurrentLocation() {
+        if (!moduleConfig.isEnabled) return
         val locationModule = runCatching { ModuleLocation.instance() }.getOrNull()
         if (locationModule == null) {
             SDKComponent.geofenceLogger.logMissingLocationModule()
@@ -102,6 +113,48 @@ class ModuleGeofence @JvmOverloads constructor(
         if (moduleConfig.locationMode != GeofenceLocationMode.AUTOMATIC) return
         // No-ops without location permission.
         locationModule.locationServices.requestLocationUpdateSilently()
+    }
+
+    /**
+     * Undoes a previous run for [GeofenceLocationMode.OFF]: OS registrations and the receivers
+     * survive app updates and fire independently of the subscriptions this mode skips, so disabling
+     * has to tear down rather than just not set up. Unlike the sign-out wipe the store is cleared
+     * unconditionally — no later refresh exists to retry a failed OS clear, and dropping
+     * registeredIds is what makes the receiver discard (and unregister) a stray transition.
+     */
+    private fun tearDownForDisabledMode(logger: GeofenceLogger) {
+        // Both guarded: this runs inside the host's `CustomerIO.initialize()`, where a throw would
+        // surface as a startup crash.
+        val sdkAndroid = runCatching { SDKComponent.android() }.getOrNull() ?: run {
+            logger.logSyncFailed("Disabled-mode teardown skipped: Android components unavailable")
+            return
+        }
+        // Cleared synchronously so the receivers — which run on their own scopes later in this launch
+        // — can't read state they'd re-register from. `prefs.edit {}` defers only the disk write.
+        runCatching { sdkAndroid.geofenceRegionStore.clearUserScopedState() }
+            .onFailure { logger.logSyncFailed("Disabled-mode store clear failed: ${it.message}") }
+
+        val teardownScope = SDKComponent.scopeProvider.geofenceScope
+        teardownScope.launch {
+            try {
+                sdkAndroid.geofenceCooldownFilter.clearAll()
+                // Pending rows are transitions that already happened; OFF stops producing events
+                // rather than retracting past ones. Before the OS clear so a failure can't skip it.
+                flushPendingGeofenceDeliveries(
+                    deliveryFlusher = sdkAndroid.geofenceDeliveryFlusher,
+                    eventBus = SDKComponent.eventBus,
+                    regionStore = sdkAndroid.geofenceRegionStore,
+                    logger = logger
+                )
+                sdkAndroid.geofenceManager.clearAll()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                logger.logSyncFailed("Disabled-mode teardown failed: ${e.message}")
+            } finally {
+                teardownScope.cancel()
+            }
+        }
     }
 
     /**

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -7,6 +7,7 @@ import io.customer.geofence.GeofenceDistanceFilter
 import io.customer.geofence.GeofenceJsonSerializer
 import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.GeofenceManager
+import io.customer.geofence.GeofencePackageInfo
 import io.customer.geofence.GeofencePermissionChecker
 import io.customer.geofence.GeofenceReceiverToggle
 import io.customer.geofence.GeofenceRepository
@@ -129,6 +130,9 @@ internal val AndroidSDKComponent.geofenceRegionStore: GeofenceRegionStore
         )
     }
 
+internal val AndroidSDKComponent.geofencePackageInfo: GeofencePackageInfo
+    get() = newInstance { GeofencePackageInfo(applicationContext) }
+
 internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
     get() = singleton<GeofenceRepository> {
         GeofenceRepositoryImpl(
@@ -140,6 +144,7 @@ internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
             cooldownFilter = geofenceCooldownFilter,
             transitionEmitter = geofenceTransitionEmitter,
             clock = SDKComponent.clock,
+            packageInfo = geofencePackageInfo,
             logger = SDKComponent.geofenceLogger
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -60,6 +60,10 @@ internal interface GeofenceRegionStore {
     fun getLastRegistrationUptime(): Long?
     fun setLastRegistrationUptime(uptimeMs: Long)
 
+    /** Package lastUpdateTime at the last successful OS registration; null if never registered. Drives app-update detection. */
+    fun getLastRegistrationPackageUpdateTime(): Long?
+    fun setLastRegistrationPackageUpdateTime(timeMs: Long)
+
     fun saveCachedConfig(config: GeofenceConfig)
     fun getCachedConfig(): GeofenceConfig?
 
@@ -119,6 +123,14 @@ internal class GeofenceRegionStoreImpl(
         prefs.edit { putLong(KEY_LAST_REGISTRATION_UPTIME, uptimeMs) }
     }
 
+    override fun getLastRegistrationPackageUpdateTime(): Long? = prefs.read {
+        if (contains(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)) getLong(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME, 0L) else null
+    }
+
+    override fun setLastRegistrationPackageUpdateTime(timeMs: Long) {
+        prefs.edit { putLong(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME, timeMs) }
+    }
+
     override fun saveCachedConfig(config: GeofenceConfig) =
         writeJson(KEY_CACHED_CONFIG, GeofenceConfig.serializer(), config)
 
@@ -155,6 +167,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
             remove(KEY_LAST_REGISTRATION_UPTIME)
+            remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
         }
     }
@@ -207,6 +220,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"
         const val KEY_LAST_SYNC = "last_sync_timestamp"
         const val KEY_LAST_REGISTRATION_UPTIME = "last_registration_uptime"
+        const val KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME = "last_registration_package_update_time"
         const val CRYPTO_KEY_ALIAS = "cio_geofence_location_key"
         val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
         val ID_SET_SERIALIZER = SetSerializer(String.serializer())

--- a/geofence/src/test/java/io/customer/geofence/GeofenceModuleConfigTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceModuleConfigTest.kt
@@ -20,4 +20,27 @@ class GeofenceModuleConfigTest {
 
         config.locationMode shouldBeEqualTo GeofenceLocationMode.MANUAL
     }
+
+    @Test
+    fun build_givenOffLocationMode_expectOff() {
+        val config = GeofenceModuleConfig.Builder()
+            .setLocationMode(GeofenceLocationMode.OFF)
+            .build()
+
+        config.locationMode shouldBeEqualTo GeofenceLocationMode.OFF
+    }
+
+    @Test
+    fun isEnabled_givenActiveModes_expectTrue() {
+        GeofenceModuleConfig.Builder().setLocationMode(GeofenceLocationMode.AUTOMATIC).build()
+            .isEnabled shouldBeEqualTo true
+        GeofenceModuleConfig.Builder().setLocationMode(GeofenceLocationMode.MANUAL).build()
+            .isEnabled shouldBeEqualTo true
+    }
+
+    @Test
+    fun isEnabled_givenOff_expectFalse() {
+        GeofenceModuleConfig.Builder().setLocationMode(GeofenceLocationMode.OFF).build()
+            .isEnabled shouldBeEqualTo false
+    }
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -48,6 +48,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     private val cooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
     private val transitionEmitter: GeofenceTransitionEmitter = mockk(relaxed = true)
     private val clock: Clock = mockk(relaxed = true)
+    private val packageInfo: GeofencePackageInfo = mockk {
+        every { lastUpdateTimeMs() } returns null
+    }
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val jsonSerializer = GeofenceJsonSerializer()
 
@@ -70,6 +73,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         cooldownFilter = cooldownFilter,
         transitionEmitter = transitionEmitter,
         clock = clock,
+        packageInfo = packageInfo,
         logger = logger
     )
 
@@ -436,20 +440,45 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenEmptyBusinessSet_expectMovementTriggerLocationCleared() = runTest {
-        // Account transitioned to 0 businesses — no movement trigger exists,
-        // so any previously-stored location is stale and must be cleared.
+    fun refresh_givenKillSwitchConfig_expectNothingRegisteredAndMovementTriggerLocationCleared() = runTest {
+        // maxBusinessGeofences = 0 is the explicit server kill switch — unregister
+        // everything, including the movement trigger and its stored location.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
         coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(emptyResponse())
+            Result.success(emptyResponse(maxBusinessGeofences = 0))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
+        captured.captured.shouldBeEmpty()
         verify(exactly = 0) { store.saveLastMovementTriggerLocation(any()) }
         verify { store.clearLastMovementTriggerLocation() }
+        // Region count alone can't distinguish this from an empty-but-still-monitoring sync.
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = false) }
+    }
+
+    @Test
+    fun refresh_givenEmptyResponseWithPositiveBudget_expectMovementTriggerKept() = runTest {
+        // `/nearest` is distance-capped, so an empty list means "none nearby", not "feature
+        // off" — a road trip through a fence-free area must keep the movement trigger
+        // registered so a later EXIT re-fetches; otherwise geofencing dies until the next
+        // app launch.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(emptyResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
+        verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
     }
 
     @Test
@@ -471,7 +500,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
         verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
         verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
-        verify { logger.logSyncSucceeded(0) }
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = true) }
     }
 
     @Test
@@ -507,7 +536,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         verify { store.setLastSyncTimestamp(any()) }
         verify { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) }
-        verify { logger.logSyncSucceeded(filtered.size) }
+        verify { logger.logSyncSucceeded(filtered.size, movementTriggerRegistered = true) }
         // Store holds the IDs of exactly what was registered (movement trigger + business),
         // so the next refresh's stale-cleanup diff is accurate.
         verify { store.saveRegisteredIds(captured.captured.map { it.id }.toSet()) }
@@ -688,6 +717,106 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenAppUpdatedSinceLastRegistration_expectAllBusinessReRegistered() = runTest {
+        // Package lastUpdateTime changed => the app was updated, which can cancel the geofence
+        // PendingIntent and drop OS registrations. Re-register all business (empty existing set)
+        // even though registeredIds still lists them, then re-stamp the new update time.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+        verify { store.setLastRegistrationPackageUpdateTime(2_000L) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationsButNoPackageStamp_expectAllBusinessReRegistered() = runTest {
+        // Upgrade migration: registrations from an SDK version that didn't stamp the package
+        // update time predate stamping — the upgrade itself was an app update, so re-register.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns null
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+        verify { store.setLastRegistrationPackageUpdateTime(2_000L) }
+    }
+
+    @Test
+    fun refresh_givenNoAppUpdateSinceLastRegistration_expectBusinessKept() = runTest {
+        // Matching update-time stamps => package untouched => trust registeredIds and keep the
+        // unchanged business geofence (skip re-upsert).
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 1_000L // unchanged
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun refresh_givenFreshCacheButAppUpdated_expectLocalReRegisterInsteadOfSkip() = runTest {
+        // App update after a fresh-cache launch: time-fresh + ranking-fresh + registeredIds intact
+        // would normally SKIP, but the update may have wiped GMS state. Force a LOCAL re-register
+        // (no network) instead of leaving nothing monitored — the exact post-update launch path.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 1) { manager.replaceGeofences(any(), any()) }
+        existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
     fun refresh_givenAddSucceedsButStaleRemovalFails_expectUnremovedStalePreserved() = runTest {
         // Order: add succeeds, then stale removal fails. The new batch is registered
         // and we treat the sync as successful — but we must preserve the unremoved
@@ -712,16 +841,17 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager.replaceGeofences(any(), any())
             manager.removeGeofencesByIds(any())
         }
-        verify { logger.logSyncSucceeded(1) }
+        verify { logger.logSyncSucceeded(1, movementTriggerRegistered = true) }
         // Persisted set includes the unremoved stale ID — next refresh will retry it.
         persisted.captured shouldContainSame
             setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-new", "biz-old")
     }
 
     @Test
-    fun refresh_givenAllPreviousAbsentFromNew_expectAllRemovedAndEmptyRegistered() = runTest {
-        // Account transitioned from "has geofences" to "no geofences": every previously
-        // registered ID must be removed, including the movement trigger.
+    fun refresh_givenAllPreviousAbsentFromNew_expectBusinessRemovedButTriggerKept() = runTest {
+        // No fences in this response: previously registered business IDs are removed as
+        // stale, but the movement trigger stays so a later EXIT can re-fetch — the
+        // distance-capped /nearest can't distinguish "none nearby" from "none exist".
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf(
             GeofenceConstants.MOVEMENT_TRIGGER_ID,
@@ -737,26 +867,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         val staleSlot = slot<List<String>>()
         coVerify { manager.removeGeofencesByIds(capture(staleSlot)) }
-        staleSlot.captured shouldContainSame listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-old")
-    }
-
-    @Test
-    fun refresh_givenZeroBusinessGeofences_expectNothingRegisteredIncludingMovementTrigger() = runTest {
-        // Customers without configured geofences must pay zero runtime cost:
-        // no movement trigger registered, no OS-side geofence activity.
-        every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(emptyResponse())
-        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
-        val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
-
-        val result = repository.refresh(latitude = 12.34, longitude = 56.78)
-
-        result.isSuccess shouldBeEqualTo true
-        captured.captured.shouldBeEmpty()
-        verify { logger.logSyncSucceeded(0) }
+        staleSlot.captured shouldContainSame listOf("biz-old")
     }
 
     @Test
@@ -782,7 +893,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify(exactly = 0) { manager.removeGeofencesByIds(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        verify(exactly = 0) { logger.logSyncSucceeded(any()) }
+        verify(exactly = 0) { logger.logSyncSucceeded(any(), any()) }
     }
 
     @Test
@@ -1472,6 +1583,31 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getLastRegistrationUptime() } returns 500_000L
         every { clock.elapsedRealtime() } returns 1_000L // rebooted
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenAppUpdateAndStaleCache_expectRemoteFetchButNoInitialEnter() = runTest {
+        // App update wiped OS state (package updateTime changed, no reboot). The launch anchor can
+        // predate the update just like a reboot, so containment can't be trusted — a newly fetched
+        // fence containing it must not synthesize either.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns emptyList()
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getLastRegistrationUptime() } returns 500L
+        every { clock.elapsedRealtime() } returns 1_000L // no reboot (uptime advanced)
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since → app-update wipe
         coEvery { apiService.fetchGeofences(any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }

--- a/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
@@ -1,26 +1,111 @@
 package io.customer.geofence
 
 import io.customer.base.internal.InternalCustomerIOApi
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.commontest.util.ScopeProviderStub
+import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.location.LocationCoordinates
 import io.customer.location.LocationServices
 import io.customer.location.ModuleLocation
+import io.customer.sdk.core.util.ScopeProvider
+import io.customer.sdk.data.store.PendingDeliveryFlusher
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(InternalCustomerIOApi::class)
-class ModuleGeofenceTest {
+@RunWith(RobolectricTestRunner::class)
+class ModuleGeofenceTest : RobolectricTest() {
 
     private val mockLocationServices: LocationServices = mockk(relaxed = true)
     private val mockLocationModule: ModuleLocation = mockk {
         every { locationServices } returns mockLocationServices
     }
 
+    // 'mock' prefix avoids shadowing the AndroidSDKComponent extension accessors
+    // inside the `android { ... }` override lambda.
+    private val mockManager: GeofenceManager = mockk(relaxed = true)
+    private val mockStore = mockk<GeofenceRegionStore>(relaxed = true)
+    private val mockCooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
+    private val mockDeliveryFlusher: PendingDeliveryFlusher<PendingGeofenceDelivery> = mockk(relaxed = true)
+
+    private val mockLogger: GeofenceLogger = mockk(relaxed = true)
+
+    // Queues the teardown coroutine instead of running it, so tests can assert what happened
+    // before it ran.
+    private val scopeProviderStub = ScopeProviderStub.Standard()
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+                diGraph {
+                    sdk {
+                        overrideDependency<ScopeProvider>(scopeProviderStub)
+                        overrideDependency<GeofenceLogger>(mockLogger)
+                    }
+                    android {
+                        overrideDependency<GeofenceManager>(mockManager)
+                        overrideDependency<GeofenceRegionStore>(mockStore)
+                        overrideDependency<GeofenceCooldownFilter>(mockCooldownFilter)
+                        overrideDependency<PendingDeliveryFlusher<PendingGeofenceDelivery>>(mockDeliveryFlusher)
+                    }
+                }
+            }
+        )
+        coEvery { mockManager.clearAll() } returns Result.success(Unit)
+    }
+
     private fun moduleWith(mode: GeofenceLocationMode) =
         ModuleGeofence(GeofenceModuleConfig.Builder().setLocationMode(mode).build())
+
+    @Test
+    fun initialize_givenOffMode_expectStoreClearedSynchronouslyAndOsClearDeferred() {
+        // OFF must actively tear down a prior run's state, not just skip setup — the registrations
+        // and receivers survive app updates and fire on their own.
+        moduleWith(GeofenceLocationMode.OFF).initialize()
+
+        // Store first, before initialize returns: the receivers run on their own scopes later in
+        // this launch, and surviving registeredIds/anchors are what they would re-register from.
+        verify(exactly = 1) { mockStore.clearUserScopedState() }
+        coVerify(exactly = 0) { mockManager.clearAll() }
+
+        scopeProviderStub.geofenceScope.testScheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockCooldownFilter.clearAll() }
+        coVerify(exactly = 1) { mockManager.clearAll() }
+    }
+
+    @Test
+    fun initialize_givenOffMode_expectPendingDeliveriesStillFlushed() {
+        // Rows are transitions that already happened; nothing else drains one whose worker
+        // enqueue failed.
+        moduleWith(GeofenceLocationMode.OFF).initialize()
+        scopeProviderStub.geofenceScope.testScheduler.advanceUntilIdle()
+
+        verify(exactly = 1) { mockDeliveryFlusher.flush(any(), any(), any()) }
+    }
+
+    @Test
+    fun refreshFromCurrentLocation_givenOffMode_expectNoOp() {
+        moduleWith(GeofenceLocationMode.OFF).refreshFromCurrentLocation()
+
+        // MANUAL is the control: without the OFF guard both modes reach the module lookup and log.
+        verify(exactly = 0) { mockLogger.logMissingLocationModule() }
+        moduleWith(GeofenceLocationMode.MANUAL).refreshFromCurrentLocation()
+        verify(exactly = 1) { mockLogger.logMissingLocationModule() }
+    }
 
     @Test
     fun autoAcquireIfNeeded_givenNoLocationAndAutomatic_expectSilentFetch() {

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -119,7 +119,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
         mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
         try {
             every { any<GeofenceApiRegion>().toDomain() } answers {
-                val region = invocation.self as GeofenceApiRegion
+                val region = firstArg<GeofenceApiRegion>()
                 if (region.id == "1") throw IllegalStateException("metadata defect") else callOriginal()
             }
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -127,6 +127,18 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastRegistrationUptime() shouldBeEqualTo 123_456L
     }
 
+    @Test
+    fun getLastRegistrationPackageUpdateTime_givenNothingStored_expectNull() {
+        store.getLastRegistrationPackageUpdateTime().shouldBeNull()
+    }
+
+    @Test
+    fun setLastRegistrationPackageUpdateTime_thenGet_expectRoundTrip() {
+        store.setLastRegistrationPackageUpdateTime(123_456L)
+
+        store.getLastRegistrationPackageUpdateTime() shouldBeEqualTo 123_456L
+    }
+
     // --- Cached config ---
 
     @Test
@@ -291,6 +303,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
+        store.setLastRegistrationPackageUpdateTime(88_888L)
         store.setLastSyncTimestamp(12_345L)
 
         store.clearUserScopedState()
@@ -300,6 +313,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()
+        store.getLastRegistrationPackageUpdateTime().shouldBeNull()
         // Freshness throttle: wiped so the next login re-fetches.
         store.getLastSyncTimestamp().shouldBeNull()
         // Cached regions/config: preserved.


### PR DESCRIPTION
[MBL-2196](https://linear.app/customerio/issue/MBL-2196/geofence-persistence)

Stacked on `feature/geofence-on-device`:

```
feature/geofence-on-device
  └─ mbl-2196-geofence-persistence  ← this PR
```

Three resilience fixes so geofence monitoring survives lifecycle events that
previously killed it silently, plus a runtime off switch.

Two commits: the empty-area/app-update fixes, then `OFF`.

### Keep the movement trigger alive in fence-free areas
`/geofences/nearest` is distance-capped, so an empty response means "none
nearby", not "feature off" — but it was treated as the kill switch and
unregistered everything, including the movement trigger. A trip through any
fence-free corridor disarmed monitoring until the next app open. The trigger
now stays registered whenever the config budget allows monitoring; only the
explicit kill switch (`max_business_geofence = 0`) clears it. The
sync-completed log now says whether the trigger was registered — region count
alone can't tell a kill-switched sync from an empty-but-monitoring one.

### Re-register after an app update
An app update can cancel the geofence `PendingIntent`, wiping OS-side
registrations while `registeredIds` survive — the diff then skips re-upsert
forever. Package `lastUpdateTime` is now stamped at each registration
(mirroring the reboot uptime stamp); a mismatch forces a full re-register, and
a missing stamp with live registrations counts as wiped so the SDK upgrade
shipping this fix heals itself.

### `GeofenceLocationMode.OFF` — disable at runtime
Lets a host ship the module but keep geofencing inert. Because a prior run's OS
registrations and receiver survive app updates and fire independently of SDK
subscriptions, OFF actively tears down (OS registrations + user-scoped store +
cooldown history), mirroring the sign-out wipe, rather than just skipping setup.
Cached workspace regions/config are kept so flipping back on re-syncs cleanly.

The store clear runs synchronously, before `initialize()` returns. The boot and
transition receivers run on their own scopes, so with the clear deferred to the
teardown coroutine — which first awaits a GMS round-trip — either could read
surviving `registeredIds`/anchors mid-teardown and re-register the geofences the
host just disabled. Clearing first makes both a no-op instead. (iOS reaches the
same guarantee by chaining teardown onto its bootstrap run tail.)

Pending deliveries are flushed rather than dropped: those rows are transitions
that already happened, and OFF stops producing events rather than retracting
past ones. It also runs on every disabled launch, so a row left behind by a
failed WorkManager enqueue is retried instead of stranded.

### Known behavior: app updates can re-fire an ENTER
Forcing a full re-register means GMS re-evaluates `INITIAL_TRIGGER_ENTER`, so
every fence the device is currently inside fires an ENTER. The SDK cannot tell
that from a real crossing — it is the same broadcast — so if the dedupe window
has lapsed it surfaces as a duplicate ENTER for a user who never left. Reboots
have always behaved this way; app updates make it more frequent. Distinguishing
the two needs presence tracking (deferred), so this is documented rather than
fixed here.

### Testing
- `:geofence` unit suite green (331 tests), `apiCheck` + ktlint + lint clean;
  1,327 tests across all modules green.
- The three OFF-mode assertions were mutation-checked: reverting the
  synchronous clear, the flush, or the `refreshFromCurrentLocation` guard each
  fails its test.
- Emulator: 0-region syncs keep re-fetching and recover on their own; a
  reinstall triggers a full re-upsert through the freshness window.
- Public API change: `+ GeofenceLocationMode.OFF` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence registration, sync skip/re-register logic, and adds a public OFF mode; forced re-register after app updates can surface duplicate ENTER events (documented). Broad unit test coverage limits regression risk.
> 
> **Overview**
> Adds **`GeofenceLocationMode.OFF`** (public API) so hosts can ship the module but disable geofencing at init. **`ModuleGeofence`** runs an active teardown (sync store clear, flush pending deliveries, GMS `clearAll`) instead of only skipping setup, and **`refreshFromCurrentLocation`** no-ops when disabled.
> 
> **Monitoring survival:** The movement trigger stays registered whenever **`maxBusinessGeofences > 0`**—empty `/nearest` or distance-filtered results no longer unregister everything. Only **`maxBusinessGeofences = 0`** is treated as the server kill switch (no trigger, cleared anchor). Sync logging now records whether the trigger was registered.
> 
> **App-update resilience:** **`GeofencePackageInfo`** reads package `lastUpdateTime`; the region store persists it at registration alongside uptime. **`osStateWiped()`** treats reboot *or* package update (including missing stamp with live IDs) like lost GMS state—forcing LOCAL re-register and skipping initial-enter synthesis when the anchor may be stale.
> 
> **Refactor:** Pending-delivery flush logic is shared via **`flushPendingGeofenceDeliveries`** for foreground and OFF init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9034ffc32408903ab89c43e4ad8b9f77255aedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

