### PR TITLE
test: add one-command Maestro SDK E2E coverage

### DIFF
--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -1,10 +1,19 @@
 name: Maestro SDK E2E
 
 on:
+  pull_request: {}
   workflow_dispatch:
     inputs:
+      profile:
+        description: Suite profile
+        type: choice
+        options:
+          - standard
+          - quick
+          - single
+        default: standard
       suite:
-        description: E2E suite to run
+        description: Suite to run when profile is single
         type: choice
         options:
           - smoke
@@ -23,10 +32,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    name: Select Android suites
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.select.outputs.suites }}
+    steps:
+      - name: Select suite matrix
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_PROFILE: ${{ inputs.profile }}
+          REQUESTED_SUITE: ${{ inputs.suite }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            profile=quick
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            profile=standard
+          else
+            profile="${REQUESTED_PROFILE:-standard}"
+          fi
+
+          case "$profile" in
+            quick) suites='["smoke"]' ;;
+            standard) suites='["smoke","geofence","message-inbox"]' ;;
+            single) suites="[\"${REQUESTED_SUITE:-smoke}\"]" ;;
+            *) echo "Unknown profile: $profile" >&2; exit 2 ;;
+          esac
+          echo "suites=$suites" >> "$GITHUB_OUTPUT"
+
   e2e:
-    name: Android ${{ inputs.suite || 'smoke' }}
+    name: Android ${{ matrix.suite }}
+    needs: prepare
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.prepare.outputs.suites) }}
     steps:
       - name: Check out Android SDK
         uses: actions/checkout@v4
@@ -68,7 +115,7 @@ jobs:
           ./.e2e-harness/e2e run \
             --platform android \
             --sdk-repo "$GITHUB_WORKSPACE" \
-            --suite "${{ inputs.suite || 'smoke' }}" \
+            --suite "${{ matrix.suite }}" \
             --headless
 
       - name: Sanitize E2E evidence
