### PR TITLE
chore(geofence): keep monitoring alive through fence-free areas and app updates

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConfig.kt
@@ -21,7 +21,8 @@ internal data class GeofenceConfig(
     // Window (ms) for suppressing duplicate transition events for the same geofence.
     @SerialName("duplicateEventsExpiry")
     val duplicateEventsExpiry: Long,
-    // Max business geofences registered at once (the movement trigger is extra).
+    // Max business geofences registered at once (the movement trigger is extra). 0 is the
+    // server-driven kill switch: nothing registers, not even the movement trigger.
     @SerialName("maxBusinessGeofences")
     val maxBusinessGeofences: Int,
     // Cap (m) on how far a business geofence can be from the device to be registered.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -112,8 +112,13 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Geofence sync failed: $message", tag = TAG)
     }
 
-    fun logSyncSucceeded(count: Int) {
-        logger.debug("Geofence sync succeeded: $count regions registered", tag = TAG)
+    fun logSyncSucceeded(count: Int, movementTriggerRegistered: Boolean) {
+        val trigger = if (movementTriggerRegistered) {
+            " + 1 movement trigger"
+        } else {
+            "; monitoring disabled (max business geofences is 0)"
+        }
+        logger.debug("Geofence sync succeeded: $count regions registered$trigger", tag = TAG)
     }
 
     fun logSyncSkipped(reason: String) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofencePackageInfo.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofencePackageInfo.kt
@@ -1,0 +1,14 @@
+package io.customer.geofence
+
+import android.content.Context
+
+/**
+ * Reads the host package's last-update timestamp. An app update can wipe GMS
+ * geofence registrations (like a reboot does), so a change in this value since
+ * the last registration means OS state can't be trusted.
+ */
+internal class GeofencePackageInfo(private val context: Context) {
+    fun lastUpdateTimeMs(): Long? = runCatching {
+        context.packageManager.getPackageInfo(context.packageName, 0).lastUpdateTime
+    }.getOrNull()
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -345,11 +345,11 @@ internal class GeofenceRepositoryImpl(
             max = config.maxBusinessGeofences,
             maxDistanceMeters = config.maxMonitoringDistance
         )
-        // Keep the movement trigger registered whenever the user has registerable geofences — even
-        // if none are near enough now (all beyond maxMonitoringDistance) — so an EXIT re-ranks them
-        // in as the device approaches. A truly empty set (no geofences / kill switch) registers nothing.
-        val hasRegisterableGeofences = regions.isNotEmpty() && config.maxBusinessGeofences > 0
-        val regionsToRegister = if (!hasRegisterableGeofences) {
+        // Keep the movement trigger registered even when no regions qualify right now — all beyond
+        // maxMonitoringDistance, or the distance-capped /nearest returned none here — so an EXIT
+        // re-ranks/re-fetches as the device travels. Only maxBusinessGeofences = 0 means "feature off".
+        val monitoringEnabled = config.maxBusinessGeofences > 0
+        val regionsToRegister = if (!monitoringEnabled) {
             emptyList()
         } else {
             listOf(buildMovementTrigger(latitude, longitude, config.localRefreshTriggerRadius)) + nearest
@@ -391,14 +391,14 @@ internal class GeofenceRepositoryImpl(
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
                     // Track the user's location at each successful registration so boot restore can
                     // re-center close to their real position. Clear only when nothing is registered
-                    // (no geofences / kill switch) — the trigger, and thus its location, is gone.
-                    if (hasRegisterableGeofences) {
+                    // (kill switch) — the trigger, and thus its location, is gone.
+                    if (monitoringEnabled) {
                         store.saveLastMovementTriggerLocation(GeofenceLocation(latitude, longitude))
                     } else {
                         store.clearLastMovementTriggerLocation()
                     }
                     onRegistered()
-                    logger.logSyncSucceeded(nearest.size)
+                    logger.logSyncSucceeded(nearest.size, movementTriggerRegistered = monitoringEnabled)
                 }
             }
             if (registrationResult.isSuccess && emitInitialEnter) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -59,6 +59,7 @@ internal class GeofenceRepositoryImpl(
     private val cooldownFilter: GeofenceCooldownFilter,
     private val transitionEmitter: GeofenceTransitionEmitter,
     private val clock: Clock,
+    private val packageInfo: GeofencePackageInfo,
     private val logger: GeofenceLogger
 ) : GeofenceRepository {
 
@@ -89,11 +90,10 @@ internal class GeofenceRepositoryImpl(
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
             val action = stateMutex.withLock { refreshAction(LocationCoordinates(latitude, longitude), config) }
-            // A launch/identify refresh runs with the persisted anchor, which a reboot can leave
-            // pointing at a pre-reboot position — containment can't be trusted, so no synthesis
-            // this pass (mirrors restoreFromCache). The flag drops once registration re-stamps
-            // uptime. Sign-in is unaffected: sign-out clears the stamp with the anchor.
-            val emitInitialEnter = !osStateWipedByReboot()
+            // A launch/identify refresh runs with the persisted anchor, which a reboot or app update
+            // can leave pointing at a stale position — containment can't be trusted, so no synthesis
+            // this pass (mirrors restoreFromCache). Drops once registration re-stamps.
+            val emitInitialEnter = !osStateWiped()
             return when (action) {
                 RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, emitInitialEnter)
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, emitInitialEnter = emitInitialEnter)
@@ -121,9 +121,9 @@ internal class GeofenceRepositoryImpl(
             movedBeyondFetchRadius(distanceFromLastFetch, config) -> RefreshAction.REMOTE
             isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
             hasUnregisteredCache() -> RefreshAction.LOCAL
-            // Without this a fresh-cache launch after a reboot would SKIP — registeredIds survive the
-            // reboot but GMS doesn't, leaving nothing monitored. Re-rank locally to re-register.
-            osStateWipedByReboot() -> RefreshAction.LOCAL
+            // Without this a fresh-cache launch after a reboot or app update would SKIP —
+            // registeredIds survive but GMS state doesn't, leaving nothing monitored.
+            osStateWiped() -> RefreshAction.LOCAL
             else -> RefreshAction.SKIP
         }
     }
@@ -158,6 +158,22 @@ internal class GeofenceRepositoryImpl(
     private fun osStateWipedByReboot(): Boolean =
         store.getLastRegistrationUptime()?.let { clock.elapsedRealtime() < it } ?: false
 
+    /**
+     * Package replaced since the last registration — an app update can cancel the geofence
+     * PendingIntent, silently dropping OS registrations while registeredIds survive.
+     * Same consequences and call sites as [osStateWipedByReboot].
+     */
+    private fun osStateWipedByAppUpdate(): Boolean {
+        val current = packageInfo.lastUpdateTimeMs() ?: return false
+        // No stamp but live registrations = they predate stamping (this upgrade is itself an
+        // app update) — treat as wiped.
+        val stamped = store.getLastRegistrationPackageUpdateTime()
+            ?: return store.getRegisteredIds().isNotEmpty()
+        return current != stamped
+    }
+
+    private fun osStateWiped(): Boolean = osStateWipedByReboot() || osStateWipedByAppUpdate()
+
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
         if (!refreshInProgress.compareAndSet(false, true)) {
@@ -178,6 +194,8 @@ internal class GeofenceRepositoryImpl(
             // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
             val needsRemoteFetch = anchor == null ||
                 movedBeyondFetchRadius(distanceFromAnchor, config)
+            // Initial-enter synthesis stays on here (unlike refresh): containment is judged against
+            // the OS's live triggering fix, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
                 performRemoteRefresh(userId, latitude, longitude)
             } else {
@@ -300,9 +318,9 @@ internal class GeofenceRepositoryImpl(
      */
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun registerWithBusinessDiff(regions: List<GeofenceRegion>): Result<Unit> {
-        // After a reboot GMS is empty, so re-register everything rather than trust the surviving
-        // registeredIds (which would otherwise be skipped as "unchanged").
-        val existingBusinessIds = if (osStateWipedByReboot()) {
+        // After a reboot or app update GMS state is gone, so re-register everything rather than
+        // trust the surviving registeredIds (which would otherwise be skipped as "unchanged").
+        val existingBusinessIds = if (osStateWiped()) {
             emptySet()
         } else {
             unchangedRegisteredIds(regions)
@@ -386,9 +404,10 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Stamp device uptime so the next refresh can detect a reboot (which wipes OS
-                    // geofences) and force a full re-register instead of trusting registeredIds.
+                    // Stamp uptime and package update time so the next refresh detects a reboot or
+                    // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
+                    packageInfo.lastUpdateTimeMs()?.let { store.setLastRegistrationPackageUpdateTime(it) }
                     // Track the user's location at each successful registration so boot restore can
                     // re-center close to their real position. Clear only when nothing is registered
                     // (kill switch) — the trigger, and thus its location, is gone.

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -7,6 +7,7 @@ import io.customer.geofence.GeofenceDistanceFilter
 import io.customer.geofence.GeofenceJsonSerializer
 import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.GeofenceManager
+import io.customer.geofence.GeofencePackageInfo
 import io.customer.geofence.GeofencePermissionChecker
 import io.customer.geofence.GeofenceReceiverToggle
 import io.customer.geofence.GeofenceRepository
@@ -129,6 +130,9 @@ internal val AndroidSDKComponent.geofenceRegionStore: GeofenceRegionStore
         )
     }
 
+internal val AndroidSDKComponent.geofencePackageInfo: GeofencePackageInfo
+    get() = newInstance { GeofencePackageInfo(applicationContext) }
+
 internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
     get() = singleton<GeofenceRepository> {
         GeofenceRepositoryImpl(
@@ -140,6 +144,7 @@ internal val AndroidSDKComponent.geofenceRepository: GeofenceRepository
             cooldownFilter = geofenceCooldownFilter,
             transitionEmitter = geofenceTransitionEmitter,
             clock = SDKComponent.clock,
+            packageInfo = geofencePackageInfo,
             logger = SDKComponent.geofenceLogger
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -60,6 +60,10 @@ internal interface GeofenceRegionStore {
     fun getLastRegistrationUptime(): Long?
     fun setLastRegistrationUptime(uptimeMs: Long)
 
+    /** Package lastUpdateTime at the last successful OS registration; null if never registered. Drives app-update detection. */
+    fun getLastRegistrationPackageUpdateTime(): Long?
+    fun setLastRegistrationPackageUpdateTime(timeMs: Long)
+
     fun saveCachedConfig(config: GeofenceConfig)
     fun getCachedConfig(): GeofenceConfig?
 
@@ -119,6 +123,14 @@ internal class GeofenceRegionStoreImpl(
         prefs.edit { putLong(KEY_LAST_REGISTRATION_UPTIME, uptimeMs) }
     }
 
+    override fun getLastRegistrationPackageUpdateTime(): Long? = prefs.read {
+        if (contains(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)) getLong(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME, 0L) else null
+    }
+
+    override fun setLastRegistrationPackageUpdateTime(timeMs: Long) {
+        prefs.edit { putLong(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME, timeMs) }
+    }
+
     override fun saveCachedConfig(config: GeofenceConfig) =
         writeJson(KEY_CACHED_CONFIG, GeofenceConfig.serializer(), config)
 
@@ -155,6 +167,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
             remove(KEY_LAST_REGISTRATION_UPTIME)
+            remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
         }
     }
@@ -207,6 +220,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"
         const val KEY_LAST_SYNC = "last_sync_timestamp"
         const val KEY_LAST_REGISTRATION_UPTIME = "last_registration_uptime"
+        const val KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME = "last_registration_package_update_time"
         const val CRYPTO_KEY_ALIAS = "cio_geofence_location_key"
         val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
         val ID_SET_SERIALIZER = SetSerializer(String.serializer())

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -48,6 +48,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     private val cooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
     private val transitionEmitter: GeofenceTransitionEmitter = mockk(relaxed = true)
     private val clock: Clock = mockk(relaxed = true)
+    private val packageInfo: GeofencePackageInfo = mockk {
+        every { lastUpdateTimeMs() } returns null
+    }
     private val logger: GeofenceLogger = mockk(relaxed = true)
     private val jsonSerializer = GeofenceJsonSerializer()
 
@@ -70,6 +73,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         cooldownFilter = cooldownFilter,
         transitionEmitter = transitionEmitter,
         clock = clock,
+        packageInfo = packageInfo,
         logger = logger
     )
 
@@ -700,6 +704,106 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns setOf("biz-1")
         every { store.getLastRegistrationUptime() } returns 10_000L
         every { clock.elapsedRealtime() } returns 5_000L
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 1) { manager.replaceGeofences(any(), any()) }
+        existingSlot.captured.shouldBeEmpty()
+    }
+
+    @Test
+    fun refresh_givenAppUpdatedSinceLastRegistration_expectAllBusinessReRegistered() = runTest {
+        // Package lastUpdateTime changed => the app was updated, which can cancel the geofence
+        // PendingIntent and drop OS registrations. Re-register all business (empty existing set)
+        // even though registeredIds still lists them, then re-stamp the new update time.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+        verify { store.setLastRegistrationPackageUpdateTime(2_000L) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationsButNoPackageStamp_expectAllBusinessReRegistered() = runTest {
+        // Upgrade migration: registrations from an SDK version that didn't stamp the package
+        // update time predate stamping — the upgrade itself was an app update, so re-register.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns null
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured.shouldBeEmpty()
+        verify { store.setLastRegistrationPackageUpdateTime(2_000L) }
+    }
+
+    @Test
+    fun refresh_givenNoAppUpdateSinceLastRegistration_expectBusinessKept() = runTest {
+        // Matching update-time stamps => package untouched => trust registeredIds and keep the
+        // unchanged business geofence (skip re-upsert).
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-1")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 1_000L // unchanged
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val existingSlot = slot<Set<String>>()
+        coEvery { manager.replaceGeofences(any(), capture(existingSlot)) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        existingSlot.captured shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun refresh_givenFreshCacheButAppUpdated_expectLocalReRegisterInsteadOfSkip() = runTest {
+        // App update after a fresh-cache launch: time-fresh + ranking-fresh + registeredIds intact
+        // would normally SKIP, but the update may have wiped GMS state. Force a LOCAL re-register
+        // (no network) instead of leaving nothing monitored — the exact post-update launch path.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastMovementTriggerLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getLastRegistrationUptime() } returns 5_000L
+        every { clock.elapsedRealtime() } returns 10_000L // no reboot
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
             listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         val existingSlot = slot<Set<String>>()
@@ -1479,6 +1583,31 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getLastRegistrationUptime() } returns 500_000L
         every { clock.elapsedRealtime() } returns 1_000L // rebooted
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refresh_givenAppUpdateAndStaleCache_expectRemoteFetchButNoInitialEnter() = runTest {
+        // App update wiped OS state (package updateTime changed, no reboot). The launch anchor can
+        // predate the update just like a reboot, so containment can't be trusted — a newly fetched
+        // fence containing it must not synthesize either.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns emptyList()
+        every { store.getRegisteredIds() } returns setOf("biz-1")
+        every { store.getLastRegistrationUptime() } returns 500L
+        every { clock.elapsedRealtime() } returns 1_000L // no reboot (uptime advanced)
+        every { store.getLastRegistrationPackageUpdateTime() } returns 1_000L
+        every { packageInfo.lastUpdateTimeMs() } returns 2_000L // updated since → app-update wipe
         coEvery { apiService.fetchGeofences(any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -436,20 +436,45 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenEmptyBusinessSet_expectMovementTriggerLocationCleared() = runTest {
-        // Account transitioned to 0 businesses — no movement trigger exists,
-        // so any previously-stored location is stale and must be cleared.
+    fun refresh_givenKillSwitchConfig_expectNothingRegisteredAndMovementTriggerLocationCleared() = runTest {
+        // maxBusinessGeofences = 0 is the explicit server kill switch — unregister
+        // everything, including the movement trigger and its stored location.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
         coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(emptyResponse())
+            Result.success(emptyResponse(maxBusinessGeofences = 0))
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
-        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
+        captured.captured.shouldBeEmpty()
         verify(exactly = 0) { store.saveLastMovementTriggerLocation(any()) }
         verify { store.clearLastMovementTriggerLocation() }
+        // Region count alone can't distinguish this from an empty-but-still-monitoring sync.
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = false) }
+    }
+
+    @Test
+    fun refresh_givenEmptyResponseWithPositiveBudget_expectMovementTriggerKept() = runTest {
+        // `/nearest` is distance-capped, so an empty list means "none nearby", not "feature
+        // off" — a road trip through a fence-free area must keep the movement trigger
+        // registered so a later EXIT re-fetches; otherwise geofencing dies until the next
+        // app launch.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(emptyResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
+        verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
     }
 
     @Test
@@ -471,7 +496,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
         verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
         verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
-        verify { logger.logSyncSucceeded(0) }
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = true) }
     }
 
     @Test
@@ -507,7 +532,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         verify { store.setLastSyncTimestamp(any()) }
         verify { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) }
-        verify { logger.logSyncSucceeded(filtered.size) }
+        verify { logger.logSyncSucceeded(filtered.size, movementTriggerRegistered = true) }
         // Store holds the IDs of exactly what was registered (movement trigger + business),
         // so the next refresh's stale-cleanup diff is accurate.
         verify { store.saveRegisteredIds(captured.captured.map { it.id }.toSet()) }
@@ -712,16 +737,17 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager.replaceGeofences(any(), any())
             manager.removeGeofencesByIds(any())
         }
-        verify { logger.logSyncSucceeded(1) }
+        verify { logger.logSyncSucceeded(1, movementTriggerRegistered = true) }
         // Persisted set includes the unremoved stale ID — next refresh will retry it.
         persisted.captured shouldContainSame
             setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-new", "biz-old")
     }
 
     @Test
-    fun refresh_givenAllPreviousAbsentFromNew_expectAllRemovedAndEmptyRegistered() = runTest {
-        // Account transitioned from "has geofences" to "no geofences": every previously
-        // registered ID must be removed, including the movement trigger.
+    fun refresh_givenAllPreviousAbsentFromNew_expectBusinessRemovedButTriggerKept() = runTest {
+        // No fences in this response: previously registered business IDs are removed as
+        // stale, but the movement trigger stays so a later EXIT can re-fetch — the
+        // distance-capped /nearest can't distinguish "none nearby" from "none exist".
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns setOf(
             GeofenceConstants.MOVEMENT_TRIGGER_ID,
@@ -737,26 +763,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         val staleSlot = slot<List<String>>()
         coVerify { manager.removeGeofencesByIds(capture(staleSlot)) }
-        staleSlot.captured shouldContainSame listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-old")
-    }
-
-    @Test
-    fun refresh_givenZeroBusinessGeofences_expectNothingRegisteredIncludingMovementTrigger() = runTest {
-        // Customers without configured geofences must pay zero runtime cost:
-        // no movement trigger registered, no OS-side geofence activity.
-        every { secureUserStore.getUserId() } returns "user-42"
-        every { store.getRegisteredIds() } returns emptySet()
-        coEvery { apiService.fetchGeofences(any()) } returns
-            Result.success(emptyResponse())
-        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
-        val captured = slot<List<GeofenceRegion>>()
-        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
-
-        val result = repository.refresh(latitude = 12.34, longitude = 56.78)
-
-        result.isSuccess shouldBeEqualTo true
-        captured.captured.shouldBeEmpty()
-        verify { logger.logSyncSucceeded(0) }
+        staleSlot.captured shouldContainSame listOf("biz-old")
     }
 
     @Test
@@ -782,7 +789,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify(exactly = 0) { manager.removeGeofencesByIds(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
-        verify(exactly = 0) { logger.logSyncSucceeded(any()) }
+        verify(exactly = 0) { logger.logSyncSucceeded(any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -119,7 +119,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
         mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
         try {
             every { any<GeofenceApiRegion>().toDomain() } answers {
-                val region = invocation.self as GeofenceApiRegion
+                val region = firstArg<GeofenceApiRegion>()
                 if (region.id == "1") throw IllegalStateException("metadata defect") else callOriginal()
             }
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -127,6 +127,18 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastRegistrationUptime() shouldBeEqualTo 123_456L
     }
 
+    @Test
+    fun getLastRegistrationPackageUpdateTime_givenNothingStored_expectNull() {
+        store.getLastRegistrationPackageUpdateTime().shouldBeNull()
+    }
+
+    @Test
+    fun setLastRegistrationPackageUpdateTime_thenGet_expectRoundTrip() {
+        store.setLastRegistrationPackageUpdateTime(123_456L)
+
+        store.getLastRegistrationPackageUpdateTime() shouldBeEqualTo 123_456L
+    }
+
     // --- Cached config ---
 
     @Test
@@ -291,6 +303,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
+        store.setLastRegistrationPackageUpdateTime(88_888L)
         store.setLastSyncTimestamp(12_345L)
 
         store.clearUserScopedState()
@@ -300,6 +313,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()
+        store.getLastRegistrationPackageUpdateTime().shouldBeNull()
         // Freshness throttle: wiped so the next login re-fetches.
         store.getLastSyncTimestamp().shouldBeNull()
         // Cached regions/config: preserved.


### PR DESCRIPTION
[MBL-2196](https://linear.app/customerio/issue/MBL-2196/geofence-persistence)

Stacked on `feature/geofence-on-device`:

```
feature/geofence-on-device
  └─ mbl-2196-geofence-keep-monitoring-and-app-update  ← this PR
```

Two ways geofencing died silently and stayed dead until the next app open, both
found on a night drive. Replaces #794, which also carried
`GeofenceLocationMode.OFF` — that mode is deferred to its own PR (see below).

### Keep the movement trigger armed through fence-free areas
`/geofences/nearest` is distance-capped, so an empty response means "none
nearby", not "feature off" — but it was treated as the kill switch and
unregistered everything, including the movement trigger. A trip through any
fence-free corridor disarmed monitoring for the rest of the journey: with
nothing left to fire an EXIT, no re-rank or re-fetch could happen. The trigger
now stays registered whenever the config budget allows monitoring; only the
explicit kill switch (`max_business_geofence = 0`) clears it and its stored
location.

The sync-completed log now states whether the trigger was registered — region
count alone can't tell a kill-switched sync from an empty-but-still-monitoring
one.

Aligned with iOS (`customerio-ios` `a934b877`).

### Re-register after an app update
An app update can cancel the geofence `PendingIntent`, wiping OS-side
registrations while `registeredIds` survive — the business diff then skips
re-upsert forever, and monitoring stays dead until a reboot, a fence edit or a
sign-out. On the same night drive the updated build reported zero business
transitions while a non-updated build on the same route reported every one.

Package `lastUpdateTime` is now stamped at each successful registration,
mirroring the reboot uptime stamp. A mismatch marks OS state untrusted: the
refresh decision re-ranks locally instead of skipping on a fresh cache, and the
diff re-registers every business fence instead of trusting surviving ids. A
missing stamp alongside live registrations counts as wiped too, so an install
predating this check heals itself on first launch.

Synthesized initial ENTER is suppressed while either wipe kind is detected — an
app update leaves the launch anchor as stale as a reboot does, so containment
can't be trusted and a newly fetched fence must not fabricate an ENTER. The
movement path keeps synthesis on: it runs off the OS's live triggering
location, not the persisted anchor.

No iOS counterpart is needed here. `CLMonitor`/`CLLocationManager` expose the
live monitored set, so iOS reconciles against OS truth at every launch; GMS has
no equivalent read, which is why Android needs the stamp.

### Known behavior: app updates can re-fire an ENTER
Forcing a full re-register means GMS re-evaluates `INITIAL_TRIGGER_ENTER`, so
every fence the device is currently inside fires an ENTER. The SDK can't tell
that from a real crossing — it's the same broadcast — so if the dedupe window
has lapsed it surfaces as a duplicate ENTER for a user who never left. Reboots
have always behaved this way; app updates make it more frequent.
Distinguishing the two needs presence tracking (deferred), so this is
documented rather than fixed here.

### Testing
- `:geofence` 325 tests green, `apiCheck` + ktlint + lint clean. No public API
  change.
- Each commit builds and passes on its own (318 tests at the second).
- Emulator: 0-region syncs keep re-fetching and recover on their own; `install
  -r` forces a full re-upsert through the freshness window.
- The first commit also fixes the `:geofence` unit test currently red on
  `feature` (`invocation.self` is the file facade for a mocked static
  extension, not the receiver — `firstArg()` is).

### Not included: `GeofenceLocationMode.OFF`
OFF was pulled out of this PR rather than shipped. Review found that an
in-flight movement sync can re-register geofences *after* the teardown has run:
`registerNearestAndPersist` commits under `stateMutex` and rechecks the signed-in
user inside the lock, which is what protects the sign-out wipe — and OFF has no
equivalent, so a sync that started before `initialize()` (a transition broadcast
waking the process in a host that initializes later than
`Application.onCreate` — i.e. wrapper SDKs, OFF's main use case) can land after
the wipe and repopulate registrations.

The fix is a process-level disabled flag consulted inside `stateMutex`, next to
the userId recheck — a design change through the repository entry points, not a
release-eve patch. OFF has no users until wrappers adopt it, so shipping it now
buys nothing. Work is preserved on `geofence-off-mode-wip` and returns as its
own PR with that flag plus an on-device teardown test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence registration and refresh decisions that affect background monitoring and transition delivery; full re-register after updates can surface duplicate ENTER events when dedupe has expired.
> 
> **Overview**
> Fixes two cases where Android geofencing could stop silently until the next app open: **empty-but-valid syncs** and **app updates** that drop GMS registrations while persisted `registeredIds` remain.
> 
> **Movement trigger stays armed** unless the server explicitly disables monitoring (`maxBusinessGeofences = 0`). An empty `/nearest` or distance-filter result no longer unregisters everything; the movement trigger is still registered so a later EXIT can re-rank or re-fetch. Sync success logging now records whether the trigger was registered, since region count alone cannot distinguish kill-switch from “none nearby.”
> 
> **App-update wipe detection** mirrors reboot handling: `GeofencePackageInfo` reads package `lastUpdateTime`, the region store persists it at each successful registration, and `osStateWiped()` treats reboot or package change as untrusted GMS state. That forces a local re-register instead of SKIP on a fresh cache, re-upserts all business fences instead of trusting surviving ids, and suppresses synthesized initial ENTER on identify/launch refresh (movement path unchanged). Upgrades without a prior stamp but with live registrations heal on first launch.
> 
> Also fixes a flaky unit test mock (`firstArg()` vs `invocation.self` for static extension mocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc848ba969b8d15f7ca939525dee68e53cd51e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->