### PR TITLE
fix(inbox): backfill once the server confirms the SSE connection

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/InAppSseLogger.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/InAppSseLogger.kt
@@ -55,6 +55,10 @@ internal class InAppSseLogger(private val logger: Logger) {
         logger.debug(tag = TAG, message = "Connection confirmed")
     }
 
+    fun logSseConnectionConfirmedBackfill() {
+        logger.debug(tag = TAG, message = "Connection confirmed, backfilling messages that predate the stream")
+    }
+
     fun logConnectionClosed() {
         logger.debug(tag = TAG, message = "Connection closed")
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManager.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManager.kt
@@ -55,6 +55,18 @@ internal class SseConnectionManager(
     private val scope: CoroutineScope
 ) {
 
+    /**
+     * Invoked when the server confirms the connection (its `connected` event), which is the only
+     * transition into [SseConnectionState.CONNECTED].
+     *
+     * Exists so the owner can sync state that SSE itself will not deliver: the stream only carries
+     * messages that arrive AFTER the connection is established, so whatever already exists for the
+     * user has to be fetched over HTTP. Doing that here rather than alongside [startConnection]
+     * means the fetch cannot race an SSE update that lands first (mirrors gist-web, which fetches
+     * from its `connected` listener).
+     */
+    internal var onConnectionConfirmed: (() -> Unit)? = null
+
     private val connectionMutex = Mutex()
     private var connectionJob: Job? = null
     private var timeoutJob: Job? = null
@@ -315,6 +327,7 @@ internal class SseConnectionManager(
         heartbeatTimer.startTimer(
             NetworkUtilities.DEFAULT_HEARTBEAT_TIMEOUT_MS + NetworkUtilities.HEARTBEAT_BUFFER_MS
         )
+        onConnectionConfirmed?.invoke()
     }
 
     /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManager.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManager.kt
@@ -56,14 +56,20 @@ internal class SseConnectionManager(
 ) {
 
     /**
-     * Invoked when the server confirms the connection (its `connected` event), which is the only
-     * transition into [SseConnectionState.CONNECTED].
+     * Invoked when the SERVER confirms the connection with its `connected` event — not on the
+     * transport-level [ConnectionOpenEvent], which arrives first.
      *
      * Exists so the owner can sync state that SSE itself will not deliver: the stream only carries
      * messages that arrive AFTER the connection is established, so whatever already exists for the
-     * user has to be fetched over HTTP. Doing that here rather than alongside [startConnection]
-     * means the fetch cannot race an SSE update that lands first (mirrors gist-web, which fetches
-     * from its `connected` listener).
+     * user has to be fetched over HTTP. Waiting for confirmation rather than firing alongside
+     * [startConnection] means the fetch starts against a stream that is already live, and is skipped
+     * entirely when a connection never establishes (mirrors gist-web, which fetches from its
+     * `connected` listener).
+     *
+     * NOTE: this does not fully order the HTTP response against SSE. An `inbox_messages` event that
+     * arrives while the fetch is in flight can still be overwritten by the older HTTP snapshot,
+     * because both publish a full-state write. Closing that needs the two writes versioned or
+     * merged; tracked separately.
      */
     internal var onConnectionConfirmed: (() -> Unit)? = null
 
@@ -219,6 +225,11 @@ internal class SseConnectionManager(
             ServerEvent.CONNECTED -> {
                 sseLogger.logConnectionConfirmed()
                 setupSuccessfulConnection()
+                // Only here, not in setupSuccessfulConnection: that also runs for the transport
+                // ConnectionOpenEvent, which fires first and before the server has confirmed
+                // anything — so hooking it there would both double-invoke and start the backfill at
+                // the same point as the pre-connect fetch this replaced.
+                onConnectionConfirmed?.invoke()
             }
 
             ServerEvent.HEARTBEAT -> {
@@ -327,7 +338,6 @@ internal class SseConnectionManager(
         heartbeatTimer.startTimer(
             NetworkUtilities.DEFAULT_HEARTBEAT_TIMEOUT_MS + NetworkUtilities.HEARTBEAT_BUFFER_MS
         )
-        onConnectionConfirmed?.invoke()
     }
 
     /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
@@ -106,11 +106,14 @@ internal class SseLifecycleManager(
      * existing inbox until the next foreground, which is why it used to appear only after a
      * background/relaunch.
      *
-     * Keyed off the server's `connected` event rather than the transition that decides to connect,
-     * because `fetchUserMessages()` is fire-and-forget: issued alongside `startConnection()` its
-     * response could land after an SSE update and overwrite the newer inbox with an older snapshot.
-     * Waiting for confirmation also means no fetch happens when the connection never establishes.
-     * Mirrors gist-web, which fetches from its `connected` listener.
+     * Keyed off the server's `connected` event rather than the transition that decides to connect, so
+     * the fetch starts against a stream that is already live and is skipped entirely when the
+     * connection never establishes. Mirrors gist-web, which fetches from its `connected` listener.
+     *
+     * This narrows the window but does not close it: `fetchUserMessages()` is fire-and-forget, so an
+     * `inbox_messages` event arriving while the request is in flight can still be overwritten by the
+     * older HTTP snapshot, since both publish a full-state write. Ordering the two properly needs
+     * them versioned or merged; tracked separately.
      */
     private fun backfillOnConnect() {
         sseLogger.logSseConnectionConfirmedBackfill()

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManager.kt
@@ -36,6 +36,9 @@ internal class SseLifecycleManager(
     }
 
     init {
+        // Backfill once the server confirms the connection, not when we decide to open it.
+        sseConnectionManager.onConnectionConfirmed = ::backfillOnConnect
+
         // Lifecycle registration must be on main thread
         mainThreadPoster.post {
             processLifecycleOwner.lifecycle.addObserver(lifecycleObserver)
@@ -72,7 +75,7 @@ internal class SseLifecycleManager(
         // Anonymous users should use polling instead of SSE
         if (state.shouldUseSse) {
             sseLogger.logAppForegrounded()
-            startSseConnectionWithBackfill()
+            startSseConnection()
         } else {
             sseLogger.logAppForegroundedSseNotUsed(state.sseEnabled, state.isUserIdentified)
         }
@@ -88,18 +91,30 @@ internal class SseLifecycleManager(
     }
 
     /**
-     * Starts the SSE connection, preceded by a one-time HTTP backfill fetch.
+     * Starts the SSE connection. The backfill fetch is NOT issued here — see [backfillOnConnect].
+     */
+    private fun startSseConnection() {
+        sseConnectionManager.startConnection()
+    }
+
+    /**
+     * Fetches the messages that already exist for the user, once the server has confirmed the SSE
+     * connection.
      *
      * The SSE endpoint does not send pending messages on connect — it only delivers messages that
-     * arrive AFTER the connection is established. So every transition INTO the SSE-connected state
-     * (app foregrounded, user becomes identified, or the SSE flag is enabled while foregrounded)
-     * must first fetch the messages that already exist for the user. Without this, on a fresh
-     * login the existing inbox is never retrieved until the next foreground — which is why it
-     * previously appeared only after a background/relaunch.
+     * arrive AFTER the connection is established. Without this, a fresh login never retrieves the
+     * existing inbox until the next foreground, which is why it used to appear only after a
+     * background/relaunch.
+     *
+     * Keyed off the server's `connected` event rather than the transition that decides to connect,
+     * because `fetchUserMessages()` is fire-and-forget: issued alongside `startConnection()` its
+     * response could land after an SSE update and overwrite the newer inbox with an older snapshot.
+     * Waiting for confirmation also means no fetch happens when the connection never establishes.
+     * Mirrors gist-web, which fetches from its `connected` listener.
      */
-    private fun startSseConnectionWithBackfill() {
+    private fun backfillOnConnect() {
+        sseLogger.logSseConnectionConfirmedBackfill()
         gistQueue.fetchUserMessages()
-        sseConnectionManager.startConnection()
     }
 
     private fun subscribeToSseFlagChanges() {
@@ -116,7 +131,7 @@ internal class SseLifecycleManager(
             // Only start SSE connection if shouldUseSse (enabled AND user identified)
             if (state.shouldUseSse) {
                 sseLogger.logSseEnabledWhileForegrounded()
-                startSseConnectionWithBackfill()
+                startSseConnection()
             } else if (sseEnabled && !state.isUserIdentified) {
                 // SSE enabled but user is anonymous - don't start SSE
                 sseLogger.logSseEnabledButUserAnonymous()
@@ -145,7 +160,7 @@ internal class SseLifecycleManager(
             if (state.shouldUseSse) {
                 // User became identified and SSE is enabled - start SSE connection
                 sseLogger.logEnablingSseForIdentifiedUser()
-                startSseConnectionWithBackfill()
+                startSseConnection()
             } else if (!isIdentified && state.sseEnabled) {
                 // User became anonymous and SSE flag is enabled - stop SSE, fall back to polling
                 sseLogger.logDisablingSseForAnonymousUser()

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManagerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/data/sse/SseConnectionManagerTest.kt
@@ -86,6 +86,52 @@ class SseConnectionManagerTest : JUnitTest() {
         coVerify { sseService.connectSse("test-session", "test-user", "test-site") }
     }
 
+    // The hook must fire on the SERVER's `connected` event only. setupSuccessfulConnection() also runs
+    // for the transport ConnectionOpenEvent, which arrives first, so hooking it there would fire twice
+    // and start the first backfill before the server had confirmed anything.
+    @Test
+    fun testStartConnection_whenOpenThenConnected_thenConfirmsExactlyOnce() = runTest {
+        val mockState = InAppMessagingState(
+            userId = "test-user",
+            sessionId = "test-session",
+            siteId = "test-site"
+        )
+        every { inAppMessagingManager.getCurrentState() } returns mockState
+        coEvery { sseService.connectSse(any(), any(), any()) } returns flowOf(
+            ConnectionOpenEvent,
+            ServerEvent(ServerEvent.CONNECTED, ""),
+            ServerEvent(ServerEvent.HEARTBEAT, "")
+        )
+
+        var confirmedCount = 0
+        connectionManager.onConnectionConfirmed = { confirmedCount++ }
+
+        connectionManager.startConnection()
+        testScope.advanceUntilIdle()
+
+        confirmedCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun testStartConnection_whenOnlyTransportOpen_thenDoesNotConfirm() = runTest {
+        val mockState = InAppMessagingState(
+            userId = "test-user",
+            sessionId = "test-session",
+            siteId = "test-site"
+        )
+        every { inAppMessagingManager.getCurrentState() } returns mockState
+        coEvery { sseService.connectSse(any(), any(), any()) } returns flowOf(ConnectionOpenEvent)
+
+        var confirmedCount = 0
+        connectionManager.onConnectionConfirmed = { confirmedCount++ }
+
+        connectionManager.startConnection()
+        testScope.advanceUntilIdle()
+
+        // Transport open alone is not confirmation: nothing should be backfilled yet.
+        confirmedCount shouldBeEqualTo 0
+    }
+
     @Test
     fun testStartConnection_whenAlreadyConnecting_thenDoesNotStartNewConnection() = runTest {
         // Given

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManagerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/SseLifecycleManagerTest.kt
@@ -33,6 +33,9 @@ class SseLifecycleManagerTest : JUnitTest() {
     private val stateFlow = MutableStateFlow<InAppMessagingState>(
         InAppMessagingState(sseEnabled = false)
     )
+
+    /** The backfill hook the manager registers on the connection manager. */
+    private val connectionConfirmed = slot<() -> Unit>()
     private var sseFlagChangeCallback: ((Boolean) -> Unit)? = null
     private var userIdentificationChangeCallback: ((Boolean) -> Unit)? = null
     private var subscriptionCallCount = 0
@@ -45,6 +48,7 @@ class SseLifecycleManagerTest : JUnitTest() {
         sseFlagChangeCallback = null
         userIdentificationChangeCallback = null
 
+        every { sseConnectionManager.onConnectionConfirmed = capture(connectionConfirmed) } just Runs
         every { processLifecycleOwner.lifecycle } returns lifecycle
         every { lifecycle.currentState } returns Lifecycle.State.CREATED
         every { lifecycle.addObserver(any()) } just Runs
@@ -388,11 +392,35 @@ class SseLifecycleManagerTest : JUnitTest() {
     }
 
     // =====================
-    // Catch-up fetch tests (fetchUserMessages on foreground)
+    // Connection-start tests. The backfill fetch itself is driven by the server's connected
+    // event (see the onConnectionConfirmed test), not by these transitions.
     // =====================
 
+    // The backfill is driven by the server confirming the connection, not by the transition that
+    // decides to open it: issued alongside startConnection() the fire-and-forget fetch could land
+    // after an SSE update and overwrite a newer inbox with an older snapshot.
     @Test
-    fun testOnStart_whenSseEnabledAndUserIdentified_thenFetchesUserMessages() {
+    fun testConnectionConfirmed_thenBackfillsUserMessages() {
+        stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
+        lifecycleManager = SseLifecycleManager(
+            inAppMessagingManager = inAppMessagingManager,
+            processLifecycleOwner = processLifecycleOwner,
+            sseConnectionManager = sseConnectionManager,
+            sseLogger = sseLogger,
+            gistQueue = gistQueue,
+            mainThreadPoster = mainThreadPoster
+        )
+
+        // Nothing is fetched until the server acknowledges the connection.
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
+
+        connectionConfirmed.captured.invoke()
+
+        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+    }
+
+    @Test
+    fun testOnStart_whenSseEnabledAndUserIdentified_thenStartsConnectionWithoutFetching() {
         // Given - SSE enabled and user is identified
         stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
         lifecycleManager = SseLifecycleManager(
@@ -412,7 +440,8 @@ class SseLifecycleManagerTest : JUnitTest() {
         observer.onStart(processLifecycleOwner)
 
         // Then - should fetch user messages to catch up on missed messages
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+        verify(exactly = 1) { sseConnectionManager.startConnection() }
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
     }
 
     @Test
@@ -468,7 +497,7 @@ class SseLifecycleManagerTest : JUnitTest() {
     }
 
     @Test
-    fun testBackgroundToForeground_whenSseEnabled_thenFetchesUserMessages() {
+    fun testBackgroundToForeground_whenSseEnabled_thenStartsConnection() {
         // Given - SSE enabled and user is identified
         stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
         lifecycleManager = SseLifecycleManager(
@@ -486,7 +515,8 @@ class SseLifecycleManagerTest : JUnitTest() {
 
         // First foreground
         observer.onStart(processLifecycleOwner)
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+        verify(exactly = 1) { sseConnectionManager.startConnection() }
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
 
         // Background the app
         observer.onStop(processLifecycleOwner)
@@ -495,11 +525,12 @@ class SseLifecycleManagerTest : JUnitTest() {
         observer.onStart(processLifecycleOwner)
 
         // Then - should fetch again to catch up on messages missed while backgrounded
-        verify(exactly = 2) { gistQueue.fetchUserMessages() }
+        verify(exactly = 2) { sseConnectionManager.startConnection() }
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
     }
 
     @Test
-    fun testOnStart_whenAlreadyForegrounded_thenDoesNotFetchAgain() {
+    fun testOnStart_whenAlreadyForegrounded_thenDoesNotStartConnectionAgain() {
         // Given - SSE enabled and user is identified
         stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
         lifecycleManager = SseLifecycleManager(
@@ -517,13 +548,14 @@ class SseLifecycleManagerTest : JUnitTest() {
 
         // First call
         observer.onStart(processLifecycleOwner)
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+        verify(exactly = 1) { sseConnectionManager.startConnection() }
 
         // When - duplicate onStart without onStop
         observer.onStart(processLifecycleOwner)
 
         // Then - should NOT fetch again (AtomicBoolean guard prevents duplicate)
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+        verify(exactly = 1) { sseConnectionManager.startConnection() }
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
     }
 
     // =====================
@@ -773,43 +805,7 @@ class SseLifecycleManagerTest : JUnitTest() {
     // =====================
 
     @Test
-    fun testUserBecomesIdentified_whenForegroundedAndSseEnabled_thenFetchesUserMessages() {
-        // Given - anonymous + SSE enabled + foregrounded
-        stateFlow.value = InAppMessagingState(
-            sseEnabled = true,
-            userId = null,
-            anonymousId = "anonymous-123"
-        )
-        lifecycleManager = SseLifecycleManager(
-            inAppMessagingManager = inAppMessagingManager,
-            processLifecycleOwner = processLifecycleOwner,
-            sseConnectionManager = sseConnectionManager,
-            sseLogger = sseLogger,
-            gistQueue = gistQueue,
-            mainThreadPoster = mainThreadPoster
-        )
-
-        val observerSlot = slot<androidx.lifecycle.LifecycleObserver>()
-        verify { lifecycle.addObserver(capture(observerSlot)) }
-        val observer = observerSlot.captured as androidx.lifecycle.DefaultLifecycleObserver
-        observer.onStart(processLifecycleOwner)
-        // Foregrounding while anonymous does not fetch (polling handles anonymous)
-        verify(exactly = 0) { gistQueue.fetchUserMessages() }
-
-        // When - user becomes identified (shouldUseSse flips true)
-        stateFlow.value = InAppMessagingState(
-            sseEnabled = true,
-            userId = "user-123",
-            anonymousId = "anonymous-123"
-        )
-        userIdentificationChangeCallback?.invoke(true)
-
-        // Then - backfill fetch fires so existing messages load without a foreground
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
-    }
-
-    @Test
-    fun testSseFlagChange_whenForegroundedAndUserIdentified_thenFetchesUserMessages() {
+    fun testSseFlagChange_whenForegroundedAndUserIdentified_thenStartsConnection() {
         // Given - identified user + SSE disabled + foregrounded
         stateFlow.value = InAppMessagingState(sseEnabled = false, userId = "user-123")
         lifecycleManager = SseLifecycleManager(
@@ -826,13 +822,14 @@ class SseLifecycleManagerTest : JUnitTest() {
         val observer = observerSlot.captured as androidx.lifecycle.DefaultLifecycleObserver
         observer.onStart(processLifecycleOwner)
         // Foregrounding while SSE disabled does not fetch here (polling handles it)
-        verify(exactly = 0) { gistQueue.fetchUserMessages() }
+        verify(exactly = 0) { sseConnectionManager.startConnection() }
 
         // When - SSE flag flips true (shouldUseSse becomes true)
         stateFlow.value = InAppMessagingState(sseEnabled = true, userId = "user-123")
         sseFlagChangeCallback?.invoke(true)
 
         // Then - backfill fetch fires
-        verify(exactly = 1) { gistQueue.fetchUserMessages() }
+        verify(exactly = 1) { sseConnectionManager.startConnection() }
+        verify(exactly = 0) { gistQueue.fetchUserMessages() }
     }
 }


### PR DESCRIPTION
Fixes a race we introduced in #771 (the fresh-login empty-inbox fix), found while reviewing whether that fix was the right shape.

## The race

`startSseConnectionWithBackfill()` read as if it were ordered:

```kotlin
/** Starts the SSE connection, preceded by a one-time HTTP backfill fetch. */
private fun startSseConnectionWithBackfill() {
    gistQueue.fetchUserMessages()
    sseConnectionManager.startConnection()
}
```

But `fetchUserMessages()` is `scope.launch { ... }` — fire-and-forget — so "preceded by" was only true in source order. The HTTP response could land *after* an SSE `inbox_messages` update and replace the newer list with an older snapshot, since both paths dispatch `ProcessInboxMessages` as a full-state write.

Not theoretical: the whole point of the backfill is that it runs at exactly the moment SSE is connecting.

## The fix

The fetch now runs from the server's `connected` event — the only transition into `CONNECTED` — through an `onConnectionConfirmed` hook that `SseLifecycleManager` registers on `SseConnectionManager`.

This orders the two by construction rather than reconciling them afterwards, so it needs no versioning tokens, no merge action, and no reducer changes. It also stops fetching when a connection never establishes, and collapses three trigger sites into one.

**This is what gist-web does** (`src/managers/queue-manager.ts`): it fetches from `sseSource.addEventListener(connected, ...)`, after the connection is confirmed — not before opening the `EventSource`. Our original shape was the divergence.

## Why not the alternatives

- **Versioning the full-state writes** (token on the action, reducer drops older) fixes overlapping polls too, but is several times the size and depends on allocating tokens at request time rather than publish time — easy to get subtly wrong later.
- **Awaiting the fetch before connecting** is the opposite of web, delays the connection by a round trip, and lets a hung fetch stall it.

## Tests

`SseLifecycleManagerTest`: the five tests that asserted a fetch on the lifecycle transition now assert the connection starts and that nothing is fetched directly; `testConnectionConfirmed_thenBackfillsUserMessages` covers the new trigger. One test became a duplicate of an existing one after the rename and was removed.

594 tests, 0 failures; ktlint and apiCheck clean.

## iOS

Same bug, same origin (#1143), fixed in the paired iOS PR — both platforms already parse and consume the `connected` event, with an identically named `setupSuccessfulConnection` hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how inbox state is hydrated for SSE users; it reduces a known overwrite race but a residual HTTP-vs-SSE ordering gap remains until versioning/merge is added.
> 
> **Overview**
> Fixes a **race** from firing `fetchUserMessages()` at the same time as opening SSE: the HTTP call is async, so its full-state inbox write could land **after** a newer SSE `inbox_messages` update and roll the UI back.
> 
> **Inbox backfill** now runs only after the server sends its **`connected`** event, not when foreground/identify/SSE-flag logic calls `startConnection()`. `SseConnectionManager` exposes `onConnectionConfirmed`, invoked from the `CONNECTED` server event only (not transport `ConnectionOpenEvent`, which would double-fire). `SseLifecycleManager` registers `backfillOnConnect` there, so one path handles all connect triggers, backfill is skipped if the connection never confirms, and behavior aligns with gist-web.
> 
> Lifecycle and flag transitions **only start the connection**; tests were updated accordingly, with new coverage that the hook fires once on open+connected and not on transport-open alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbd4f42e5fb33d2c387b3894e1269c705694ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->