@@ -87,7 +134,7 @@ jobs:
         if: ${{ always() && steps.sanitize.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-android-${{ inputs.suite || 'smoke' }}
+          name: maestro-android-${{ matrix.suite }}
           path: artifacts/e2e/
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -23,7 +23,7 @@ on:
       harness_ref:
         description: customerio/mobile-e2e branch, tag, or commit
         type: string
-        default: a70446def847935b20158c804c513ec81b0f2a6b
+        default: main
   schedule:
     - cron: "17 6 * * 1-5"
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: customerio/mobile-e2e
-          ref: ${{ inputs.harness_ref || 'a70446def847935b20158c804c513ec81b0f2a6b' }}
+          ref: ${{ inputs.harness_ref || 'main' }}
           path: .e2e-harness
 
       - uses: ./.github/actions/setup-android

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -65,11 +65,12 @@ jobs:
     name: Android ${{ matrix.suite }}
     needs: prepare
     if: >-
+      (vars.MOBILE_E2E_ENABLED == 'true' || github.event_name == 'workflow_dispatch') &&
       github.actor != 'dependabot[bot]' &&
       (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -84,9 +85,16 @@ jobs:
           repository: customerio/mobile-e2e
           ref: ${{ inputs.harness_ref || 'main' }}
           path: .e2e-harness
-          token: ${{ secrets.MOBILE_E2E_REPO_TOKEN || github.token }}
 
       - uses: ./.github/actions/setup-android
+
+      - name: Install Android emulator packages
+        run: |
+          sdkmanager \
+            "platform-tools" \
+            "emulator" \
+            "platforms;android-35" \
+            "system-images;android-35;google_apis;x86_64"
 
       - name: Enable emulator acceleration
         run: sudo chmod 666 /dev/kvm
@@ -105,6 +113,24 @@ jobs:
         run: |
           printf 'cdpApiKey=%s\nsiteId=%s\nworkspace=%s\n' \
             "$CDP_API_KEY" "$SITE_ID" "Mobile E2E" > samples/local.properties
+
+      - name: Validate E2E backend configuration
+        env:
+          SUITE: ${{ matrix.suite }}
+          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
+          MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
+          INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
+        run: |
+          required=(MAESTRO_EXT_API_KEY)
+          if [[ "$SUITE" == "message-inbox" ]]; then
+            required+=(MAESTRO_APP_API_KEY INBOX_TRANSACTIONAL_MESSAGE_ID)
+          fi
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is not configured for Maestro E2E"
+              exit 1
+            fi
+          done
 
       - name: Run SDK to backend E2E
         env:

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -1,0 +1,93 @@
+name: Maestro SDK E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: E2E suite to run
+        type: choice
+        options:
+          - smoke
+          - geofence
+          - message-inbox
+        default: smoke
+      harness_ref:
+        description: customerio/mobile-e2e branch, tag, or commit
+        type: string
+        default: main
+  schedule:
+    - cron: "17 6 * * 1-5"
+
+concurrency:
+  group: maestro-android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Android ${{ inputs.suite || 'smoke' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out Android SDK
+        uses: actions/checkout@v4
+
+      - name: Check out shared E2E harness
+        uses: actions/checkout@v4
+        with:
+          repository: customerio/mobile-e2e
+          ref: ${{ inputs.harness_ref || 'main' }}
+          path: .e2e-harness
+          token: ${{ secrets.MOBILE_E2E_REPO_TOKEN || github.token }}
+
+      - uses: ./.github/actions/setup-android
+
+      - name: Enable emulator acceleration
+        run: sudo chmod 666 /dev/kvm
+
+      - name: Install Maestro and evidence dependencies
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg python3-pil
+
+      - name: Configure sample workspace
+        env:
+          CDP_API_KEY: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_CDP_API_KEY }}
+          SITE_ID: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_SITE_ID }}
+        run: |
+          printf 'cdpApiKey=%s\nsiteId=%s\nworkspace=%s\n' \
+            "$CDP_API_KEY" "$SITE_ID" "Mobile E2E" > samples/local.properties
+
+      - name: Run SDK to backend E2E
+        env:
+          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
+          MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
+          INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
+        run: |
+          ./.e2e-harness/e2e run \
+            --platform android \
+            --sdk-repo "$GITHUB_WORKSPACE" \
+            --suite "${{ inputs.suite || 'smoke' }}" \
+            --headless
+
+      - name: Sanitize E2E evidence
+        id: sanitize
+        if: always()
+        env:
+          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
+          MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
+        run: |
+          if [[ -d artifacts/e2e ]]; then
+            python3 .e2e-harness/scripts/redact_artifacts.py artifacts/e2e
+            python3 .e2e-harness/scripts/redact_artifacts.py --check artifacts/e2e
+          fi
+
+      - name: Upload E2E evidence
+        if: ${{ always() && steps.sanitize.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-android-${{ inputs.suite || 'smoke' }}
+          path: artifacts/e2e/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -23,7 +23,7 @@ on:
       harness_ref:
         description: customerio/mobile-e2e branch, tag, or commit
         type: string
-        default: main
+        default: 755d9771aed3766b8bc02ecda1e5890066eeb2d2
   schedule:
     - cron: "17 6 * * 1-5"
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: customerio/mobile-e2e
-          ref: ${{ inputs.harness_ref || 'main' }}
+          ref: ${{ inputs.harness_ref || '755d9771aed3766b8bc02ecda1e5890066eeb2d2' }}
           path: .e2e-harness
 
       - uses: ./.github/actions/setup-android
@@ -111,6 +111,12 @@ jobs:
           CDP_API_KEY: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_CDP_API_KEY }}
           SITE_ID: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_SITE_ID }}
         run: |
+          for name in CDP_API_KEY SITE_ID; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is not configured for Maestro E2E"
+              exit 1
+            fi
+          done
           printf 'cdpApiKey=%s\nsiteId=%s\nworkspace=%s\n' \
             "$CDP_API_KEY" "$SITE_ID" "Mobile E2E" > samples/local.properties
 
@@ -134,6 +140,7 @@ jobs:
 
       - name: Run SDK to backend E2E
         env:
+          SUITE: ${{ matrix.suite }}
           MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
           INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
@@ -141,7 +148,7 @@ jobs:
           ./.e2e-harness/e2e run \
             --platform android \
             --sdk-repo "$GITHUB_WORKSPACE" \
-            --suite "${{ matrix.suite }}" \
+            --suite "$SUITE" \
             --headless
 
       - name: Sanitize E2E evidence
@@ -150,6 +157,8 @@ jobs:
         env:
           MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
+          ANDROID_CDP_API_KEY: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_CDP_API_KEY }}
+          ANDROID_SITE_ID: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_SITE_ID }}
         run: |
           if [[ -d artifacts/e2e ]]; then
             python3 .e2e-harness/scripts/redact_artifacts.py artifacts/e2e

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -23,7 +23,7 @@ on:
       harness_ref:
         description: customerio/mobile-e2e branch, tag, or commit
         type: string
