### PR TITLE
chore(geofence): rank nearest regions by boundary distance, not centre

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
@@ -1,13 +1,23 @@
 package io.customer.geofence
 
+import kotlin.math.round
+
 /**
  * Selects the geofence regions closest to a reference location, capped at a maximum count and
  * (optionally) a maximum distance.
  *
  * The OS limits the number of geofences an app can register simultaneously; this filter
  * picks the most relevant subset based on straight-line distance from the device's
- * current location. Regions beyond [maxDistanceMeters] are excluded entirely; local re-ranking
- * re-includes them as the device approaches.
+ * current location. Regions whose boundary is beyond [maxDistanceMeters] are excluded entirely;
+ * local re-ranking re-includes them as the device approaches.
+ *
+ * Ranking and the cap both measure to the region's *boundary* ([edgeDistanceTo]), so a region the
+ * device is inside always sorts first and survives both the count limit and the distance cap.
+ *
+ * Ties break on ascending [GeofenceRegion.id], and distances round to whole meters first:
+ * `Location.distanceBetween` can return sub-meter-varying results for the same inputs, which would
+ * otherwise defeat the tiebreak and leave equidistant regions ordered by the server's response
+ * order. Matches iOS so both platforms pick the same set at the cap.
  */
 internal class GeofenceDistanceFilter {
     fun nearest(
@@ -19,9 +29,9 @@ internal class GeofenceDistanceFilter {
     ): List<GeofenceRegion> {
         if (max <= 0 || regions.isEmpty()) return emptyList()
         return regions
-            .map { it to it.distanceTo(latitude, longitude) }
+            .map { it to round(it.edgeDistanceTo(latitude, longitude)) }
             .filter { (_, distance) -> distance <= maxDistanceMeters }
-            .sortedBy { (_, distance) -> distance }
+            .sortedWith(compareBy({ (_, distance) -> distance }, { (region, _) -> region.id }))
             .take(max)
             .map { (region, _) -> region }
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -63,6 +63,17 @@ internal fun GeofenceRegion.distanceTo(lat: Double, lng: Double): Float {
 }
 
 /**
+ * Straight-line distance in meters from this region's *boundary* to the given coordinates, `0` when
+ * they fall inside the region.
+ *
+ * Relevance for monitoring is proximity to the boundary, not to the center: ranking on center
+ * distance evicts a region the device currently occupies once enough regions have nearer centers,
+ * and an unmonitored region can never report its exit.
+ */
+internal fun GeofenceRegion.edgeDistanceTo(lat: Double, lng: Double): Float =
+    (distanceTo(lat, lng) - radius).coerceAtLeast(0f)
+
+/**
  * Converts the SDK transition types to a GMS bitmask for [Geofence.Builder.setTransitionTypes].
  * E.g., [ENTER, EXIT] → GEOFENCE_TRANSITION_ENTER | GEOFENCE_TRANSITION_EXIT.
  */

--- a/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
@@ -87,19 +87,94 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
     }
 
     @Test
-    fun nearest_givenEquallyDistantRegions_expectStableInputOrder() {
-        // Two regions equally distant from origin — Kotlin's sortedBy is stable
-        val first = region("biz-first", 1.0, 0.0)
+    fun nearest_givenEquallyDistantRegions_expectOrderedByIdNotInputOrder() {
+        // Equally distant either side of the origin, supplied in reverse id order: the id tiebreak
+        // must decide, so the result can't depend on the server's response order.
         val second = region("biz-second", -1.0, 0.0)
+        val first = region("biz-first", 1.0, 0.0)
 
-        val result = filter.nearest(listOf(first, second), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
+        val result = filter.nearest(listOf(second, first), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
 
         result.map { it.id } shouldBeEqualTo listOf("biz-first", "biz-second")
+    }
+
+    @Test
+    fun nearest_givenSubMeterDistanceDifference_expectRoundingLetsIdTiebreakDecide() {
+        // Same centre, radii chosen so the boundary distances are 1000.4 m and 1000.2 m — a sub-meter
+        // gap that rounds to the same whole meter. On raw distance "biz-b" would sort first; rounding
+        // makes it a tie so the id decides, which is what keeps the order deterministic.
+        val centreDistance = region("probe", 0.01, 0.0).distanceTo(0.0, 0.0)
+        val a = region("biz-a", 0.01, 0.0, radius = centreDistance - 1000.4f)
+        val b = region("biz-b", 0.01, 0.0, radius = centreDistance - 1000.2f)
+
+        val result = filter.nearest(listOf(a, b), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-a", "biz-b")
+    }
+
+    @Test
+    fun nearest_givenOccupiedRegionAndNearerCenteredRegions_expectOccupiedRegionKeptAndRankedFirst() {
+        // Device sits inside a 5 km region ~2.2 km from its center, so ranking on center distance
+        // would place it 4th and the count budget would evict it — leaving it unmonitored and its
+        // exit unreportable.
+        val occupied = region("biz-occupied", 0.02, 0.0, radius = 5_000f)
+        val small1 = region("biz-small-1", 0.001, 0.0) // ~110 m center, ~10 m edge
+        val small2 = region("biz-small-2", 0.002, 0.0) // ~221 m center, ~121 m edge
+        val small3 = region("biz-small-3", 0.003, 0.0) // ~332 m center, ~232 m edge
+
+        val result = filter.nearest(
+            listOf(small1, small2, small3, occupied),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 3,
+            maxDistanceMeters = noDistanceCap
+        )
+
+        // The occupied region sorts first at edge distance 0; the farthest small region is evicted.
+        result.map { it.id } shouldBeEqualTo listOf("biz-occupied", "biz-small-1", "biz-small-2")
+    }
+
+    @Test
+    fun nearest_givenOccupiedRegionCenterBeyondDistanceCap_expectRegionStillIncluded() {
+        // Center ~5.5 km away with an 8 km radius: the device is inside, but the center falls outside
+        // the 3 km cap, so measuring to the center would filter out a region containing the device.
+        val occupied = region("biz-occupied", 0.05, 0.0, radius = 8_000f)
+        // Control: neither the center (~11 km) nor the boundary (~11 km) is within the cap.
+        val beyond = region("biz-beyond", 0.1, 0.0)
+
+        val result = filter.nearest(
+            listOf(occupied, beyond),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 5,
+            maxDistanceMeters = 3_000f
+        )
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-occupied")
+    }
+
+    @Test
+    fun nearest_givenLargeRegionWithCloserBoundary_expectRankedAheadOfNearerCenteredSmallRegion() {
+        // Applies to regions the device is outside too: a 2 km region centered ~2.2 km away has its
+        // boundary ~211 m off, nearer than a 100 m region centered ~1.1 km away.
+        val bigFar = region("biz-big-far", 0.02, 0.0, radius = 2_000f)
+        val smallNear = region("biz-small-near", 0.01, 0.0)
+
+        val result = filter.nearest(
+            listOf(smallNear, bigFar),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 2,
+            maxDistanceMeters = noDistanceCap
+        )
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-big-far", "biz-small-near")
     }
 
     private fun region(
         id: String,
         latitude: Double,
-        longitude: Double
-    ) = GeofenceRegion(id = id, latitude = latitude, longitude = longitude, radius = 100f)
+        longitude: Double,
+        radius: Float = 100f
+    ) = GeofenceRegion(id = id, latitude = latitude, longitude = longitude, radius = radius)
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRegionTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRegionTest.kt
@@ -42,16 +42,41 @@ class GeofenceRegionTest : RobolectricTest() {
             (Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
     }
 
+    @Test
+    fun edgeDistanceTo_givenCoordinatesInsideRegion_expectZero() {
+        val region = buildRegion(radius = 5_000f)
+
+        // ~2.2 km from center, well within the radius.
+        region.edgeDistanceTo(0.02, 0.0) shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun edgeDistanceTo_givenCoordinatesOnBoundary_expectZero() {
+        val centerDistance = buildRegion().distanceTo(0.01, 0.0)
+        val region = buildRegion(radius = centerDistance)
+
+        region.edgeDistanceTo(0.01, 0.0) shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun edgeDistanceTo_givenCoordinatesOutsideRegion_expectDistanceLessRadius() {
+        val region = buildRegion(radius = 1_000f)
+        val centerDistance = region.distanceTo(0.05, 0.0)
+
+        region.edgeDistanceTo(0.05, 0.0) shouldBeEqualTo centerDistance - 1_000f
+    }
+
     private fun buildRegion(
         transitionTypes: List<GeofenceTransitionType> = listOf(
             GeofenceTransitionType.ENTER,
             GeofenceTransitionType.EXIT
-        )
+        ),
+        radius: Float = 100f
     ) = GeofenceRegion(
         id = "test-geofence",
         latitude = 0.0,
         longitude = 0.0,
-        radius = 100f,
+        radius = radius,
         transitionTypes = transitionTypes
     )
 }


### PR DESCRIPTION
## What

Nearest-set selection ranked and capped on distance to each region's **centre**, ignoring radius.

A region the device is inside therefore ranks at roughly its own radius, so a large occupied region is evicted from the monitored set as soon as `maxBusinessGeofences` regions have nearer centres — and an unmonitored region can never report its exit. The `maxMonitoringDistance` cap had the same flaw: a region whose centre fell outside the cap was filtered out even when its area contained the device.

## How

New `GeofenceRegion.edgeDistanceTo()` = `(distanceTo - radius).coerceAtLeast(0f)`, used for both the distance filter and the ranking, so within the fetched set an occupied region sorts first and survives both the cap and the count limit.

Distances round to whole metres and ties break on ascending id, so equidistant regions at the eviction boundary order deterministically instead of following the server's response order.

## Deliberate behaviour changes

- Equal-radius ranking is **unchanged** — subtracting a constant preserves order.
- The distance cap **widens by one radius**: regions just outside the old `maxMonitoringDistance` now register. The default is 1 000 km, so this is inert unless a workspace sets a tight cap.
- Regions the device is outside are now ordered by boundary proximity, so a large region up the road outranks a small one further away.

## Known limitation

This ranks the set the server returned; it cannot recover a region the server never sent. `/geofences/nearest` omits `limit`, so CDP applies its default of 100 and orders by **centre** distance before truncating. In a workspace dense enough to exceed that, a large region containing the device can be cut server-side and never reach this sort. Aligning the server-side limit and ordering with boundary distance is a backend follow-up; until then "occupied regions are retained" holds within the fetched set, not absolutely.

## Not changed

The containment checks in `GeofenceRepository` stay centre-based (`distanceTo <= radius`) — edge distance would make them always true.

## Testing

1642 unit tests across all modules, 0 failures. `apiCheck` clean — everything added is `internal`. ktlint clean. Sample app builds.

6 new tests, mutation-verified by reverting to `distanceTo`: that fails all three new filter tests with the exact symptom (occupied region evicted / filtered out entirely / ranking inverted) while leaving the pre-existing filter tests passing.

## Notes

Independent of the other geofence patch PR in flight; both branch from `main` with no ordering requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which geofences are registered under count and distance limits—a correctness fix for missed exit events, but workspaces with tight distance caps may monitor a slightly wider set of regions.
> 
> **Overview**
> **Nearest geofence selection** now ranks and applies the monitoring distance cap using **boundary** distance (`edgeDistanceTo`) instead of distance to the region center, so a region the device is inside always ranks first and is not dropped when the OS geofence budget or `maxMonitoringDistance` would have evicted it under center-based math.
> 
> `GeofenceDistanceFilter.nearest` rounds distances to whole meters and breaks ties on ascending region `id` (aligned with iOS) so equidistant regions at the cap are deterministic rather than following server list order.
> 
> New unit tests cover occupied-region retention, distance-cap behavior when the center is outside the cap, boundary-vs-center ranking for large regions, and sub-meter rounding tiebreaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b175e15f936ace96dc00e805b9e1d4799d3a29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->