### PR TITLE
chore(geofence): retry a location-starved sync on app foreground

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -11,7 +11,8 @@ import io.customer.sdk.data.store.PendingDeliveryFlusher
 /**
  * Registered with `ProcessLifecycleOwner` at geofence-module init. On every foreground
  * entry it flushes pending OS-delivered transitions through the analytics pipeline,
- * independent of the location tracking mode (so MANUAL still delivers).
+ * independent of the location tracking mode (so MANUAL still delivers), then runs
+ * [onForeground] — the retry hook for a sync still waiting on a location fix.
  *
  * The shared [PendingDeliveryFlusher] runs [PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE]:
  * publish, remove, then best-effort cancel the WorkManager delivery. The worker
@@ -25,11 +26,13 @@ internal class GeofenceLifecycleObserver(
     private val deliveryFlusher: PendingDeliveryFlusher<PendingGeofenceDelivery>,
     private val eventBus: EventBus,
     private val regionStore: GeofenceRegionStore,
-    private val logger: GeofenceLogger
+    private val logger: GeofenceLogger,
+    private val onForeground: () -> Unit
 ) : DefaultLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
         flushPendingGeofenceDeliveries()
+        onForeground()
     }
 
     private fun flushPendingGeofenceDeliveries() {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -61,6 +61,18 @@ internal interface GeofenceServices {
      * launch.
      */
     fun onLocationAcquired(latitude: Double, longitude: Double)