-        default: 755d9771aed3766b8bc02ecda1e5890066eeb2d2
+        default: a70446def847935b20158c804c513ec81b0f2a6b
   schedule:
     - cron: "17 6 * * 1-5"
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: customerio/mobile-e2e
-          ref: ${{ inputs.harness_ref || '755d9771aed3766b8bc02ecda1e5890066eeb2d2' }}
+          ref: ${{ inputs.harness_ref || 'a70446def847935b20158c804c513ec81b0f2a6b' }}
           path: .e2e-harness
 
       - uses: ./.github/actions/setup-android
@@ -123,13 +123,12 @@ jobs:
       - name: Validate E2E backend configuration
         env:
           SUITE: ${{ matrix.suite }}
-          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
           INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
         run: |
-          required=(MAESTRO_EXT_API_KEY)
+          required=(MAESTRO_APP_API_KEY)
           if [[ "$SUITE" == "message-inbox" ]]; then
-            required+=(MAESTRO_APP_API_KEY INBOX_TRANSACTIONAL_MESSAGE_ID)
+            required+=(INBOX_TRANSACTIONAL_MESSAGE_ID)
           fi
           for name in "${required[@]}"; do
             if [[ -z "${!name}" ]]; then
@@ -141,7 +140,6 @@ jobs:
       - name: Run SDK to backend E2E
         env:
           SUITE: ${{ matrix.suite }}
-          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
           INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
         run: |
@@ -155,7 +153,6 @@ jobs:
         id: sanitize
         if: always()
         env:
-          MAESTRO_EXT_API_KEY: ${{ secrets.MOBILE_E2E_EXT_API_KEY }}
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
           ANDROID_CDP_API_KEY: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_CDP_API_KEY }}
           ANDROID_SITE_ID: ${{ secrets.CUSTOMERIO_JAVA_WORKSPACE_SITE_ID }}

--- a/.maestro/.env.example
+++ b/.maestro/.env.example
@@ -1,9 +1,7 @@
 # Copy to .env and fill in values. `.env` is gitignored.
 # The Maestro CLI picks this up automatically when run from this directory.
 
-# Test-prod Ext API key (Customer.io → Settings → API Credentials → App API Keys).
-MAESTRO_EXT_API_KEY=paste-32-hex-char-app-api-key-here
-# Optional; defaults to MAESTRO_EXT_API_KEY.
-MAESTRO_APP_API_KEY=
+# Test-prod App API key (Customer.io → Settings → API Credentials → App API Keys).
+MAESTRO_APP_API_KEY=paste-32-hex-char-app-api-key-here
 # Published visual Inbox transactional message.
 INBOX_TRANSACTIONAL_MESSAGE_ID=21

--- a/.maestro/.env.example
+++ b/.maestro/.env.example
@@ -3,3 +3,7 @@
 
 # Test-prod Ext API key (Customer.io → Settings → API Credentials → App API Keys).
 MAESTRO_EXT_API_KEY=paste-32-hex-char-app-api-key-here
+# Optional; defaults to MAESTRO_EXT_API_KEY.
+MAESTRO_APP_API_KEY=
+# Published visual Inbox transactional message.
+INBOX_TRANSACTIONAL_MESSAGE_ID=21

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -13,34 +13,37 @@ unique to the Android sample.
 
 ## Prereqs
 
-1. `maestro` CLI (tested with 2.0.9).
-2. Android SDK + a booted Pixel emulator.
-3. `ffmpeg`, Python 3 with Pillow (`pip3 install pillow`).
+1. `maestro` CLI.
+2. Android SDK + Java 17. The runner creates/boots the emulator.
+3. `ffmpeg` and Python 3. Pillow is optional but enables annotated MP4s.
 4. An Ext API bearer token for the test-prod Customer.io workspace.
 5. `cdpApiKey` + `siteId` in `samples/local.properties` set to the same
