### PR TITLE
fix(inbox): show the spinner while a concurrent fetch is still running

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/VisualInbox.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/inbox/VisualInbox.kt
@@ -63,6 +63,13 @@ class VisualInbox internal constructor(
     val isInboxVisible: Boolean
         get() = repository.isInboxVisible
 
+    /**
+     * True while a templates/branding fetch cycle is running. The overlay reads this to tell a
+     * not-yet-renderable inbox that is still loading apart from one that has settled on Hidden.
+     */
+    val isFetchInFlight: Boolean
+        get() = repository.isFetchInFlight
+
     fun getVisibility(): InboxVisibility = repository.computeVisibility()
 
     suspend fun loadTemplatesAndBranding(): InboxFetchOutcome = repository.loadTemplatesAndBranding()

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/VisualInboxOverlayState.kt
@@ -152,7 +152,16 @@ internal class VisualInboxController(
         }
         // Fetch (or serve-stale) templates + branding; outcome folds into getVisibility() below.
         visualInbox.loadTemplatesAndBranding()
-        return snapshot()
+        val snapshot = snapshot()
+        // A concurrent poll-driven fetch makes loadTemplatesAndBranding() return immediately on the
+        // repository's in-flight guard, before anything is cached. Reporting that as a settled Hidden
+        // would render nothing at all until observeContentChanges fires; report loading instead so
+        // the panel shows its spinner, matching iOS (which sets .loading before it fetches).
+        return if (!snapshot.isVisible && visualInbox.isFetchInFlight) {
+            snapshot.copy(loading = true)
+        } else {
+            snapshot
+        }
     }
 
     /** Builds a snapshot from the current data-layer state without triggering a fetch. */

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/VisualInboxControllerTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/VisualInboxControllerTest.kt
@@ -87,6 +87,36 @@ class VisualInboxControllerTest {
         state.visibility.shouldBeInstanceOf<InboxVisibility.Hidden>()
     }
 
+    // A concurrent poll-driven fetch makes loadTemplatesAndBranding() return on the repository's
+    // in-flight guard before anything is cached. That must report loading, not a settled Hidden:
+    // Hidden renders nothing at all, so the panel would sit blank instead of showing its spinner.
+    @Test
+    fun load_givenFetchInFlightAndNotYetRenderable_expectLoading() = runTest {
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        every { visualInbox.isEnabled } returns true
+        every { visualInbox.getVisibility() } returns InboxVisibility.Hidden("templates unavailable")
+        every { visualInbox.isFetchInFlight } returns true
+
+        val state = VisualInboxController(visualInbox).load()
+
+        state.loading shouldBeEqualTo true
+        state.isVisible shouldBeEqualTo false
+    }
+
+    // Control: once nothing is in flight, a Hidden inbox is settled and must NOT claim to be loading,
+    // or the panel would spin forever on a genuinely non-renderable inbox.
+    @Test
+    fun load_givenHiddenAndNoFetchInFlight_expectNotLoading() = runTest {
+        val visualInbox = mockk<VisualInbox>(relaxed = true)
+        every { visualInbox.isEnabled } returns true
+        every { visualInbox.getVisibility() } returns InboxVisibility.Hidden("templates unavailable")
+        every { visualInbox.isFetchInFlight } returns false
+
+        val state = VisualInboxController(visualInbox).load()
+
+        state.loading shouldBeEqualTo false
+    }
+
     @Test
     fun load_givenEnabledAndVisible_expectSnapshotWithUnopenedCount() = runTest {
         val messages = listOf(message("a", opened = false), message("b", opened = true))


### PR DESCRIPTION
Follow-up to the review of #769, addressing the Bugbot finding raised against the merged feature branch.

## The problem

When a queue poll is already fetching templates and branding, a concurrent overlay `load()` returns immediately on the repository's in-flight guard, before anything is cached. That produced a settled `Hidden` snapshot with `loading = false`, and `InboxListContent` renders nothing at all for `Hidden` — so the panel sat blank until `observeContentChanges` fired after the real fetch finished, instead of showing its spinner.

## The fix

`load()` reports `loading` when the inbox is not yet renderable AND a fetch is still running. `isFetchInFlight` is exposed on `VisualInbox` for that check.

This brings Android in line with iOS, which already behaves correctly for a different reason: `performRevalidation` sets `.loading` before fetching, so a concurrent caller hitting its own in-flight guard returns early and leaves `.loading` in place.

## Tests

- `load_givenFetchInFlightAndNotYetRenderable_expectLoading`
- `load_givenHiddenAndNoFetchInFlight_expectNotLoading` — the control, so a genuinely non-renderable inbox cannot spin forever

594 tests, 0 failures across `messaginginapp` + `messaginginbox`; ktlint and apiCheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized overlay UI state logic with unit tests; no auth, data mutation, or network behavior changes.
> 
> **Overview**
> Fixes a blank inbox panel when overlay `load()` runs while a queue poll is already fetching templates/branding: `loadTemplatesAndBranding()` returns immediately on the repository in-flight guard, so the UI used to get **Hidden** with `loading = false` and render nothing until `observeContentChanges` fired.
> 
> **`VisualInbox`** now exposes **`isFetchInFlight`** (from the repository). **`VisualInboxController.load()`** sets **`loading = true`** when the snapshot is not yet visible but a fetch is still running, so the panel shows its spinner instead of an empty state—aligned with iOS behavior.
> 
> Unit tests cover the in-flight loading case and the control where a settled Hidden inbox must not spin forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997e5a40ac82d5c253aac7b52043642d028eeb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->