### PR TITLE
fix(live-notifications): address review findings

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
@@ -11,40 +11,22 @@ import java.net.MalformedURLException
 import java.net.URL
 
 @InternalCustomerIOApi
-enum class HttpMethod { GET, POST, PUT, DELETE }
-
-@InternalCustomerIOApi
 data class HttpRequestParams(
     val path: String,
-    val method: HttpMethod = HttpMethod.POST,
     val headers: Map<String, String> = emptyMap(),
     val body: String? = null
 )
-
-/**
- * IOException carrying the HTTP [statusCode] for non-2xx responses ([statusCode]
- * is null for transport-level failures). Lets callers apply status-aware retry
- * (e.g. retry 5xx, skip 4xx) without parsing the message.
- */
-@InternalCustomerIOApi
-class HttpRequestException(
-    val statusCode: Int?,
-    message: String,
-    cause: Throwable? = null
-) : IOException(message, cause)
 
 /** HTTP client for Customer.io API calls with SDK authentication. */
 @InternalCustomerIOApi
 interface CustomerIOHttpClient {
     /**
-     * Performs an HTTP request to [params.path] using [params.method], with
-     * [params.headers] and [params.body].
+     * Performs a POST request to [params.path] with [params.headers] and [params.body].
      *
-     * @param params The request parameters (path, method, headers, body).
+     * @param params The request parameters (path, headers, body).
      * @return A `Result<String>`:
      *   - `Result.success(responseBody)` for 2xx response codes
      *   - `Result.failure(exception)` for network errors or non-2xx codes
-     *     (an [HttpRequestException] for non-2xx, carrying the status code)
      */
     suspend fun request(params: HttpRequestParams): Result<String>
 }
@@ -84,7 +66,7 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
             // Configure the connection
             connection.connectTimeout = connectTimeoutMs
             connection.readTimeout = readTimeoutMs
-            connection.requestMethod = params.method.name
+            connection.requestMethod = "POST"
             connection.setRequestProperty("User-Agent", client.toString())
 
             // Authorization: Basic <base64("writeKey:")>
@@ -119,7 +101,7 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
             if (responseCode in 200..299) {
                 Result.success(responseBody)
             } else {
-                Result.failure(HttpRequestException(responseCode, "HTTP $responseCode: $responseBody"))
+                Result.failure(IOException("HTTP $responseCode: $responseBody"))
             }
         } catch (e: IOException) {
             Result.failure(e)

--- a/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/GlobalPreferenceStore.kt
@@ -12,10 +12,8 @@ import kotlinx.serialization.json.Json
 interface GlobalPreferenceStore {
     fun saveDeviceToken(token: String)
     fun saveSettings(value: Settings)
-    fun saveInstallationId(value: String)
     fun getDeviceToken(): String?
     fun getSettings(): Settings?
-    fun getInstallationId(): String?
     fun removeDeviceToken()
     fun clear(key: String)
     fun clearAll()
@@ -37,10 +35,6 @@ internal class GlobalPreferenceStoreImpl(
         putString(KEY_CONFIG_SETTINGS, Json.encodeToString(Settings.serializer(), value))
     }
 
-    override fun saveInstallationId(value: String) = prefs.edit {
-        putString(KEY_INSTALLATION_ID, value)
-    }
-
     override fun getDeviceToken(): String? = prefs.read {
         getString(KEY_DEVICE_TOKEN, null)
     }
@@ -54,15 +48,10 @@ internal class GlobalPreferenceStoreImpl(
         }.getOrNull()
     }
 
-    override fun getInstallationId(): String? = prefs.read {
-        getString(KEY_INSTALLATION_ID, null)
-    }
-
     override fun removeDeviceToken() = clear(KEY_DEVICE_TOKEN)
 
     companion object {
         private const val KEY_DEVICE_TOKEN = "device_token"
         private const val KEY_CONFIG_SETTINGS = "config_settings"
-        private const val KEY_INSTALLATION_ID = "installation_id"
     }
 }

--- a/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
+++ b/datapipelines/src/main/kotlin/io/customer/datapipelines/plugins/ContextPlugin.kt
@@ -14,7 +14,6 @@ import io.customer.sdk.data.store.DeviceStore
  */
 internal class ContextPlugin(
     private val deviceStore: DeviceStore,
-    private val installationId: String,
     private val eventProcessor: ContextPluginEventProcessor = DefaultContextPluginEventProcessor()
 ) : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
@@ -24,7 +23,7 @@ internal class ContextPlugin(
     internal var deviceToken: String? = null
 
     override fun execute(event: BaseEvent): BaseEvent {
-        return eventProcessor.execute(event, deviceStore, installationId) { deviceToken }
+        return eventProcessor.execute(event, deviceStore) { deviceToken }
     }
 }
 