+
+    /**
+     * Retries a sync still waiting on a location fix. Same freshness handling as [onAppLaunch];
+     * separate reason so device logs tell the two apart.
+     */
+    fun onForegroundRetry(latitude: Double?, longitude: Double?)
+
+    /**
+     * Whether a trigger is waiting on a location fix — a no-location skip or an [onRefreshRequested]
+     * that never received one. Peeks only; [onLocationAcquired] still owns clearing the flags.
+     */
+    fun isAwaitingLocation(): Boolean
 }
 
 internal class GeofenceServicesImpl(
@@ -124,6 +136,18 @@ internal class GeofenceServicesImpl(
         onUserIdentified(latitude, longitude)
     }
 
+    override fun onForegroundRetry(latitude: Double?, longitude: Double?) {
+        triggerSync(
+            reason = REASON_FOREGROUND_RETRY,
+            latitude = latitude,
+            longitude = longitude,
+            action = repository::refresh
+        )
+    }
+
+    override fun isAwaitingLocation(): Boolean =
+        lastSkippedForNoLocation.get() || explicitRefreshRequested.get()
+
     override fun onUserSignedOut() {
         // Drop any pending refresh intent so a previous user's request can't drive a
         // sync for the next user — sign-out wipes user-scoped session state.
@@ -174,5 +198,6 @@ internal class GeofenceServicesImpl(
         const val REASON_MOVEMENT_EXIT = "movement-trigger-exit"
         const val REASON_USER_IDENTIFIED = "user-identified"
         const val REASON_APP_LAUNCH = "app-launch"
+        const val REASON_FOREGROUND_RETRY = "foreground-retry"
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -73,6 +73,13 @@ internal interface GeofenceServices {
      * that never received one. Peeks only; [onLocationAcquired] still owns clearing the flags.
      */
     fun isAwaitingLocation(): Boolean
+
+    /**
+     * Whether a host refresh ([onRefreshRequested]) is still waiting on its fix. It asked for a
+     * live location, so the foreground retry must re-request one instead of settling for the
+     * anchor — otherwise the flag stays armed and retries forever. Peeks only.
+     */
+    fun isHostRefreshPending(): Boolean
 }
 
 internal class GeofenceServicesImpl(
@@ -147,6 +154,8 @@ internal class GeofenceServicesImpl(
 
     override fun isAwaitingLocation(): Boolean =
         lastSkippedForNoLocation.get() || explicitRefreshRequested.get()
+
+    override fun isHostRefreshPending(): Boolean = explicitRefreshRequested.get()
 
     override fun onUserSignedOut() {
         // Drop any pending refresh intent so a previous user's request can't drive a

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -168,7 +168,8 @@ class ModuleGeofence @JvmOverloads constructor(
                     deliveryFlusher = sdkAndroid.geofenceDeliveryFlusher,
                     eventBus = eventBus,
                     regionStore = sdkAndroid.geofenceRegionStore,
-                    logger = logger
+                    logger = logger,
+                    onForeground = { retrySyncAwaitingLocation(sdkAndroid, locationModule) }
                 )
             )
 
@@ -195,6 +196,30 @@ class ModuleGeofence @JvmOverloads constructor(
                     // the launch read completes rather than leaking its Job.
                     launchScope.cancel()
                 }
+            }
+        }
+    }
+
+    /**
+     * A silent fix that never arrives — cancelled when the app backgrounds mid-fetch, timed out,
+     * location services off — leaves the sync armed with nothing to consume it, and nothing else
+     * re-requests one until the next cold launch. Foreground entry is the next chance.
+     */
+    private fun retrySyncAwaitingLocation(sdkAndroid: AndroidSDKComponent, locationModule: ModuleLocation) {
+        // Cheap atomic reads, so the healthy case never reaches the anchor read below.
+        if (!sdkAndroid.geofenceServices.isAwaitingLocation()) return
+        // Anchor read hits SharedPreferences plus a Keystore decrypt; onStart is the main thread.
+        val retryScope = SDKComponent.scopeProvider.geofenceScope
+        retryScope.launch {
+            try {
+                val anchor = refreshAnchor(sdkAndroid, locationModule)
+                sdkAndroid.geofenceServices.onForegroundRetry(
+                    latitude = anchor?.latitude,
+                    longitude = anchor?.longitude
+                )
+                autoAcquireIfNeeded(locationModule, anchor)
+            } finally {
+                retryScope.cancel()
             }
         }
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -217,7 +217,13 @@ class ModuleGeofence @JvmOverloads constructor(
                     latitude = anchor?.latitude,
                     longitude = anchor?.longitude
                 )
-                autoAcquireIfNeeded(locationModule, anchor)
+                if (sdkAndroid.geofenceServices.isHostRefreshPending()) {
+                    // The host asked for a live fix — an anchor can't satisfy it. Re-request like
+                    // refreshFromCurrentLocation does (mode-independent); the fix consumes the flag.
+                    locationModule.locationServices.requestLocationUpdateSilently()
+                } else {
+                    autoAcquireIfNeeded(locationModule, anchor)
+                }
             } finally {
                 retryScope.cancel()
             }

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -212,18 +212,22 @@ class ModuleGeofence @JvmOverloads constructor(
         val retryScope = SDKComponent.scopeProvider.geofenceScope
         retryScope.launch {
             try {
+                if (sdkAndroid.geofenceServices.isHostRefreshPending()) {
+                    // The host asked for a live fix — an anchor can't satisfy it, so don't sync
+                    // from one. Re-request like refreshFromCurrentLocation does (mode-independent);
+                    // the arriving fix consumes the flag and drives the sync.
+                    locationModule.locationServices.requestLocationUpdateSilently()
+                    return@launch
+                }
                 val anchor = refreshAnchor(sdkAndroid, locationModule)
+                // Re-check after the anchor read: a fix that landed meanwhile has already consumed
+                // the flags and synced — retrying now would re-center on the pre-fix anchor.
+                if (!sdkAndroid.geofenceServices.isAwaitingLocation()) return@launch
                 sdkAndroid.geofenceServices.onForegroundRetry(
                     latitude = anchor?.latitude,
                     longitude = anchor?.longitude
                 )
-                if (sdkAndroid.geofenceServices.isHostRefreshPending()) {
-                    // The host asked for a live fix — an anchor can't satisfy it. Re-request like
-                    // refreshFromCurrentLocation does (mode-independent); the fix consumes the flag.
-                    locationModule.locationServices.requestLocationUpdateSilently()
-                } else {
-                    autoAcquireIfNeeded(locationModule, anchor)
-                }
+                autoAcquireIfNeeded(locationModule, anchor)
             } finally {
                 retryScope.cancel()
             }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
@@ -22,11 +22,14 @@ class GeofenceLifecycleObserverTest {
     private val mockRegionStore: GeofenceRegionStore = mockk(relaxed = true)
     private val mockLogger: GeofenceLogger = mockk(relaxed = true)
 
+    private var foregroundHookRuns = 0
+
     private val observer = GeofenceLifecycleObserver(
         deliveryFlusher = mockDeliveryFlusher,
         eventBus = mockEventBus,
         regionStore = mockRegionStore,
-        logger = mockLogger
+        logger = mockLogger,
+        onForeground = { foregroundHookRuns++ }
     )
 
     @Test
@@ -38,6 +41,14 @@ class GeofenceLifecycleObserverTest {
         verify(exactly = 2) {
             mockDeliveryFlusher.flush(any(), PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE, any())
         }
+    }
+
+    @Test
+    fun onStart_expectForegroundHookRunOncePerEntry() {
+        observer.onStart(owner)
+        observer.onStart(owner)
+
+        foregroundHookRuns shouldBeEqualTo 2
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -357,6 +357,34 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun isHostRefreshPending_givenRequestThenFix_expectArmedThenConsumed() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onRefreshRequested()
+        services.isHostRefreshPending() shouldBeEqualTo true
+
+        // Only the live fix satisfies a host refresh — the foreground retry keeps
+        // re-requesting one until this consumes the flag.
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        services.isHostRefreshPending() shouldBeEqualTo false
+    }
+
+    @Test
+    fun isHostRefreshPending_givenOnlyNoLocationSkip_expectFalse() = runTest(StandardTestDispatcher()) {
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+
+        // A no-location skip retries via the anchor/auto-acquire path, not a forced re-request.
+        services.isHostRefreshPending() shouldBeEqualTo false
+    }
+
+    @Test
     fun onUserSignedOut_expectRepositoryResetInvoked() = runTest(StandardTestDispatcher()) {
         // Sign-out delegates the wipe decision to repository.reset(); the services layer
         // just drops the anchor synchronously and kicks reset off the scope.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -263,6 +263,100 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun onForegroundRetry_expectRefreshUnderItsOwnReason() = runTest(StandardTestDispatcher()) {
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onForegroundRetry(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        coVerify { repository.refresh(1.0, 2.0) }
+        verify { logger.logSyncTriggered("foreground-retry") }
+    }
+
+    @Test
+    fun onForegroundRetry_givenStillNoLocation_expectStaysArmed() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        // A retry that still has no anchor must leave the flag up, or the fix it kicks off
+        // arrives with nothing armed to consume it.
+        services.onUserIdentified(latitude = null, longitude = null)
+        services.onForegroundRetry(latitude = null, longitude = null)
+        advanceUntilIdle()
+        services.isAwaitingLocation() shouldBeEqualTo true
+
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify { repository.refresh(12.0, 34.0) }
+    }
+
+    @Test
+    fun isAwaitingLocation_givenNoLocationSkip_expectTrue() = runTest(StandardTestDispatcher()) {
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+
+        services.isAwaitingLocation() shouldBeEqualTo true
+    }
+
+    @Test
+    fun isAwaitingLocation_givenExplicitRefreshRequested_expectTrue() = runTest(StandardTestDispatcher()) {
+        val services = servicesWith(this)
+
+        services.onRefreshRequested()
+
+        services.isAwaitingLocation() shouldBeEqualTo true
+    }
+
+    @Test
+    fun isAwaitingLocation_givenSuccessfulTrigger_expectFalse() = runTest(StandardTestDispatcher()) {
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        services.isAwaitingLocation() shouldBeEqualTo false
+    }
+
+    @Test
+    fun isAwaitingLocation_expectPeekLeavesFlagForTheReturningFix() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns "user-1"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+        // Repeated foreground entries peek; only the arriving fix may consume the flag.
+        services.isAwaitingLocation() shouldBeEqualTo true
+        services.isAwaitingLocation() shouldBeEqualTo true
+
+        services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
+        advanceUntilIdle()
+
+        coVerify { repository.refresh(12.0, 34.0) }
+        services.isAwaitingLocation() shouldBeEqualTo false
+    }
+
+    @Test
+    fun isAwaitingLocation_afterSignOut_expectFalse() = runTest(StandardTestDispatcher()) {
+        coEvery { repository.reset() } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = null, longitude = null)
+        advanceUntilIdle()
+        services.onUserSignedOut()
+        advanceUntilIdle()
+
+        // Otherwise the next user's first foreground entry would retry the previous user's skip.
+        services.isAwaitingLocation() shouldBeEqualTo false
+    }
+
+    @Test
     fun onUserSignedOut_expectRepositoryResetInvoked() = runTest(StandardTestDispatcher()) {
         // Sign-out delegates the wipe decision to repository.reset(); the services layer
         // just drops the anchor synchronously and kicks reset off the scope.


### PR DESCRIPTION
## Summary

Fixes the sync-stuck-after-cancel gap Bugbot flagged on #763 ([finding](https://github.com/customerio/customerio-android/pull/763#discussion_r3649994176)): a first-ever sync that skips for no location arms the rearm flag and kicks off a silent fix — but if that fix never returns, nothing consumes the flag and nothing re-requests one until the next cold launch, so geofencing stays unregistered for the life of the process. The likeliest killer is the app backgrounding mid-fetch (`cancelInFlightRequest`), which on a fresh install with a slow first fix is an ordinary onboarding flow; provider failure and location services being off die the same way.

## Changes

- **Foreground entry retries the starved sync.** `GeofenceLifecycleObserver` (already registered for the pending-transition flush) now runs a retry hook: peek the armed flags — two atomic reads, so the healthy case costs nothing — then re-run the sync under its own `foreground-retry` log reason and re-acquire a silent fix when there's still no anchor. AUTOMATIC-mode only for the acquire; MANUAL keeps the host in charge.
- **The arriving fix consumes the flags exactly as before** — the retry peeks without clearing, so a retry that still finds no location leaves the state armed for the fix it just requested.
- Anchor read (SharedPreferences + Keystore decrypt) stays off the main thread behind the atomic guard.

Every foreground becomes a recovery opportunity, healing all the ways the first fix can be lost, not just the background-cancel.

## Stack

```
main ← feature/geofence-on-device ← this PR
```

## Tests

- Observer runs the retry hook on every foreground entry.
- Retry refreshes under its own reason; a retry that still has no location stays armed so the returning fix is consumed (the key invariant).
- `isAwaitingLocation`: armed by a no-location skip and by an explicit host refresh; peeking doesn't consume; cleared by a successful trigger and by sign-out (so the next user's foreground can't retry the previous user's skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches geofence sync triggering and location acquisition on every foreground entry; logic is guarded and well-tested but affects when geofences register after failed first fixes.
> 
> **Overview**
> Fixes a gap where a geofence sync armed after a **no-location skip** (or a host `refreshFromCurrentLocation`) could stay stuck for the rest of the process if the silent location request never completes—e.g. app backgrounds mid-fetch.
> 
> **Foreground recovery:** `GeofenceLifecycleObserver` now invokes an `onForeground` hook after flushing pending transitions. `ModuleGeofence.retrySyncAwaitingLocation` peeks `isAwaitingLocation()` (cheap atomics on the main thread), then on a background scope either re-requests a silent fix when a **host refresh** is still pending, or calls `onForegroundRetry` with the registration/last-known anchor and `autoAcquireIfNeeded` in AUTOMATIC mode.
> 
> **GeofenceServices** adds `onForegroundRetry` (logged as `foreground-retry`), plus peek-only `isAwaitingLocation()` and `isHostRefreshPending()` so retries do not clear flags—`onLocationAcquired` still owns consumption. Sign-out continues to clear both flags so the next user cannot inherit a stale retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318ed72d0b50f7b8fa25d383d31202ae5d6ec418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->