-   workspace the Ext API key targets (currently
-   `cdpApiKey=a898c13577974eabf608`, `siteId=38eda114ab3f4593e11f`).
+   workspace the Ext API key targets.
 
 ## Setup
 
 ```bash
 cp .maestro/.env.example .maestro/.env
-# paste MAESTRO_EXT_API_KEY into .maestro/.env
-
-./gradlew :samples:java_layout:installDebug
+# Fill MAESTRO_EXT_API_KEY; message Inbox uses fixture ID 21.
+make e2e-setup
 ```
 
 ## Run
 
 ```bash
-./.maestro/run.sh                             # default: campaign_141 (shared)
-./.maestro/run.sh smoke_login_event.yaml      # also shared (in harness)
-./.maestro/run.sh inline_messages.yaml        # also shared (in harness)
+make e2e          # smoke + geofence + message Inbox; one build
+make e2e-quick    # smoke only
+make e2e-inbox    # message Inbox only
 ```
 
-All three flows live in [customerio/mobile-e2e/flows/](https://github.com/customerio/mobile-e2e/tree/main/flows) — the `run.sh` wrapper resolves them from `.maestro/harness/flows/` automatically.
+`make e2e` clones/updates the shared harness, provisions the emulator, builds
+and installs the sample, runs the deterministic Android profile, and prints one
+combined summary. Nothing needs to be started manually.
 
-Outputs land in `artifacts/<flow>/` (gitignored):
+`./.maestro/run.sh <flow.yaml>` remains available when an app is already
+installed and a single low-level flow is being debugged.
+
+Outputs land in `artifacts/e2e/android/<flow>/` (gitignored):
 
 | File | What it is |
 |---|---|
@@ -54,6 +57,7 @@ Outputs land in `artifacts/<flow>/` (gitignored):
 
 | File | Purpose |
 |---|---|
+| `e2e.sh` | One-command setup/profile wrapper around the shared top-level runner |
 | `run.sh` | Starts sink + emulator capture, runs Maestro, renders HTML + annotated video |
 | `.env.example` | Template — copy to `.env` and fill in `MAESTRO_EXT_API_KEY` |
 | `.env` | Your `MAESTRO_EXT_API_KEY` (gitignored) |

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -16,15 +16,15 @@ unique to the Android sample.
 1. `maestro` CLI.
 2. Android SDK + Java 17. The runner creates/boots the emulator.
 3. `ffmpeg` and Python 3. Pillow is optional but enables annotated MP4s.
-4. An Ext API bearer token for the test-prod Customer.io workspace.
+4. An App API key for the test-prod Customer.io workspace.
 5. `cdpApiKey` + `siteId` in `samples/local.properties` set to the same
-   workspace the Ext API key targets.
+   workspace the App API key targets.
 
 ## Setup
 
 ```bash
 cp .maestro/.env.example .maestro/.env
-# Fill MAESTRO_EXT_API_KEY; message Inbox uses fixture ID 21.
+# Fill MAESTRO_APP_API_KEY; message Inbox uses fixture ID 21.
 make e2e-setup
 ```
 
@@ -62,8 +62,8 @@ summary links to those snapshots. Both locations are gitignored.
 |---|---|
 | `e2e.sh` | One-command setup/profile wrapper around the shared top-level runner |
 | `run.sh` | Starts sink + emulator capture, runs Maestro, renders HTML + annotated video |
-| `.env.example` | Template — copy to `.env` and fill in `MAESTRO_EXT_API_KEY` |
-| `.env` | Your `MAESTRO_EXT_API_KEY` (gitignored) |
+| `.env.example` | Template — copy to `.env` and fill in `MAESTRO_APP_API_KEY` |
+| `.env` | Your `MAESTRO_APP_API_KEY` (gitignored) |
 | `harness/` | Shared scripts + flows auto-cloned from [`customerio/mobile-e2e`](https://github.com/customerio/mobile-e2e) (gitignored) |
 
 ## Selector strategy
@@ -97,6 +97,7 @@ widget's matching `accessibilityIdentifier`.
 ## CI rollout
 
 The workflow is wired for PR smoke, weekday standard, and focused manual runs.
-PR/scheduled jobs require `MOBILE_E2E_ENABLED=true`, the two `MOBILE_E2E_*_API_KEY`
-secrets, and the Inbox message-ID variable. Leave the flag unset until the shared
-harness is merged and one manual dispatch has passed.
+PR/scheduled jobs require `MOBILE_E2E_ENABLED=true`, the
+`MOBILE_E2E_APP_API_KEY` secret, and the Inbox message-ID variable. Leave the
+flag unset until the shared harness is merged and one manual dispatch has
+passed.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -43,7 +43,10 @@ combined summary. Nothing needs to be started manually.
 `./.maestro/run.sh <flow.yaml>` remains available when an app is already
 installed and a single low-level flow is being debugged.
 
-Outputs land in `artifacts/e2e/android/<flow>/` (gitignored):
+The latest focused artifacts land in `artifacts/e2e/android/<flow>/`. Profile
+runs also archive immutable snapshots beneath
+`.maestro/harness/artifacts/e2e/profile-<timestamp>/android/<flow>/`; the printed
+summary links to those snapshots. Both locations are gitignored.
 
 | File | What it is |
 |---|---|
@@ -90,3 +93,10 @@ widget's matching `accessibilityIdentifier`.
   to a 5 fps `screenshot` poll — see the iOS sample's `capture_frames.sh`.
 - No cleanup of created Customer.io customers. Test-prod workspace is
   fine for now.
+
+## CI rollout
+
+The workflow is wired for PR smoke, weekday standard, and focused manual runs.
+PR/scheduled jobs require `MOBILE_E2E_ENABLED=true`, the two `MOBILE_E2E_*_API_KEY`
+secrets, and the Inbox message-ID variable. Leave the flag unset until the shared
+harness is merged and one manual dispatch has passed.

--- a/.maestro/e2e.sh
+++ b/.maestro/e2e.sh
@@ -17,8 +17,11 @@ fi
 
 if [[ -z "${E2E_HARNESS_DIR:-}" ]]; then
   if [[ ! -d "$HARNESS_DIR/.git" ]]; then
-    echo ">> cloning shared E2E harness"
-    git clone --depth 1 --branch "$HARNESS_REF" "$HARNESS_REPO" "$HARNESS_DIR"
+    echo ">> fetching shared E2E harness"
+    git init -q "$HARNESS_DIR"
+    git -C "$HARNESS_DIR" remote add origin "$HARNESS_REPO"
+    git -C "$HARNESS_DIR" fetch --depth 1 origin "$HARNESS_REF" >/dev/null
+    git -C "$HARNESS_DIR" checkout --detach FETCH_HEAD >/dev/null
   else
     git -C "$HARNESS_DIR" fetch --depth 1 origin "$HARNESS_REF" >/dev/null
     git -C "$HARNESS_DIR" checkout --detach FETCH_HEAD >/dev/null

--- a/.maestro/e2e.sh
+++ b/.maestro/e2e.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Native-repo shortcut for the shared one-command mobile E2E runner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HARNESS_DIR="${E2E_HARNESS_DIR:-$SCRIPT_DIR/harness}"
+HARNESS_REPO="${E2E_HARNESS_REPO:-https://github.com/customerio/mobile-e2e.git}"
+HARNESS_REF="${E2E_HARNESS_REF:-main}"
+COMMAND="test"
+
+if [[ "${1:-}" == "setup" ]]; then
+  COMMAND="setup"
+  shift
+fi
+
+if [[ -z "${E2E_HARNESS_DIR:-}" ]]; then
+  if [[ ! -d "$HARNESS_DIR/.git" ]]; then
+    echo ">> cloning shared E2E harness"
+    git clone --depth 1 --branch "$HARNESS_REF" "$HARNESS_REPO" "$HARNESS_DIR"
+  else
+    git -C "$HARNESS_DIR" fetch --depth 1 origin "$HARNESS_REF" >/dev/null
+    git -C "$HARNESS_DIR" checkout --detach FETCH_HEAD >/dev/null
+  fi
+fi
+
+[[ -x "$HARNESS_DIR/e2e" ]] || {
+  echo "error: shared E2E runner is missing at $HARNESS_DIR/e2e" >&2
+  exit 2
+}
+
+exec "$HARNESS_DIR/e2e" "$COMMAND" \
+  --platform android \
+  --android-sdk-repo "$REPO_ROOT" \
+  "$@"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 SHELL = /bin/sh
 
+.PHONY: e2e e2e-setup e2e-quick e2e-inbox
+
+# One-command deterministic Android SDK → backend → SDK validation.
+e2e:
+	./.maestro/e2e.sh
+
+e2e-setup:
+	./.maestro/e2e.sh setup
+
+e2e-quick:
+	./.maestro/e2e.sh --profile quick
+
+e2e-inbox:
+	./.maestro/e2e.sh --suite message-inbox
+
 lint-error-message:
 	echo "\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\nLooks like there are lint errors to fix.\nRead the LINT.md document in this project to learn how to fix these problems.\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -144,6 +144,10 @@
             android:exported="false"
             android:label="@string/label_inbox_messages_activity" />
         <activity
+            android:name=".ui.inbox.VisualInboxActivity"
+            android:exported="false"
+            android:label="@string/visual_inbox" />
+        <activity
             android:name=".ui.livenotification.LiveNotificationDemoActivity"
             android:exported="false"
             android:label="@string/label_live_notification_demo_activity" />

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/DashboardActivity.java
@@ -33,6 +33,7 @@ import io.customer.android.sample.java_layout.databinding.ActivityDashboardBindi
 import io.customer.android.sample.java_layout.sdk.CustomerIORepository;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.android.sample.java_layout.ui.inbox.InboxMessagesActivity;
+import io.customer.android.sample.java_layout.ui.inbox.VisualInboxActivity;
 import io.customer.android.sample.java_layout.ui.inline.InlineExamplesActivity;
 import io.customer.android.sample.java_layout.ui.livenotification.LiveNotificationDemoActivity;
 import io.customer.android.sample.java_layout.ui.location.LocationTestActivity;
@@ -160,6 +161,9 @@ public class DashboardActivity extends BaseActivity<ActivityDashboardBinding> {
         });
         binding.inboxMessagesButton.setOnClickListener(view -> {
             startInboxMessagesActivity();
+        });
+        binding.visualInboxButton.setOnClickListener(view -> {
+            startActivity(new Intent(DashboardActivity.this, VisualInboxActivity.class));
         });
         binding.liveNotificationDemoButton.setOnClickListener(view -> {
             startActivity(new Intent(DashboardActivity.this, LiveNotificationDemoActivity.class));

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/NotificationInboxOverlayView.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/dashboard/NotificationInboxOverlayView.kt
@@ -10,7 +10,7 @@ import io.customer.messaginginbox.NotificationInboxOverlay
 
 // Host-supplied custom fonts for the Visual Inbox. Keys must match the workspace theme's `fontFamily`
 // tokens; Jist resolves a theme font ONLY from this map (falls back to the system font otherwise).
-private val jistCustomFonts: Map<String, FontFamily> = mapOf(
+internal val visualInboxFonts: Map<String, FontFamily> = mapOf(
     "Abril Fatface" to FontFamily(Font(R.font.abril_fatface, FontWeight.Normal)),
     "DM Sans" to FontFamily(
         Font(R.font.dm_sans_regular, FontWeight.Normal),
@@ -37,7 +37,7 @@ object NotificationInboxOverlayView {
     fun mount(composeView: ComposeView) {
         composeView.setContent {
             ComposeTheme {
-                NotificationInboxOverlay(fonts = jistCustomFonts)
+                NotificationInboxOverlay(fonts = visualInboxFonts)
             }
         }
     }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/inbox/VisualInboxActivity.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/inbox/VisualInboxActivity.kt
@@ -1,0 +1,39 @@
+package io.customer.android.sample.java_layout.ui.inbox
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.ui.Modifier
+import io.customer.android.sample.java_layout.databinding.ActivityVisualInboxBinding
+import io.customer.android.sample.java_layout.ui.core.BaseActivity
+import io.customer.android.sample.java_layout.ui.dashboard.visualInboxFonts
+import io.customer.android.sample.java_layout.ui.inline.compose.ComposeTheme
+import io.customer.messaginginbox.NotificationInboxView
+
+/**
+ * Dedicated full-screen host for Customer.io's visual notification inbox list.
+ *
+ * This demonstrates the screen-style integration customers can use instead of the convenience
+ * floating-bell overlay. Message content still comes from Customer.io and is rendered by Jist.
+ */
+class VisualInboxActivity : BaseActivity<ActivityVisualInboxBinding>() {
+    override fun inflateViewBinding(): ActivityVisualInboxBinding =
+        ActivityVisualInboxBinding.inflate(layoutInflater)
+
+    override fun setupContent() {
+        binding.toolbar.setNavigationOnClickListener { finish() }
+        binding.visualInboxContent.setContent {
+            ComposeTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colors.background
+                ) {
+                    NotificationInboxView(
+                        modifier = Modifier.fillMaxSize(),
+                        fonts = visualInboxFonts
+                    )
+                }
+            }
+        }
+    }
+}

--- a/samples/java_layout/src/main/res/layout/activity_dashboard.xml
+++ b/samples/java_layout/src/main/res/layout/activity_dashboard.xml
@@ -233,10 +233,23 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_default"
                 android:text="@string/inbox_messages"
-                app:layout_constraintBottom_toTopOf="@id/live_notification_demo_button"
+                app:layout_constraintBottom_toTopOf="@id/visual_inbox_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/inline_examples_button"
+                app:layout_constraintWidth_max="@dimen/material_button_max_width" />
+
+            <Button
+                android:id="@+id/visual_inbox_button"
+                style="?attr/materialButtonStyle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_default"
+                android:text="@string/visual_inbox"
+                app:layout_constraintBottom_toTopOf="@id/live_notification_demo_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/inbox_messages_button"
                 app:layout_constraintWidth_max="@dimen/material_button_max_width" />
 
             <Button
@@ -249,7 +262,7 @@
                 app:layout_constraintBottom_toTopOf="@id/logout_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/inbox_messages_button"
+                app:layout_constraintTop_toBottomOf="@id/visual_inbox_button"
                 app:layout_constraintWidth_max="@dimen/material_button_max_width" />
 
             <Button

--- a/samples/java_layout/src/main/res/layout/activity_visual_inbox.xml
+++ b/samples/java_layout/src/main/res/layout/activity_visual_inbox.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:navigationIcon="@drawable/ic_arrow_back_24"
+            app:title="@string/visual_inbox" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/visual_inbox_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/visual_inbox"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
 
     <!-- Inbox Messages -->
     <string name="inbox_messages">Inbox Messages</string>
+    <string name="visual_inbox">Visual Inbox</string>
     <string name="label_inbox_messages_activity">InboxMessagesActivity</string>
     <string name="inbox_empty_state">No inbox messages</string>
     <string name="inbox_fetch_error">Failed to fetch inbox messages</string>


### PR DESCRIPTION
## Summary

Adds Android sample and CI integration for the shared Maestro SDK-to-backend suite.

- adds native `make e2e`, setup, quick, and Message Inbox shortcuts
- adds a full-screen SDK Message Inbox sample alongside the existing overlay presentation
- exposes stable sample selectors used by Maestro without changing SDK API behavior
- runs smoke coverage on internal PRs and the standard profile on a weekday schedule
- provisions the API 35 emulator image explicitly and uploads evidence on success or failure
- keeps PR and scheduled execution behind `MOBILE_E2E_ENABLED` until rollout is proven

## Dependency

Depends on customerio/mobile-e2e#1. The workflow intentionally remains disabled for PR and scheduled execution until the shared harness is merged and repository configuration is present.

## Validation

- shared standard profile passed Android smoke, geofence, and Message Inbox end to end
- repeat quick profile passed Android smoke and preserved the earlier evidence archive
- `make format` passed
- `make lint` passed locally and in the pre-push hook
- `./gradlew :samples:java_layout:assembleDebug` passed
- workflow YAML parsing and `git diff --check` passed

## Repository configuration after merge

Add `MOBILE_E2E_APP_API_KEY` and the `MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID` repository variable; manually dispatch the workflow once, then set `MOBILE_E2E_ENABLED=true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to sample app UI, Maestro/docs, and CI; SDK API behavior is unchanged and PR/scheduled runs stay disabled until MOBILE_E2E_ENABLED is set.
> 
> **Overview**
> Adds **one-command Maestro SDK-to-backend E2E** for the Android `java_layout` sample, wired to the shared **customerio/mobile-e2e** harness locally and in CI.
> 
> **Local:** New `.maestro/e2e.sh` and Makefile targets (`make e2e`, `e2e-setup`, `e2e-quick`, `e2e-inbox`) clone/update the harness and run Android profiles. Maestro env/docs switch from `MAESTRO_EXT_API_KEY` to **`MAESTRO_APP_API_KEY`** and document **`INBOX_TRANSACTIONAL_MESSAGE_ID`**.
> 
> **Sample:** Adds a full-screen **Visual Inbox** (`VisualInboxActivity` + dashboard entry) using `NotificationInboxView`, and shares `visualInboxFonts` with the existing overlay for the message-inbox suite.
> 
> **CI:** New **Maestro SDK E2E** workflow runs smoke on PRs (when enabled), full smoke/geofence/message-inbox on weekdays, or manual dispatch; provisions API 35 emulator, validates secrets, runs the harness headless, redacts artifacts, and uploads evidence. Gated by **`MOBILE_E2E_ENABLED`** until rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d4b88e46aa8fe995f8f21830dbdabaaf08164a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