@@ -33,12 +32,7 @@ internal class ContextPlugin(
  * Allows custom logic to be injected for testing or extension.
  */
 internal interface ContextPluginEventProcessor {
-    fun execute(
-        event: BaseEvent,
-        deviceStore: DeviceStore,
-        installationId: String,
-        deviceTokenProvider: () -> String?
-    ): BaseEvent
+    fun execute(event: BaseEvent, deviceStore: DeviceStore, deviceTokenProvider: () -> String?): BaseEvent
 }
 
 /**
@@ -46,12 +40,7 @@ internal interface ContextPluginEventProcessor {
  * in the context and ensures the device token is added if not already present.
  */
 internal class DefaultContextPluginEventProcessor : ContextPluginEventProcessor {
-    override fun execute(
-        event: BaseEvent,
-        deviceStore: DeviceStore,
-        installationId: String,
-        deviceTokenProvider: () -> String?
-    ): BaseEvent {
+    override fun execute(event: BaseEvent, deviceStore: DeviceStore, deviceTokenProvider: () -> String?): BaseEvent {
         // Set user agent in context as it is required by Customer.io Data Pipelines
         event.putInContext("userAgent", deviceStore.buildUserAgent())
         // Remove analytics library information from context as Customer.io
@@ -65,10 +54,6 @@ internal class DefaultContextPluginEventProcessor : ContextPluginEventProcessor 
             // Device token is expected to be attached to device in context
             event.putInContextUnderKey("device", "token", token)
         }
-
-        // Attach installation id to device in context so backend can correlate
-        // events to a single install across identify/clearIdentify cycles.
-        event.putInContextUnderKey("device", "installationId", installationId)
 
         return event
     }

--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -41,7 +41,6 @@ import io.customer.sdk.data.model.Settings
 import io.customer.sdk.events.TrackMetric
 import io.customer.sdk.util.EventNames
 import io.customer.tracking.migration.MigrationProcessor
-import java.util.UUID
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.serializer
 
@@ -110,7 +109,7 @@ class CustomerIO private constructor(
         )
     )
 
-    private val contextPlugin: ContextPlugin
+    private val contextPlugin: ContextPlugin = ContextPlugin(deviceStore)
 
     // Tracks the last userId successfully identified in this SDK session. Used to dedup
     // back-to-back identify(userId) calls with no traits, which are no-ops server-side.
@@ -131,14 +130,6 @@ class CustomerIO private constructor(
         // Set analytics logger and debug logs based on SDK logger configuration
         Analytics.debugLogsEnabled = logger.logLevel == CioLogLevel.DEBUG
         Analytics.setLogger(segmentLogger)
-
-        // Resolve installation id: load if present, otherwise generate once and persist.
-        // Survives clearIdentify and SDK re-init; only OS app-data clear wipes it.
-        val installationId = globalPreferenceStore.getInstallationId()
-            ?: UUID.randomUUID().toString().also { id ->
-                globalPreferenceStore.saveInstallationId(id)
-            }
-        contextPlugin = ContextPlugin(deviceStore = deviceStore, installationId = installationId)
 
         // Add required plugins to analytics instance
         analytics.add(contextPlugin)

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginBehaviorTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginBehaviorTest.kt
@@ -65,9 +65,7 @@ class ContextPluginBehaviorTest : JUnitTest() {
     @Test
     fun execute_whenDeviceTokenIsSetFromAnotherThread_thenAddsCorrectTokenToEvent() {
         val rounds = ROUND_COUNT
-        // #689 added a required `installationId` to ContextPlugin; the deterministic test
-        // only asserts on deviceToken propagation, so a fixed stub id is sufficient.
-        val contextPlugin = ContextPlugin(deviceStore, installationId = "test-installation-id")
+        val contextPlugin = ContextPlugin(deviceStore)
         // We exercise contextPlugin.execute(event) in isolation — no need to
         // attach to analytics. ContextPlugin.execute does not touch the
         // `analytics` lateinit; attaching it under JUnitTest's StandardTestDispatcher

--- a/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/plugins/ContextPluginTest.kt
@@ -12,19 +12,14 @@ import io.customer.datapipelines.testutils.core.DataPipelinesTestConfig
 import io.customer.datapipelines.testutils.core.JUnitTest
 import io.customer.datapipelines.testutils.core.testConfiguration
 import io.customer.datapipelines.testutils.extensions.deviceToken
-import io.customer.datapipelines.testutils.extensions.installationId
 import io.customer.datapipelines.testutils.utils.OutputReaderPlugin
 import io.customer.datapipelines.testutils.utils.trackEvents
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.store.GlobalPreferenceStore
 import io.mockk.every
-import io.mockk.slot
-import io.mockk.verify
-import java.util.UUID
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldHaveSingleItem
-import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
 class ContextPluginTest : JUnitTest() {
@@ -101,84 +96,6 @@ class ContextPluginTest : JUnitTest() {
         val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
         result.event shouldBeEqualTo givenEventName
         result.context.deviceToken.shouldBeNull()
-    }
-
-    @Test
-    fun process_givenInstallationIdExists_expectAttachedToDeviceContext() {
-        val givenInstallationId = UUID.randomUUID().toString()
-        setupWithConfig(
-            testConfiguration {
-                diGraph {
-                    android {
-                        every { globalPreferenceStore.getInstallationId() } returns givenInstallationId
-                    }
-                }
-            }
-        )
-
-        val givenEventName = String.random
-        analytics.process(TrackEvent(emptyJsonObject, givenEventName))
-
-        val result = outputReaderPlugin.trackEvents.shouldHaveSingleItem()
-        result.event shouldBeEqualTo givenEventName
-        result.context.installationId shouldBeEqualTo givenInstallationId
-    }
-
-    @Test
-    fun process_givenNoInstallationIdStored_expectGeneratedAndPersisted() {
-        val savedIdSlot = slot<String>()
-        setupWithConfig(
-            testConfiguration {
-                diGraph {
-                    android {
-                        every { globalPreferenceStore.getInstallationId() } returns null
-                        every { globalPreferenceStore.saveInstallationId(capture(savedIdSlot)) } returns Unit
-                    }
-                }
-            }
-        )
-
-        verify(exactly = 1) { globalPreferenceStore.saveInstallationId(any()) }
-        val persistedId = savedIdSlot.captured
-        // Ensure it parses as a valid UUID
-        UUID.fromString(persistedId).shouldNotBeNull()
-
-        val firstEventName = String.random
-        analytics.process(TrackEvent(emptyJsonObject, firstEventName))
-        val secondEventName = String.random
-        analytics.process(TrackEvent(emptyJsonObject, secondEventName))
-
-        val events = outputReaderPlugin.trackEvents
-        events[0].context.installationId shouldBeEqualTo persistedId
-        events[1].context.installationId shouldBeEqualTo persistedId
-    }
-
-    @Test
-    fun process_acrossClearIdentify_expectInstallationIdUnchanged() {
-        val givenInstallationId = UUID.randomUUID().toString()
-        setupWithConfig(
-            testConfiguration {
-                diGraph {
-                    android {
-                        every { globalPreferenceStore.getInstallationId() } returns givenInstallationId
-                    }
-                }
-            }
-        )
-
-        val firstEventName = String.random
-        analytics.process(TrackEvent(emptyJsonObject, firstEventName))
-        val installationIdBefore = outputReaderPlugin.trackEvents.last().context.installationId
-        outputReaderPlugin.reset()
-
-        sdkInstance.clearIdentify()
-
-        val secondEventName = String.random
-        analytics.process(TrackEvent(emptyJsonObject, secondEventName))
-        val installationIdAfter = outputReaderPlugin.trackEvents.last().context.installationId
-
-        installationIdBefore shouldBeEqualTo givenInstallationId
-        installationIdAfter shouldBeEqualTo installationIdBefore
     }
 }
 

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/core/UnitTestDelegate.kt
@@ -81,7 +81,6 @@ class UnitTestDelegate(
             androidSDKComponent.overrideDependency<GlobalPreferenceStore>(instance)
         }
         every { globalPreferenceStore.getDeviceToken() } returns null
-        every { globalPreferenceStore.getInstallationId() } returns null
         // Mock device store to avoid reading/writing to device store
         // Spy on the stub to provide custom implementation for the test
         val deviceStoreStub = DeviceStoreStub().getDeviceStore(androidSDKComponent.client)

--- a/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExtensions.kt
+++ b/datapipelines/src/test/java/io/customer/datapipelines/testutils/extensions/JsonExtensions.kt
@@ -85,9 +85,6 @@ private fun <T> Json.encode(value: T?): JsonElement = when (value) {
 internal val JsonObject.deviceToken: String?
     get() = this.getStringAtPath("device.token")
 
-internal val JsonObject.installationId: String?
-    get() = this.getStringAtPath("device.installationId")
-
 fun JsonObject.getStringAtPath(path: String): String? {
     return findAtPath(path).firstOrNull()?.content
 }

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -22,9 +22,10 @@ public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
 	public static final field Companion Lio/customer/messagingpush/MessagingPushModuleConfig$Companion;
-	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lio/customer/messagingpush/livenotification/LiveNotificationBranding;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/config/PushClickBehavior;Lio/customer/messagingpush/livenotification/LiveNotificationBranding;Ljava/util/Set;Lio/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoTrackPushEvents ()Z
 	public final fun getLiveNotificationBranding ()Lio/customer/messagingpush/livenotification/LiveNotificationBranding;
+	public final fun getLiveNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback;
 	public final fun getLiveNotificationTypes ()Ljava/util/Set;
 	public final fun getNotificationCallback ()Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;
 	public final fun getPushClickBehavior ()Lio/customer/messagingpush/config/PushClickBehavior;
@@ -39,6 +40,7 @@ public final class io/customer/messagingpush/MessagingPushModuleConfig$Builder :
 	public final fun enableLiveNotificationTypes ([Lio/customer/messagingpush/livenotification/LiveNotificationType;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setAutoTrackPushEvents (Z)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setLiveNotificationBranding (Lio/customer/messagingpush/livenotification/LiveNotificationBranding;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
+	public final fun setLiveNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setNotificationCallback (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 	public final fun setPushClickBehavior (Lio/customer/messagingpush/config/PushClickBehavior;)Lio/customer/messagingpush/MessagingPushModuleConfig$Builder;
 }
@@ -84,20 +86,23 @@ public final class io/customer/messagingpush/config/PushClickBehavior : java/lan
 	public static fun values ()[Lio/customer/messagingpush/config/PushClickBehavior;
 }
 
-public abstract interface class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback {
+public abstract interface class io/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback {
 	public abstract fun createLiveNotification (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Landroid/app/Notification;
+}
+
+public abstract interface class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback {
 	public abstract fun onNotificationClicked (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public abstract fun onNotificationComposed (Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
 
 public final class io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback$DefaultImpls {
-	public static fun createLiveNotification (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Landroid/app/Notification;
 	public static fun onNotificationClicked (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroid/content/Context;)Lkotlin/Unit;
 	public static fun onNotificationComposed (Lio/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback;Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload;Landroidx/core/app/NotificationCompat$Builder;)V
 }
 
 public final class io/customer/messagingpush/data/model/CustomerIOParsedPushPayload : android/os/Parcelable {
 	public static final field CREATOR Lio/customer/messagingpush/data/model/CustomerIOParsedPushPayload$CREATOR;
+	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Landroid/os/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroid/os/Parcel;)V

--- a/messagingpush/src/main/AndroidManifest.xml
+++ b/messagingpush/src/main/AndroidManifest.xml
@@ -3,7 +3,14 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
+
+    <!--
+    NOTE: android.permission.POST_PROMOTED_NOTIFICATIONS is intentionally NOT declared here.
+    Live notifications are opt-in, so the SDK does not add a promoted-notification permission
+    to every app that merely depends on this module. Apps that enable live notifications and
+    want the promoted "live update" treatment on Android 16+ declare it themselves; without it
+    the SDK posts standard ongoing notifications instead (see Api36LiveNotificationBuilder).
+    -->
 
     <application>
         <!-- Transparent activity for push interactions 

--- a/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/Api36LiveNotificationBuilder.kt
@@ -66,7 +66,10 @@ internal object Api36LiveNotificationBuilder {
                 builder.addExtras(extras)
             } else {
                 SDKComponent.logger.debug(
-                    "POST_PROMOTED_NOTIFICATIONS not granted; posting as standard ongoing"
+                    "POST_PROMOTED_NOTIFICATIONS not granted; posting as a standard ongoing " +
+                        "notification. Declare <uses-permission " +
+                        "android:name=\"android.permission.POST_PROMOTED_NOTIFICATIONS\" /> in the " +
+                        "app manifest to get the promoted live-update treatment on Android 16+."
                 )
             }
         }

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -137,13 +137,9 @@ internal class CustomerIOPushNotificationHandler(
         val notificationManager =
             context.getSystemService(FirebaseMessagingService.NOTIFICATION_SERVICE) as NotificationManager
 
-        val channelId = notificationChannelCreator.createNotificationChannelIfNeededAndReturnChannelId(
-            context = context,
-            applicationName = applicationName,
-            appMetaData = appMetaData,
-            notificationManager = notificationManager
-        )
-
+        // Branch before creating the standard channel: live notifications use their own
+        // channel, so registering the standard one here would add a channel the user sees
+        // in app settings but that nothing ever posts to.
         val activityId = bundle.getString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY)
         if (activityId != null) {
             val liveChannelId = notificationChannelCreator.createLiveNotificationChannelIfNeededAndReturnChannelId(
@@ -164,6 +160,13 @@ internal class CustomerIOPushNotificationHandler(
             )
             return
         }
+
+        val channelId = notificationChannelCreator.createNotificationChannelIfNeededAndReturnChannelId(
+            context = context,
+            applicationName = applicationName,
+            appMetaData = appMetaData,
+            notificationManager = notificationManager
+        )
 
         val requestCode = abs(System.currentTimeMillis().toInt())
         bundle.putInt(NOTIFICATION_REQUEST_CODE, requestCode)

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -60,8 +60,12 @@ internal class LiveNotificationHandler(
 
     fun handle(
         context: Context,
-        deliveryId: String,
-        deliveryToken: String,
+        // Null for locally-started activities: they were never delivered by Customer.io, so
+        // there is nothing to attribute a delivery metric to. The public
+        // [CustomerIOParsedPushPayload] types these as non-null, so they are flattened to ""
+        // when the payload is built below, and the click path skips metric reporting on blank.
+        deliveryId: String?,
+        deliveryToken: String?,
         @DrawableRes smallIcon: Int,
         @ColorInt tintColor: Int?,
         channelId: String,
@@ -188,8 +192,8 @@ internal class LiveNotificationHandler(
         val parsedPayload = CustomerIOParsedPushPayload(
             extras = Bundle(bundle),
             deepLink = result?.deepLink ?: bundle.getString(CustomerIOPushNotificationHandler.DEEP_LINK_KEY),
-            cioDeliveryId = deliveryId,
-            cioDeliveryToken = deliveryToken,
+            cioDeliveryId = deliveryId.orEmpty(),
+            cioDeliveryToken = deliveryToken.orEmpty(),
             title = result?.title ?: bundle.getString(CustomerIOPushNotificationHandler.TITLE_KEY).orEmpty(),
             body = result?.body ?: bundle.getString(CustomerIOPushNotificationHandler.BODY_KEY).orEmpty(),
             activityId = activityId

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -15,7 +15,6 @@ import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.di.pushModuleConfig
-import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import io.customer.messagingpush.livenotification.LiveNotificationDismissReceiver
 import io.customer.messagingpush.livenotification.template.TemplateAssets
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
@@ -140,10 +139,15 @@ internal class LiveNotificationHandler(
             }
         }
 
-        // Advance the high-water mark on BOTH paths: a local render must also bump it
+        // Advances the high-water mark on BOTH paths: a local render must also bump it
         // so a later delayed remote push at an intermediate timestamp can't overwrite
         // newer local content.
-        if (timestamp != null) {
+        //
+        // Deliberately invoked only once this render is committed (past the supersede
+        // check below), not up-front: a local render invalidated by a logout must not
+        // write any state back into the store that reset just cleared.
+        fun advanceHighWaterMark() {
+            if (timestamp == null) return
             val lastSeen = store.lastTimestamp(activityId)
             if (lastSeen == null || timestamp > lastSeen) {
                 store.setLastTimestamp(activityId, timestamp)
@@ -153,7 +157,8 @@ internal class LiveNotificationHandler(
         val template = TemplateRegistry.find(activityType)
         val data = extractData(bundle)
         val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
-        val effectiveSmallIcon = resolveSmallIcon(branding, smallIcon)
+        // Branding overrides the status-bar icon for live notifications only.
+        val effectiveSmallIcon = branding?.smallIcon ?: smallIcon
 
         val result = template?.render(
             context = context,
@@ -174,6 +179,7 @@ internal class LiveNotificationHandler(
         val notifId = notificationId(activityId)
 
         if (result?.cancelImmediately == true) {
+            advanceHighWaterMark()
             notificationManager.cancel(activityId, notifId)
             return
         }
@@ -194,7 +200,7 @@ internal class LiveNotificationHandler(
         val deletePendingIntent = if (isEnd) null else createDeleteIntent(context, notifId, activityId, activityType)
 
         // The host app may fully render the notification; otherwise fall back to the SDK template.
-        val appNotification = SDKComponent.pushModuleConfig.notificationCallback
+        val appNotification = SDKComponent.pushModuleConfig.liveNotificationCallback
             ?.createLiveNotification(parsedPayload, context)
         val notification = appNotification ?: result?.let {
             buildSdkNotification(context, channelId, effectiveSmallIcon, it, pendingIntent, deletePendingIntent, ongoing = !isEnd)
@@ -202,13 +208,16 @@ internal class LiveNotificationHandler(
 
         // A logout/reset may have landed while the branding logo downloaded or the app
         // renderer ran above. If so, drop this render: don't post the notification and don't
-        // write the activity type back into the store that reset just cleared.
+        // write the activity type or the high-water mark back into the store that reset
+        // just cleared.
         if (isSuperseded()) {
             SDKComponent.logger.debug(
                 "Live notification render for '$activityId' was superseded by a reset; dropping."
             )
             return
         }
+
+        advanceHighWaterMark()
 
         when {
             notification != null -> {
@@ -348,14 +357,6 @@ internal class LiveNotificationHandler(
         } catch (e: JSONException) {
             raw
         }
-    }
-
-    @DrawableRes
-    private fun resolveSmallIcon(
-        branding: LiveNotificationBranding?,
-        fallback: Int
-    ): Int {
-        return branding?.smallIcon ?: fallback
     }
 
     private fun createIntentForNotificationClick(

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -58,6 +58,17 @@ internal class LiveNotificationHandler(
         )
     }
 
+    /**
+     * Renders and posts the live notification described by the bundle.
+     *
+     * Every failure is contained here rather than at the call sites, because both callers
+     * run somewhere a throw is fatal: the FCM path executes on
+     * `FirebaseMessagingService.onMessageReceived`, and the local path on an SDK-owned
+     * coroutine scope with no exception handler. The risky work — template rendering, asset
+     * decoding/download, the host app's
+     * [io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback], and
+     * the `notify` call itself — is all inside. A failure drops this render only.
+     */
     fun handle(
         context: Context,
         // Null for locally-started activities: they were never delivered by Customer.io, so
@@ -80,6 +91,38 @@ internal class LiveNotificationHandler(
         // logout/reset landed during rendering, in which case the render is dropped so it
         // can't post or re-store a previous user's activity. Local renders only.
         isSuperseded: () -> Boolean = { false }
+    ) {
+        runCatching {
+            handleInternal(
+                context = context,
+                deliveryId = deliveryId,
+                deliveryToken = deliveryToken,
+                smallIcon = smallIcon,
+                tintColor = tintColor,
+                channelId = channelId,
+                notificationManager = notificationManager,
+                bypassOrderGuard = bypassOrderGuard,
+                isSuperseded = isSuperseded
+            )
+        }.onFailure { cause ->
+            SDKComponent.logger.error(
+                "Failed to render live notification " +
+                    "'${bundle.getString(CIO_INSTANCE_ID_KEY)}': ${cause.message}"
+            )
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun handleInternal(
+        context: Context,
+        deliveryId: String?,
+        deliveryToken: String?,
+        @DrawableRes smallIcon: Int,
+        @ColorInt tintColor: Int?,
+        channelId: String,
+        notificationManager: NotificationManager,
+        bypassOrderGuard: Boolean,
+        isSuperseded: () -> Boolean
     ) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             ContextCompat.checkSelfPermission(context, android.Manifest.permission.POST_NOTIFICATIONS)
@@ -183,6 +226,14 @@ internal class LiveNotificationHandler(
         val notifId = notificationId(activityId)
 
         if (result?.cancelImmediately == true) {
+            // Same supersede gate as the post path below: a render invalidated by a logout
+            // must not touch the store the reset just cleared, on any exit path.
+            if (isSuperseded()) {
+                SDKComponent.logger.debug(
+                    "Live notification render for '$activityId' was superseded by a reset; dropping."
+                )
+                return
+            }
             advanceHighWaterMark()
             notificationManager.cancel(activityId, notifId)
             return

--- a/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/MessagingPushModuleConfig.kt
@@ -2,6 +2,7 @@ package io.customer.messagingpush
 
 import io.customer.messagingpush.config.PushClickBehavior
 import io.customer.messagingpush.config.PushClickBehavior.ACTIVITY_PREVENT_RESTART
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
 import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
 import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import io.customer.messagingpush.livenotification.LiveNotificationType
@@ -18,13 +19,16 @@ import io.customer.sdk.core.module.CustomerIOModuleConfig
  * live notifications. `null` means templates fall back to FCM metadata values.
  * @property liveNotificationTypes activity type identifiers (built-in + custom)
  * the host app enabled.
+ * @property liveNotificationCallback lets the host app render live notifications
+ * itself. `null` means the SDK renders its built-in templates.
  */
 class MessagingPushModuleConfig private constructor(
     val autoTrackPushEvents: Boolean,
     val notificationCallback: CustomerIOPushNotificationCallback?,
     val pushClickBehavior: PushClickBehavior,
     val liveNotificationBranding: LiveNotificationBranding?,
-    val liveNotificationTypes: Set<String>
+    val liveNotificationTypes: Set<String>,
+    val liveNotificationCallback: CustomerIOLiveNotificationsCallback?
 ) : CustomerIOModuleConfig {
     class Builder : CustomerIOModuleConfig.Builder<MessagingPushModuleConfig> {
         private var autoTrackPushEvents: Boolean = true
@@ -32,6 +36,7 @@ class MessagingPushModuleConfig private constructor(
         private var pushClickBehavior: PushClickBehavior = ACTIVITY_PREVENT_RESTART
         private var liveNotificationBranding: LiveNotificationBranding? = null
         private val liveNotificationTypes: MutableSet<String> = mutableSetOf()
+        private var liveNotificationCallback: CustomerIOLiveNotificationsCallback? = null
 
         /**
          * Allows to enable/disable automatic tracking of push events. Auto tracking will generate
@@ -82,6 +87,12 @@ class MessagingPushModuleConfig private constructor(
          * enabled or the feature is a no-op. Repeatable and additive with
          * [enableCustomLiveNotificationTypes].
          *
+         * For the promoted "live update" treatment on Android 16+ (a notification
+         * pinned to the status bar / lock screen), the host app must declare
+         * `android.permission.POST_PROMOTED_NOTIFICATIONS` in its manifest — the
+         * SDK deliberately does not declare it on the app's behalf. Without it,
+         * live notifications still post as standard ongoing notifications.
+         *
          * @param types built-in activity types to enable.
          */
         fun enableLiveNotificationTypes(vararg types: LiveNotificationType): Builder {
@@ -92,8 +103,8 @@ class MessagingPushModuleConfig private constructor(
         /**
          * Enables live notifications for customer-defined [types] (reverse-DNS
          * identifier strings). Custom types have no built-in template, so a
-         * [CustomerIOPushNotificationCallback.createLiveNotification] must render
-         * them.
+         * [CustomerIOLiveNotificationsCallback] set via
+         * [setLiveNotificationCallback] must render them.
          *
          * Repeatable and additive with [enableLiveNotificationTypes].
          *
@@ -104,19 +115,32 @@ class MessagingPushModuleConfig private constructor(
             return this
         }
 
+        /**
+         * Lets the host app render live notifications itself instead of using the
+         * SDK's built-in templates. Required for custom activity types enabled via
+         * [enableCustomLiveNotificationTypes], which have no built-in template.
+         *
+         * @param liveNotificationCallback renderer invoked for every live notification.
+         */
+        fun setLiveNotificationCallback(liveNotificationCallback: CustomerIOLiveNotificationsCallback): Builder {
+            this.liveNotificationCallback = liveNotificationCallback
+            return this
+        }
+
         override fun build(): MessagingPushModuleConfig {
             return MessagingPushModuleConfig(
                 autoTrackPushEvents = autoTrackPushEvents,
                 notificationCallback = notificationCallback,
                 pushClickBehavior = pushClickBehavior,
                 liveNotificationBranding = liveNotificationBranding,
-                liveNotificationTypes = liveNotificationTypes.toSet()
+                liveNotificationTypes = liveNotificationTypes.toSet(),
+                liveNotificationCallback = liveNotificationCallback
             )
         }
     }
 
     override fun toString(): String {
-        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding, liveNotificationTypes=$liveNotificationTypes)"
+        return "MessagingPushModuleConfig(autoTrackPushEvents=$autoTrackPushEvents, notificationCallback=$notificationCallback, pushClickBehavior=$pushClickBehavior, liveNotificationBranding=$liveNotificationBranding, liveNotificationTypes=$liveNotificationTypes, liveNotificationCallback=$liveNotificationCallback)"
     }
 
     companion object {

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -89,7 +89,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
      * Starts a live notification locally for a customer-defined [activityType]
      * (one enabled via [MessagingPushModuleConfig.Builder.enableCustomLiveNotificationTypes]).
      * Custom types have no built-in template, so a
-     * [io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback.createLiveNotification]
+     * [io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback]
      * must render them.
      *
      * As with the templated overload, lifecycle events are reported to

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOLiveNotificationsCallback.kt
@@ -1,0 +1,44 @@
+package io.customer.messagingpush.data.communication
+
+import android.app.Notification
+import android.content.Context
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+
+/**
+ * Lets the host app render live notifications itself, instead of using the SDK's
+ * built-in templates.
+ *
+ * Registered via
+ * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.setLiveNotificationCallback].
+ * This is deliberately separate from [CustomerIOPushNotificationCallback] so that
+ * implementing live-notification rendering never forces a change on apps that only
+ * customise standard push, and vice versa.
+ */
+interface CustomerIOLiveNotificationsCallback {
+    /**
+     * Called for every live notification the SDK is about to post. Return a
+     * fully-built [Notification] to take complete control of its appearance and
+     * intents, or `null` to fall back to the SDK's built-in template.
+     *
+     * Required for customer-defined activity types (enabled via
+     * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.enableCustomLiveNotificationTypes]),
+     * which have no built-in template; if this returns `null` for such a type, the
+     * notification is dropped.
+     *
+     * The SDK still owns the posting lifecycle: it posts the returned notification
+     * keyed by the activity id (so later updates replace it) and cancels it on
+     * `end`. It does NOT modify the returned notification, so any dismissal
+     * reporting is the app's responsibility.
+     *
+     * Called on a background thread. Throwing from here is caught and logged by
+     * the SDK, but the notification is then dropped — prefer returning `null`.
+     *
+     * @param payload parsed live-notification payload (activity id + flattened
+     * fields in [CustomerIOParsedPushPayload.extras]).
+     * @param context reference to application context.
+     */
+    fun createLiveNotification(
+        payload: CustomerIOParsedPushPayload,
+        context: Context
+    ): Notification?
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/communication/CustomerIOPushNotificationCallback.kt
@@ -1,6 +1,5 @@
 package io.customer.messagingpush.data.communication
 
-import android.app.Notification
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
@@ -43,28 +42,4 @@ interface CustomerIOPushNotificationCallback {
         payload: CustomerIOParsedPushPayload,
         builder: NotificationCompat.Builder
     ) = Unit
-
-    /**
-     * Called for live notifications to let the host app render the notification
-     * itself. Return a fully-built [Notification] to take complete control of
-     * its appearance and intents, or null to use the SDK's built-in template.
-     *
-     * Required for customer-defined activity types (registered via
-     * [io.customer.messagingpush.MessagingPushModuleConfig.Builder.registerLiveNotificationTypes]),
-     * which have no built-in template; if this returns null for such a type, the
-     * notification is dropped.
-     *
-     * The SDK still owns the posting lifecycle: it posts the returned
-     * notification keyed by `activity_id` (so later updates replace it) and
-     * cancels it on `end`. It does NOT modify the returned notification, so any
-     * dismissal reporting is the app's responsibility.
-     *
-     * @param payload parsed live-notification payload (activity id + flattened
-     * fields in [CustomerIOParsedPushPayload.extras]).
-     * @param context reference to application context.
-     */
-    fun createLiveNotification(
-        payload: CustomerIOParsedPushPayload,
-        context: Context
-    ): Notification? = null
 }

--- a/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/data/model/CustomerIOParsedPushPayload.kt
@@ -24,6 +24,21 @@ data class CustomerIOParsedPushPayload(
     val body: String,
     val activityId: String? = null
 ) : Parcelable {
+    /**
+     * Preserves the pre-live-notifications 6-argument constructor in the ABI.
+     * Adding [activityId] with a default value replaces the old 6-arg entry point
+     * with a 7-arg one plus a synthetic bridge, so host apps compiled against an
+     * earlier release would otherwise hit `NoSuchMethodError` at runtime.
+     */
+    constructor(
+        extras: Bundle,
+        deepLink: String?,
+        cioDeliveryId: String,
+        cioDeliveryToken: String,
+        title: String,
+        body: String
+    ) : this(extras, deepLink, cioDeliveryId, cioDeliveryToken, title, body, null)
+
     constructor(parcel: Parcel) : this(
         extras = parcel.readBundle(Bundle::class.java.classLoader) ?: Bundle(),
         deepLink = parcel.readString(),

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiver.kt
@@ -1,6 +1,7 @@
 package io.customer.messagingpush.livenotification
 
 import android.content.BroadcastReceiver
+import android.content.BroadcastReceiver.PendingResult
 import android.content.Context
 import android.content.Intent
 import io.customer.messagingpush.di.liveNotificationLifecycleClient
@@ -42,7 +43,9 @@ class LiveNotificationDismissReceiver : BroadcastReceiver() {
         }
         // Keep the process alive past onReceive() so the async CDP pipeline can
         // persist the end event before the receiver's process is torn down.
-        val pendingResult = goAsync()
+        // Only available while the framework is dispatching the broadcast — null when
+        // onReceive is invoked directly, in which case there is nothing to finish.
+        val pendingResult: PendingResult? = goAsync()
         CoroutineScope(SDKComponent.dispatchersProvider.background).launch {
             try {
                 SDKComponent.liveNotificationLifecycleClient.reportEnd(
@@ -51,7 +54,7 @@ class LiveNotificationDismissReceiver : BroadcastReceiver() {
                     deviceId = deviceId
                 )
             } finally {
-                pendingResult.finish()
+                pendingResult?.finish()
             }
         }
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -13,7 +13,7 @@ import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
 import io.customer.sdk.core.util.DispatchersProvider
-import java.util.concurrent.ConcurrentHashMap
+import java.util.Collections
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -37,7 +37,18 @@ internal class LiveNotificationManager(
     // Last bundle rendered per activity id, so end() can re-render the final
     // state as a dismissible notification and resolve the activity type even if
     // the initial render never posted.
-    private val lastBundles = ConcurrentHashMap<String, Bundle>()
+    //
+    // Bounded: entries are only removed by end() or logout, so an app that starts
+    // activities it never ends would otherwise grow this for the process lifetime.
+    // Evicting the least-recently-written id degrades gracefully — end() falls back
+    // to the persisted activity type and cancels instead of re-rendering a terminal
+    // state (the same path taken after process death).
+    private val lastBundles: MutableMap<String, Bundle> = Collections.synchronizedMap(
+        object : LinkedHashMap<String, Bundle>(MAX_CACHED_BUNDLES, 0.75f, false) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Bundle>): Boolean =
+                size > MAX_CACHED_BUNDLES
+        }
+    )
 
     private val renderScope: CoroutineScope by lazy {
         CoroutineScope(SupervisorJob() + dispatchers.background)
@@ -210,7 +221,20 @@ internal class LiveNotificationManager(
             // may invoke a slow app renderer. A logout can land during that window — after
             // this pre-check passed — so the handler re-checks the generation immediately
             // before it posts the notification and writes the activity type back.
-            renderLocally(bundle, isSuperseded = { generation != renderGeneration })
+            //
+            // Contained here because this coroutine runs on an SDK-owned scope with no
+            // exception handler: an app-supplied CustomerIOLiveNotificationsCallback that
+            // throws, or a NotificationManager rejection (e.g. oversized RemoteViews), would
+            // otherwise surface as an uncaught exception and take the host process down from
+            // a thread the app cannot guard. Drop the render and keep the chain alive instead.
+            runCatching {
+                renderLocally(bundle, isSuperseded = { generation != renderGeneration })
+            }.onFailure { cause ->
+                SDKComponent.logger.error(
+                    "Failed to render live notification " +
+                        "'${bundle.getString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY)}': ${cause.message}"
+                )
+            }
         }
     }
 
@@ -284,6 +308,9 @@ internal class LiveNotificationManager(
     }
 
     companion object {
+        // Generous relative to any realistic number of concurrently-live activities on one
+        // device, while still bounding the cache for an app that never calls end().
+        private const val MAX_CACHED_BUNDLES = 50
         private const val EVENT_START = "start"
         private const val EVENT_UPDATE = "update"
         private const val EVENT_END = "end"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -218,11 +218,11 @@ internal class LiveNotificationManager(
             // this pre-check passed — so the handler re-checks the generation immediately
             // before it posts the notification and writes the activity type back.
             //
-            // Contained here because this coroutine runs on an SDK-owned scope with no
-            // exception handler: an app-supplied CustomerIOLiveNotificationsCallback that
-            // throws, or a NotificationManager rejection (e.g. oversized RemoteViews), would
-            // otherwise surface as an uncaught exception and take the host process down from
-            // a thread the app cannot guard. Drop the render and keep the chain alive instead.
+            // LiveNotificationHandler.handle contains its own failures, so this covers the
+            // setup around it (metadata lookup, channel creation, system service). Needed
+            // because this coroutine runs on an SDK-owned scope with no exception handler,
+            // where anything escaping would take the host process down from a thread the app
+            // cannot guard. Drop the render and keep the chain alive instead.
             runCatching {
                 renderLocally(bundle, isSuperseded = { generation != renderGeneration })
             }.onFailure { cause ->

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -13,7 +13,7 @@ import io.customer.messagingpush.util.NotificationChannelCreator
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.extensions.applicationMetaData
 import io.customer.sdk.core.util.DispatchersProvider
-import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -38,17 +38,13 @@ internal class LiveNotificationManager(
     // state as a dismissible notification and resolve the activity type even if
     // the initial render never posted.
     //
-    // Bounded: entries are only removed by end() or logout, so an app that starts
-    // activities it never ends would otherwise grow this for the process lifetime.
-    // Evicting the least-recently-written id degrades gracefully — end() falls back
-    // to the persisted activity type and cancels instead of re-rendering a terminal
-    // state (the same path taken after process death).
-    private val lastBundles: MutableMap<String, Bundle> = Collections.synchronizedMap(
-        object : LinkedHashMap<String, Bundle>(MAX_CACHED_BUNDLES, 0.75f, false) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Bundle>): Boolean =
-                size > MAX_CACHED_BUNDLES
-        }
-    )
+    // Entries are dropped by end() and by logout, but not by a remote end or a user
+    // swipe, so an activity finished either of those ways keeps its bundle until the
+    // next logout or process death. That is a few hundred bytes per activity against
+    // a count bounded by how many live notifications one app start actually shows, so
+    // it is left unbounded rather than adding eviction that could discard the terminal
+    // state a later end() wants to render.
+    private val lastBundles = ConcurrentHashMap<String, Bundle>()
 
     private val renderScope: CoroutineScope by lazy {
         CoroutineScope(SupervisorJob() + dispatchers.background)
@@ -259,8 +255,9 @@ internal class LiveNotificationManager(
 
         LiveNotificationHandler(bundle).handle(
             context = ctx,
-            deliveryId = "",
-            deliveryToken = "",
+            // Locally started: no Customer.io delivery to attribute metrics to.
+            deliveryId = null,
+            deliveryToken = null,
             smallIcon = smallIcon,
             tintColor = tintColor,
             channelId = channelId,
@@ -308,9 +305,6 @@ internal class LiveNotificationManager(
     }
 
     companion object {
-        // Generous relative to any realistic number of concurrently-live activities on one
-        // device, while still bounding the cache for an app that never calls end().
-        private const val MAX_CACHED_BUNDLES = 50
         private const val EVENT_START = "start"
         private const val EVENT_UPDATE = "update"
         private const val EVENT_END = "end"

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationRegistrar.kt
@@ -28,7 +28,20 @@ internal class LiveNotificationRegistrar(
     private val enabledTypes: Set<String>
         get() = SDKComponent.pushModuleConfig.liveNotificationTypes
 
+    // This registrar is a DI singleton and its subscriptions are never torn down, so a repeat
+    // initialize() would otherwise stack a second set of handlers on every event and register
+    // (or re-register) each type once per call.
+    @Volatile
+    private var started: Boolean = false
+
+    @Synchronized
     fun start() {
+        if (started) {
+            SDKComponent.logger.debug("Live Notifications: registrar already started; ignoring.")
+            return
+        }
+        started = true
+
         val clearedByMigration = store.migrate()
         if (clearedByMigration > 0) {
             SDKComponent.logger.debug(

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
@@ -59,12 +59,47 @@ internal class LiveNotificationStore(context: Context) {
         prefs.edit { remove(TS_PREFIX + activityId) }
     }
 
-    /** Removes timestamp entries (and their paired activity types + ended markers) recorded longer than [ttlMs] ago. Intended to run on app launch. */
+    /**
+     * Reclaims every per-activity entry (timestamp + activity type + ended marker) whose most
+     * recent write is older than [ttlMs]. Intended to run on app launch.
+     *
+     * All three families are swept, not just `ts:`: a push that arrives without a `timestamp`
+     * records an activity type and possibly an ended marker but no timestamp entry, so keying
+     * reclamation off `ts:` alone would leak those entries forever and keep inflating
+     * [trackedActivityIds]. An id is only dropped once *all* of its present entries have aged
+     * out, so a fresh write in one family always keeps the whole id alive.
+     */
     fun trimStaleTimestamps(ttlMs: Long = DEFAULT_TS_TTL_MS, now: Long = System.currentTimeMillis()) {
-        val staleActivityIds = prefs.all.entries.filter { (key, value) ->
-            key.startsWith(TS_PREFIX) &&
-                ((value as? String)?.substringAfter('|', "")?.toLongOrNull()?.let { now - it > ttlMs } ?: true)
-        }.map { it.key.removePrefix(TS_PREFIX) }
+        // activity id -> most recent write time across its entries; null once any entry's write
+        // time is unknown but a newer one may still be found (unknown is treated as oldest).
+        val lastWriteByActivityId = mutableMapOf<String, Long?>()
+
+        fun record(activityId: String, writtenAt: Long?) {
+            if (!lastWriteByActivityId.containsKey(activityId)) {
+                lastWriteByActivityId[activityId] = writtenAt
+                return
+            }
+            val known = lastWriteByActivityId[activityId]
+            if (known == null || (writtenAt != null && writtenAt > known)) {
+                lastWriteByActivityId[activityId] = writtenAt ?: known
+            }
+        }
+
+        for ((key, value) in prefs.all) {
+            val raw = value as? String
+            when {
+                key.startsWith(TS_PREFIX) ->
+                    record(key.removePrefix(TS_PREFIX), raw?.substringAfterLast('|')?.toLongOrNull())
+                key.startsWith(TYPE_PREFIX) ->
+                    record(key.removePrefix(TYPE_PREFIX), raw?.writeTimeOrNull())
+                key.startsWith(END_PREFIX) ->
+                    record(key.removePrefix(END_PREFIX), raw?.toLongOrNull())
+            }
+        }
+
+        val staleActivityIds = lastWriteByActivityId
+            .filterValues { lastWrite -> lastWrite == null || now - lastWrite > ttlMs }
+            .keys
         if (staleActivityIds.isNotEmpty()) {
             prefs.edit {
                 staleActivityIds.forEach {
@@ -102,10 +137,15 @@ internal class LiveNotificationStore(context: Context) {
 
     /** The activity type last rendered for [activityId], or null if unknown. */
     fun activityType(activityId: String): String? =
-        prefs.getString(TYPE_PREFIX + activityId, null)
+        prefs.getString(TYPE_PREFIX + activityId, null)?.let { stored ->
+            // Values are stamped `type|writeTimeMillis` so [trimStaleTimestamps] can age them
+            // out. Split from the right so a customer-defined type containing '|' round-trips,
+            // and fall back to the raw value for entries written before stamping existed.
+            if (stored.writeTimeOrNull() != null) stored.substringBeforeLast('|') else stored
+        }
 
-    fun setActivityType(activityId: String, activityType: String) {
-        prefs.edit { putString(TYPE_PREFIX + activityId, activityType) }
+    fun setActivityType(activityId: String, activityType: String, now: Long = System.currentTimeMillis()) {
+        prefs.edit { putString(TYPE_PREFIX + activityId, "$activityType|$now") }
     }
 
     fun clearActivityType(activityId: String) {
@@ -127,6 +167,13 @@ internal class LiveNotificationStore(context: Context) {
                 .forEach { remove(it) }
         }
     }
+
+    /**
+     * The trailing `|writeTimeMillis` stamp on a stored value, or null when the value carries
+     * no stamp (written by a build predating stamping, so treated as arbitrarily old).
+     */
+    private fun String.writeTimeOrNull(): Long? =
+        if (contains('|')) substringAfterLast('|').toLongOrNull() else null
 
     companion object {
         private const val PREFS_NAME = "io.customer.messagingpush.live_notifications"

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -218,6 +218,14 @@ internal class PushNotificationLogger(private val logger: Logger) {
         )
     }
 
+    fun logNotificationClickMetricsSkippedForLocalNotification(payload: CustomerIOParsedPushPayload) {
+        logger.debug(
+            tag = TAG,
+            message = "Skipping opened metric for notification without a delivery id/token " +
+                "(locally started, not delivered by Customer.io): $payload"
+        )
+    }
+
     fun logFailedToHandlePushClick(throwable: Throwable) {
         logger.error(
             tag = TAG,

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushMessageProcessorImpl.kt
@@ -139,18 +139,25 @@ internal class PushMessageProcessorImpl(
     }
 
     private fun trackNotificationClickMetrics(payload: CustomerIOParsedPushPayload) {
-        if (moduleConfig.autoTrackPushEvents) {
-            pushLogger.logTrackingPushMessageOpened(payload)
-            eventBus.publish(
-                Event.TrackPushMetricEvent(
-                    event = Metric.Opened,
-                    deliveryId = payload.cioDeliveryId,
-                    deviceToken = payload.cioDeliveryToken
-                )
-            )
-        } else {
+        if (!moduleConfig.autoTrackPushEvents) {
             pushLogger.logPushMetricsAutoTrackingDisabled()
+            return
         }
+        // A locally-started live notification was never delivered by Customer.io, so it has
+        // no delivery id/token. Reporting an `opened` metric for it would send a delivery
+        // event with empty identifiers, which the backend cannot attribute to anything.
+        if (payload.cioDeliveryId.isBlank() || payload.cioDeliveryToken.isBlank()) {
+            pushLogger.logNotificationClickMetricsSkippedForLocalNotification(payload)
+            return
+        }
+        pushLogger.logTrackingPushMessageOpened(payload)
+        eventBus.publish(
+            Event.TrackPushMetricEvent(
+                event = Metric.Opened,
+                deliveryId = payload.cioDeliveryId,
+                deviceToken = payload.cioDeliveryToken
+            )
+        )
     }
 
     private fun handleNotificationDeepLink(

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
@@ -103,6 +103,29 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
     }
 
     @Test
+    fun throwingCallback_onPushPath_isContainedAndPostsNothing() {
+        // The FCM path runs on FirebaseMessagingService.onMessageReceived, which has no
+        // try/catch of its own, so a throwing host renderer would take the process down.
+        // Containment lives in LiveNotificationHandler.handle and therefore covers this
+        // path as well as the local one — matching what the callback KDoc promises.
+        attach(
+            object : CustomerIOLiveNotificationsCallback {
+                override fun createLiveNotification(
+                    payload: CustomerIOParsedPushPayload,
+                    context: Context
+                ): Notification = throw IllegalStateException("app renderer blew up")
+            }
+        )
+
+        // Must not propagate (invoke() drives the push path: bypassOrderGuard = false).
+        invoke(bundle(customType))
+
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
     fun customType_endWithoutRenderer_cancelsSinceThereIsNoEndState() {
         // Custom type, no callback → no end-state to post. With nothing to show for the
         // end, the SDK cancels the notification rather than leaving the prior ongoing

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationCallbackTest.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import io.customer.commontest.extensions.assertCalledNever
 import io.customer.commontest.extensions.attachToSDKComponent
-import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.livenotification.LiveNotificationType
 import io.customer.messagingpush.testutils.core.IntegrationTest
@@ -21,8 +21,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Covers the host-app render override (`createLiveNotification`) and
- * customer-defined activity types.
+ * Covers the host-app render override ([CustomerIOLiveNotificationsCallback]) and
+ * customer-defined activity types. Live-notification rendering is deliberately a
+ * separate callback from `CustomerIOPushNotificationCallback`, so it is registered
+ * via `setLiveNotificationCallback`, not `setNotificationCallback`.
  */
 @RunWith(RobolectricTestRunner::class)
 internal class LiveNotificationCallbackTest : IntegrationTest() {
@@ -30,10 +32,10 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
     private val notificationManager: NotificationManager = mockk(relaxed = true)
     private val customType = "com.acme.live.ride"
 
-    private fun attach(callback: CustomerIOPushNotificationCallback?) {
+    private fun attach(callback: CustomerIOLiveNotificationsCallback?) {
         ModuleMessagingPushFCM(
             MessagingPushModuleConfig.Builder().apply {
-                callback?.let { setNotificationCallback(it) }
+                callback?.let { setLiveNotificationCallback(it) }
                 // Enable a built-in type (for the override test) and the custom type.
                 enableLiveNotificationTypes(LiveNotificationType.SEGMENTS)
                 enableCustomLiveNotificationTypes(customType)
@@ -41,7 +43,7 @@ internal class LiveNotificationCallbackTest : IntegrationTest() {
         ).attachToSDKComponent()
     }
 
-    private fun callbackReturning(notification: Notification) = object : CustomerIOPushNotificationCallback {
+    private fun callbackReturning(notification: Notification) = object : CustomerIOLiveNotificationsCallback {
         override fun createLiveNotification(payload: CustomerIOParsedPushPayload, context: Context): Notification =
             notification
     }

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationHandlerTest.kt
@@ -288,15 +288,21 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
     fun handle_givenSupersededByReset_dropsRenderWithoutNotifyingOrStoring() {
         // A logout can land while the branding logo downloads or the app renderer runs. When it
         // does, the render must be dropped after that work completes: it must not post the
-        // notification nor write the activity type back into the store the reset just cleared.
+        // notification, nor write the activity type OR the timestamp high-water mark back into
+        // the store the reset just cleared.
         val activityId = "live-act-1"
 
-        invoke(handlerFor(newBundle(activityId = activityId)), bypassOrderGuard = true, isSuperseded = { true })
+        invoke(
+            handlerFor(newBundle(activityId = activityId, timestamp = 100L)),
+            bypassOrderGuard = true,
+            isSuperseded = { true }
+        )
 
         assertCalledNever {
             notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
         }
         SDKComponent.liveNotificationStore.activityType(activityId).shouldBeNull()
+        SDKComponent.liveNotificationStore.lastTimestamp(activityId).shouldBeNull()
     }
 
     @Test
@@ -304,12 +310,17 @@ internal class LiveNotificationHandlerTest : IntegrationTest() {
         // The complement of the guard above: a render that is still current posts and writes back.
         val activityId = "live-act-1"
 
-        invoke(handlerFor(newBundle(activityId = activityId)), bypassOrderGuard = true, isSuperseded = { false })
+        invoke(
+            handlerFor(newBundle(activityId = activityId, timestamp = 100L)),
+            bypassOrderGuard = true,
+            isSuperseded = { false }
+        )
 
         verify {
             notificationManager.notify(activityId, any<Int>(), any<Notification>())
         }
         SDKComponent.liveNotificationStore.activityType(activityId).shouldNotBeNull()
+        SDKComponent.liveNotificationStore.lastTimestamp(activityId) shouldBeEqualTo 100L
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/MessagingPushModuleConfigTest.kt
@@ -13,7 +13,7 @@ class MessagingPushModuleConfigTest : JUnit5Test() {
         val config = MessagingPushModuleConfig.default()
 
         val actual = config.toString()
-        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null, liveNotificationTypes=[])", actual)
+        assertEquals("MessagingPushModuleConfig(autoTrackPushEvents=true, notificationCallback=null, pushClickBehavior=ACTIVITY_PREVENT_RESTART, liveNotificationBranding=null, liveNotificationTypes=[], liveNotificationCallback=null)", actual)
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiverTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationDismissReceiverTest.kt
@@ -1,10 +1,17 @@
 package io.customer.messagingpush.livenotification
 
 import android.content.Intent
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.DispatchersProvider
+import io.mockk.mockk
+import io.mockk.verify
 import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -13,19 +20,80 @@ import org.robolectric.RobolectricTestRunner
 internal class LiveNotificationDismissReceiverTest : IntegrationTest() {
 
     private val type = "io.customer.livenotifications.segments"
+    private val lifecycleClient: LiveNotificationLifecycleClient = mockk(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        // The end report runs on the background dispatcher; the stub makes it inline+synchronous.
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<DispatchersProvider>(DispatchersProviderStub())
+                        overrideDependency<LiveNotificationLifecycleClient>(lifecycleClient)
+                    }
+                }
+            } + testConfig
+        )
+    }
+
+    private fun dismiss(activityId: String, activityType: String? = type) {
+        val intent = Intent().apply {
+            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_ID, activityId)
+            activityType?.let { putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_TYPE, it) }
+        }
+        LiveNotificationDismissReceiver().onReceive(contextMock, intent)
+    }
+
+    @Test
+    fun onReceive_givenTokenAndUnendedActivity_reportsEndAndMarksTerminal() {
+        // The core swipe-to-dismiss contract: a user clearing an in-progress live notification
+        // reports `end` to Customer.io and marks the id terminal so a later push can't repost it.
+        SDKComponent.android().globalPreferenceStore.saveDeviceToken("fcm-tok")
+
+        dismiss("act-1")
+
+        verify(exactly = 1) {
+            lifecycleClient.reportEnd(
+                instanceUUID = "act-1",
+                activityType = type,
+                deviceId = "fcm-tok",
+                contentState = any()
+            )
+        }
+        SDKComponent.liveNotificationStore.isEnded("act-1").shouldBeTrue()
+    }
+
+    @Test
+    fun onReceive_givenAlreadyEndedActivity_doesNotReportSecondEnd() {
+        // endLiveNotification (or a remote end) already claimed the terminal transition, so a
+        // subsequent swipe must not emit a duplicate end.
+        SDKComponent.android().globalPreferenceStore.saveDeviceToken("fcm-tok")
+        SDKComponent.liveNotificationStore.markEnded("act-1")
+
+        dismiss("act-1")
+
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun onReceive_givenMissingActivityType_isIgnored() {
+        SDKComponent.android().globalPreferenceStore.saveDeviceToken("fcm-tok")
+
+        dismiss("act-1", activityType = null)
+
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any(), any()) }
+        SDKComponent.liveNotificationStore.isEnded("act-1").shouldBeFalse()
+    }
 
     @Test
     fun onReceive_withoutFcmToken_doesNotMarkEnded() {
         // With no device token the receiver can't report `end`, so it must NOT mark the
         // id terminal — doing so would lose the end and block any later one.
         SDKComponent.android().globalPreferenceStore.removeDeviceToken()
-        val intent = Intent().apply {
-            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_ID, "act-1")
-            putExtra(LiveNotificationDismissReceiver.EXTRA_ACTIVITY_TYPE, type)
-        }
 
-        LiveNotificationDismissReceiver().onReceive(contextMock, intent)
+        dismiss("act-1")
 
+        verify(exactly = 0) { lifecycleClient.reportEnd(any(), any(), any(), any()) }
         SDKComponent.liveNotificationStore.isEnded("act-1").shouldBeFalse()
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationManagerTest.kt
@@ -1,8 +1,16 @@
 package io.customer.messagingpush.livenotification
 
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.attachToSDKComponent
 import io.customer.commontest.util.DispatchersProviderStub
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.testutils.core.IntegrationTest
 import io.customer.sdk.core.di.SDKComponent
@@ -17,9 +25,11 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeEmpty
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 /**
  * Tests for [LiveNotificationManager], the on-device (client-initiated) path.
@@ -209,5 +219,63 @@ internal class LiveNotificationManagerTest : IntegrationTest() {
 
         // The queued render saw the bumped generation and dropped, so nothing was re-added.
         SDKComponent.liveNotificationStore.trackedActivityIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun start_givenThrowingAppRenderer_doesNotCrashAndStillReports() {
+        // The render runs on an SDK-owned coroutine scope with no exception handler, so an
+        // app-supplied renderer that throws would otherwise take the host process down from a
+        // thread the app cannot guard. The failure must be contained to this render.
+        saveToken()
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder()
+                .enableLiveNotificationTypes(LiveNotificationType.SEGMENTS)
+                .setLiveNotificationCallback(
+                    object : CustomerIOLiveNotificationsCallback {
+                        override fun createLiveNotification(
+                            payload: CustomerIOParsedPushPayload,
+                            context: Context
+                        ): Notification = throw IllegalStateException("app renderer blew up")
+                    }
+                )
+                .build()
+        ).attachToSDKComponent()
+
+        // Would propagate out of the render coroutine and crash the process before the fix.
+        manager.start("act-throw", type, attributes = emptyMap(), contentState = mapOf("status" to "Preparing"))
+
+        // Reporting is decoupled from rendering, so the lifecycle event is still emitted.
+        verify { lifecycleClient.reportStart("act-throw", type, "fcm-tok", any(), any()) }
+    }
+
+    @Test
+    fun update_givenThrowingAppRenderer_laterRendersStillRun() {
+        // The render chain must survive a failed render: a subsequent update still posts.
+        saveToken()
+        var shouldThrow = true
+        val notificationManager = SDKComponent.android().applicationContext
+            .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder()
+                .enableLiveNotificationTypes(LiveNotificationType.SEGMENTS)
+                .setLiveNotificationCallback(
+                    object : CustomerIOLiveNotificationsCallback {
+                        override fun createLiveNotification(
+                            payload: CustomerIOParsedPushPayload,
+                            context: Context
+                        ): Notification? {
+                            if (shouldThrow) throw IllegalStateException("app renderer blew up")
+                            return null // fall back to the SDK template
+                        }
+                    }
+                )
+                .build()
+        ).attachToSDKComponent()
+
+        manager.start("act-chain", type, attributes = emptyMap(), contentState = mapOf("status" to "Preparing"))
+        shouldThrow = false
+        manager.update("act-chain", type, attributes = emptyMap(), contentState = mapOf("status" to "Arriving"))
+
+        Shadows.shadowOf(notificationManager).allNotifications.shouldNotBeEmpty()
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
@@ -90,11 +90,65 @@ internal class LiveNotificationStoreTest : IntegrationTest() {
         val ttl = 1_000L
 
         store.setLastTimestamp("old", 1L, now = now - ttl - 1)
-        store.setActivityType("old", "io.customer.livenotifications.segments")
+        store.setActivityType("old", "io.customer.livenotifications.segments", now = now - ttl - 1)
 
         store.trimStaleTimestamps(ttlMs = ttl, now = now)
 
         store.activityType("old").shouldBeNull()
+    }
+
+    @Test
+    fun trimStaleTimestamps_removesOrphanedActivityTypeWithNoTimestampEntry() {
+        // A push that arrives without a `timestamp` records an activity type but no timestamp
+        // entry. Reclamation must not key off `ts:` alone, or such ids leak forever and keep
+        // inflating trackedActivityIds().
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        store.setActivityType("orphan", "io.customer.livenotifications.segments", now = now - ttl - 1)
+        store.lastTimestamp("orphan").shouldBeNull()
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.activityType("orphan").shouldBeNull()
+        store.trackedActivityIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun trimStaleTimestamps_removesOrphanedEndedMarkerWithNoTimestampEntry() {
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        store.markEnded("orphan-end", now = now - ttl - 1)
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.isEnded("orphan-end").shouldBeFalse()
+    }
+
+    @Test
+    fun trimStaleTimestamps_keepsIdWhenAnyEntryIsStillFresh() {
+        // The timestamp aged out but the activity was re-rendered recently, so the id is still
+        // live: dropping it would lose the ability to cancel it on logout.
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+
+        store.setLastTimestamp("mixed", 1L, now = now - ttl - 1)
+        store.setActivityType("mixed", "io.customer.livenotifications.segments", now = now - 1)
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+
+        store.activityType("mixed") shouldBeEqualTo "io.customer.livenotifications.segments"
+        store.lastTimestamp("mixed") shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun activityType_givenTypeContainingSeparator_roundTrips() {
+        // Types are customer-defined strings, and the stored value is stamped `type|writeTime`,
+        // so the split must tolerate a '|' inside the type itself.
+        store.setActivityType("act-1", "com.acme.live|weird")
+
+        store.activityType("act-1") shouldBeEqualTo "com.acme.live|weird"
     }
 
     @Test
@@ -124,7 +178,7 @@ internal class LiveNotificationStoreTest : IntegrationTest() {
         val ttl = 1_000L
 
         store.setLastTimestamp("old", 1L, now = now - ttl - 1)
-        store.markEnded("old")
+        store.markEnded("old", now = now - ttl - 1)
 
         store.trimStaleTimestamps(ttlMs = ttl, now = now)
 

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushMessageProcessorTest.kt
@@ -429,6 +429,70 @@ class PushMessageProcessorTest : IntegrationTest() {
     }
 
     @Test
+    fun processNotificationClick_givenLocallyStartedLiveNotification_expectDoNotTrackOpened() {
+        // A locally started live notification is rendered by the SDK on the app's behalf and was
+        // never delivered by Customer.io, so it carries no delivery id/token. Tracking `opened`
+        // for it would emit a delivery metric with empty identifiers that cannot be attributed.
+        setupModuleConfig(autoTrackPushEvents = true)
+        val processor = pushMessageProcessor()
+        val givenPayload = CustomerIOParsedPushPayload(
+            extras = Bundle.EMPTY,
+            deepLink = null,
+            cioDeliveryId = "",
+            cioDeliveryToken = "",
+            title = String.random,
+            body = String.random,
+            activityId = String.random
+        )
+        val intent = Intent().apply {
+            putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, givenPayload)
+        }
+        setupDeepLinkResponse(
+            deepLink = null,
+            defaultHostAppIntent = emptyIntent().withTestFlags()
+        )
+
+        processor.processNotificationClick(contextMock, intent)
+
+        // No metric published, but the click itself is still handled (deep link / launcher).
+        assertCalledNever {
+            eventBus.publish(any<Event.TrackPushMetricEvent>())
+        }
+        assertCalledOnce {
+            mockPushLogger.logNotificationClickMetricsSkippedForLocalNotification(givenPayload)
+            deepLinkUtilMock.createDefaultHostAppIntent(any())
+        }
+    }
+
+    @Test
+    fun processNotificationClick_givenPushDeliveredNotification_expectTrackOpened() {
+        // Complement of the guard above: a real Customer.io push has both identifiers, so the
+        // `opened` metric must still be reported.
+        setupModuleConfig(autoTrackPushEvents = true)
+        val processor = pushMessageProcessor()
+        val givenPayload = pushMessagePayload()
+        val intent = Intent().apply {
+            putExtra(NotificationClickReceiverActivity.NOTIFICATION_PAYLOAD_EXTRA, givenPayload)
+        }
+        setupDeepLinkResponse(
+            deepLink = null,
+            defaultHostAppIntent = emptyIntent().withTestFlags()
+        )
+
+        processor.processNotificationClick(contextMock, intent)
+
+        assertCalledOnce {
+            eventBus.publish(
+                Event.TrackPushMetricEvent(
+                    event = Metric.Opened,
+                    deliveryId = givenPayload.cioDeliveryId,
+                    deviceToken = givenPayload.cioDeliveryToken
+                )
+            )
+        }
+    }
+
+    @Test
     fun processNotificationClick_givenAutoTrackingDisabled_expectDoNotTrackOpened() {
         setupModuleConfig(autoTrackPushEvents = false)
         val processor = pushMessageProcessor()

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -36,8 +36,15 @@ public class CustomerIORepository {
     /**
      * The push module instance, retained so the live-notification demo screen can call
      * {@link ModuleMessagingPushFCM#startLiveNotification} (the public local-start API).
+     * Reached through {@link io.customer.android.sample.java_layout.di.ApplicationGraph},
+     * which already owns this repository — no static state needed.
      */
-    public static ModuleMessagingPushFCM messagingPushModule;
+    private ModuleMessagingPushFCM messagingPushModule;
+
+    @NonNull
+    public ModuleMessagingPushFCM getMessagingPushModule() {
+        return messagingPushModule;
+    }
 
     public void initializeSdk(SampleApplication application) {
         ApplicationGraph appGraph = application.getApplicationGraph();
@@ -63,7 +70,7 @@ public class CustomerIORepository {
                                 new LiveNotificationAsset.Drawable(R.drawable.ic_live_delivery_scooter) // typed logo
                         ))
                         // App-rendered custom types go through this callback.
-                        .setNotificationCallback(new LiveNotificationCallback())
+                        .setLiveNotificationCallback(new LiveNotificationCallback())
                         // Live notifications are opt-in: enable the built-in template types...
                         .enableLiveNotificationTypes(
                                 LiveNotificationType.SEGMENTS,

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/LiveNotificationCallback.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/LiveNotificationCallback.kt
@@ -14,7 +14,7 @@ import android.text.style.ForegroundColorSpan
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import io.customer.android.sample.java_layout.R
-import io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 
 /**
@@ -24,7 +24,7 @@ import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
  * and [ACTIVITY_TYPE_WORKOUT] via the standard NotificationCompat builder — and
  * `null` for built-in types so the SDK renders those itself.
  */
-class LiveNotificationCallback : CustomerIOPushNotificationCallback {
+class LiveNotificationCallback : CustomerIOLiveNotificationsCallback {
 
     override fun createLiveNotification(
         payload: CustomerIOParsedPushPayload,

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/livenotification/LiveNotificationDemoActivity.java
@@ -291,7 +291,7 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
 
     /** Demonstrates the typed local-start API: {@code startLiveNotification(LiveNotificationData)}. */
     private void startViaApi() {
-        ModuleMessagingPushFCM module = CustomerIORepository.messagingPushModule;
+        ModuleMessagingPushFCM module = customerIORepository.getMessagingPushModule();
         if (module == null) return;
         LiveNotificationData.Segments data = new LiveNotificationData.Segments(
                 /* header */ "Order #API-1001",
@@ -312,7 +312,7 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
      * started via {@link #startViaApi()}.
      */
     private void updateViaApi() {
-        ModuleMessagingPushFCM module = CustomerIORepository.messagingPushModule;
+        ModuleMessagingPushFCM module = customerIORepository.getMessagingPushModule();
         if (module == null || lastApiActivityId == null) return;
         LiveNotificationData.Segments data = new LiveNotificationData.Segments(
                 /* header */ "Order #API-1001",
@@ -328,7 +328,7 @@ public class LiveNotificationDemoActivity extends BaseActivity<ActivityLiveNotif
 
     /** Demonstrates the local-end API: {@code endLiveNotification(activityId)}. */
     private void endViaApi() {
-        ModuleMessagingPushFCM module = CustomerIORepository.messagingPushModule;
+        ModuleMessagingPushFCM module = customerIORepository.getMessagingPushModule();
         if (module == null || lastApiActivityId == null) return;
         module.endLiveNotification(lastApiActivityId);
         binding.statusTextView.setText(R.string.live_notification_status_ended);

--- a/samples/java_layout/src/main/res/layout/notification_rideshare_collapsed.xml
+++ b/samples/java_layout/src/main/res/layout/notification_rideshare_collapsed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Custom RemoteViews layout for the app-rendered "rideshare" live notification
      (collapsed). Kept compact to fit the system's short collapsed content height.
-     Driven via CustomerIOPushNotificationCallback.createLiveNotification. -->
+     Driven via CustomerIOLiveNotificationsCallback.createLiveNotification. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/samples/java_layout/src/main/res/layout/notification_rideshare_expanded.xml
+++ b/samples/java_layout/src/main/res/layout/notification_rideshare_expanded.xml
@@ -2,7 +2,7 @@
 <!-- Custom RemoteViews layout for the app-rendered "rideshare" live notification
      (expanded): header (avatar, name + rating, ETA pill), status, 4-stop tracker
      and progress bar. Driven via
-     CustomerIOPushNotificationCallback.createLiveNotification. -->
+     CustomerIOLiveNotificationsCallback.createLiveNotification. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"


### PR DESCRIPTION
Addresses the code-review findings on #734: correctness fixes (click metrics, render crash containment, superseded-render state writes), API-compatibility fixes, resource bounds, and the out-of-scope core changes reverted. Detail is in the two commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Push module public API changes (live renderer callback split) and notification/metrics behavior affect integrators; core reverts remove installation-id event context if anything had started depending on it from the prior PR.
> 
> **Overview**
> Addresses review feedback on live notifications while **rolling back** unrelated core/datapipelines work: the HTTP client is **POST-only** again (no `HttpMethod` / `HttpRequestException`), and **persisted `installationId` plus `device.installationId` on events** are removed.
> 
> **Live notification API and behavior:** Custom rendering moves from `CustomerIOPushNotificationCallback` to a new **`CustomerIOLiveNotificationsCallback`**, wired via **`MessagingPushModuleConfig.Builder.setLiveNotificationCallback`**. `CustomerIOParsedPushPayload` keeps a **6-argument constructor** for binary compatibility when `activityId` was added. The SDK **no longer declares** `POST_PROMOTED_NOTIFICATIONS`; apps opt in for Android 16+ promoted live updates, with clearer debug guidance when it is missing.
> 
> **Correctness and safety:** FCM handling **creates the live notification channel only on the live path**, avoiding an unused standard channel in settings. **`LiveNotificationHandler.handle`** wraps rendering in **`runCatching`** so host renderers or asset work cannot crash FCM or SDK coroutines; **timestamp high-water marks** are advanced only after supersede/logout checks (including immediate-cancel paths). **Opened push metrics** are skipped when delivery id/token are blank (locally started live notifications). **`LiveNotificationStore.trimStaleTimestamps`** reclaims orphaned type/end entries and stamps activity types with write times. **`LiveNotificationRegistrar.start`** is idempotent; dismiss **`goAsync()`** is null-safe.
> 
> Tests and the Java sample are updated for the new callback and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d91e5fce962fafa758022a123a4be9af98be1a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->