### PR TITLE
fix(live-notifications): address bugbot review findings

### DIFF
--- a/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
+++ b/datapipelines/src/main/kotlin/io/customer/sdk/CustomerIO.kt
@@ -306,6 +306,12 @@ class CustomerIO private constructor(
             traits = traits,
             serializationStrategy = serializationStrategy
         )
+        // Reflect identity synchronously on the caller's thread so isUserIdentified is correct
+        // immediately, before analytics.userId() catches up (see syncUserIdentified). Must be set
+        // before publishUserChanged: the mirror takes precedence over the analytics fallback, so a
+        // subscriber that gates on isUserIdentified would otherwise read a stale `false` left by an
+        // earlier clearIdentify() even though analytics.userId() is already correct.
+        syncUserIdentified = true
         // Publish for other modules. Must come after analytics.identify() so analytics.userId()
         // returns the new userId for subscribers that gate on it (e.g. location resync).
         publishUserChanged(userId)
@@ -323,9 +329,6 @@ class CustomerIO private constructor(
         // Update the per-session marker after a successful identify (with or without traits)
         // so that a subsequent no-traits identify of the same userId can be deduped.
         lastIdentifiedUserIdThisSession = userId
-        // Reflect identity synchronously on the caller's thread so isUserIdentified is correct
-        // immediately, before analytics.userId() catches up (see syncUserIdentified).
-        syncUserIdentified = true
     }
 
     /**

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOPushNotificationHandler.kt
@@ -16,6 +16,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+import io.customer.messagingpush.di.liveNotificationManager
 import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.extensions.*
@@ -149,15 +150,21 @@ internal class CustomerIOPushNotificationHandler(
                 notificationManager = notificationManager
             )
             // onNotificationComposed is intentionally not called for live notifications.
-            LiveNotificationHandler(bundle).handle(
-                context = context,
-                deliveryId = deliveryId,
-                deliveryToken = deliveryToken,
-                smallIcon = smallIcon,
-                tintColor = tintColor,
-                channelId = liveChannelId,
-                notificationManager = notificationManager
-            )
+            // Dispatched rather than run inline: the handler performs a blocking branding-logo
+            // download (up to ~20s), which would otherwise hold Firebase's onMessageReceived
+            // thread and delay follow-up pushes.
+            SDKComponent.liveNotificationManager.renderFromPush(activityId) { isSuperseded ->
+                LiveNotificationHandler(bundle).handle(
+                    context = context,
+                    deliveryId = deliveryId,
+                    deliveryToken = deliveryToken,
+                    smallIcon = smallIcon,
+                    tintColor = tintColor,
+                    channelId = liveChannelId,
+                    notificationManager = notificationManager,
+                    isSuperseded = isSuperseded
+                )
+            }
             return
         }
 

--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -89,7 +89,8 @@ internal class LiveNotificationHandler(
         // Re-checked after the (potentially slow) render work and immediately before the
         // notification is posted and the activity type is written back. Returns true when a
         // logout/reset landed during rendering, in which case the render is dropped so it
-        // can't post or re-store a previous user's activity. Local renders only.
+        // can't post or re-store a previous user's activity. Supplied for every render that
+        // runs on LiveNotificationManager's render chain — local and server-delivered alike.
         isSuperseded: () -> Boolean = { false }
     ) {
         runCatching {

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationManager.kt
@@ -206,6 +206,29 @@ internal class LiveNotificationManager(
      */
     @Synchronized
     private fun render(bundle: Bundle) {
+        enqueueRender(bundle.getString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY)) { isSuperseded ->
+            renderLocally(bundle, isSuperseded)
+        }
+    }
+
+    /**
+     * Renders a server-delivered live notification off the caller's thread.
+     *
+     * Push renders used to run inline on Firebase's `onMessageReceived` thread, where the
+     * blocking branding-logo download (up to ~20s) held up Firebase's message handler and
+     * delayed follow-up pushes. Routing them through the same chain as local renders releases
+     * that thread immediately and keeps push and local renders from interleaving.
+     */
+    @Synchronized
+    fun renderFromPush(activityId: String?, render: (isSuperseded: () -> Boolean) -> Unit) {
+        enqueueRender(activityId, render)
+    }
+
+    /**
+     * Queues [render] behind any in-flight render so the two can't interleave, and drops it if a
+     * logout/reset lands first.
+     */
+    private fun enqueueRender(activityId: String?, render: (isSuperseded: () -> Boolean) -> Unit) {
         val generation = renderGeneration
         val previous = renderChain
         renderChain = renderScope.launch {
@@ -224,11 +247,10 @@ internal class LiveNotificationManager(
             // where anything escaping would take the host process down from a thread the app
             // cannot guard. Drop the render and keep the chain alive instead.
             runCatching {
-                renderLocally(bundle, isSuperseded = { generation != renderGeneration })
+                render { generation != renderGeneration }
             }.onFailure { cause ->
                 SDKComponent.logger.error(
-                    "Failed to render live notification " +
-                        "'${bundle.getString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY)}': ${cause.message}"
+                    "Failed to render live notification '$activityId': ${cause.message}"
                 )
             }
         }


### PR DESCRIPTION
Fixes the two automated-review findings on `feature/live-notifications` that were worth acting on.

- **Identity mirror set too late** — `syncUserIdentified` is now set immediately after `analytics.identify()` rather than at the end of `identifyImpl`, so subscribers gating on `isUserIdentified` during `publishUserChanged` no longer read a stale `false` left by an earlier `clearIdentify()`.
- **Push render blocked the FCM thread** — server-delivered live notifications now render on `LiveNotificationManager`'s existing render chain instead of inline on Firebase's `onMessageReceived` thread, where the branding-logo download can block for ~20s.

## Verification

- `:messagingpush:testDebugUnitTest` — 261 tests, 0 failures
- `:datapipelines:testDebugUnitTest` — 220 tests, 0 failures
- `./gradlew apiCheck` clean (no public API change — `LiveNotificationManager` is `internal`)
- ktlint (`make lint-no-format`) and `lintDebug` clean on both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)