### PR TITLE
chore(geofence): refresh discovery from a live fix on foreground entry

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -130,8 +130,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
-            // Serialized across broadcasts: each runs on its own scope, so two transitions for the
-            // same fence would otherwise interleave read-decide-persist and lose a containment record.
+            // Each broadcast runs on its own scope, so two transitions for one fence would
+            // otherwise interleave read-decide-persist and lose a containment record.
             transitionMutex.withLock {
                 handleBusinessTransition(
                     geofenceId = geofenceId,
@@ -162,28 +162,21 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         androidComponent: AndroidSDKComponent,
         logger: GeofenceLogger
     ) {
-        // Containment bookkeeping runs before the identity checks below: being inside a fence is
-        // a physical fact, independent of whether the transition is deliverable.
+        // Ahead of the identity checks below: being inside a fence is a physical fact, independent of
+        // whether the transition is deliverable.
         val store = androidComponent.geofenceRegionStore
         val cachedRegion = store.getCachedRegion(geofenceId)
         when (transition) {
             Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
-            // claimExit runs first either way so the record is consumed atomically; the checks
-            // after it only decide whether an unmatched EXIT is trusted.
-            //
-            // Two cases where an absent record proves nothing, so the EXIT is delivered:
-            // a region registered without ENTER monitoring can never produce one to record, and
-            // an install upgraded from an SDK without the set has no data until the first
-            // registration seeds it. A missing cache row is treated the same way — unknown
-            // transition types can't justify dropping a crossing.
+            // An unmatched EXIT is a GMS reconciliation artifact, not a crossing — delivering it
+            // fires EXIT campaigns at people who were never there. The two guards after claimExit
+            // cover the cases where an absent record proves nothing: an upgraded install with no set
+            // yet, and a region that never monitored ENTER (a missing cache row counts as unknown).
             Event.GeofenceTransition.EXIT -> if (
                 !store.claimExit(geofenceId) &&
                 store.hasContainmentRecord() &&
                 cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
             ) {
-                // GMS reports EXIT for a fence it never reported as entered — an artifact of its
-                // own state reconciliation, not a crossing. Delivering it fires EXIT-triggered
-                // campaigns at people who were never there.
                 logger.logExitDroppedNeverEntered(geofenceId)
                 return
             }
@@ -192,9 +185,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
         // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
         val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
-        // Geofencing is identified-only: the backend rejects anonymous geofence tracks, so an
-        // anonymous transition has no deliverable path. Drop it before spending a cooldown slot
-        // or persisting a row neither channel could ever send.
+        // Identified-only: the backend rejects anonymous geofence tracks, so drop before spending a
+        // cooldown slot or persisting a row neither channel could send.
         if (userId == null) {
             logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
             return

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -128,6 +128,33 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
+            // Containment bookkeeping runs before the identity checks below: being inside a fence is
+            // a physical fact, independent of whether the transition is deliverable.
+            val store = androidComponent.geofenceRegionStore
+            val cachedRegion = store.getCachedRegion(geofenceId)
+            when (transition) {
+                Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
+                // claimExit runs first either way so the record is consumed atomically; the checks
+                // after it only decide whether an unmatched EXIT is trusted.
+                //
+                // Two cases where an absent record proves nothing, so the EXIT is delivered:
+                // a region registered without ENTER monitoring can never produce one to record, and
+                // an install upgraded from an SDK without the set has no data until the first
+                // registration seeds it. A missing cache row is treated the same way — unknown
+                // transition types can't justify dropping a crossing.
+                Event.GeofenceTransition.EXIT -> if (
+                    !store.claimExit(geofenceId) &&
+                    store.hasContainmentRecord() &&
+                    cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
+                ) {
+                    // GMS reports EXIT for a fence it never reported as entered — an artifact of its
+                    // own state reconciliation, not a crossing. Delivering it fires EXIT-triggered
+                    // campaigns at people who were never there.
+                    logger.logExitDroppedNeverEntered(geofenceId)
+                    return@forEach
+                }
+            }
+
             // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
             // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
             val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
@@ -139,7 +166,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 return@forEach
             }
 
-            val cachedRegion = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
             transitionEmitter.emit(
                 geofenceId = geofenceId,
                 transition = transition,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -12,6 +12,7 @@ import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
 import io.customer.geofence.di.geofenceTransitionEmitter
 import io.customer.sdk.communication.Event
+import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
@@ -20,6 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 
 /** Receives OS geofence transition callbacks and dispatches them to the SDK. */
@@ -94,7 +97,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val timestamp = SDKComponent.clock.currentTimeSeconds()
         val dispatchStartUptimeMs = SDKComponent.clock.elapsedRealtime()
         val androidComponent = SDKComponent.android()
-        val transitionEmitter = androidComponent.geofenceTransitionEmitter
         // Defense-in-depth against orphans (failed clearAll, app-data wipe, SDK
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
@@ -128,53 +130,17 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
-            // Containment bookkeeping runs before the identity checks below: being inside a fence is
-            // a physical fact, independent of whether the transition is deliverable.
-            val store = androidComponent.geofenceRegionStore
-            val cachedRegion = store.getCachedRegion(geofenceId)
-            when (transition) {
-                Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
-                // claimExit runs first either way so the record is consumed atomically; the checks
-                // after it only decide whether an unmatched EXIT is trusted.
-                //
-                // Two cases where an absent record proves nothing, so the EXIT is delivered:
-                // a region registered without ENTER monitoring can never produce one to record, and
-                // an install upgraded from an SDK without the set has no data until the first
-                // registration seeds it. A missing cache row is treated the same way — unknown
-                // transition types can't justify dropping a crossing.
-                Event.GeofenceTransition.EXIT -> if (
-                    !store.claimExit(geofenceId) &&
-                    store.hasContainmentRecord() &&
-                    cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
-                ) {
-                    // GMS reports EXIT for a fence it never reported as entered — an artifact of its
-                    // own state reconciliation, not a crossing. Delivering it fires EXIT-triggered
-                    // campaigns at people who were never there.
-                    logger.logExitDroppedNeverEntered(geofenceId)
-                    return@forEach
-                }
+            // Serialized across broadcasts: each runs on its own scope, so two transitions for the
+            // same fence would otherwise interleave read-decide-persist and lose a containment record.
+            transitionMutex.withLock {
+                handleBusinessTransition(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    timestamp = timestamp,
+                    androidComponent = androidComponent,
+                    logger = logger
+                )
             }
-
-            // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
-            // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
-            val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
-            // Geofencing is identified-only: the backend rejects anonymous geofence tracks, so an
-            // anonymous transition has no deliverable path. Drop it before spending a cooldown slot
-            // or persisting a row neither channel could ever send.
-            if (userId == null) {
-                logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
-                return@forEach
-            }
-
-            transitionEmitter.emit(
-                geofenceId = geofenceId,
-                transition = transition,
-                userId = userId,
-                timestampSeconds = timestamp,
-                geofenceName = cachedRegion?.name,
-                metadata = cachedRegion?.metadata ?: emptyMap(),
-                geosetIds = cachedRegion?.geosetIds ?: emptyList()
-            )
         }
 
         // Hold the goAsync window open until the refresh lands so the OS doesn't kill a
@@ -189,6 +155,63 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
+    private suspend fun handleBusinessTransition(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        timestamp: Long,
+        androidComponent: AndroidSDKComponent,
+        logger: GeofenceLogger
+    ) {
+        // Containment bookkeeping runs before the identity checks below: being inside a fence is
+        // a physical fact, independent of whether the transition is deliverable.
+        val store = androidComponent.geofenceRegionStore
+        val cachedRegion = store.getCachedRegion(geofenceId)
+        when (transition) {
+            Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
+            // claimExit runs first either way so the record is consumed atomically; the checks
+            // after it only decide whether an unmatched EXIT is trusted.
+            //
+            // Two cases where an absent record proves nothing, so the EXIT is delivered:
+            // a region registered without ENTER monitoring can never produce one to record, and
+            // an install upgraded from an SDK without the set has no data until the first
+            // registration seeds it. A missing cache row is treated the same way — unknown
+            // transition types can't justify dropping a crossing.
+            Event.GeofenceTransition.EXIT -> if (
+                !store.claimExit(geofenceId) &&
+                store.hasContainmentRecord() &&
+                cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
+            ) {
+                // GMS reports EXIT for a fence it never reported as entered — an artifact of its
+                // own state reconciliation, not a crossing. Delivering it fires EXIT-triggered
+                // campaigns at people who were never there.
+                logger.logExitDroppedNeverEntered(geofenceId)
+                return
+            }
+        }
+
+        // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
+        // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
+        val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+        // Geofencing is identified-only: the backend rejects anonymous geofence tracks, so an
+        // anonymous transition has no deliverable path. Drop it before spending a cooldown slot
+        // or persisting a row neither channel could ever send.
+        if (userId == null) {
+            logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
+            return
+        }
+
+        androidComponent.geofenceTransitionEmitter.emit(
+            geofenceId = geofenceId,
+            transition = transition,
+            userId = userId,
+            timestampSeconds = timestamp,
+            geofenceName = cachedRegion?.name,
+            metadata = cachedRegion?.metadata ?: emptyMap(),
+            geosetIds = cachedRegion?.geosetIds ?: emptyList(),
+            monitorsExit = cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.EXIT) == true
+        )
+    }
+
     private fun transitionName(gmsTransitionType: Int): String = when (gmsTransitionType) {
         Geofence.GEOFENCE_TRANSITION_ENTER -> "ENTER"
         Geofence.GEOFENCE_TRANSITION_EXIT -> "EXIT"
@@ -200,5 +223,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         // goAsync grants ~10s before the OS considers the receiver blocked; total budget for
         // one dispatch (persistence + GMS awaits + movement-refresh wait), with headroom.
         private const val DISPATCH_WAIT_BUDGET_MS = 8_000L
+
+        // Process-wide: a receiver instance lives for one broadcast, so the lock has to outlive it.
+        private val transitionMutex = Mutex()
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -60,6 +60,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logExitDroppedNeverEntered(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' EXIT: dropped — no record of the device being inside, so the OS is reconciling its own state", tag = TAG)
+    }
+
     fun logTransitionDroppedAnonymous(geofenceId: String, transitionName: String) {
         logger.debug("Geofence '$geofenceId' $transitionName: dropped — no identified user (geofencing is identified-only)", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -60,6 +60,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logEnterDroppedAlreadyReported(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' ENTER: dropped — already reported as entered and no exit since, so the OS is re-reporting a state we already sent", tag = TAG)
+    }
+
     fun logExitDroppedNeverEntered(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' EXIT: dropped — no record of the device being inside, so the OS is reconciling its own state", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -96,6 +96,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence sync skipped ($reason): no location available", tag = TAG)
     }
 
+    fun logSyncSkippedInvalidLocation(reason: String, latitude: Double, longitude: Double) {
+        logger.error("Geofence sync skipped ($reason): OS reported an unusable fix ($latitude, $longitude)", tag = TAG)
+    }
+
     fun logSyncSkippedNoPermission(reason: String) {
         logger.debug("Geofence sync skipped ($reason): location permissions not granted", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -86,8 +86,7 @@ internal class GeofenceRepositoryImpl(
             }
 
             val config = store.getCachedConfigOrFallback()
-            // Captured with the coordinates, before any network or GMS await: an exit claimed while
-            // this sync is in flight must beat the geometry derived from this fix.
+            // Captured with the coordinates: an exit claimed mid-sync must beat this fix's geometry.
             val containmentEpoch = store.containmentEpoch()
             // Decided under stateMutex so a concurrent sign-out reset can't wipe state right
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -401,6 +401,11 @@ internal class GeofenceRepositoryImpl(
             // override here (unlike the registration diff): callers disable synthesis outright
             // while the reboot flag is up — the anchor can predate the reboot.
             val unchangedRegistered = unchangedRegisteredIds(nearest)
+            // Registered before this pass but not cache-equal: the ID survived a geometry edit.
+            val previouslyRegistered = store.getRegisteredIds()
+            val reRegisteredIds = nearest.map { it.id }
+                .filter { it in previouslyRegistered && it !in unchangedRegistered }
+                .toSet()
             val registrationResult = register(regionsToRegister).also { result ->
                 if (result.isSuccess) {
                     // Stale cleanup — Manager added new−existing, we remove
@@ -423,16 +428,22 @@ internal class GeofenceRepositoryImpl(
                     // Seed containment from our own geometry: synthesis is suppressed after a
                     // reboot or app update, and without a record the later genuine EXIT looks
                     // unentered and gets dropped.
+                    val insideIds = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
+                        .map { it.id }
+                        .toSet()
+                    // A moved circle keeps its ID, so containment and the reported-ENTER mark can
+                    // describe where the fence used to be. Reset both, but only once the new geometry
+                    // agrees the device is out, or trimming a radius manufactures a second arrival.
+                    val movedAwayIds = reRegisteredIds - insideIds
                     store.reconcileEnteredIds(
                         registeredIds = idsToSave,
-                        inside = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
-                            .map { it.id }
-                            .toSet(),
+                        inside = insideIds,
                         // Registration awaited GMS, so an EXIT since this fix is newer evidence.
-                        sinceEpoch = containmentEpoch
+                        sinceEpoch = containmentEpoch,
+                        resetIds = movedAwayIds
                     )
                     // Same snapshot: a dropped fence never reports the EXIT that would re-arm it.
-                    store.pruneEmittedEnterIds(idsToSave)
+                    store.pruneEmittedEnterIds(idsToSave - movedAwayIds)
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -411,6 +411,16 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // Seed containment from our own geometry rather than waiting on a GMS ENTER:
+                    // synthesis is suppressed after a reboot or app update, so no ENTER is emitted
+                    // for a fence the device is already sitting inside, and its later genuine EXIT
+                    // would otherwise look unentered and be dropped.
+                    store.reconcileEnteredIds(
+                        registeredIds = idsToSave,
+                        inside = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
+                            .map { it.id }
+                            .toSet()
+                    )
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -453,7 +453,7 @@ internal class GeofenceRepositoryImpl(
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {
-                    emitInitialEnters(nearest, unchangedRegistered, userId)
+                    emitInitialEnters(nearest, unchangedRegistered, userId, latitude, longitude)
                 } else {
                     logger.logSyncSkipped("user changed during refresh — initial-enter synthesis skipped")
                 }
@@ -469,21 +469,25 @@ internal class GeofenceRepositoryImpl(
      * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
      * collapse to one event.
      *
-     * Containment is read back from the store, not recomputed: reconcile has already applied this
-     * fix's geometry and any departure reported since, so a second pass could synthesize an ENTER
-     * for a fence we were just told we left.
+     * Requires the stored containment record and this fix's geometry to agree — reconcile carries a
+     * record forward for a still-registered fence, so it can outlive the visit.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
         unchangedRegisteredIds: Set<String>,
-        userId: String
+        userId: String,
+        latitude: Double,
+        longitude: Double
     ) {
         val timestamp = clock.currentTimeSeconds()
         val contained = store.getEnteredIds()
         candidates.forEach { region ->
             val newlyRegistered = region.id !in unchangedRegisteredIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
-            if (!newlyRegistered || !monitorsEnter || region.id !in contained) return@forEach
+            // Both: a carried-forward record can outlive the visit, and geometry alone ignores an
+            // EXIT reported while GMS was awaited.
+            val insideNow = region.distanceTo(latitude, longitude) <= region.radius
+            if (!newlyRegistered || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
             logger.logInitialEnterInside(region.id)
             transitionEmitter.emit(
                 geofenceId = region.id,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -482,7 +482,8 @@ internal class GeofenceRepositoryImpl(
                 timestampSeconds = timestamp,
                 geofenceName = region.name,
                 metadata = region.metadata,
-                geosetIds = region.geosetIds
+                geosetIds = region.geosetIds,
+                monitorsExit = GeofenceTransitionType.EXIT in region.transitionTypes
             )
         }
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -421,21 +421,18 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Seed containment from our own geometry rather than waiting on a GMS ENTER:
-                    // synthesis is suppressed after a reboot or app update, so no ENTER is emitted
-                    // for a fence the device is already sitting inside, and its later genuine EXIT
-                    // would otherwise look unentered and be dropped.
+                    // Seed containment from our own geometry: synthesis is suppressed after a
+                    // reboot or app update, and without a record the later genuine EXIT looks
+                    // unentered and gets dropped.
                     store.reconcileEnteredIds(
                         registeredIds = idsToSave,
                         inside = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
                             .map { it.id }
                             .toSet(),
-                        // Registration awaited GMS, so an EXIT can have landed since this fix: that
-                        // report is newer evidence than the geometry and must not be undone here.
+                        // Registration awaited GMS, so an EXIT since this fix is newer evidence.
                         sinceEpoch = containmentEpoch
                     )
-                    // Same snapshot: a fence dropped from the monitored set never reports the EXIT
-                    // that would re-arm it, so its mark must go with its registration.
+                    // Same snapshot: a dropped fence never reports the EXIT that would re-arm it.
                     store.pruneEmittedEnterIds(idsToSave)
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
@@ -473,10 +470,9 @@ internal class GeofenceRepositoryImpl(
      * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
      * collapse to one event.
      *
-     * Containment is read back from the store rather than recomputed here. The reconcile above has
-     * already applied this fix's geometry *and* any departure the OS reported since it was taken, so
-     * a second geometry pass could synthesize an ENTER for a fence we have just been told we left —
-     * whose genuine EXIT the phantom guard would then drop, leaving the ENTER unbalanced.
+     * Containment is read back from the store, not recomputed: reconcile has already applied this
+     * fix's geometry and any departure reported since, so a second pass could synthesize an ENTER
+     * for a fence we were just told we left.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -457,7 +457,7 @@ internal class GeofenceRepositoryImpl(
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {
-                    emitInitialEnters(nearest, unchangedRegistered, userId, latitude, longitude)
+                    emitInitialEnters(nearest, unchangedRegistered, userId)
                 } else {
                     logger.logSyncSkipped("user changed during refresh — initial-enter synthesis skipped")
                 }
@@ -472,21 +472,23 @@ internal class GeofenceRepositoryImpl(
      * "New" = not in [unchangedRegisteredIds]: brand-new fences and re-added param changes fire,
      * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
      * collapse to one event.
+     *
+     * Containment is read back from the store rather than recomputed here. The reconcile above has
+     * already applied this fix's geometry *and* any departure the OS reported since it was taken, so
+     * a second geometry pass could synthesize an ENTER for a fence we have just been told we left —
+     * whose genuine EXIT the phantom guard would then drop, leaving the ENTER unbalanced.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
         unchangedRegisteredIds: Set<String>,
-        userId: String,
-        latitude: Double,
-        longitude: Double
+        userId: String
     ) {
         val timestamp = clock.currentTimeSeconds()
+        val contained = store.getEnteredIds()
         candidates.forEach { region ->
             val newlyRegistered = region.id !in unchangedRegisteredIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
-            // Compare against the full radius: GMS has no per-region monitored-radius cap.
-            val inside = region.distanceTo(latitude, longitude) <= region.radius
-            if (!newlyRegistered || !monitorsEnter || !inside) return@forEach
+            if (!newlyRegistered || !monitorsEnter || region.id !in contained) return@forEach
             logger.logInitialEnterInside(region.id)
             transitionEmitter.emit(
                 geofenceId = region.id,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -435,15 +435,17 @@ internal class GeofenceRepositoryImpl(
                     // describe where the fence used to be. Reset both, but only once the new geometry
                     // agrees the device is out, or trimming a radius manufactures a second arrival.
                     val movedAwayIds = reRegisteredIds - insideIds
-                    store.reconcileEnteredIds(
+                    val resetApplied = store.reconcileEnteredIds(
                         registeredIds = idsToSave,
                         inside = insideIds,
-                        // Registration awaited GMS, so an EXIT since this fix is newer evidence.
+                        // Registration awaited GMS, so a transition since this fix is newer evidence.
                         sinceEpoch = containmentEpoch,
                         resetIds = movedAwayIds
                     )
-                    // Same snapshot: a dropped fence never reports the EXIT that would re-arm it.
-                    store.pruneEmittedEnterIds(idsToSave - movedAwayIds)
+                    // What the store actually reset, not what we asked it to: an arrival reported
+                    // during the await keeps its record, and the mark that record was reported with.
+                    // A fence dropped from the set never reports the EXIT that would re-arm it.
+                    store.pruneEmittedEnterIds(idsToSave - resetApplied)
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -86,6 +86,9 @@ internal class GeofenceRepositoryImpl(
             }
 
             val config = store.getCachedConfigOrFallback()
+            // Captured with the coordinates, before any network or GMS await: an exit claimed while
+            // this sync is in flight must beat the geometry derived from this fix.
+            val containmentEpoch = store.containmentEpoch()
             // Decided under stateMutex so a concurrent sign-out reset can't wipe state right
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
@@ -95,8 +98,8 @@ internal class GeofenceRepositoryImpl(
             // this pass (mirrors restoreFromCache). Drops once registration re-stamps.
             val emitInitialEnter = !osStateWiped()
             return when (action) {
-                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, emitInitialEnter)
-                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, emitInitialEnter = emitInitialEnter)
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, containmentEpoch, emitInitialEnter)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, emitInitialEnter = emitInitialEnter)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
@@ -189,6 +192,7 @@ internal class GeofenceRepositoryImpl(
 
             val anchor = store.getLastApiFetchLocation()
             val config = store.getCachedConfigOrFallback()
+            val containmentEpoch = store.containmentEpoch()
             val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
             // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
             // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
@@ -197,16 +201,16 @@ internal class GeofenceRepositoryImpl(
             // Initial-enter synthesis stays on here (unlike refresh): containment is judged against
             // the OS's live triggering fix, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
-                val remote = performRemoteRefresh(userId, latitude, longitude)
+                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch)
                 if (remote.isFailure) {
                     // The trigger already fired, and a failed pass never re-centres it — leaving it
                     // where the device just exited, so nothing can fire again. Re-rank to re-arm it.
                     logger.logMovementRearmedAfterFailedRefresh()
-                    performLocalRefresh(userId, latitude, longitude, config)
+                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
                 }
                 remote
             } else {
-                performLocalRefresh(userId, latitude, longitude, config)
+                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
             }
         } finally {
             refreshInProgress.set(false)
@@ -243,6 +247,7 @@ internal class GeofenceRepositoryImpl(
             latitude = effectiveLocation.latitude,
             longitude = effectiveLocation.longitude,
             cachedConfig = cachedConfig,
+            containmentEpoch = store.containmentEpoch(),
             register = manager::replaceGeofencesForBootRestore,
             // No initial-enter on boot restore: the cached anchor may be stale if the device moved
             // while off, so containment can't be trusted.
@@ -255,6 +260,7 @@ internal class GeofenceRepositoryImpl(
         userId: String,
         latitude: Double,
         longitude: Double,
+        containmentEpoch: Long,
         emitInitialEnter: Boolean = true
     ): Result<Unit> {
         // The device location lets the backend return the nearby set; the request carries no user
@@ -280,6 +286,7 @@ internal class GeofenceRepositoryImpl(
                     longitude = longitude,
                     regions = regions,
                     config = config,
+                    containmentEpoch = containmentEpoch,
                     emitInitialEnter = emitInitialEnter,
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
@@ -305,6 +312,7 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig,
+        containmentEpoch: Long,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
         emitInitialEnter: Boolean = true
     ): Result<Unit> = registerNearestAndPersist(
@@ -313,6 +321,7 @@ internal class GeofenceRepositoryImpl(
         longitude = longitude,
         regions = store.getCachedRegions(),
         config = cachedConfig,
+        containmentEpoch = containmentEpoch,
         register = register,
         emitInitialEnter = emitInitialEnter
     )
@@ -358,6 +367,7 @@ internal class GeofenceRepositoryImpl(
         longitude: Double,
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
+        containmentEpoch: Long,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
         onRegistered: () -> Unit = {},
         emitInitialEnter: Boolean = true
@@ -419,7 +429,10 @@ internal class GeofenceRepositoryImpl(
                         registeredIds = idsToSave,
                         inside = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
                             .map { it.id }
-                            .toSet()
+                            .toSet(),
+                        // Registration awaited GMS, so an EXIT can have landed since this fix: that
+                        // report is newer evidence than the geometry and must not be undone here.
+                        sinceEpoch = containmentEpoch
                     )
                     // Same snapshot: a fence dropped from the monitored set never reports the EXIT
                     // that would re-arm it, so its mark must go with its registration.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -421,6 +421,9 @@ internal class GeofenceRepositoryImpl(
                             .map { it.id }
                             .toSet()
                     )
+                    // Same snapshot: a fence dropped from the monitored set never reports the EXIT
+                    // that would re-arm it, so its mark must go with its registration.
+                    store.pruneEmittedEnterIds(idsToSave)
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -187,9 +187,8 @@ internal class GeofenceServicesImpl(
             logger.logSyncSkippedNoLocation(reason)
             return null
         }
-        // NaN, infinite or out-of-range coordinates make `Location.distanceBetween` throw, which the
-        // ranking and containment maths would hit part-way through the sync. Rearm as for a missing
-        // fix so the next usable one drives a sync.
+        // NaN, infinite and out-of-range coordinates all make `Location.distanceBetween` throw,
+        // part way through the sync. Rearm as for a missing fix.
         if (!LocationCoordinates.isValid(latitude, longitude)) {
             lastSkippedForNoLocation.set(true)
             logger.logSyncSkippedInvalidLocation(reason, latitude, longitude)
@@ -214,9 +213,8 @@ internal class GeofenceServicesImpl(
     }
 
     /**
-     * Backstop for work launched on [scope]. It carries a `SupervisorJob` and no exception handler,
-     * so an exception escaping here would otherwise reach the thread's default handler and take the
-     * host app down — a geofence sync must never be able to do that. Fatal [Error]s propagate.
+     * Backstop for work launched on [scope], which has no exception handler — anything escaping would
+     * reach the thread's default handler and take the host app down. Fatal [Error]s propagate.
      */
     private suspend fun runSafely(description: String, block: suspend () -> Unit) {
         try {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -2,8 +2,10 @@ package io.customer.geofence
 
 import android.annotation.SuppressLint
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.location.LocationCoordinates
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -170,7 +172,7 @@ internal class GeofenceServicesImpl(
         regionStore.clearLastMovementTriggerLocation()
         logger.logGeofenceStateResetOnSignOut()
         scope.launch {
-            repository.reset()
+            runSafely("sign-out reset") { repository.reset() }
         }
     }
 
@@ -183,6 +185,14 @@ internal class GeofenceServicesImpl(
         if (latitude == null || longitude == null) {
             lastSkippedForNoLocation.set(true)
             logger.logSyncSkippedNoLocation(reason)
+            return null
+        }
+        // NaN, infinite or out-of-range coordinates make `Location.distanceBetween` throw, which the
+        // ranking and containment maths would hit part-way through the sync. Rearm as for a missing
+        // fix so the next usable one drives a sync.
+        if (!LocationCoordinates.isValid(latitude, longitude)) {
+            lastSkippedForNoLocation.set(true)
+            logger.logSyncSkippedInvalidLocation(reason, latitude, longitude)
             return null
         }
         if (!permissionChecker.hasRequiredLocationPermissions()) {
@@ -198,9 +208,24 @@ internal class GeofenceServicesImpl(
         // permissions are revoked, so no mid-flight revocation to handle.
         @SuppressLint("MissingPermission")
         val syncJob = scope.launch {
-            action(latitude, longitude)
+            runSafely("sync ($reason)") { action(latitude, longitude) }
         }
         return syncJob
+    }
+
+    /**
+     * Backstop for work launched on [scope]. It carries a `SupervisorJob` and no exception handler,
+     * so an exception escaping here would otherwise reach the thread's default handler and take the
+     * host app down — a geofence sync must never be able to do that. Fatal [Error]s propagate.
+     */
+    private suspend fun runSafely(description: String, block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.logSyncFailed("$description threw ${e.javaClass.simpleName}: ${e.message}")
+        }
     }
 
     private companion object {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -1,5 +1,6 @@
 package io.customer.geofence
 
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
@@ -9,17 +10,25 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Cooldown-gated, per-geoset fan-out for one crossing: persist the batch, then schedule delivery.
+ * Gated, per-geoset fan-out for one crossing: persist the batch, then schedule delivery.
  * Shared by the OS broadcast path ([GeofenceBroadcastReceiver]) and the synthesized initial-enter
- * path ([GeofenceRepository]) so both produce identical rows and dedupe via the cooldown filter.
+ * path ([GeofenceRepository]) so both produce identical rows and pass the same gates.
+ *
+ * Two gates, in order: an ENTER already reported and not yet balanced by an EXIT is dropped
+ * outright, then the time-based cooldown dedupes the rest. Both paths share the first gate, which is
+ * why it lives here rather than in the receiver — the synthesized path never touches the receiver.
  */
 internal class GeofenceTransitionEmitter(
     private val cooldownFilter: GeofenceCooldownFilter,
     private val pendingStore: PendingDeliveryStore<PendingGeofenceDelivery>,
     private val scheduler: GeofenceEventScheduler,
+    private val regionStore: GeofenceRegionStore,
     private val logger: GeofenceLogger
 ) {
-    /** @return false when the cooldown suppressed it or the persist failed (cooldown rolled back). */
+    /**
+     * @return false when the ENTER was already reported, the cooldown suppressed it, or the persist
+     * failed (cooldown rolled back).
+     */
     suspend fun emit(
         geofenceId: String,
         transition: Event.GeofenceTransition,
@@ -29,6 +38,14 @@ internal class GeofenceTransitionEmitter(
         metadata: Map<String, JsonElement>,
         geosetIds: List<String>
     ): Boolean {
+        // Every reboot and app update re-registers with INITIAL_TRIGGER_ENTER, so the OS re-reports
+        // ENTER for a fence the device never left. Ahead of the cooldown so the drop doesn't spend
+        // the fence's slot. Read-then-mark isn't atomic — the mark waits for a durable write below —
+        // but tryAcquire is, so two concurrent duplicates still collapse to one.
+        if (transition == Event.GeofenceTransition.ENTER && regionStore.hasEmittedEnter(geofenceId)) {
+            logger.logEnterDroppedAlreadyReported(geofenceId)
+            return false
+        }
         if (!cooldownFilter.tryAcquire(userId, geofenceId, transition)) {
             logger.logTransitionSuppressed(geofenceId, transition.name)
             return false
@@ -60,6 +77,12 @@ internal class GeofenceTransitionEmitter(
             logger.logPersistFailed(geofenceId, transition.name)
             cooldownFilter.release(userId, geofenceId, transition)
             return false
+        }
+        // Only once the rows are durable, so a rolled-back write doesn't leave a fence marked as
+        // reported (which would suppress the retry) or unmarked (which would let a duplicate through).
+        when (transition) {
+            Event.GeofenceTransition.ENTER -> regionStore.markEnterEmitted(geofenceId)
+            Event.GeofenceTransition.EXIT -> regionStore.clearEnterEmitted(geofenceId)
         }
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -36,13 +36,20 @@ internal class GeofenceTransitionEmitter(
         timestampSeconds: Long,
         geofenceName: String?,
         metadata: Map<String, JsonElement>,
-        geosetIds: List<String>
+        geosetIds: List<String>,
+        monitorsExit: Boolean
     ): Boolean {
         // Every reboot and app update re-registers with INITIAL_TRIGGER_ENTER, so the OS re-reports
         // ENTER for a fence the device never left. Ahead of the cooldown so the drop doesn't spend
         // the fence's slot. Read-then-mark isn't atomic — the mark waits for a durable write below —
         // but tryAcquire is, so two concurrent duplicates still collapse to one.
-        if (transition == Event.GeofenceTransition.ENTER && regionStore.hasEmittedEnter(geofenceId)) {
+        //
+        // Only where an EXIT can clear the mark: an enter-only fence never reports one, so the mark
+        // would stand for the life of the registration and swallow every later arrival.
+        val isRedundantEnter = transition == Event.GeofenceTransition.ENTER &&
+            monitorsExit &&
+            regionStore.hasEmittedEnter(userId, geofenceId)
+        if (isRedundantEnter) {
             logger.logEnterDroppedAlreadyReported(geofenceId)
             return false
         }
@@ -80,8 +87,8 @@ internal class GeofenceTransitionEmitter(
         }
         // Only once the rows are durable, so a rolled-back write can't leave a fence marked as
         // reported and suppress its own retry. The EXIT side is cleared in `claimExit`.
-        if (transition == Event.GeofenceTransition.ENTER) {
-            regionStore.markEnterEmitted(geofenceId)
+        if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
+            regionStore.markEnterEmitted(userId, geofenceId)
         }
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -14,9 +14,8 @@ import kotlinx.serialization.json.JsonElement
  * Shared by the OS broadcast path ([GeofenceBroadcastReceiver]) and the synthesized initial-enter
  * path ([GeofenceRepository]) so both produce identical rows and pass the same gates.
  *
- * Two gates, in order: an ENTER already reported and not yet balanced by an EXIT is dropped
- * outright, then the time-based cooldown dedupes the rest. Both paths share the first gate, which is
- * why it lives here rather than in the receiver — the synthesized path never touches the receiver.
+ * Two gates, in order: an ENTER already reported and not yet balanced by an EXIT is dropped, then
+ * the time-based cooldown dedupes the rest. Shared by both paths, which is why they live here.
  */
 internal class GeofenceTransitionEmitter(
     private val cooldownFilter: GeofenceCooldownFilter,
@@ -39,13 +38,10 @@ internal class GeofenceTransitionEmitter(
         geosetIds: List<String>,
         monitorsExit: Boolean
     ): Boolean {
-        // Every reboot and app update re-registers with INITIAL_TRIGGER_ENTER, so the OS re-reports
+        // Reboot and app update both re-register with INITIAL_TRIGGER_ENTER, so the OS re-reports
         // ENTER for a fence the device never left. Ahead of the cooldown so the drop doesn't spend
-        // the fence's slot. Read-then-mark isn't atomic — the mark waits for a durable write below —
-        // but tryAcquire is, so two concurrent duplicates still collapse to one.
-        //
-        // Only where an EXIT can clear the mark: an enter-only fence never reports one, so the mark
-        // would stand for the life of the registration and swallow every later arrival.
+        // the fence's slot, and only where an EXIT can clear the mark — an enter-only fence never
+        // reports one, so the mark would swallow every later arrival.
         val isRedundantEnter = transition == Event.GeofenceTransition.ENTER &&
             monitorsExit &&
             regionStore.hasEmittedEnter(userId, geofenceId)
@@ -85,8 +81,7 @@ internal class GeofenceTransitionEmitter(
             cooldownFilter.release(userId, geofenceId, transition)
             return false
         }
-        // Only once the rows are durable, so a rolled-back write can't leave a fence marked as
-        // reported and suppress its own retry. The EXIT side is cleared in `claimExit`.
+        // Only once the rows are durable, so a rolled-back write can't suppress its own retry.
         if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
             regionStore.markEnterEmitted(userId, geofenceId)
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -78,11 +78,10 @@ internal class GeofenceTransitionEmitter(
             cooldownFilter.release(userId, geofenceId, transition)
             return false
         }
-        // Only once the rows are durable, so a rolled-back write doesn't leave a fence marked as
-        // reported (which would suppress the retry) or unmarked (which would let a duplicate through).
-        when (transition) {
-            Event.GeofenceTransition.ENTER -> regionStore.markEnterEmitted(geofenceId)
-            Event.GeofenceTransition.EXIT -> regionStore.clearEnterEmitted(geofenceId)
+        // Only once the rows are durable, so a rolled-back write can't leave a fence marked as
+        // reported and suppress its own retry. The EXIT side is cleared in `claimExit`.
+        if (transition == Event.GeofenceTransition.ENTER) {
+            regionStore.markEnterEmitted(geofenceId)
         }
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -17,6 +17,7 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.util.HandlerMainThreadPoster
 import io.customer.sdk.core.util.MainThreadPoster
+import io.customer.sdk.data.store.SecureUserStore
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
@@ -170,8 +171,17 @@ class ModuleGeofence @JvmOverloads constructor(
                     regionStore = sdkAndroid.geofenceRegionStore,
                     logger = logger,
                     onForeground = {
-                        if (!refreshOnForeground(sdkAndroid.geofenceServices, locationModule)) {
-                            retrySyncAwaitingLocation(sdkAndroid, locationModule)
+                        // Off the main thread: deciding whether to take a fix needs the identity read,
+                        // a Keystore decrypt that can block for hundreds of ms on some OEMs.
+                        val foregroundScope = SDKComponent.scopeProvider.geofenceScope
+                        foregroundScope.launch {
+                            try {
+                                if (!refreshOnForeground(sdkAndroid.geofenceServices, sdkAndroid.secureUserStore, locationModule)) {
+                                    retrySyncAwaitingLocation(sdkAndroid, locationModule)
+                                }
+                            } finally {
+                                foregroundScope.cancel()
+                            }
                         }
                     }
                 )
@@ -209,14 +219,21 @@ class ModuleGeofence @JvmOverloads constructor(
      * hours, and every other path anchors at the last registration center — where the device used to
      * be — so nothing else notices it has moved.
      *
-     * Returns false when no fix was taken and [retrySyncAwaitingLocation] handles the entry instead:
-     * MANUAL leaves fixes to the host, and a sync already stuck without one has its own recovery.
+     * Returns false when no fix was taken: MANUAL leaves fixes to the host, nobody is identified to
+     * sync for, or a sync is already stuck without one and [retrySyncAwaitingLocation] owns that case.
      */
     @VisibleForTesting
     @OptIn(InternalCustomerIOApi::class)
-    internal fun refreshOnForeground(services: GeofenceServices, locationModule: ModuleLocation): Boolean {
+    internal fun refreshOnForeground(
+        services: GeofenceServices,
+        secureUserStore: SecureUserStore,
+        locationModule: ModuleLocation
+    ): Boolean {
         if (moduleConfig.locationMode != GeofenceLocationMode.AUTOMATIC) return false
         if (services.isAwaitingLocation()) return false
+        // The sync drops a fix that arrives with nobody identified, so taking one before the first
+        // identify — or on every resume after sign-out — spends location and battery on nothing.
+        if (secureUserStore.getUserId().isNullOrEmpty()) return false
         // Arm before requesting, so the returning fix drives the sync.
         services.onRefreshRequested()
         locationModule.locationServices.requestLocationUpdateSilently()

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -169,7 +169,11 @@ class ModuleGeofence @JvmOverloads constructor(
                     eventBus = eventBus,
                     regionStore = sdkAndroid.geofenceRegionStore,
                     logger = logger,
-                    onForeground = { retrySyncAwaitingLocation(sdkAndroid, locationModule) }
+                    onForeground = {
+                        if (!refreshOnForeground(sdkAndroid.geofenceServices, locationModule)) {
+                            retrySyncAwaitingLocation(sdkAndroid, locationModule)
+                        }
+                    }
                 )
             )
 
@@ -198,6 +202,25 @@ class ModuleGeofence @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Refreshes discovery from a live fix on foreground entry: OS geofence callbacks can stop for
+     * hours, and every other path anchors at the last registration center — where the device used to
+     * be — so nothing else notices it has moved.
+     *
+     * Returns false when no fix was taken and [retrySyncAwaitingLocation] handles the entry instead:
+     * MANUAL leaves fixes to the host, and a sync already stuck without one has its own recovery.
+     */
+    @VisibleForTesting
+    @OptIn(InternalCustomerIOApi::class)
+    internal fun refreshOnForeground(services: GeofenceServices, locationModule: ModuleLocation): Boolean {
+        if (moduleConfig.locationMode != GeofenceLocationMode.AUTOMATIC) return false
+        if (services.isAwaitingLocation()) return false
+        // Arm before requesting, so the returning fix drives the sync.
+        services.onRefreshRequested()
+        locationModule.locationServices.requestLocationUpdateSilently()
+        return true
     }
 
     /**

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -100,6 +100,7 @@ internal val AndroidSDKComponent.geofenceTransitionEmitter: GeofenceTransitionEm
             cooldownFilter = geofenceCooldownFilter,
             pendingStore = pendingGeofenceDeliveryStore,
             scheduler = geofenceEventScheduler,
+            regionStore = geofenceRegionStore,
             logger = SDKComponent.geofenceLogger
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -79,14 +79,28 @@ internal interface GeofenceRegionStore {
     fun claimExit(geofenceId: String): Boolean
 
     /**
+     * Counter of claimed exits, read before a sync computes its geometry and handed back to
+     * [reconcileEnteredIds] so a departure reported while that sync was in flight wins over it.
+     *
+     * In-memory: it only has to order two live coroutines, and a process that dies mid-sync never
+     * reaches the reconcile.
+     */
+    fun containmentEpoch(): Long
+
+    /**
      * Prunes the entered set to [registeredIds] and unions in [inside], the fences our own geometry
      * puts the device within at registration time.
      *
      * Union rather than replace: [inside] may be computed from the persisted anchor rather than a
      * live fix, and a stale anchor that wrongly reports "outside" must not erase real containment —
      * that would swallow a genuine EXIT.
+     *
+     * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from. A fence whose exit
+     * was claimed after that is dropped from [inside]: registration awaits GMS for seconds, and
+     * re-seeding from the older fix would resurrect containment the OS has since told us to drop —
+     * leaving the device recorded inside a fence it left, which disarms the EXIT guard for it.
      */
-    fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>)
+    fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>, sinceEpoch: Long)
 
     /**
      * Whether containment has ever been recorded, i.e. whether the entered set carries data at all.
@@ -206,11 +220,22 @@ internal class GeofenceRegionStoreImpl(
         // Same step: deferring this to a successful persist strands the mark on a write failure or
         // anonymous drop, and a stranded mark silences the next genuine arrival.
         clearEnterEmitted(geofenceId)
+        // Only a consumed record counts. A claim that found nothing is a suspected GMS artifact, and
+        // letting it block the geometry seed would leave the fence with no containment at all.
+        exitEpoch += 1
+        exitEpochByGeofenceId[geofenceId] = exitEpoch
         true
     }
 
-    override fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>) = synchronized(enteredLock) {
-        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + inside)
+    override fun containmentEpoch(): Long = synchronized(enteredLock) { exitEpoch }
+
+    override fun reconcileEnteredIds(
+        registeredIds: Set<String>,
+        inside: Set<String>,
+        sinceEpoch: Long
+    ) = synchronized(enteredLock) {
+        val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + stillInside)
     }
 
     override fun hasEmittedEnter(userId: String, geofenceId: String): Boolean = synchronized(enteredLock) {
@@ -354,6 +379,12 @@ internal class GeofenceRegionStoreImpl(
     }
 
     private val enteredLock = Any()
+
+    // Guarded by [enteredLock]. Bumped per claimed exit; the per-fence value is the epoch at which
+    // that fence's exit was last claimed. Bounded by the registered set in practice, and process
+    // lifetime is the only scope that matters — see [containmentEpoch].
+    private var exitEpoch = 0L
+    private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
 
     private companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -74,7 +74,7 @@ internal interface GeofenceRegionStore {
      */
     fun claimExit(geofenceId: String): Boolean
 
-    /** Claimed-exit counter, read before a sync computes its geometry and passed to [reconcileEnteredIds]. */
+    /** Reported-transition counter, read before a sync computes its geometry and passed to [reconcileEnteredIds]. */
     fun containmentEpoch(): Long
 
     /**
@@ -87,14 +87,19 @@ internal interface GeofenceRegionStore {
      * over the older geometry.
      *
      * [resetIds] have their carried record dropped rather than pruned and kept, for fences the caller
-     * knows the stored containment no longer describes; [inside] still re-adds them.
+     * knows the stored containment no longer describes; [inside] still re-adds them. A fence that
+     * reported an entry after [sinceEpoch] keeps its record — the OS placing the device inside
+     * outranks the caller's older geometry.
+     *
+     * Returns the [resetIds] whose record was actually dropped, so a caller resetting related state
+     * can act on the same decision instead of its own guess.
      */
     fun reconcileEnteredIds(
         registeredIds: Set<String>,
         inside: Set<String>,
         sinceEpoch: Long,
         resetIds: Set<String> = emptySet()
-    )
+    ): Set<String>
 
     /**
      * Whether containment has ever been recorded. False on an install upgraded from a version that
@@ -194,6 +199,10 @@ internal class GeofenceRegionStoreImpl(
         if (geofenceId !in current) {
             writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current + geofenceId)
         }
+        // Stamped even when the id is already recorded: a repeat report still says the OS puts the
+        // device inside now, which a sync holding an older fix has to defer to.
+        epoch += 1
+        enterEpochByGeofenceId[geofenceId] = epoch
     }
 
     override fun claimExit(geofenceId: String): Boolean = synchronized(enteredLock) {
@@ -204,26 +213,29 @@ internal class GeofenceRegionStoreImpl(
         clearEnterEmitted(geofenceId)
         // Only a consumed record bumps the epoch; a claim that found nothing is a suspected GMS
         // artifact and must not block the geometry seed.
-        exitEpoch += 1
-        exitEpochByGeofenceId[geofenceId] = exitEpoch
+        epoch += 1
+        exitEpochByGeofenceId[geofenceId] = epoch
         true
     }
 
-    override fun containmentEpoch(): Long = synchronized(enteredLock) { exitEpoch }
+    override fun containmentEpoch(): Long = synchronized(enteredLock) { epoch }
 
     override fun reconcileEnteredIds(
         registeredIds: Set<String>,
         inside: Set<String>,
         sinceEpoch: Long,
         resetIds: Set<String>
-    ) {
-        synchronized(enteredLock) {
-            val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
-            val carried = (getEnteredIds() intersect registeredIds) - resetIds
-            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
-            // Bound the map, after the filter has read it.
-            exitEpochByGeofenceId.keys.retainAll(registeredIds)
-        }
+    ): Set<String> = synchronized(enteredLock) {
+        val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
+        // An entry reported since the caller's fix describes the geometry being registered now, so
+        // it survives a reset aimed at the geometry it replaced.
+        val dropped = resetIds.filter { (enterEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }.toSet() - stillInside
+        val carried = (getEnteredIds() intersect registeredIds) - dropped
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
+        // Bound the maps, after the filters have read them.
+        exitEpochByGeofenceId.keys.retainAll(registeredIds)
+        enterEpochByGeofenceId.keys.retainAll(registeredIds)
+        dropped
     }
 
     override fun hasEmittedEnter(userId: String, geofenceId: String): Boolean = synchronized(enteredLock) {
@@ -365,10 +377,12 @@ internal class GeofenceRegionStoreImpl(
 
     private val enteredLock = Any()
 
-    // Guarded by [enteredLock]. Bumped per claimed exit; the per-fence value is the epoch at which
-    // that fence's exit was last claimed.
-    private var exitEpoch = 0L
+    // Guarded by [enteredLock]. Bumped per reported transition, so a sync can tell which of the two
+    // directions a fence reported most recently against the fix the sync is holding. Per-fence
+    // values are the epoch at which that fence last reported in that direction.
+    private var epoch = 0L
     private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
+    private val enterEpochByGeofenceId = mutableMapOf<String, Long>()
 
     private companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -27,9 +27,7 @@ import kotlinx.serialization.builtins.serializer
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
  *   enteredIds                  — fences the device is inside; goes with the registrations it
  *                                  describes, since sign-out drops those from the OS.
- *   emittedEnterIds             — fences we have reported entered, plus the userId they belong to;
- *                                  the next user must not inherit a suppressed ENTER for a fence
- *                                  they were never told about.
+ *   emittedEnterIds             — fences reported entered, plus the userId they belong to.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
@@ -68,62 +66,45 @@ internal interface GeofenceRegionStore {
     fun recordEntered(geofenceId: String)
 
     /**
-     * Atomically drops [geofenceId] from the entered set, returning whether it was there. On `true`
-     * the reported-ENTER mark is dropped in the same step — see [hasEmittedEnter].
+     * Atomically drops [geofenceId] from the entered set, returning whether it was there, and on
+     * `true` drops the reported-ENTER mark in the same step.
      *
-     * `false` means we have no record of the device ever being inside, so the EXIT is a GMS
-     * reconciliation artifact rather than a crossing: GMS can mark a fence INSIDE while evaluating
-     * a registration against a coarse fix, emit no initial ENTER, then report EXIT once an accurate
-     * fix arrives — observed on a fence the device was never within 500m of.
+     * `false` means no record of the device ever being inside, so the EXIT is a GMS reconciliation
+     * artifact rather than a crossing.
      */
     fun claimExit(geofenceId: String): Boolean
 
     /**
      * Counter of claimed exits, read before a sync computes its geometry and handed back to
-     * [reconcileEnteredIds] so a departure reported while that sync was in flight wins over it.
-     *
-     * In-memory: it only has to order two live coroutines, and a process that dies mid-sync never
-     * reaches the reconcile.
+     * [reconcileEnteredIds]. In-memory: it only has to order two live coroutines.
      */
     fun containmentEpoch(): Long
 
     /**
      * Prunes the entered set to [registeredIds] and unions in [inside], the fences our own geometry
-     * puts the device within at registration time.
+     * puts the device within at registration time. Union rather than replace, because [inside] may
+     * come from a stale anchor whose "outside" must not erase real containment.
      *
-     * Union rather than replace: [inside] may be computed from the persisted anchor rather than a
-     * live fix, and a stale anchor that wrongly reports "outside" must not erase real containment —
-     * that would swallow a genuine EXIT.
-     *
-     * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from. A fence whose exit
-     * was claimed after that is dropped from [inside]: registration awaits GMS for seconds, and
-     * re-seeding from the older fix would resurrect containment the OS has since told us to drop —
-     * leaving the device recorded inside a fence it left, which disarms the EXIT guard for it.
+     * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from; a fence whose exit
+     * was claimed after that is dropped, so a departure reported during the sync's GMS await wins
+     * over the older geometry.
      */
     fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>, sinceEpoch: Long)
 
     /**
-     * Whether containment has ever been recorded, i.e. whether the entered set carries data at all.
-     *
-     * False on an install upgraded from an SDK version that predates the set, until the first
-     * registration seeds it. The EXIT guard defers while this is false: an empty set and "no data
-     * yet" are indistinguishable from [getEnteredIds] alone, and treating the second as the first
-     * would drop a genuine EXIT for a fence entered before the upgrade.
+     * Whether containment has ever been recorded. False on an install upgraded from a version that
+     * predates the set, until the first registration seeds it — the EXIT guard defers while it is,
+     * since "empty" and "no data yet" are otherwise indistinguishable.
      */
     fun hasContainmentRecord(): Boolean
 
     /**
-     * Fences we have reported an ENTER for and not yet reported an EXIT for — i.e. what the backend
-     * currently believes. Deliberately distinct from [getEnteredIds]: that one tracks where the
-     * device *is* (seeded from our own geometry on every sync), this one tracks what we have *said*.
+     * Fences reported entered with no EXIT reported since — what the backend currently believes.
+     * Distinct from [getEnteredIds], which tracks where the device *is*: a sync seeds containment
+     * 20-46ms before the OS reports the matching ENTER, so one set would swallow real crossings.
      *
-     * Conflating them would swallow real crossings, because a sync seeds containment moments before
-     * the OS reports the matching ENTER — measured at 20-46ms on a Pixel 6.
-     *
-     * Scoped to [userId], since a direct A-to-B identify publishes no `ResetEvent`: without scoping,
-     * B would inherit A's marks for every fence that stayed registered and lose their first arrival.
-     *
-     * Set by [markEnterEmitted] once an ENTER is durably persisted, cleared by [claimExit].
+     * Scoped to [userId] because a direct A-to-B identify publishes no `ResetEvent`. Set by
+     * [markEnterEmitted], cleared by [claimExit].
      */
     fun hasEmittedEnter(userId: String, geofenceId: String): Boolean
 
@@ -131,12 +112,9 @@ internal interface GeofenceRegionStore {
     fun markEnterEmitted(userId: String, geofenceId: String)
 
     /**
-     * Drops reported-ENTER marks for fences no longer in [registeredIds], so the set can't outlive
-     * the monitoring that would clear it.
-     *
-     * A fence dropped from the monitored set while the device is still inside never reports its
-     * EXIT, so without this its mark would stand indefinitely and swallow the ENTER of a genuine
-     * revisit months later. Pruned to the same registration snapshot as [reconcileEnteredIds].
+     * Drops reported-ENTER marks for fences no longer in [registeredIds]. A fence dropped while the
+     * device is inside never reports the EXIT that would clear its mark, which would then swallow a
+     * genuine revisit.
      */
     fun pruneEmittedEnterIds(registeredIds: Set<String>)
 
@@ -204,8 +182,8 @@ internal class GeofenceRegionStoreImpl(
 
     override fun hasContainmentRecord(): Boolean = prefs.read { contains(KEY_ENTERED_IDS) } ?: false
 
-    // The three mutators share a lock because each is a read-modify-write, and transitions arrive
-    // on the receiver's coroutine while registration runs on the sync path.
+    // The mutators share a lock: each is a read-modify-write, and transitions arrive on the
+    // receiver's coroutine while registration runs on the sync path.
     override fun recordEntered(geofenceId: String) = synchronized(enteredLock) {
         val current = getEnteredIds()
         if (geofenceId !in current) {
@@ -217,11 +195,10 @@ internal class GeofenceRegionStoreImpl(
         val current = getEnteredIds()
         if (geofenceId !in current) return@synchronized false
         writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current - geofenceId)
-        // Same step: deferring this to a successful persist strands the mark on a write failure or
-        // anonymous drop, and a stranded mark silences the next genuine arrival.
+        // Same step: a mark stranded by a later failure would silence the next genuine arrival.
         clearEnterEmitted(geofenceId)
-        // Only a consumed record counts. A claim that found nothing is a suspected GMS artifact, and
-        // letting it block the geometry seed would leave the fence with no containment at all.
+        // Only a consumed record bumps the epoch; a claim that found nothing is a suspected GMS
+        // artifact and must not block the geometry seed.
         exitEpoch += 1
         exitEpochByGeofenceId[geofenceId] = exitEpoch
         true
@@ -237,9 +214,7 @@ internal class GeofenceRegionStoreImpl(
         synchronized(enteredLock) {
             val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
             writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + stillInside)
-            // Bound the map to what is monitored, after the filter has read it. An unregistered fence
-            // can't reach `inside` again until it is re-registered, by which point the old claim is
-            // older than any sync that could seed it.
+            // Bound the map, after the filter has read it.
             exitEpochByGeofenceId.keys.retainAll(registeredIds)
         }
     }
@@ -249,11 +224,8 @@ internal class GeofenceRegionStoreImpl(
         geofenceId in readEmittedEnterIds()
     }
 
-    // Shares [enteredLock] with the entered set: both are read-modify-write on the same prefs file,
-    // and one transition touches both.
     override fun markEnterEmitted(userId: String, geofenceId: String) = synchronized(enteredLock) {
-        // The set belongs to one identity at a time, so a different owner makes it stale: replace it
-        // rather than add to it.
+        // One identity owns the set at a time, so a different owner makes it stale — replace, not add.
         val sameOwner = readEmittedEnterOwner() == userId
         val current = if (sameOwner) readEmittedEnterIds() else emptySet()
         if (!sameOwner) {
@@ -387,8 +359,7 @@ internal class GeofenceRegionStoreImpl(
     private val enteredLock = Any()
 
     // Guarded by [enteredLock]. Bumped per claimed exit; the per-fence value is the epoch at which
-    // that fence's exit was last claimed. Trimmed to the registered set on every reconcile, and
-    // process lifetime is the only scope that matters — see [containmentEpoch].
+    // that fence's exit was last claimed.
     private var exitEpoch = 0L
     private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
 

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -85,8 +85,16 @@ internal interface GeofenceRegionStore {
      * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from; a fence whose exit
      * was claimed after that is dropped, so a departure reported during the sync's GMS await wins
      * over the older geometry.
+     *
+     * [resetIds] have their carried record dropped rather than pruned and kept, for fences the caller
+     * knows the stored containment no longer describes; [inside] still re-adds them.
      */
-    fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>, sinceEpoch: Long)
+    fun reconcileEnteredIds(
+        registeredIds: Set<String>,
+        inside: Set<String>,
+        sinceEpoch: Long,
+        resetIds: Set<String> = emptySet()
+    )
 
     /**
      * Whether containment has ever been recorded. False on an install upgraded from a version that
@@ -206,11 +214,13 @@ internal class GeofenceRegionStoreImpl(
     override fun reconcileEnteredIds(
         registeredIds: Set<String>,
         inside: Set<String>,
-        sinceEpoch: Long
+        sinceEpoch: Long,
+        resetIds: Set<String>
     ) {
         synchronized(enteredLock) {
             val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
-            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + stillInside)
+            val carried = (getEnteredIds() intersect registeredIds) - resetIds
+            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
             // Bound the map, after the filter has read it.
             exitEpochByGeofenceId.keys.retainAll(registeredIds)
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -27,6 +27,8 @@ import kotlinx.serialization.builtins.serializer
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
  *   enteredIds                  — fences the device is inside; goes with the registrations it
  *                                  describes, since sign-out drops those from the OS.
+ *   emittedEnterIds             — fences we have reported entered; the next user must not inherit
+ *                                  a suppressed ENTER for a fence they were never told about.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
@@ -93,6 +95,32 @@ internal interface GeofenceRegionStore {
      * would drop a genuine EXIT for a fence entered before the upgrade.
      */
     fun hasContainmentRecord(): Boolean
+
+    /**
+     * Fences we have reported an ENTER for and not yet reported an EXIT for — i.e. what the backend
+     * currently believes. Deliberately distinct from [getEnteredIds]: that one tracks where the
+     * device *is* (seeded from our own geometry on every sync), this one tracks what we have *said*.
+     *
+     * Conflating them would swallow real crossings, because a sync seeds containment moments before
+     * the OS reports the matching ENTER — measured at 20-46ms on a Pixel 6.
+     */
+    fun hasEmittedEnter(geofenceId: String): Boolean
+
+    /** Records that an ENTER for [geofenceId] reached the delivery pipeline. Idempotent. */
+    fun markEnterEmitted(geofenceId: String)
+
+    /** Records that an EXIT for [geofenceId] reached the delivery pipeline, re-arming its ENTER. */
+    fun clearEnterEmitted(geofenceId: String)
+
+    /**
+     * Drops reported-ENTER marks for fences no longer in [registeredIds], so the set can't outlive
+     * the monitoring that would clear it.
+     *
+     * A fence dropped from the monitored set while the device is still inside never reports its
+     * EXIT, so without this its mark would stand indefinitely and swallow the ENTER of a genuine
+     * revisit months later. Pruned to the same registration snapshot as [reconcileEnteredIds].
+     */
+    fun pruneEmittedEnterIds(registeredIds: Set<String>)
 
     /** Device uptime at the last successful OS registration; null if never registered. Drives reboot detection. */
     fun getLastRegistrationUptime(): Long?
@@ -178,6 +206,33 @@ internal class GeofenceRegionStoreImpl(
         writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + inside)
     }
 
+    override fun hasEmittedEnter(geofenceId: String): Boolean =
+        geofenceId in (readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet())
+
+    // Shares [enteredLock] with the entered set: both are read-modify-write on the same prefs file,
+    // and one transition touches both.
+    override fun markEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
+        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+        if (geofenceId !in current) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current + geofenceId)
+        }
+    }
+
+    override fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
+        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+        if (geofenceId in current) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current - geofenceId)
+        }
+    }
+
+    override fun pruneEmittedEnterIds(registeredIds: Set<String>) = synchronized(enteredLock) {
+        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+        val retained = current intersect registeredIds
+        if (retained.size != current.size) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, retained)
+        }
+    }
+
     override fun getLastRegistrationUptime(): Long? = prefs.read {
         if (contains(KEY_LAST_REGISTRATION_UPTIME)) getLong(KEY_LAST_REGISTRATION_UPTIME, 0L) else null
     }
@@ -230,6 +285,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
             remove(KEY_ENTERED_IDS)
+            remove(KEY_EMITTED_ENTER_IDS)
             remove(KEY_LAST_REGISTRATION_UPTIME)
             remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
@@ -282,6 +338,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_CACHED_REGIONS = "cached_regions"
         const val KEY_REGISTERED_IDS = "registered_ids"
         const val KEY_ENTERED_IDS = "entered_ids"
+        const val KEY_EMITTED_ENTER_IDS = "emitted_enter_ids"
         const val KEY_CACHED_CONFIG = "cached_config"
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -27,8 +27,9 @@ import kotlinx.serialization.builtins.serializer
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
  *   enteredIds                  — fences the device is inside; goes with the registrations it
  *                                  describes, since sign-out drops those from the OS.
- *   emittedEnterIds             — fences we have reported entered; the next user must not inherit
- *                                  a suppressed ENTER for a fence they were never told about.
+ *   emittedEnterIds             — fences we have reported entered, plus the userId they belong to;
+ *                                  the next user must not inherit a suppressed ENTER for a fence
+ *                                  they were never told about.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
@@ -105,12 +106,15 @@ internal interface GeofenceRegionStore {
      * Conflating them would swallow real crossings, because a sync seeds containment moments before
      * the OS reports the matching ENTER — measured at 20-46ms on a Pixel 6.
      *
+     * Scoped to [userId], since a direct A-to-B identify publishes no `ResetEvent`: without scoping,
+     * B would inherit A's marks for every fence that stayed registered and lose their first arrival.
+     *
      * Set by [markEnterEmitted] once an ENTER is durably persisted, cleared by [claimExit].
      */
-    fun hasEmittedEnter(geofenceId: String): Boolean
+    fun hasEmittedEnter(userId: String, geofenceId: String): Boolean
 
-    /** Records that an ENTER for [geofenceId] reached the delivery pipeline. Idempotent. */
-    fun markEnterEmitted(geofenceId: String)
+    /** Records that an ENTER for [geofenceId] reached the delivery pipeline for [userId]. Idempotent. */
+    fun markEnterEmitted(userId: String, geofenceId: String)
 
     /**
      * Drops reported-ENTER marks for fences no longer in [registeredIds], so the set can't outlive
@@ -209,27 +213,40 @@ internal class GeofenceRegionStoreImpl(
         writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + inside)
     }
 
-    override fun hasEmittedEnter(geofenceId: String): Boolean =
-        geofenceId in (readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet())
+    override fun hasEmittedEnter(userId: String, geofenceId: String): Boolean = synchronized(enteredLock) {
+        if (readEmittedEnterOwner() != userId) return@synchronized false
+        geofenceId in readEmittedEnterIds()
+    }
 
     // Shares [enteredLock] with the entered set: both are read-modify-write on the same prefs file,
     // and one transition touches both.
-    override fun markEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
-        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+    override fun markEnterEmitted(userId: String, geofenceId: String) = synchronized(enteredLock) {
+        // The set belongs to one identity at a time, so a different owner makes it stale: replace it
+        // rather than add to it.
+        val sameOwner = readEmittedEnterOwner() == userId
+        val current = if (sameOwner) readEmittedEnterIds() else emptySet()
+        if (!sameOwner) {
+            prefs.edit { putString(KEY_EMITTED_ENTER_OWNER, userId) }
+        }
         if (geofenceId !in current) {
             writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current + geofenceId)
         }
     }
 
+    private fun readEmittedEnterIds(): Set<String> =
+        readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+
+    private fun readEmittedEnterOwner(): String? = prefs.read { getString(KEY_EMITTED_ENTER_OWNER, null) }
+
     private fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
-        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+        val current = readEmittedEnterIds()
         if (geofenceId in current) {
             writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current - geofenceId)
         }
     }
 
     override fun pruneEmittedEnterIds(registeredIds: Set<String>) = synchronized(enteredLock) {
-        val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+        val current = readEmittedEnterIds()
         val retained = current intersect registeredIds
         if (retained.size != current.size) {
             writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, retained)
@@ -289,6 +306,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_REGISTERED_IDS)
             remove(KEY_ENTERED_IDS)
             remove(KEY_EMITTED_ENTER_IDS)
+            remove(KEY_EMITTED_ENTER_OWNER)
             remove(KEY_LAST_REGISTRATION_UPTIME)
             remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
@@ -342,6 +360,7 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_REGISTERED_IDS = "registered_ids"
         const val KEY_ENTERED_IDS = "entered_ids"
         const val KEY_EMITTED_ENTER_IDS = "emitted_enter_ids"
+        const val KEY_EMITTED_ENTER_OWNER = "emitted_enter_owner"
         const val KEY_CACHED_CONFIG = "cached_config"
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -233,9 +233,15 @@ internal class GeofenceRegionStoreImpl(
         registeredIds: Set<String>,
         inside: Set<String>,
         sinceEpoch: Long
-    ) = synchronized(enteredLock) {
-        val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
-        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + stillInside)
+    ) {
+        synchronized(enteredLock) {
+            val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
+            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + stillInside)
+            // Bound the map to what is monitored, after the filter has read it. An unregistered fence
+            // can't reach `inside` again until it is re-registered, by which point the old claim is
+            // older than any sync that could seed it.
+            exitEpochByGeofenceId.keys.retainAll(registeredIds)
+        }
     }
 
     override fun hasEmittedEnter(userId: String, geofenceId: String): Boolean = synchronized(enteredLock) {
@@ -381,8 +387,8 @@ internal class GeofenceRegionStoreImpl(
     private val enteredLock = Any()
 
     // Guarded by [enteredLock]. Bumped per claimed exit; the per-fence value is the epoch at which
-    // that fence's exit was last claimed. Bounded by the registered set in practice, and process
-    // lifetime is the only scope that matters — see [containmentEpoch].
+    // that fence's exit was last claimed. Trimmed to the registered set on every reconcile, and
+    // process lifetime is the only scope that matters — see [containmentEpoch].
     private var exitEpoch = 0L
     private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
 

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -67,7 +67,8 @@ internal interface GeofenceRegionStore {
     fun recordEntered(geofenceId: String)
 
     /**
-     * Atomically drops [geofenceId] from the entered set, returning whether it was there.
+     * Atomically drops [geofenceId] from the entered set, returning whether it was there. On `true`
+     * the reported-ENTER mark is dropped in the same step — see [hasEmittedEnter].
      *
      * `false` means we have no record of the device ever being inside, so the EXIT is a GMS
      * reconciliation artifact rather than a crossing: GMS can mark a fence INSIDE while evaluating
@@ -103,14 +104,13 @@ internal interface GeofenceRegionStore {
      *
      * Conflating them would swallow real crossings, because a sync seeds containment moments before
      * the OS reports the matching ENTER — measured at 20-46ms on a Pixel 6.
+     *
+     * Set by [markEnterEmitted] once an ENTER is durably persisted, cleared by [claimExit].
      */
     fun hasEmittedEnter(geofenceId: String): Boolean
 
     /** Records that an ENTER for [geofenceId] reached the delivery pipeline. Idempotent. */
     fun markEnterEmitted(geofenceId: String)
-
-    /** Records that an EXIT for [geofenceId] reached the delivery pipeline, re-arming its ENTER. */
-    fun clearEnterEmitted(geofenceId: String)
 
     /**
      * Drops reported-ENTER marks for fences no longer in [registeredIds], so the set can't outlive
@@ -199,6 +199,9 @@ internal class GeofenceRegionStoreImpl(
         val current = getEnteredIds()
         if (geofenceId !in current) return@synchronized false
         writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current - geofenceId)
+        // Same step: deferring this to a successful persist strands the mark on a write failure or
+        // anonymous drop, and a stranded mark silences the next genuine arrival.
+        clearEnterEmitted(geofenceId)
         true
     }
 
@@ -218,7 +221,7 @@ internal class GeofenceRegionStoreImpl(
         }
     }
 
-    override fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
+    private fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
         val current = readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
         if (geofenceId in current) {
             writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current - geofenceId)

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -25,6 +25,8 @@ import kotlinx.serialization.builtins.serializer
  *
  * Cleared on sign-out:
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
+ *   enteredIds                  — fences the device is inside; goes with the registrations it
+ *                                  describes, since sign-out drops those from the OS.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
@@ -55,6 +57,42 @@ internal interface GeofenceRegionStore {
 
     fun saveRegisteredIds(ids: Set<String>)
     fun getRegisteredIds(): Set<String>
+
+    /** Fences the device is known to be inside. Drives the EXIT guard — see [claimExit]. */
+    fun getEnteredIds(): Set<String>
+
+    /** Records that the device is inside [geofenceId]. Idempotent. */
+    fun recordEntered(geofenceId: String)
+
+    /**
+     * Atomically drops [geofenceId] from the entered set, returning whether it was there.
+     *
+     * `false` means we have no record of the device ever being inside, so the EXIT is a GMS
+     * reconciliation artifact rather than a crossing: GMS can mark a fence INSIDE while evaluating
+     * a registration against a coarse fix, emit no initial ENTER, then report EXIT once an accurate
+     * fix arrives — observed on a fence the device was never within 500m of.
+     */
+    fun claimExit(geofenceId: String): Boolean
+
+    /**
+     * Prunes the entered set to [registeredIds] and unions in [inside], the fences our own geometry
+     * puts the device within at registration time.
+     *
+     * Union rather than replace: [inside] may be computed from the persisted anchor rather than a
+     * live fix, and a stale anchor that wrongly reports "outside" must not erase real containment —
+     * that would swallow a genuine EXIT.
+     */
+    fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>)
+
+    /**
+     * Whether containment has ever been recorded, i.e. whether the entered set carries data at all.
+     *
+     * False on an install upgraded from an SDK version that predates the set, until the first
+     * registration seeds it. The EXIT guard defers while this is false: an empty set and "no data
+     * yet" are indistinguishable from [getEnteredIds] alone, and treating the second as the first
+     * would drop a genuine EXIT for a fence entered before the upgrade.
+     */
+    fun hasContainmentRecord(): Boolean
 
     /** Device uptime at the last successful OS registration; null if never registered. Drives reboot detection. */
     fun getLastRegistrationUptime(): Long?
@@ -115,6 +153,31 @@ internal class GeofenceRegionStoreImpl(
     override fun getRegisteredIds(): Set<String> =
         readJson(KEY_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
 
+    override fun getEnteredIds(): Set<String> =
+        readJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
+
+    override fun hasContainmentRecord(): Boolean = prefs.read { contains(KEY_ENTERED_IDS) } ?: false
+
+    // The three mutators share a lock because each is a read-modify-write, and transitions arrive
+    // on the receiver's coroutine while registration runs on the sync path.
+    override fun recordEntered(geofenceId: String) = synchronized(enteredLock) {
+        val current = getEnteredIds()
+        if (geofenceId !in current) {
+            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current + geofenceId)
+        }
+    }
+
+    override fun claimExit(geofenceId: String): Boolean = synchronized(enteredLock) {
+        val current = getEnteredIds()
+        if (geofenceId !in current) return@synchronized false
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current - geofenceId)
+        true
+    }
+
+    override fun reconcileEnteredIds(registeredIds: Set<String>, inside: Set<String>) = synchronized(enteredLock) {
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, (getEnteredIds() intersect registeredIds) + inside)
+    }
+
     override fun getLastRegistrationUptime(): Long? = prefs.read {
         if (contains(KEY_LAST_REGISTRATION_UPTIME)) getLong(KEY_LAST_REGISTRATION_UPTIME, 0L) else null
     }
@@ -166,6 +229,7 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_API_FETCH_LOCATION)
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
+            remove(KEY_ENTERED_IDS)
             remove(KEY_LAST_REGISTRATION_UPTIME)
             remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
@@ -212,9 +276,12 @@ internal class GeofenceRegionStoreImpl(
         }
     }
 
+    private val enteredLock = Any()
+
     private companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"
         const val KEY_REGISTERED_IDS = "registered_ids"
+        const val KEY_ENTERED_IDS = "entered_ids"
         const val KEY_CACHED_CONFIG = "cached_config"
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -26,7 +26,7 @@ import kotlinx.serialization.builtins.serializer
  * Cleared on sign-out:
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
  *   enteredIds                  — fences the device is inside; goes with the registrations it
- *                                  describes, since sign-out drops those from the OS.
+ *                                  describes.
  *   emittedEnterIds             — fences reported entered, plus the userId they belong to.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
@@ -74,10 +74,7 @@ internal interface GeofenceRegionStore {
      */
     fun claimExit(geofenceId: String): Boolean
 
-    /**
-     * Counter of claimed exits, read before a sync computes its geometry and handed back to
-     * [reconcileEnteredIds]. In-memory: it only has to order two live coroutines.
-     */
+    /** Claimed-exit counter, read before a sync computes its geometry and passed to [reconcileEnteredIds]. */
     fun containmentEpoch(): Long
 
     /**

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -684,6 +685,81 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenReportedEnterForFenceMonitoringExit_expectDropped() = runTest {
+        every { mockStore.hasEmittedEnter("user-42", "biz-geofence-2") } returns true
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenReportedEnterForEnterOnlyFence_expectDelivered() = runTest {
+        // An enter-only fence never reports an EXIT, so nothing would ever clear its mark. Honouring
+        // the guard here would suppress every arrival after the first for the life of the
+        // registration — the mirror of the exit-only exemption above.
+        every { mockStore.hasEmittedEnter("user-42", "biz-geofence-2") } returns true
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns GeofenceRegion(
+            id = "biz-geofence-2",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f,
+            transitionTypes = listOf(GeofenceTransitionType.ENTER)
+        )
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenConcurrentBroadcastsForSameFence_expectBookkeepingSerialized() = runTest {
+        // Each broadcast is handled on its own scope, so without the lock an ENTER and an EXIT for
+        // the same fence interleave their read-decide-persist: the ENTER reads the mark the EXIT is
+        // about to clear and is dropped, then the EXIT drops containment, leaving the device inside
+        // with no record and its next EXIT dropped too.
+        val inFlight = AtomicInteger()
+        val peakInFlight = AtomicInteger()
+        coEvery { mockScheduler.schedule(any()) } coAnswers {
+            val depth = inFlight.incrementAndGet()
+            peakInFlight.updateAndGet { peak -> maxOf(peak, depth) }
+            delay(100)
+            inFlight.decrementAndGet()
+        }
+
+        val enter = launch {
+            receiver.dispatchTransition(
+                gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+                triggeringGeofenceIds = listOf("biz-1"),
+                latitude = 0.0,
+                longitude = 0.0
+            )
+        }
+        val exit = launch {
+            receiver.dispatchTransition(
+                gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+                triggeringGeofenceIds = listOf("biz-1"),
+                latitude = 0.0,
+                longitude = 0.0
+            )
+        }
+        enter.join()
+        exit.join()
+
+        peakInFlight.get() shouldBeEqualTo 1
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -102,6 +102,15 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             "biz-geofence-1",
             "biz-geofence-2"
         )
+        // Default: the device counts as inside every fence, so the EXIT guard is a no-op.
+        // Tests for the guard override.
+        every { mockStore.claimExit(any()) } returns true
+        // Default: containment has been recorded, i.e. not a freshly-upgraded install.
+        every { mockStore.hasContainmentRecord() } returns true
+        // Default: fences monitor both transitions, so the EXIT guard applies. Exit-only fences and
+        // uncached ids are exempt from it and have their own tests.
+        every { mockStore.getCachedRegion(any()) } returns
+            GeofenceRegion("biz-geofence-2", 0.0, 0.0, 100f)
         pendingStore.removeAll()
         receiver = GeofenceBroadcastReceiver()
     }
@@ -598,6 +607,128 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // Both transitions were appended before their schedule attempt.
         pendingStore.loadAll().map { it.geofenceId } shouldBeEqualTo listOf("biz-1", "biz-2")
         coVerify { mockScheduler.schedule(match { it.geofenceId == "biz-2" }) }
+    }
+
+    @Test
+    fun dispatchTransition_givenExitForFenceNeverEntered_expectDroppedAndOsRegistrationKept() = runTest {
+        // GMS reports EXIT for a fence it never reported as entered — its own state
+        // reconciliation, not a crossing. Unlike an orphan ID the registration is still
+        // wanted, so it must NOT be removed from the OS.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
+        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitForExitOnlyFence_expectDeliveredNotDropped() = runTest {
+        // An exit-only fence is registered without ENTER monitoring, so the OS can never report an
+        // ENTER for the guard to record. Applying the guard would drop every one of its EXITs.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns GeofenceRegion(
+            id = "biz-geofence-2",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f,
+            transitionTypes = listOf(GeofenceTransitionType.EXIT)
+        )
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitForUncachedFence_expectDeliveredNotDropped() = runTest {
+        // No cache row means unknown transition types, which can't justify dropping a crossing.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns null
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitOnUpgradedInstall_expectDeliveredNotDropped() = runTest {
+        // Upgrade path: the install predates the entered set, so there is no containment data to
+        // judge against until the first registration seeds it. A fence entered before the upgrade
+        // must still report its EXIT.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.hasContainmentRecord() } returns false
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenEnterTransition_expectContainmentRecorded() = runTest {
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        // Recording the ENTER is what lets the matching EXIT through later.
+        verify { mockStore.recordEntered("biz-geofence-2") }
+    }
+
+    @Test
+    fun dispatchTransition_givenAnonymousEnter_expectContainmentStillRecorded() = runTest {
+        // Containment is physical, so it is tracked even when the event isn't deliverable —
+        // otherwise identifying between a crossing's ENTER and EXIT would lose the EXIT.
+        every { mockSecureUserStore.getUserId() } returns null
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        verify { mockStore.recordEntered("biz-geofence-2") }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenMovementTriggerExit_expectGuardNotApplied() = runTest {
+        // The movement trigger is internal plumbing and is never "entered", so running it
+        // through the guard would permanently stall movement-driven refreshes.
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        verify(exactly = 0) { mockStore.claimExit(any()) }
+        verify { mockServices.onMovementTriggerExit(any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1639,6 +1639,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet() // newly registered
         every { store.getCachedConfig() } returns sampleConfig()
+        // Reconcile seeded containment from this fix's geometry; synthesis follows that, not a
+        // second geometry pass.
+        every { store.getEnteredIds() } returns setOf("biz-1")
         every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
@@ -1670,6 +1673,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getEnteredIds() } returns setOf("biz-1")
         every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
@@ -1687,6 +1691,27 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 monitorsExit = false
             )
         }
+    }
+
+    @Test
+    fun refresh_givenExitClaimedWhileRegistering_expectNoSynthesizedEnter() = runTest {
+        // The device left during the GMS await, so reconcile did not seed the fence. Synthesizing
+        // from this fix's geometry anyway would send an ENTER for a fence we were just told we left,
+        // and the phantom guard would drop its genuine EXIT — an ENTER the backend never balances.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet() // newly registered
+        every { store.getCachedConfig() } returns sampleConfig()
+        // Geometry from the fix says inside; containment says otherwise because the exit was claimed.
+        every { store.getEnteredIds() } returns emptySet()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1770,6 +1795,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
         every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
         coEvery { apiService.fetchGeofences(any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -585,6 +586,25 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         // Nothing is monitored, so claiming containment would let a later phantom EXIT through.
         verify(exactly = 0) { store.reconcileEnteredIds(any(), any()) }
+        verify(exactly = 0) { store.pruneEmittedEnterIds(any()) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationSucceeds_expectEmittedEnterPrunedToRegisteredSet() = runTest {
+        // The reported-ENTER marks must be pruned to the same snapshot the registrations are, or a
+        // fence evicted while the device is inside keeps a mark no EXIT will ever clear.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        val pruned = slot<Set<String>>()
+        verify { store.pruneEmittedEnterIds(capture(pruned)) }
+        pruned.captured shouldContain "biz-inside"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -547,6 +547,47 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenRegistrationSucceeds_expectContainmentSeededFromGeometryNotFromEnterEvents() = runTest {
+        // Initial-ENTER synthesis is suppressed after a reboot/app update, so no ENTER is emitted
+        // for a fence the device is already inside. Without seeding containment here, that fence's
+        // later genuine EXIT would look unentered and be dropped by the guard.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        val inside = GeofenceRegion("biz-inside", 0.0, 0.0, 500f)
+        val outside = GeofenceRegion("biz-outside", 1.0, 1.0, 100f)
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(inside, outside)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        result.isSuccess shouldBeEqualTo true
+        // Only the fence whose radius actually contains the device is seeded; the far one is not,
+        // so a phantom EXIT for it is still dropped.
+        verify {
+            store.reconcileEnteredIds(
+                registeredIds = any(),
+                inside = setOf("biz-inside")
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenRegistrationFails_expectContainmentNotSeeded() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(IOException("gms down"))
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Nothing is monitored, so claiming containment would let a later phantom EXIT through.
+        verify(exactly = 0) { store.reconcileEnteredIds(any(), any()) }
+    }
+
+    @Test
     fun refresh_givenBusinessGeofences_expectMovementTriggerPrependedAndRegistered() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1818,6 +1818,39 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenStaleContainmentRecordAndDeviceOutside_expectNoInitialEnter() = runTest {
+        // reconcile carries containment forward for fences that stay registered, so a param-drift
+        // re-add can find a record that outlived the visit. Geometry has to agree before we
+        // synthesize, or we report an arrival somewhere the device left long ago.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1") // stale: carried forward, not current
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // ~1.1 km north of g-1, far outside its 100 m radius.
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        coVerify(exactly = 0) {
+            transitionEmitter.emit(
+                geofenceId = "g-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = any(),
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = any()
+            )
+        }
+    }
+
+    @Test
     fun refresh_givenUserChangesDuringRegistration_expectNoInitialEnter() = runTest {
         // clearIdentify rewrites the user store without taking stateMutex, so identity can change
         // while the GMS call is awaited; synthesis must recheck before queueing a delivery row.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1818,6 +1818,51 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenFenceMovedAwayFromDevice_expectContainmentAndMarkReset() = runTest {
+        // g-1's circle moved while the device was recorded inside the old one. GMS promises no EXIT
+        // for a circle it no longer holds, so carrying the record and the reported-ENTER mark forward
+        // would drop the first genuine arrival at the new circle and deliver its EXIT unmatched.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // Device ~1.1 km away: outside the new circle, so the old record cannot be trusted.
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
+        // Mark dropped, so the arrival at the new circle is not mistaken for a repeat.
+        verify { store.pruneEmittedEnterIds(match { "g-1" !in it }) }
+    }
+
+    @Test
+    fun refresh_givenFenceReRegisteredWhileDeviceInside_expectRecordAndMarkKept() = runTest {
+        // Radius grew 50 → 100 m with the device inside throughout. Resetting here would let the
+        // synthesized ENTER fire for a visit already reported.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), emptySet()) }
+        verify { store.pruneEmittedEnterIds(match { "g-1" in it }) }
+    }
+
+    @Test
     fun refresh_givenStaleContainmentRecordAndDeviceOutside_expectNoInitialEnter() = runTest {
         // reconcile carries containment forward for fences that stay registered, so a param-drift
         // re-add can find a record that outlived the visit. Geometry has to agree before we
@@ -1851,6 +1896,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun refresh_givenUserChangesDuringRegistration_expectNoInitialEnter() = runTest {
         // clearIdentify rewrites the user store without taking stateMutex, so identity can change
         // while the GMS call is awaited; synthesis must recheck before queueing a delivery row.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1629,7 +1629,39 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 timestampSeconds = any(),
                 geofenceName = any(),
                 metadata = any(),
-                geosetIds = any()
+                geosetIds = any(),
+                monitorsExit = true
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenNewlyRegisteredEnterOnlyFenceDeviceInside_expectInitialEnterNotLatched() = runTest {
+        // The synthesized ENTER must carry the fence's real monitoring shape: latching an enter-only
+        // fence would suppress every later arrival, since no EXIT can ever release it.
+        val cached = listOf(
+            GeofenceRegion("biz-1", 0.0, 0.0, 100f, transitionTypes = listOf(GeofenceTransitionType.ENTER))
+        )
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = false
             )
         }
     }
@@ -1656,7 +1688,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify { manager.replaceGeofences(any(), emptySet()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1678,7 +1710,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1703,7 +1735,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1730,7 +1762,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 timestampSeconds = any(),
                 geofenceName = any(),
                 metadata = any(),
-                geosetIds = any()
+                geosetIds = any(),
+                monitorsExit = any()
             )
         }
     }
@@ -1758,7 +1791,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         gmsGate.complete(Unit)
         refreshJob.join()
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1779,7 +1812,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // ~2.2 km move → local re-rank runs, and the device is inside biz-1 (radius 300 m at 0.02,0.0).
         repository.refresh(latitude = 0.02, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1797,7 +1830,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1816,7 +1849,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1832,7 +1865,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1852,7 +1885,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.restoreFromCache()
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     private fun sampleConfig(

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -568,9 +568,32 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify {
             store.reconcileEnteredIds(
                 registeredIds = any(),
-                inside = setOf("biz-inside")
+                inside = setOf("biz-inside"),
+                sinceEpoch = any()
             )
         }
+    }
+
+    @Test
+    fun refresh_givenExitClaimedWhileRegistering_expectEpochFromBeforeTheAwait() = runTest {
+        // The seed must be judged against the containment state as of this sync's fix, not as of
+        // whenever GMS finished. Registration awaits GMS for seconds, and an EXIT landing in that
+        // window is newer evidence than the geometry.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.containmentEpoch() } returns 5L
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            // A transition claims an exit mid-registration, advancing the epoch.
+            every { store.containmentEpoch() } returns 7L
+            Result.success(Unit)
+        }
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(registeredIds = any(), inside = any(), sinceEpoch = 5L) }
     }
 
     @Test
@@ -585,7 +608,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         // Nothing is monitored, so claiming containment would let a later phantom EXIT through.
-        verify(exactly = 0) { store.reconcileEnteredIds(any(), any()) }
+        verify(exactly = 0) { store.reconcileEnteredIds(any(), any(), any()) }
         verify(exactly = 0) { store.pruneEmittedEnterIds(any()) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1832,6 +1832,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns setOf("g-1")
 
         // Device ~1.1 km away: outside the new circle, so the old record cannot be trusted.
         repository.refresh(latitude = 0.01, longitude = 0.0)
@@ -1839,6 +1840,30 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
         // Mark dropped, so the arrival at the new circle is not mistaken for a repeat.
         verify { store.pruneEmittedEnterIds(match { "g-1" !in it }) }
+    }
+
+    @Test
+    fun refresh_givenArrivalReportedWhileRegistrationAwaited_expectMarkKeptWithRecord() = runTest {
+        // Same moved circle, but GMS reported an arrival at it while registration was awaited, so the
+        // store keeps the record. The mark has to follow: it belongs to that reported arrival, and
+        // clearing it would let the next report through as a fresh one.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        // Store declines the reset because the arrival is newer than the fix that asked for it.
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns emptySet()
+
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
+        verify { store.pruneEmittedEnterIds(match { "g-1" in it }) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -115,6 +115,57 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun onMovementTriggerExit_givenUnusableFix_expectSkipAndStayArmed() = runTest(StandardTestDispatcher()) {
+        // NaN, infinite and out-of-range coordinates all make Location.distanceBetween throw, part
+        // way through a sync that has no exception handler above it.
+        val services = servicesWith(this)
+
+        val unusable = listOf(
+            Double.NaN to 2.0,
+            1.0 to Double.NaN,
+            Double.POSITIVE_INFINITY to 2.0,
+            91.0 to 2.0,
+            1.0 to 181.0
+        )
+        unusable.forEach { (lat, lng) ->
+            services.onMovementTriggerExit(latitude = lat, longitude = lng).shouldBeNull()
+        }
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
+        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        verify(exactly = unusable.size) { logger.logSyncSkippedInvalidLocation(any(), any(), any()) }
+        // Armed like a missing fix, so the next usable one drives a sync.
+        services.isAwaitingLocation() shouldBeEqualTo true
+    }
+
+    @Test
+    fun onMovementTriggerExit_givenRepositoryThrows_expectLoggedAndNotRethrown() = runTest(StandardTestDispatcher()) {
+        // The services scope carries a SupervisorJob and no exception handler, so anything escaping
+        // here would reach the thread's default handler and take the host app down.
+        coEvery { repository.handleMovement(any(), any()) } throws IllegalStateException("boom")
+        val services = servicesWith(this)
+
+        val job = services.onMovementTriggerExit(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        job.shouldNotBeNull()
+        job.isCancelled shouldBeEqualTo false
+        verify { logger.logSyncFailed(match { it?.contains("IllegalStateException") == true }) }
+    }
+
+    @Test
+    fun onUserSignedOut_givenResetThrows_expectLoggedAndNotRethrown() = runTest(StandardTestDispatcher()) {
+        coEvery { repository.reset() } throws IllegalStateException("boom")
+        val services = servicesWith(this)
+
+        services.onUserSignedOut()
+        advanceUntilIdle()
+
+        verify { logger.logSyncFailed(match { it?.contains("IllegalStateException") == true }) }
+    }
+
+    @Test
     fun onMovementTriggerExit_givenPermissionsNotGranted_expectSkipAndLog() = runTest(StandardTestDispatcher()) {
         every { permissionChecker.hasRequiredLocationPermissions() } returns false
         val services = servicesWith(this)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -124,7 +124,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
-    fun emit_givenExitWhileEnterReported_expectDeliveredAndEnterRearmed() = runTest {
+    fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
         every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
@@ -133,7 +133,6 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
         // The gate is ENTER-only: an EXIT must never be blocked by it.
         emitted.shouldBeTrue()
-        verify(exactly = 1) { mockRegionStore.clearEnterEmitted("biz-1") }
     }
 
     @Test
@@ -158,26 +157,14 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
-    fun emit_givenExitPersistFails_expectEnterStaysReported() = runTest {
+    fun emit_givenExitDelivered_expectMarkNotTouchedHere() = runTest {
         every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
-        every { mockPendingStore.appendAll(any()) } returns false
+        every { mockPendingStore.appendAll(any()) } returns true
 
         emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
 
-        // Clearing on a failed write would let the next ENTER through while the backend still
-        // believes the user is inside.
-        verify(exactly = 0) { mockRegionStore.clearEnterEmitted(any()) }
-    }
-
-    @Test
-    fun emit_givenExitSuppressedByCooldown_expectEnterStaysReported() = runTest {
-        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
-
-        emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
-
-        // A suppressed EXIT was never sent, so the backend's view is unchanged.
-        verify(exactly = 0) { mockRegionStore.clearEnterEmitted(any()) }
+        // Re-arming belongs to `claimExit`, which runs whether or not delivery gets this far.
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any()) }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -1,6 +1,7 @@
 package io.customer.geofence
 
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
@@ -28,10 +29,15 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     private val mockScheduler: GeofenceEventScheduler = mockk(relaxed = true)
     private val mockLogger: GeofenceLogger = mockk(relaxed = true)
 
+    // Relaxed default is `hasEmittedEnter = false`, i.e. nothing reported yet — the state every
+    // pre-existing test assumes.
+    private val mockRegionStore: GeofenceRegionStore = mockk(relaxed = true)
+
     private val emitter = GeofenceTransitionEmitter(
         cooldownFilter = mockCooldownFilter,
         pendingStore = mockPendingStore,
         scheduler = mockScheduler,
+        regionStore = mockRegionStore,
         logger = mockLogger
     )
 
@@ -103,5 +109,75 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         emitted.shouldBeFalse()
         verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenEnterAlreadyReported_expectDroppedWithoutSpendingCooldown() = runTest {
+        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+
+        emitted.shouldBeFalse()
+        // Ahead of the cooldown, so the slot stays free for the next genuine transition.
+        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        verify(exactly = 0) { mockPendingStore.appendAll(any()) }
+    }
+
+    @Test
+    fun emit_givenExitWhileEnterReported_expectDeliveredAndEnterRearmed() = runTest {
+        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
+
+        // The gate is ENTER-only: an EXIT must never be blocked by it.
+        emitted.shouldBeTrue()
+        verify(exactly = 1) { mockRegionStore.clearEnterEmitted("biz-1") }
+    }
+
+    @Test
+    fun emit_givenEnterDelivered_expectMarkedReported() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+
+        verify(exactly = 1) { mockRegionStore.markEnterEmitted("biz-1") }
+    }
+
+    @Test
+    fun emit_givenEnterPersistFails_expectNotMarkedSoRetryCanDeliver() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns false
+
+        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+
+        // Marking a rolled-back write would suppress the retry and lose the crossing entirely.
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any()) }
+    }
+
+    @Test
+    fun emit_givenExitPersistFails_expectEnterStaysReported() = runTest {
+        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns false
+
+        emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
+
+        // Clearing on a failed write would let the next ENTER through while the backend still
+        // believes the user is inside.
+        verify(exactly = 0) { mockRegionStore.clearEnterEmitted(any()) }
+    }
+
+    @Test
+    fun emit_givenExitSuppressedByCooldown_expectEnterStaysReported() = runTest {
+        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
+
+        emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
+
+        // A suppressed EXIT was never sent, so the backend's view is unchanged.
+        verify(exactly = 0) { mockRegionStore.clearEnterEmitted(any()) }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -41,11 +41,30 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         logger = mockLogger
     )
 
+    /** Defaults describe the common case: an ENTER on a fence monitoring both transitions. */
+    private suspend fun emit(
+        geofenceId: String = "biz-1",
+        transition: Event.GeofenceTransition = Event.GeofenceTransition.ENTER,
+        userId: String = "user-1",
+        geofenceName: String? = null,
+        geosetIds: List<String> = emptyList(),
+        monitorsExit: Boolean = true
+    ): Boolean = emitter.emit(
+        geofenceId = geofenceId,
+        transition = transition,
+        userId = userId,
+        timestampSeconds = 100L,
+        geofenceName = geofenceName,
+        metadata = emptyMap(),
+        geosetIds = geosetIds,
+        monitorsExit = monitorsExit
+    )
+
     @Test
     fun emit_givenCooldownSuppresses_expectFalseAndNoPersist() = runTest {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit()
 
         emitted.shouldBeFalse()
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
@@ -58,7 +77,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, "Cafe", emptyMap(), emptyList())
+        val emitted = emit(geofenceName = "Cafe")
 
         emitted.shouldBeTrue()
         verify { mockPendingStore.appendAll(capture(entries)) }
@@ -76,7 +95,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         val entries = slot<List<PendingGeofenceDelivery>>()
 
         // "g1" listed twice → deduped to one entry.
-        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2", "g1"))
+        emit(geosetIds = listOf("g1", "g2", "g1"))
 
         verify { mockPendingStore.appendAll(capture(entries)) }
         entries.captured.map { it.geosetId } shouldBeEqualTo listOf("g1", "g2")
@@ -92,7 +111,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockPendingStore.appendAll(any()) } returns true
         coEvery { mockScheduler.schedule(match { it.geosetId == "g1" }) } throws RuntimeException("boom")
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2"))
+        val emitted = emit(geosetIds = listOf("g1", "g2"))
 
         emitted.shouldBeTrue()
         coVerify(exactly = 1) { mockScheduler.schedule(match { it.geosetId == "g2" }) }
@@ -104,7 +123,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns false
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit()
 
         emitted.shouldBeFalse()
         verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
@@ -113,9 +132,9 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenEnterAlreadyReported_expectDroppedWithoutSpendingCooldown() = runTest {
-        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit()
 
         emitted.shouldBeFalse()
         // Ahead of the cooldown, so the slot stays free for the next genuine transition.
@@ -124,12 +143,35 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
-    fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
-        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+    fun emit_givenEnterOnlyFenceAlreadyReported_expectDelivered() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit(monitorsExit = false)
+
+        // GMS never reports an EXIT for this fence, so nothing would ever clear the mark: honouring
+        // it here would suppress every arrival after the first for the life of the registration.
+        emitted.shouldBeTrue()
+    }
+
+    @Test
+    fun emit_givenEnterOnlyFenceDelivered_expectNoMarkRecorded() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit(monitorsExit = false)
+
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
+    }
+
+    @Test
+    fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        val emitted = emit(transition = Event.GeofenceTransition.EXIT)
 
         // The gate is ENTER-only: an EXIT must never be blocked by it.
         emitted.shouldBeTrue()
@@ -140,9 +182,9 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
-        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        emit()
 
-        verify(exactly = 1) { mockRegionStore.markEnterEmitted("biz-1") }
+        verify(exactly = 1) { mockRegionStore.markEnterEmitted("user-1", "biz-1") }
     }
 
     @Test
@@ -150,21 +192,21 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns false
 
-        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        emit()
 
         // Marking a rolled-back write would suppress the retry and lose the crossing entirely.
-        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any()) }
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
     }
 
     @Test
     fun emit_givenExitDelivered_expectMarkNotTouchedHere() = runTest {
-        every { mockRegionStore.hasEmittedEnter("biz-1") } returns true
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
-        emitter.emit("biz-1", Event.GeofenceTransition.EXIT, "user-1", 100L, null, emptyMap(), emptyList())
+        emit(transition = Event.GeofenceTransition.EXIT)
 
         // Re-arming belongs to `claimExit`, which runs whether or not delivery gets this far.
-        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any()) }
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
@@ -4,6 +4,7 @@ import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.location.LocationCoordinates
 import io.customer.location.LocationServices
 import io.customer.location.ModuleLocation
+import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -18,6 +19,9 @@ class ModuleGeofenceTest {
     private val mockLocationServices: LocationServices = mockk(relaxed = true)
     private val mockLocationModule: ModuleLocation = mockk {
         every { locationServices } returns mockLocationServices
+    }
+    private val identifiedUserStore: SecureUserStore = mockk {
+        every { getUserId() } returns "user-42"
     }
 
     private fun moduleWith(mode: GeofenceLocationMode) =
@@ -50,7 +54,7 @@ class ModuleGeofenceTest {
         val mockServices: GeofenceServices = mockk(relaxed = true)
 
         moduleWith(GeofenceLocationMode.AUTOMATIC)
-            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo true
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo true
 
         // Arming after the request would race the fix and drop it.
         verifyOrder {
@@ -64,7 +68,7 @@ class ModuleGeofenceTest {
         val mockServices: GeofenceServices = mockk(relaxed = true)
 
         moduleWith(GeofenceLocationMode.MANUAL)
-            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo false
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo false
 
         verify(exactly = 0) { mockServices.onRefreshRequested() }
         verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
@@ -77,7 +81,23 @@ class ModuleGeofenceTest {
         }
 
         moduleWith(GeofenceLocationMode.AUTOMATIC)
-            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo false
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenNoIdentifiedUser_expectNoFetchOrArm() {
+        // Resume before the first identify, and every resume after sign-out. The sync discards a fix
+        // that arrives with nobody identified, so requesting one is spent battery.
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+        val signedOutStore: SecureUserStore = mockk {
+            every { getUserId() } returns null
+        }
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, signedOutStore, mockLocationModule) shouldBeEqualTo false
 
         verify(exactly = 0) { mockServices.onRefreshRequested() }
         verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }

--- a/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
@@ -7,6 +7,7 @@ import io.customer.location.ModuleLocation
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.Test
@@ -41,6 +42,44 @@ class ModuleGeofenceTest {
         moduleWith(GeofenceLocationMode.AUTOMATIC)
             .autoAcquireIfNeeded(mockLocationModule, currentLocation = LocationCoordinates(latitude = 1.0, longitude = 2.0))
 
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenAutomatic_expectArmedAndSilentFetch() {
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo true
+
+        // Arming after the request would race the fix and drop it.
+        verifyOrder {
+            mockServices.onRefreshRequested()
+            mockLocationServices.requestLocationUpdateSilently()
+        }
+    }
+
+    @Test
+    fun refreshOnForeground_givenManual_expectNoFetchOrArm() {
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+
+        moduleWith(GeofenceLocationMode.MANUAL)
+            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenSyncAlreadyAwaitingLocation_expectDeferredToStuckSyncPath() {
+        val mockServices: GeofenceServices = mockk(relaxed = true) {
+            every { isAwaitingLocation() } returns true
+        }
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
         verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -148,11 +148,78 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         store.reconcileEnteredIds(
             registeredIds = setOf("biz-kept", "biz-new-inside"),
-            inside = setOf("biz-new-inside")
+            inside = setOf("biz-new-inside"),
+            sinceEpoch = store.containmentEpoch()
         )
 
         // "biz-unregistered" pruned, "biz-kept" survives because it is still registered.
         store.getEnteredIds() shouldContainSame setOf("biz-kept", "biz-new-inside")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenExitClaimedAfterFixWasTaken_expectFenceNotReSeeded() {
+        store.recordEntered("biz-1")
+        // A sync captures the epoch with its fix, then awaits GMS for seconds.
+        val epochAtFix = store.containmentEpoch()
+
+        // Mid-flight the OS reports the departure and the receiver consumes the record.
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // The sync now writes back geometry from the older fix, which still contained the fence.
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        // Resurrecting it would leave the device recorded inside a fence it left, disarming the EXIT
+        // guard for that fence until its next departure.
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenExitClaimedBeforeFixWasTaken_expectFenceSeeded() {
+        // Same fence, opposite order: the departure is already history when the fix is taken, so the
+        // geometry is the newer evidence — e.g. the device drove back in while the process was dead.
+        store.recordEntered("biz-1")
+        store.claimExit("biz-1").shouldBeTrue()
+        val epochAtFix = store.containmentEpoch()
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenUnclaimedExitForSameFence_expectStillSeeded() {
+        // A claim that found no record is a suspected GMS artifact, not a departure. Letting it block
+        // the seed would leave the fence with no containment at all, so its next genuine EXIT would
+        // be dropped as never-entered — the failure the seed exists to prevent.
+        val epochAtFix = store.containmentEpoch()
+
+        store.claimExit("biz-1").shouldBeFalse()
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun containmentEpoch_givenClaimedExit_expectAdvanced() {
+        store.recordEntered("biz-1")
+        val before = store.containmentEpoch()
+
+        store.claimExit("biz-1")
+
+        (store.containmentEpoch() > before).shouldBeTrue()
     }
 
     @Test
@@ -166,7 +233,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     fun hasContainmentRecord_givenReconcileWithNothingInside_expectTrue() {
         // The first registration seeds the key even when the device is inside nothing, which is what
         // ends the upgrade grace period.
-        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet())
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
 
         store.hasContainmentRecord().shouldBeTrue()
         store.getEnteredIds().shouldBeEmpty()
@@ -178,7 +245,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // anchor wrongly says "outside", erasing containment would swallow the genuine EXIT.
         store.recordEntered("biz-1")
 
-        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet())
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
 
         store.getEnteredIds() shouldContainSame setOf("biz-1")
     }
@@ -275,7 +342,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         store.getEnteredIds().shouldBeEmpty()
 
-        store.reconcileEnteredIds(registeredIds = setOf("biz-2"), inside = setOf("biz-2"))
+        store.reconcileEnteredIds(registeredIds = setOf("biz-2"), inside = setOf("biz-2"), sinceEpoch = store.containmentEpoch())
 
         store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
         store.hasEmittedEnter(USER, "biz-2").shouldBeFalse()

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -142,6 +142,36 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun reconcileEnteredIds_givenReRegisteredFenceDeviceNoLongerInside_expectRecordDropped() {
+        // The circle moved but kept its ID, so the old record describes somewhere else.
+        store.recordEntered("biz-moved")
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-moved"),
+            inside = emptySet(),
+            sinceEpoch = store.containmentEpoch(),
+            resetIds = setOf("biz-moved")
+        )
+
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenReRegisteredFenceStillInside_expectRecordKept() {
+        // A radius edit made while the device is inside must not manufacture a fresh arrival.
+        store.recordEntered("biz-widened")
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-widened"),
+            inside = setOf("biz-widened"),
+            sinceEpoch = store.containmentEpoch(),
+            resetIds = setOf("biz-widened")
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-widened")
+    }
+
+    @Test
     fun reconcileEnteredIds_expectPrunedToRegisteredAndUnionedWithInside() {
         store.recordEntered("biz-kept")
         store.recordEntered("biz-unregistered")

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -13,7 +13,9 @@ import io.customer.geofence.GeofenceTransitionType
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
@@ -113,6 +115,72 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRegisteredIds(emptySet())
 
         store.getRegisteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun claimExit_givenNeverEntered_expectFalse() {
+        // The phantom-EXIT guard: no containment record means GMS is reconciling its own
+        // state rather than reporting a crossing.
+        store.claimExit("biz-1") shouldBeEqualTo false
+    }
+
+    @Test
+    fun claimExit_givenEntered_expectTrueThenFalseOnSecondCall() {
+        store.recordEntered("biz-1")
+
+        store.claimExit("biz-1") shouldBeEqualTo true
+        // Consumed: a duplicate EXIT for the same crossing doesn't pass twice.
+        store.claimExit("biz-1") shouldBeEqualTo false
+    }
+
+    @Test
+    fun recordEntered_givenCalledTwice_expectSingleEntry() {
+        store.recordEntered("biz-1")
+        store.recordEntered("biz-1")
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_expectPrunedToRegisteredAndUnionedWithInside() {
+        store.recordEntered("biz-kept")
+        store.recordEntered("biz-unregistered")
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-kept", "biz-new-inside"),
+            inside = setOf("biz-new-inside")
+        )
+
+        // "biz-unregistered" pruned, "biz-kept" survives because it is still registered.
+        store.getEnteredIds() shouldContainSame setOf("biz-kept", "biz-new-inside")
+    }
+
+    @Test
+    fun hasContainmentRecord_givenNothingEverRecorded_expectFalse() {
+        // Upgraded install: distinguishable from "recorded, and nothing is entered".
+        store.hasContainmentRecord().shouldBeFalse()
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun hasContainmentRecord_givenReconcileWithNothingInside_expectTrue() {
+        // The first registration seeds the key even when the device is inside nothing, which is what
+        // ends the upgrade grace period.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet())
+
+        store.hasContainmentRecord().shouldBeTrue()
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenStaleAnchorReportsOutside_expectExistingContainmentPreserved() {
+        // A launch refresh can run off the persisted anchor rather than a live fix. If that
+        // anchor wrongly says "outside", erasing containment would swallow the genuine EXIT.
+        store.recordEntered("biz-1")
+
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet())
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
     }
 
     @Test
@@ -273,11 +341,13 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastSyncTimestamp(12_345L)
+        store.recordEntered("biz-1")
 
         store.clearAll()
 
         store.getCachedRegions().shouldBeEmpty()
         store.getRegisteredIds().shouldBeEmpty()
+        store.getEnteredIds().shouldBeEmpty()
         store.getCachedConfig().shouldBeNull()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
@@ -300,6 +370,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedRegions(regions)
         store.saveCachedConfig(config)
         store.saveRegisteredIds(setOf("biz-1"))
+        store.recordEntered("biz-1")
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
@@ -310,6 +381,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         // User-specific: wiped.
         store.getRegisteredIds().shouldBeEmpty()
+        // Goes with the registrations it describes — sign-out drops those from the OS.
+        store.getEnteredIds().shouldBeEmpty()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -184,6 +184,62 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun hasEmittedEnter_givenNothingReported_expectFalse() {
+        store.hasEmittedEnter("biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_givenCalledTwice_expectStillReportedAndIdempotent() {
+        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted("biz-1")
+
+        store.hasEmittedEnter("biz-1").shouldBeTrue()
+        store.clearEnterEmitted("biz-1")
+        store.hasEmittedEnter("biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun pruneEmittedEnterIds_expectMarksDroppedForUnregisteredFences() {
+        store.markEnterEmitted("biz-kept")
+        store.markEnterEmitted("biz-evicted")
+
+        store.pruneEmittedEnterIds(setOf("biz-kept"))
+
+        store.hasEmittedEnter("biz-kept").shouldBeTrue()
+        store.hasEmittedEnter("biz-evicted").shouldBeFalse()
+    }
+
+    @Test
+    fun pruneEmittedEnterIds_givenFenceEvictedWhileInside_expectLaterRevisitNotSuppressed() {
+        // Without the prune the mark outlives the monitoring that would clear it: a fence dropped
+        // from the nearest set while the device is inside never reports its EXIT, so a genuine
+        // revisit months later would be swallowed.
+        store.markEnterEmitted("biz-1")
+
+        // Evicted from the monitored set — no EXIT is ever delivered for it.
+        store.pruneEmittedEnterIds(setOf("biz-other"))
+        // Re-registered on a later sync when the device comes back into range.
+        store.pruneEmittedEnterIds(setOf("biz-1"))
+
+        store.hasEmittedEnter("biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_expectIndependentOfEnteredSet() {
+        // The two sets answer different questions — where the device is vs. what we have sent — and
+        // the geometry seeding writes only the former. Coupling them would let a sync's reconcile
+        // suppress the OS ENTER that follows it milliseconds later.
+        store.markEnterEmitted("biz-1")
+
+        store.getEnteredIds().shouldBeEmpty()
+
+        store.reconcileEnteredIds(registeredIds = setOf("biz-2"), inside = setOf("biz-2"))
+
+        store.hasEmittedEnter("biz-1").shouldBeTrue()
+        store.hasEmittedEnter("biz-2").shouldBeFalse()
+    }
+
+    @Test
     fun getLastRegistrationUptime_givenNothingStored_expectNull() {
         store.getLastRegistrationUptime().shouldBeNull()
     }
@@ -371,6 +427,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedConfig(config)
         store.saveRegisteredIds(setOf("biz-1"))
         store.recordEntered("biz-1")
+        store.markEnterEmitted("biz-1")
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
@@ -383,6 +440,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getRegisteredIds().shouldBeEmpty()
         // Goes with the registrations it describes — sign-out drops those from the OS.
         store.getEnteredIds().shouldBeEmpty()
+        // The next user must not inherit a suppressed ENTER for a fence they were never told about.
+        store.hasEmittedEnter("biz-1").shouldBeFalse()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -185,49 +185,70 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
     @Test
     fun hasEmittedEnter_givenNothingReported_expectFalse() {
-        store.hasEmittedEnter("biz-1").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
     }
 
     @Test
     fun markEnterEmitted_givenCalledTwice_expectStillReportedAndIdempotent() {
-        store.markEnterEmitted("biz-1")
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
+        store.markEnterEmitted(USER, "biz-1")
 
-        store.hasEmittedEnter("biz-1").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
     }
 
     @Test
     fun claimExit_givenEnterReported_expectMarkClearedWithContainment() {
         store.recordEntered("biz-1")
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
 
         store.claimExit("biz-1").shouldBeTrue()
 
         // Both drop together: the mark can't be left behind for a delivery path that may not run.
         store.getEnteredIds().shouldBeEmpty()
-        store.hasEmittedEnter("biz-1").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
     }
 
     @Test
     fun claimExit_givenNeverEntered_expectMarkRetained() {
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
 
         store.claimExit("biz-1").shouldBeFalse()
 
         // An unclaimed EXIT is a GMS artifact, not a departure — re-arming on it would let the next
         // OS re-report of ENTER through as a fresh arrival.
-        store.hasEmittedEnter("biz-1").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
+    }
+
+    @Test
+    fun hasEmittedEnter_givenMarkOwnedByAnotherUser_expectFalse() {
+        store.markEnterEmitted(USER, "biz-1")
+
+        // A direct A-to-B identify publishes no ResetEvent, so B reaches a still-registered fence
+        // with A's mark in place. Honouring it would swallow B's first arrival.
+        store.hasEmittedEnter(OTHER_USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_givenNewOwner_expectPreviousUsersMarksDiscarded() {
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.markEnterEmitted(OTHER_USER, "biz-2")
+
+        store.hasEmittedEnter(OTHER_USER, "biz-2").shouldBeTrue()
+        store.hasEmittedEnter(OTHER_USER, "biz-1").shouldBeFalse()
+        // The set belongs to one identity at a time, so A's marks are gone rather than parked.
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
     }
 
     @Test
     fun pruneEmittedEnterIds_expectMarksDroppedForUnregisteredFences() {
-        store.markEnterEmitted("biz-kept")
-        store.markEnterEmitted("biz-evicted")
+        store.markEnterEmitted(USER, "biz-kept")
+        store.markEnterEmitted(USER, "biz-evicted")
 
         store.pruneEmittedEnterIds(setOf("biz-kept"))
 
-        store.hasEmittedEnter("biz-kept").shouldBeTrue()
-        store.hasEmittedEnter("biz-evicted").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-kept").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-evicted").shouldBeFalse()
     }
 
     @Test
@@ -235,14 +256,14 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // Without the prune the mark outlives the monitoring that would clear it: a fence dropped
         // from the nearest set while the device is inside never reports its EXIT, so a genuine
         // revisit months later would be swallowed.
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
 
         // Evicted from the monitored set — no EXIT is ever delivered for it.
         store.pruneEmittedEnterIds(setOf("biz-other"))
         // Re-registered on a later sync when the device comes back into range.
         store.pruneEmittedEnterIds(setOf("biz-1"))
 
-        store.hasEmittedEnter("biz-1").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
     }
 
     @Test
@@ -250,14 +271,14 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // The two sets answer different questions — where the device is vs. what we have sent — and
         // the geometry seeding writes only the former. Coupling them would let a sync's reconcile
         // suppress the OS ENTER that follows it milliseconds later.
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
 
         store.getEnteredIds().shouldBeEmpty()
 
         store.reconcileEnteredIds(registeredIds = setOf("biz-2"), inside = setOf("biz-2"))
 
-        store.hasEmittedEnter("biz-1").shouldBeTrue()
-        store.hasEmittedEnter("biz-2").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-2").shouldBeFalse()
     }
 
     @Test
@@ -448,7 +469,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedConfig(config)
         store.saveRegisteredIds(setOf("biz-1"))
         store.recordEntered("biz-1")
-        store.markEnterEmitted("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
@@ -462,7 +483,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // Goes with the registrations it describes — sign-out drops those from the OS.
         store.getEnteredIds().shouldBeEmpty()
         // The next user must not inherit a suppressed ENTER for a fence they were never told about.
-        store.hasEmittedEnter("biz-1").shouldBeFalse()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()
@@ -588,6 +609,11 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             maxBusinessGeofences = 19,
             maxMonitoringDistance = 1_000_000f
         )
+    }
+
+    private companion object {
+        private const val USER = "user-1"
+        private const val OTHER_USER = "user-2"
     }
 
     private fun writeRaw(key: String, value: String) {

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -213,6 +213,23 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun reconcileEnteredIds_givenFenceUnregisteredAfterClaim_expectClaimForgottenSoLaterSeedWorks() {
+        // The claim record is per-fence state that would otherwise accumulate for the life of the
+        // process. Trimming it to the registered set is safe: a fence has to be re-registered before
+        // geometry can seed it again, and by then the old claim is older than any such sync.
+        store.recordEntered("biz-1")
+        val epochAtFix = store.containmentEpoch()
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // Fence drops out of the monitored set, so its claim record is trimmed.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-other"), inside = emptySet(), sinceEpoch = epochAtFix)
+        // Re-registered later with the device inside it, using the same stale epoch.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = setOf("biz-1"), sinceEpoch = epochAtFix)
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
     fun containmentEpoch_givenClaimedExit_expectAdvanced() {
         store.recordEntered("biz-1")
         val before = store.containmentEpoch()

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -194,8 +194,29 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.markEnterEmitted("biz-1")
 
         store.hasEmittedEnter("biz-1").shouldBeTrue()
-        store.clearEnterEmitted("biz-1")
+    }
+
+    @Test
+    fun claimExit_givenEnterReported_expectMarkClearedWithContainment() {
+        store.recordEntered("biz-1")
+        store.markEnterEmitted("biz-1")
+
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // Both drop together: the mark can't be left behind for a delivery path that may not run.
+        store.getEnteredIds().shouldBeEmpty()
         store.hasEmittedEnter("biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun claimExit_givenNeverEntered_expectMarkRetained() {
+        store.markEnterEmitted("biz-1")
+
+        store.claimExit("biz-1").shouldBeFalse()
+
+        // An unclaimed EXIT is a GMS artifact, not a departure — re-arming on it would let the next
+        // OS re-report of ENTER through as a fresh arrival.
+        store.hasEmittedEnter("biz-1").shouldBeTrue()
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -146,7 +146,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // The circle moved but kept its ID, so the old record describes somewhere else.
         store.recordEntered("biz-moved")
 
-        store.reconcileEnteredIds(
+        val dropped = store.reconcileEnteredIds(
             registeredIds = setOf("biz-moved"),
             inside = emptySet(),
             sinceEpoch = store.containmentEpoch(),
@@ -154,6 +154,31 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         )
 
         store.getEnteredIds().shouldBeEmpty()
+        // Reported back so the caller resets the matching mark on the same decision.
+        dropped shouldContainSame setOf("biz-moved")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenEnterReportedAfterFixWasTaken_expectRecordKeptDespiteReset() {
+        store.recordEntered("biz-moved")
+        // A sync captures the epoch with its fix, then awaits GMS for seconds.
+        val epochAtFix = store.containmentEpoch()
+
+        // Mid-flight the OS reports an arrival at the circle being registered — our fix said the
+        // device was outside it, GMS says otherwise and is looking at the newer position.
+        store.recordEntered("biz-moved")
+
+        val dropped = store.reconcileEnteredIds(
+            registeredIds = setOf("biz-moved"),
+            inside = emptySet(),
+            sinceEpoch = epochAtFix,
+            resetIds = setOf("biz-moved")
+        )
+
+        // Dropping it here would leave the device inside with no record, so its genuine EXIT would
+        // be discarded as never-entered.
+        store.getEnteredIds() shouldContainSame setOf("biz-moved")
+        dropped.shouldBeEmpty()
     }
 
     @Test
@@ -161,7 +186,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // A radius edit made while the device is inside must not manufacture a fresh arrival.
         store.recordEntered("biz-widened")
 
-        store.reconcileEnteredIds(
+        val dropped = store.reconcileEnteredIds(
             registeredIds = setOf("biz-widened"),
             inside = setOf("biz-widened"),
             sinceEpoch = store.containmentEpoch(),
@@ -169,6 +194,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         )
 
         store.getEnteredIds() shouldContainSame setOf("biz-widened")
+        // Nothing was dropped, so the caller must not drop the mark either.
+        dropped.shouldBeEmpty()
     }
 
     @Test


### PR DESCRIPTION
## What

Refreshes the nearby geofence set from a live location fix on foreground entry, so the SDK notices it
has moved without waiting on the OS.

Discovery today has a single input: an OS geofence callback. When those stop arriving, nothing else
re-evaluates where the device is — every other refresh path anchors at the last registration center,
which is by definition where the device used to be, so the tier table sees no movement and skips.

Observed on a 20 km drive on 2 August: Play Services logged nothing device-wide for 90 minutes (zero
`Geofencer` lines, across all apps), and two installs resumed within 43 ms of each other when it came
back. The device sat 23 km from the nearest fence it knew about, and no code path could ask where it
was.

## How

On foreground entry, in `GeofenceLocationMode.AUTOMATIC`, arm a refresh and request a silent
(no-analytics) fix — the pair `refreshFromCurrentLocation()` already uses. The returning fix drives
the refresh through `onLocationAcquired`, anchored at the device's real position where
`movedBeyondFetchRadius` can finally see the move.

The fresh fix does double duty: Play Services evaluates geofences off location updates rather than
polling, so a fix flowing through the fused provider also gives it a reason to re-evaluate regions it
is holding stale state for.

Two cases keep their existing behaviour, both decided inside `refreshOnForeground` so tests cover
them rather than an untestable lifecycle lambda:

- **MANUAL** hands acquisition to the host, so it never arms — a flag no fix consumes would sit set
  until some unrelated fix landed.
- **A sync already stuck without a location** keeps its narrower recovery, which requests a live fix
  itself where one is needed and falls back to the anchor where that is the best available.

No throttle. Repeat entries are gated by the existing tier table, which returns SKIP when the device
hasn't moved — measured at ~5 ms with no network and no OS re-registration.

## Behaviour

Only `AUTOMATIC` mode changes, and only on foreground entry. No persisted state is added, so there is
nothing to migrate on upgrade and no key an older install could be missing.

## Testing

Three unit tests. Four mutations verified, each caught only by its own test: dropping the AUTOMATIC
guard, dropping the stuck-sync guard, arming after the request instead of before, and never arming.

Emulator with a mock-location provider, 23 km jump with the app backgrounded, then foregrounded —
patched vs an unpatched control build on the same app data:

|  | patched | control |
|---|---|---|
| silent fix on foreground entry | yes, +32 ms after the flush | none |
| sync triggered | yes, +39 ms | none |
| re-registered at the new position | yes | not until the OS trigger fired |

The patched build also beat the OS's own movement trigger by 3.3 s. Five foreground entries while
stationary each acquired a fix and each hit tier SKIP in ~5 ms.

1678 unit tests across all modules, ktlint, `apiCheck` and `lintDebug` clean.

## Known limitation

This does not make Play Services deliver callbacks; a device that never opens the app still sees the
gap. The emulator cannot reproduce hours-long dormancy, so what is measured above is the mechanism
and the latency, not a fix for the dormancy itself. Keeping a monitored boundary near the device at
all times — concentric discovery rings — is the only lever with a mechanism against that, and it is
feature-sized: it spends slots from the 19+1 budget and changes registration, eviction and the tier
table.

## Stack

```
main
 └── geofence/nearest-edge-distance      #806
 └── geofence/containment-guards         #805
      └── geofence/foreground-discovery  this PR
```

Shares `ModuleGeofence`'s foreground hook with #805, so merge #806 → #805 → this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches foreground lifecycle, location acquisition, and identity reads; behavior is gated but repeat foregrounds can trigger silent fixes (tier table should SKIP when stationary).
> 
> **Overview**
> **AUTOMATIC** geofence mode now tries to **rediscover nearby fences from a real GPS fix** whenever the app returns to the foreground, instead of only running the stuck-sync retry path.
> 
> On foreground, work moves to **`geofenceScope`** (identity read / Keystore decrypt off the main thread). New **`refreshOnForeground`** arms `onRefreshRequested()` then requests a silent location update—same pattern as `refreshFromCurrentLocation()`—so movement can be detected when OS geofence callbacks go quiet. It is skipped for **MANUAL** mode, when **no user is identified**, or when a sync is **already awaiting location** (existing `retrySyncAwaitingLocation` still handles that).
> 
> Unit tests cover those guards and **arm-before-request** ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c56aec0b9cb99ceb7757350504545c504d7d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->