### PR TITLE
chore(geofence): re-arm the movement trigger when a refresh fails

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -112,6 +112,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Geofence sync failed: $message", tag = TAG)
     }
 
+    fun logMovementRearmedAfterFailedRefresh() {
+        logger.debug("Movement refresh failed; re-ranking from cache to re-arm the movement trigger", tag = TAG)
+    }
+
     fun logSyncSucceeded(count: Int, movementTriggerRegistered: Boolean) {
         val trigger = if (movementTriggerRegistered) {
             " + 1 movement trigger"

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -197,7 +197,14 @@ internal class GeofenceRepositoryImpl(
             // Initial-enter synthesis stays on here (unlike refresh): containment is judged against
             // the OS's live triggering fix, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
-                performRemoteRefresh(userId, latitude, longitude)
+                val remote = performRemoteRefresh(userId, latitude, longitude)
+                if (remote.isFailure) {
+                    // The trigger already fired, and a failed pass never re-centres it — leaving it
+                    // where the device just exited, so nothing can fire again. Re-rank to re-arm it.
+                    logger.logMovementRearmedAfterFailedRefresh()
+                    performLocalRefresh(userId, latitude, longitude, config)
+                }
+                remote
             } else {
                 performLocalRefresh(userId, latitude, longitude, config)
             }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -230,6 +230,32 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun handleMovement_givenRemoteFetchFails_expectMovementTriggerRearmedAtCurrentFix() = runTest {
+        // A failed pass leaves the trigger where the device already exited, so nothing fires again.
+        val error = IOException("network down")
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns emptyList()
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.failure(error)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val result = repository.handleMovement(latitude = 1.0, longitude = 0.0)
+
+        result.isFailure shouldBeEqualTo true
+        result.exceptionOrNull() shouldBeEqualTo error
+        coVerify { manager.replaceGeofences(any(), any()) }
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(1.0, 0.0)) }
+        verify { logger.logMovementRearmedAfterFailedRefresh() }
+        // Anchor and freshness stay untouched, so the next EXIT still fetches remotely rather than
+        // treating the re-rank as a successful sync.
+        verify(exactly = 0) { store.saveLastApiFetchLocation(any()) }
+        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+    }
+
+    @Test
     fun handleMovement_givenMovedWithinFetchRadius_expectLocalReRankNoFetch() = runTest {
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"


### PR DESCRIPTION
## Summary

A movement-triggered refresh that fails leaves the movement trigger centred where the device **just exited**. A GMS geofence only fires EXIT on an exit transition, so it can never fire again — nearby-fence discovery stops for the rest of the process. Already-registered fences keep monitoring and delivering normally, so the failure is silent.

Relaunching does not recover it: `onAppLaunch` anchors at `getLastMovementTriggerLocation()` — the same stale centre — so `refreshAction` measures ~0 distance from it, finds the cache fully registered and no OS wipe, and returns `SKIP`. Recovery otherwise needs the 24h freshness window, physically re-entering *and* re-exiting the stale trigger, `refreshFromCurrentLocation()`, or sign-out/in.

## Found on device

One DNS failure during a movement fetch, then **53 minutes and ~38 km with zero sync activity**:

```
21:29:59  Geofence sync succeeded: 9 regions registered + 1 movement trigger
21:30:09  Geofence sync triggered: movement-trigger-exit
21:30:15  Geofence sync failed: Unable to resolve host "cdp.customer.io"
          … no sync, no movement-trigger line for the next 53 minutes …
21:43:56  Geofence '8176' ENTER: suppressed — same transition fired within the cooldown window
21:50:33  Geofence '109'  ENTER: suppressed — same transition fired within the cooldown window
```

GMS was demonstrably alive throughout (those suppressed ENTERs are real crossings), and delivery recovered on its own — the ENTER/EXIT captured during the outage were retried and delivered once DNS returned. Only the trigger stayed dead. Retracing the route appeared to fix it, but only because re-entering the stale trigger let it fire again; a one-way trip would not recover.

## Change

On a failed movement refresh, re-rank from cache so the trigger is re-centred at the current fix and the next move retries.

Two properties matter:

- **The anchor and sync timestamp stay untouched.** `performLocalRefresh` passes no `onRegistered`, so `last_api_fetch_location` and `last_sync_timestamp` are not written — the next EXIT still fetches remotely instead of treating the re-rank as a successful sync. A relaunch also now measures a real distance from the stale API anchor to the new centre, so it can recover too.
- **Scoped to `handleMovement`.** The launch/identify path keeps its existing no-register-on-failure contract, and is harmless there: its trigger is still registered and centred from the previous session.

The fallback also covers a failure inside `registerNearestAndPersist` (not just the fetch), which has the same un-recentred outcome — hence the failure-agnostic log wording.

## Stack

```
main ← feature/geofence-on-device ← this PR
```

## Tests

`handleMovement_givenRemoteFetchFails_expectMovementTriggerRearmedAtCurrentFix` — registration happens despite the failure, the trigger is recorded at the *current* fix, the original error still propagates, and the anchor/timestamp are left alone.

336 geofence tests green (715 across `geofence`/`location`/`core`/`datapipelines`); `lintDebug`, `apiCheck`, ktlint clean. Mutation-verified twice: removing the fallback fails the test, and making the fallback write the anchor/timestamp also fails it.

## Notes

- No public API change.
- No Linear ticket: found during pre-release device testing of the geofence feature branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches movement-trigger recovery in `handleMovement` (background geofence sync); behavior is scoped to that path and covered by a focused test, but incorrect fallback logic could affect when remote vs local sync runs.
> 
> **Overview**
> Fixes a silent failure mode where a **movement-trigger EXIT** followed by a failed remote refresh left the movement geofence centered where the device had already exited. Because GMS only fires **EXIT** on a transition, the trigger could not fire again and nearby-fence sync stopped until relaunch, 24h freshness, or manual recovery.
> 
> When **`handleMovement`**’s remote path fails (network or registration), the repository now runs a **cache-only local re-rank** via `performLocalRefresh` to re-center the movement trigger at the current fix. The call still **returns the original failure**; API fetch anchor and sync timestamp are **not** updated (local refresh has no `onRegistered`), so the next EXIT still attempts a remote fetch.
> 
> Adds **`logMovementRearmedAfterFailedRefresh`** and a unit test asserting OS re-registration, trigger location at the current coordinates, failure propagation, and unchanged anchor/timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9da83cf9be4203f3d8ad4f11bec6349fb2ddbe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
