### PR TITLE
fix(geofence): correct transition accuracy and region discovery reliability

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -12,6 +12,7 @@ import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
 import io.customer.geofence.di.geofenceTransitionEmitter
 import io.customer.sdk.communication.Event
+import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
@@ -20,6 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 
 /** Receives OS geofence transition callbacks and dispatches them to the SDK. */
@@ -94,7 +97,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val timestamp = SDKComponent.clock.currentTimeSeconds()
         val dispatchStartUptimeMs = SDKComponent.clock.elapsedRealtime()
         val androidComponent = SDKComponent.android()
-        val transitionEmitter = androidComponent.geofenceTransitionEmitter
         // Defense-in-depth against orphans (failed clearAll, app-data wipe, SDK
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
@@ -128,27 +130,17 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
-            // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
-            // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
-            val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
-            // Geofencing is identified-only: the backend rejects anonymous geofence tracks, so an
-            // anonymous transition has no deliverable path. Drop it before spending a cooldown slot
-            // or persisting a row neither channel could ever send.
-            if (userId == null) {
-                logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
-                return@forEach
+            // Each broadcast runs on its own scope, so two transitions for one fence would
+            // otherwise interleave read-decide-persist and lose a containment record.
+            transitionMutex.withLock {
+                handleBusinessTransition(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    timestamp = timestamp,
+                    androidComponent = androidComponent,
+                    logger = logger
+                )
             }
-
-            val cachedRegion = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
-            transitionEmitter.emit(
-                geofenceId = geofenceId,
-                transition = transition,
-                userId = userId,
-                timestampSeconds = timestamp,
-                geofenceName = cachedRegion?.name,
-                metadata = cachedRegion?.metadata ?: emptyMap(),
-                geosetIds = cachedRegion?.geosetIds ?: emptyList()
-            )
         }
 
         // Hold the goAsync window open until the refresh lands so the OS doesn't kill a
@@ -163,6 +155,55 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
+    private suspend fun handleBusinessTransition(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        timestamp: Long,
+        androidComponent: AndroidSDKComponent,
+        logger: GeofenceLogger
+    ) {
+        // Ahead of the identity checks below: being inside a fence is a physical fact, independent of
+        // whether the transition is deliverable.
+        val store = androidComponent.geofenceRegionStore
+        val cachedRegion = store.getCachedRegion(geofenceId)
+        when (transition) {
+            Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
+            // An unmatched EXIT is a GMS reconciliation artifact, not a crossing — delivering it
+            // fires EXIT campaigns at people who were never there. The two guards after claimExit
+            // cover the cases where an absent record proves nothing: an upgraded install with no set
+            // yet, and a region that never monitored ENTER (a missing cache row counts as unknown).
+            Event.GeofenceTransition.EXIT -> if (
+                !store.claimExit(geofenceId) &&
+                store.hasContainmentRecord() &&
+                cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
+            ) {
+                logger.logExitDroppedNeverEntered(geofenceId)
+                return
+            }
+        }
+
+        // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
+        // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
+        val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+        // Identified-only: the backend rejects anonymous geofence tracks, so drop before spending a
+        // cooldown slot or persisting a row neither channel could send.
+        if (userId == null) {
+            logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
+            return
+        }
+
+        androidComponent.geofenceTransitionEmitter.emit(
+            geofenceId = geofenceId,
+            transition = transition,
+            userId = userId,
+            timestampSeconds = timestamp,
+            geofenceName = cachedRegion?.name,
+            metadata = cachedRegion?.metadata ?: emptyMap(),
+            geosetIds = cachedRegion?.geosetIds ?: emptyList(),
+            monitorsExit = cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.EXIT) == true
+        )
+    }
+
     private fun transitionName(gmsTransitionType: Int): String = when (gmsTransitionType) {
         Geofence.GEOFENCE_TRANSITION_ENTER -> "ENTER"
         Geofence.GEOFENCE_TRANSITION_EXIT -> "EXIT"
@@ -174,5 +215,8 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         // goAsync grants ~10s before the OS considers the receiver blocked; total budget for
         // one dispatch (persistence + GMS awaits + movement-refresh wait), with headroom.
         private const val DISPATCH_WAIT_BUDGET_MS = 8_000L
+
+        // Process-wide: a receiver instance lives for one broadcast, so the lock has to outlive it.
+        private val transitionMutex = Mutex()
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceDistanceFilter.kt
@@ -1,13 +1,23 @@
 package io.customer.geofence
 
+import kotlin.math.round
+
 /**
  * Selects the geofence regions closest to a reference location, capped at a maximum count and
  * (optionally) a maximum distance.
  *
  * The OS limits the number of geofences an app can register simultaneously; this filter
  * picks the most relevant subset based on straight-line distance from the device's
- * current location. Regions beyond [maxDistanceMeters] are excluded entirely; local re-ranking
- * re-includes them as the device approaches.
+ * current location. Regions whose boundary is beyond [maxDistanceMeters] are excluded entirely;
+ * local re-ranking re-includes them as the device approaches.
+ *
+ * Ranking and the cap both measure to the region's *boundary* ([edgeDistanceTo]), so a region the
+ * device is inside always sorts first and survives both the count limit and the distance cap.
+ *
+ * Ties break on ascending [GeofenceRegion.id], and distances round to whole meters first:
+ * `Location.distanceBetween` can return sub-meter-varying results for the same inputs, which would
+ * otherwise defeat the tiebreak and leave equidistant regions ordered by the server's response
+ * order. Matches iOS so both platforms pick the same set at the cap.
  */
 internal class GeofenceDistanceFilter {
     fun nearest(
@@ -19,9 +29,9 @@ internal class GeofenceDistanceFilter {
     ): List<GeofenceRegion> {
         if (max <= 0 || regions.isEmpty()) return emptyList()
         return regions
-            .map { it to it.distanceTo(latitude, longitude) }
+            .map { it to round(it.edgeDistanceTo(latitude, longitude)) }
             .filter { (_, distance) -> distance <= maxDistanceMeters }
-            .sortedBy { (_, distance) -> distance }
+            .sortedWith(compareBy({ (_, distance) -> distance }, { (region, _) -> region.id }))
             .take(max)
             .map { (region, _) -> region }
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -60,6 +60,14 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logEnterDroppedAlreadyReported(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' ENTER: dropped — already reported as entered and no exit since, so the OS is re-reporting a state we already sent", tag = TAG)
+    }
+
+    fun logExitDroppedNeverEntered(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' EXIT: dropped — no record of the device being inside, so the OS is reconciling its own state", tag = TAG)
+    }
+
     fun logTransitionDroppedAnonymous(geofenceId: String, transitionName: String) {
         logger.debug("Geofence '$geofenceId' $transitionName: dropped — no identified user (geofencing is identified-only)", tag = TAG)
     }
@@ -86,6 +94,10 @@ internal class GeofenceLogger(private val logger: Logger) {
 
     fun logSyncSkippedNoLocation(reason: String) {
         logger.debug("Geofence sync skipped ($reason): no location available", tag = TAG)
+    }
+
+    fun logSyncSkippedInvalidLocation(reason: String, latitude: Double, longitude: Double) {
+        logger.error("Geofence sync skipped ($reason): OS reported an unusable fix ($latitude, $longitude)", tag = TAG)
     }
 
     fun logSyncSkippedNoPermission(reason: String) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
@@ -51,20 +51,18 @@ internal class GeofenceManager(
         existingBusinessIds: Set<String> = emptySet()
     ): Result<Unit> = replaceGeofencesInternal(
         regions = regions,
-        movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_ENTER,
+        // The movement trigger evaluates the device's position at register time, so a stale center
+        // fires EXIT straight away and the next handleMovement re-centers on a real fix. ENTER is
+        // not used: it only delivers a transition the receiver ignores, and combining the two stops
+        // GMS delivering the trigger's later EXIT at all.
+        movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_EXIT,
         existingBusinessIds = existingBusinessIds
     )
 
-    /**
-     * Boot-restore variant of [replaceGeofences]: registers the movement
-     * trigger with `INITIAL_TRIGGER_EXIT` so the OS evaluates current
-     * location at register time. If the user moved beyond the cached circle
-     * while the device was off, EXIT fires immediately and the next
-     * handleMovement self-heals with real coordinates.
-     */
+    /** Boot-restore entry point; registration is identical to [replaceGeofences]. */
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun replaceGeofencesForBootRestore(regions: List<GeofenceRegion>): Result<Unit> =
-        replaceGeofencesInternal(regions, movementInitialTrigger = GeofencingRequest.INITIAL_TRIGGER_EXIT)
+        replaceGeofences(regions)
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     private suspend fun replaceGeofencesInternal(

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -63,6 +63,17 @@ internal fun GeofenceRegion.distanceTo(lat: Double, lng: Double): Float {
 }
 
 /**
+ * Straight-line distance in meters from this region's *boundary* to the given coordinates, `0` when
+ * they fall inside the region.
+ *
+ * Relevance for monitoring is proximity to the boundary, not to the center: ranking on center
+ * distance evicts a region the device currently occupies once enough regions have nearer centers,
+ * and an unmonitored region can never report its exit.
+ */
+internal fun GeofenceRegion.edgeDistanceTo(lat: Double, lng: Double): Float =
+    (distanceTo(lat, lng) - radius).coerceAtLeast(0f)
+
+/**
  * Converts the SDK transition types to a GMS bitmask for [Geofence.Builder.setTransitionTypes].
  * E.g., [ENTER, EXIT] → GEOFENCE_TRANSITION_ENTER | GEOFENCE_TRANSITION_EXIT.
  */

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -12,20 +12,35 @@ import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Geofence sync pipeline. Two public entry points:
  *
  * - [refresh] — for identify / app-launch. Reuses the cached set within the freshness window
  *   (re-registering locally or skipping); otherwise fetches fresh from the API.
+ * - [refreshFromLiveFix] — same pass, for a fix the SDK asked for and received.
  * - [handleMovement] — for movement-trigger EXIT. Re-ranks the cached regions for the new
  *   location.
  */
 internal interface GeofenceRepository {
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun refresh(latitude: Double, longitude: Double): Result<Unit>
+
+    /**
+     * [refresh] for a just-acquired fix, which waits for an in-flight sync instead of dropping.
+     * The two run the same pass; they differ only in what a collision costs. Identify and
+     * app-launch collide constantly and share one anchor, so dropping loses nothing — but this
+     * caller holds the device's real position while the sync in flight is working from a stored
+     * anchor that can be kilometres stale, and the fix is consumed whether or not it is used.
+     */
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    suspend fun refreshFromLiveFix(latitude: Double, longitude: Double): Result<Unit>
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit>
@@ -63,21 +78,42 @@ internal class GeofenceRepositoryImpl(
     private val logger: GeofenceLogger
 ) : GeofenceRepository {
 
-    // Dedup gate shared by refresh() and handleMovement(). If either is already running,
-    // a concurrent trigger drops fast so we don't burn redundant work. Released in
-    // `finally` so a failure or cancellation doesn't permanently latch the gate.
+    // One sync pass at a time. A pass carrying its own live fix waits for the slot rather than
+    // dropping — see [awaitRefreshSlot]; [refresh] drops, because identify and app-launch fire
+    // together on the same anchor and only one needs to run. Released in `finally` so a failure
+    // or cancellation can't latch the gate.
     private val refreshInProgress = AtomicBoolean(false)
 
     // Serializes state-mutation against reset() (sign-out). Held only around the
     // write block — the long-running API call happens outside the lock.
     private val stateMutex = Mutex()
 
+    private fun tryTakeRefreshSlot(): Boolean = refreshInProgress.compareAndSet(false, true)
+
+    private fun releaseRefreshSlot() {
+        refreshInProgress.set(false)
+    }
+
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
-        if (!refreshInProgress.compareAndSet(false, true)) {
+        if (!tryTakeRefreshSlot()) {
             logger.logSyncSkipped("refresh already in progress")
             return Result.success(Unit)
         }
+        return runRefresh(latitude, longitude)
+    }
+
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    override suspend fun refreshFromLiveFix(latitude: Double, longitude: Double): Result<Unit> {
+        if (!awaitRefreshSlot()) {
+            logger.logSyncSkipped("refresh already in progress after waiting")
+            return Result.success(Unit)
+        }
+        return runRefresh(latitude, longitude)
+    }
+
+    @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    private suspend fun runRefresh(latitude: Double, longitude: Double): Result<Unit> {
         try {
             val userId = secureUserStore.getUserId()
             if (userId.isNullOrBlank()) {
@@ -105,7 +141,7 @@ internal class GeofenceRepositoryImpl(
                 }
             }
         } finally {
-            refreshInProgress.set(false)
+            releaseRefreshSlot()
         }
     }
 
@@ -176,10 +212,28 @@ internal class GeofenceRepositoryImpl(
 
     private fun osStateWiped(): Boolean = osStateWipedByReboot() || osStateWipedByAppUpdate()
 
+    /**
+     * Takes the in-flight slot for a pass that can't be dropped, waiting for the holder instead.
+     * For a movement pass, the OS holds a fired trigger in the outside state, so returning without
+     * re-centring it stops discovery until the next app open, reboot or update; for a live fix, the
+     * fix is spent on arrival and nothing re-requests one.
+     */
+    private suspend fun awaitRefreshSlot(): Boolean {
+        if (tryTakeRefreshSlot()) return true
+        return withTimeoutOrNull(MOVEMENT_SLOT_WAIT) {
+            // Nothing suspends between a winning CAS and the return, so a timeout can't land in
+            // between and leave the flag set with nobody to clear it.
+            while (!tryTakeRefreshSlot()) {
+                delay(MOVEMENT_SLOT_POLL)
+            }
+            true
+        } == true
+    }
+
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
-        if (!refreshInProgress.compareAndSet(false, true)) {
-            logger.logSyncSkipped("refresh already in progress")
+        if (!awaitRefreshSlot()) {
+            logger.logSyncSkipped("refresh already in progress after waiting")
             return Result.success(Unit)
         }
         try {
@@ -212,7 +266,7 @@ internal class GeofenceRepositoryImpl(
                 performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
             }
         } finally {
-            refreshInProgress.set(false)
+            releaseRefreshSlot()
         }
     }
 
@@ -547,4 +601,14 @@ internal class GeofenceRepositoryImpl(
         radius = radiusMeters,
         transitionTypes = listOf(GeofenceTransitionType.EXIT)
     )
+
+    private companion object {
+        // Long enough to outlast the slowest holder: a remote pass can spend the HTTP client's
+        // connect plus read timeout (10s each) before it releases, and giving up on one that then
+        // fails to register is the case that strands the trigger. Deliberately past the receiver's
+        // DISPATCH_WAIT_BUDGET_MS — the receiver only bounds how long it joins, and a pass that
+        // lands late still re-centres, whereas a dropped one leaves nothing to re-centre.
+        val MOVEMENT_SLOT_WAIT = 30.seconds
+        val MOVEMENT_SLOT_POLL = 50.milliseconds
+    }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -86,6 +86,8 @@ internal class GeofenceRepositoryImpl(
             }
 
             val config = store.getCachedConfigOrFallback()
+            // Captured with the coordinates: an exit claimed mid-sync must beat this fix's geometry.
+            val containmentEpoch = store.containmentEpoch()
             // Decided under stateMutex so a concurrent sign-out reset can't wipe state right
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
@@ -95,8 +97,8 @@ internal class GeofenceRepositoryImpl(
             // this pass (mirrors restoreFromCache). Drops once registration re-stamps.
             val emitInitialEnter = !osStateWiped()
             return when (action) {
-                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, emitInitialEnter)
-                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, emitInitialEnter = emitInitialEnter)
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, containmentEpoch, emitInitialEnter)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, emitInitialEnter = emitInitialEnter)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
@@ -189,6 +191,7 @@ internal class GeofenceRepositoryImpl(
 
             val anchor = store.getLastApiFetchLocation()
             val config = store.getCachedConfigOrFallback()
+            val containmentEpoch = store.containmentEpoch()
             val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
             // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
             // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
@@ -197,16 +200,16 @@ internal class GeofenceRepositoryImpl(
             // Initial-enter synthesis stays on here (unlike refresh): containment is judged against
             // the OS's live triggering fix, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
-                val remote = performRemoteRefresh(userId, latitude, longitude)
+                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch)
                 if (remote.isFailure) {
                     // The trigger already fired, and a failed pass never re-centres it — leaving it
                     // where the device just exited, so nothing can fire again. Re-rank to re-arm it.
                     logger.logMovementRearmedAfterFailedRefresh()
-                    performLocalRefresh(userId, latitude, longitude, config)
+                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
                 }
                 remote
             } else {
-                performLocalRefresh(userId, latitude, longitude, config)
+                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
             }
         } finally {
             refreshInProgress.set(false)
@@ -243,6 +246,7 @@ internal class GeofenceRepositoryImpl(
             latitude = effectiveLocation.latitude,
             longitude = effectiveLocation.longitude,
             cachedConfig = cachedConfig,
+            containmentEpoch = store.containmentEpoch(),
             register = manager::replaceGeofencesForBootRestore,
             // No initial-enter on boot restore: the cached anchor may be stale if the device moved
             // while off, so containment can't be trusted.
@@ -255,6 +259,7 @@ internal class GeofenceRepositoryImpl(
         userId: String,
         latitude: Double,
         longitude: Double,
+        containmentEpoch: Long,
         emitInitialEnter: Boolean = true
     ): Result<Unit> {
         // The device location lets the backend return the nearby set; the request carries no user
@@ -280,6 +285,7 @@ internal class GeofenceRepositoryImpl(
                     longitude = longitude,
                     regions = regions,
                     config = config,
+                    containmentEpoch = containmentEpoch,
                     emitInitialEnter = emitInitialEnter,
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
@@ -305,6 +311,7 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig,
+        containmentEpoch: Long,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
         emitInitialEnter: Boolean = true
     ): Result<Unit> = registerNearestAndPersist(
@@ -313,6 +320,7 @@ internal class GeofenceRepositoryImpl(
         longitude = longitude,
         regions = store.getCachedRegions(),
         config = cachedConfig,
+        containmentEpoch = containmentEpoch,
         register = register,
         emitInitialEnter = emitInitialEnter
     )
@@ -358,6 +366,7 @@ internal class GeofenceRepositoryImpl(
         longitude: Double,
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
+        containmentEpoch: Long,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
         onRegistered: () -> Unit = {},
         emitInitialEnter: Boolean = true
@@ -392,6 +401,11 @@ internal class GeofenceRepositoryImpl(
             // override here (unlike the registration diff): callers disable synthesis outright
             // while the reboot flag is up — the anchor can predate the reboot.
             val unchangedRegistered = unchangedRegisteredIds(nearest)
+            // Registered before this pass but not cache-equal: the ID survived a geometry edit.
+            val previouslyRegistered = store.getRegisteredIds()
+            val reRegisteredIds = nearest.map { it.id }
+                .filter { it in previouslyRegistered && it !in unchangedRegistered }
+                .toSet()
             val registrationResult = register(regionsToRegister).also { result ->
                 if (result.isSuccess) {
                     // Stale cleanup — Manager added new−existing, we remove
@@ -411,6 +425,27 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // Seed containment from our own geometry: synthesis is suppressed after a
+                    // reboot or app update, and without a record the later genuine EXIT looks
+                    // unentered and gets dropped.
+                    val insideIds = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
+                        .map { it.id }
+                        .toSet()
+                    // A moved circle keeps its ID, so containment and the reported-ENTER mark can
+                    // describe where the fence used to be. Reset both, but only once the new geometry
+                    // agrees the device is out, or trimming a radius manufactures a second arrival.
+                    val movedAwayIds = reRegisteredIds - insideIds
+                    val resetApplied = store.reconcileEnteredIds(
+                        registeredIds = idsToSave,
+                        inside = insideIds,
+                        // Registration awaited GMS, so a transition since this fix is newer evidence.
+                        sinceEpoch = containmentEpoch,
+                        resetIds = movedAwayIds
+                    )
+                    // What the store actually reset, not what we asked it to: an arrival reported
+                    // during the await keeps its record, and the mark that record was reported with.
+                    // A fence dropped from the set never reports the EXIT that would re-arm it.
+                    store.pruneEmittedEnterIds(idsToSave - resetApplied)
                     // Stamp uptime and package update time so the next refresh detects a reboot or
                     // app update (both wipe OS geofences) and re-registers instead of trusting ids.
                     store.setLastRegistrationUptime(clock.elapsedRealtime())
@@ -446,6 +481,9 @@ internal class GeofenceRepositoryImpl(
      * "New" = not in [unchangedRegisteredIds]: brand-new fences and re-added param changes fire,
      * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
      * collapse to one event.
+     *
+     * Requires the stored containment record and this fix's geometry to agree — reconcile carries a
+     * record forward for a still-registered fence, so it can outlive the visit.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
@@ -455,12 +493,14 @@ internal class GeofenceRepositoryImpl(
         longitude: Double
     ) {
         val timestamp = clock.currentTimeSeconds()
+        val contained = store.getEnteredIds()
         candidates.forEach { region ->
             val newlyRegistered = region.id !in unchangedRegisteredIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
-            // Compare against the full radius: GMS has no per-region monitored-radius cap.
-            val inside = region.distanceTo(latitude, longitude) <= region.radius
-            if (!newlyRegistered || !monitorsEnter || !inside) return@forEach
+            // Both: a carried-forward record can outlive the visit, and geometry alone ignores an
+            // EXIT reported while GMS was awaited.
+            val insideNow = region.distanceTo(latitude, longitude) <= region.radius
+            if (!newlyRegistered || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
             logger.logInitialEnterInside(region.id)
             transitionEmitter.emit(
                 geofenceId = region.id,
@@ -469,7 +509,8 @@ internal class GeofenceRepositoryImpl(
                 timestampSeconds = timestamp,
                 geofenceName = region.name,
                 metadata = region.metadata,
-                geosetIds = region.geosetIds
+                geosetIds = region.geosetIds,
+                monitorsExit = GeofenceTransitionType.EXIT in region.transitionTypes
             )
         }
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -17,7 +17,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Geofence sync pipeline. Two public entry points:
@@ -219,15 +218,17 @@ internal class GeofenceRepositoryImpl(
      * fix is spent on arrival and nothing re-requests one.
      */
     private suspend fun awaitRefreshSlot(): Boolean {
-        if (tryTakeRefreshSlot()) return true
-        return withTimeoutOrNull(MOVEMENT_SLOT_WAIT) {
-            // Nothing suspends between a winning CAS and the return, so a timeout can't land in
-            // between and leave the flag set with nobody to clear it.
-            while (!tryTakeRefreshSlot()) {
-                delay(MOVEMENT_SLOT_POLL)
-            }
-            true
-        } == true
+        // Bounded polling rather than a timeout around the wait: a deadline enforced by cancellation
+        // can land between a winning CAS and the block's completion, discarding the result while the
+        // slot stays taken — latching the flag so every later pass drops for the life of the process.
+        // Here the CAS result is the return value, so a slot can only be held by a caller that got
+        // `true`. Scheduling delay stretches the wait rather than shortening it, which is the safe
+        // direction: the point is to outlast the holder, not to give up on time.
+        repeat(MOVEMENT_SLOT_ATTEMPTS) {
+            if (tryTakeRefreshSlot()) return true
+            delay(MOVEMENT_SLOT_POLL)
+        }
+        return tryTakeRefreshSlot()
     }
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -610,5 +611,6 @@ internal class GeofenceRepositoryImpl(
         // lands late still re-centres, whereas a dropped one leaves nothing to re-centre.
         val MOVEMENT_SLOT_WAIT = 30.seconds
         val MOVEMENT_SLOT_POLL = 50.milliseconds
+        val MOVEMENT_SLOT_ATTEMPTS = (MOVEMENT_SLOT_WAIT / MOVEMENT_SLOT_POLL).toInt()
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -142,7 +142,14 @@ internal class GeofenceServicesImpl(
         val userId = secureUserStore.getUserId()
         // No user yet: skip; a later identify re-triggers.
         if (userId.isNullOrEmpty()) return
-        onUserIdentified(latitude, longitude)
+        // Not onUserIdentified: the flags above are already consumed, so a pass dropped for a
+        // collision spends this fix without using it and nothing requests another.
+        triggerSync(
+            reason = REASON_LOCATION_ACQUIRED,
+            latitude = latitude,
+            longitude = longitude,
+            action = repository::refreshFromLiveFix
+        )
     }
 
     override fun onForegroundRetry(latitude: Double?, longitude: Double?) {
@@ -231,5 +238,6 @@ internal class GeofenceServicesImpl(
         const val REASON_USER_IDENTIFIED = "user-identified"
         const val REASON_APP_LAUNCH = "app-launch"
         const val REASON_FOREGROUND_RETRY = "foreground-retry"
+        const val REASON_LOCATION_ACQUIRED = "location-acquired"
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -2,8 +2,10 @@ package io.customer.geofence
 
 import android.annotation.SuppressLint
 import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.location.LocationCoordinates
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -170,7 +172,7 @@ internal class GeofenceServicesImpl(
         regionStore.clearLastMovementTriggerLocation()
         logger.logGeofenceStateResetOnSignOut()
         scope.launch {
-            repository.reset()
+            runSafely("sign-out reset") { repository.reset() }
         }
     }
 
@@ -183,6 +185,13 @@ internal class GeofenceServicesImpl(
         if (latitude == null || longitude == null) {
             lastSkippedForNoLocation.set(true)
             logger.logSyncSkippedNoLocation(reason)
+            return null
+        }
+        // NaN, infinite and out-of-range coordinates all make `Location.distanceBetween` throw,
+        // part way through the sync. Rearm as for a missing fix.
+        if (!LocationCoordinates.isValid(latitude, longitude)) {
+            lastSkippedForNoLocation.set(true)
+            logger.logSyncSkippedInvalidLocation(reason, latitude, longitude)
             return null
         }
         if (!permissionChecker.hasRequiredLocationPermissions()) {
@@ -198,9 +207,23 @@ internal class GeofenceServicesImpl(
         // permissions are revoked, so no mid-flight revocation to handle.
         @SuppressLint("MissingPermission")
         val syncJob = scope.launch {
-            action(latitude, longitude)
+            runSafely("sync ($reason)") { action(latitude, longitude) }
         }
         return syncJob
+    }
+
+    /**
+     * Backstop for work launched on [scope], which has no exception handler — anything escaping would
+     * reach the thread's default handler and take the host app down. Fatal [Error]s propagate.
+     */
+    private suspend fun runSafely(description: String, block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.logSyncFailed("$description threw ${e.javaClass.simpleName}: ${e.message}")
+        }
     }
 
     private companion object {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -1,5 +1,6 @@
 package io.customer.geofence
 
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
@@ -9,17 +10,24 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Cooldown-gated, per-geoset fan-out for one crossing: persist the batch, then schedule delivery.
+ * Gated, per-geoset fan-out for one crossing: persist the batch, then schedule delivery.
  * Shared by the OS broadcast path ([GeofenceBroadcastReceiver]) and the synthesized initial-enter
- * path ([GeofenceRepository]) so both produce identical rows and dedupe via the cooldown filter.
+ * path ([GeofenceRepository]) so both produce identical rows and pass the same gates.
+ *
+ * Two gates, in order: an ENTER already reported and not yet balanced by an EXIT is dropped, then
+ * the time-based cooldown dedupes the rest. Shared by both paths, which is why they live here.
  */
 internal class GeofenceTransitionEmitter(
     private val cooldownFilter: GeofenceCooldownFilter,
     private val pendingStore: PendingDeliveryStore<PendingGeofenceDelivery>,
     private val scheduler: GeofenceEventScheduler,
+    private val regionStore: GeofenceRegionStore,
     private val logger: GeofenceLogger
 ) {
-    /** @return false when the cooldown suppressed it or the persist failed (cooldown rolled back). */
+    /**
+     * @return false when the ENTER was already reported, the cooldown suppressed it, or the persist
+     * failed (cooldown rolled back).
+     */
     suspend fun emit(
         geofenceId: String,
         transition: Event.GeofenceTransition,
@@ -27,8 +35,20 @@ internal class GeofenceTransitionEmitter(
         timestampSeconds: Long,
         geofenceName: String?,
         metadata: Map<String, JsonElement>,
-        geosetIds: List<String>
+        geosetIds: List<String>,
+        monitorsExit: Boolean
     ): Boolean {
+        // Reboot and app update both re-register with INITIAL_TRIGGER_ENTER, so the OS re-reports
+        // ENTER for a fence the device never left. Ahead of the cooldown so the drop doesn't spend
+        // the fence's slot, and only where an EXIT can clear the mark — an enter-only fence never
+        // reports one, so the mark would swallow every later arrival.
+        val isRedundantEnter = transition == Event.GeofenceTransition.ENTER &&
+            monitorsExit &&
+            regionStore.hasEmittedEnter(userId, geofenceId)
+        if (isRedundantEnter) {
+            logger.logEnterDroppedAlreadyReported(geofenceId)
+            return false
+        }
         if (!cooldownFilter.tryAcquire(userId, geofenceId, transition)) {
             logger.logTransitionSuppressed(geofenceId, transition.name)
             return false
@@ -60,6 +80,10 @@ internal class GeofenceTransitionEmitter(
             logger.logPersistFailed(geofenceId, transition.name)
             cooldownFilter.release(userId, geofenceId, transition)
             return false
+        }
+        // Only once the rows are durable, so a rolled-back write can't suppress its own retry.
+        if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
+            regionStore.markEnterEmitted(userId, geofenceId)
         }
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -17,6 +17,7 @@ import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.util.HandlerMainThreadPoster
 import io.customer.sdk.core.util.MainThreadPoster
+import io.customer.sdk.data.store.SecureUserStore
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
@@ -169,7 +170,20 @@ class ModuleGeofence @JvmOverloads constructor(
                     eventBus = eventBus,
                     regionStore = sdkAndroid.geofenceRegionStore,
                     logger = logger,
-                    onForeground = { retrySyncAwaitingLocation(sdkAndroid, locationModule) }
+                    onForeground = {
+                        // Off the main thread: deciding whether to take a fix needs the identity read,
+                        // a Keystore decrypt that can block for hundreds of ms on some OEMs.
+                        val foregroundScope = SDKComponent.scopeProvider.geofenceScope
+                        foregroundScope.launch {
+                            try {
+                                if (!refreshOnForeground(sdkAndroid.geofenceServices, sdkAndroid.secureUserStore, locationModule)) {
+                                    retrySyncAwaitingLocation(sdkAndroid, locationModule)
+                                }
+                            } finally {
+                                foregroundScope.cancel()
+                            }
+                        }
+                    }
                 )
             )
 
@@ -198,6 +212,32 @@ class ModuleGeofence @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Refreshes discovery from a live fix on foreground entry: OS geofence callbacks can stop for
+     * hours, and every other path anchors at the last registration center — where the device used to
+     * be — so nothing else notices it has moved.
+     *
+     * Returns false when no fix was taken: MANUAL leaves fixes to the host, nobody is identified to
+     * sync for, or a sync is already stuck without one and [retrySyncAwaitingLocation] owns that case.
+     */
+    @VisibleForTesting
+    @OptIn(InternalCustomerIOApi::class)
+    internal fun refreshOnForeground(
+        services: GeofenceServices,
+        secureUserStore: SecureUserStore,
+        locationModule: ModuleLocation
+    ): Boolean {
+        if (moduleConfig.locationMode != GeofenceLocationMode.AUTOMATIC) return false
+        if (services.isAwaitingLocation()) return false
+        // The sync drops a fix that arrives with nobody identified, so taking one before the first
+        // identify — or on every resume after sign-out — spends location and battery on nothing.
+        if (secureUserStore.getUserId().isNullOrEmpty()) return false
+        // Arm before requesting, so the returning fix drives the sync.
+        services.onRefreshRequested()
+        locationModule.locationServices.requestLocationUpdateSilently()
+        return true
     }
 
     /**

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -100,6 +100,7 @@ internal val AndroidSDKComponent.geofenceTransitionEmitter: GeofenceTransitionEm
             cooldownFilter = geofenceCooldownFilter,
             pendingStore = pendingGeofenceDeliveryStore,
             scheduler = geofenceEventScheduler,
+            regionStore = geofenceRegionStore,
             logger = SDKComponent.geofenceLogger
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -25,6 +25,9 @@ import kotlinx.serialization.builtins.serializer
  *
  * Cleared on sign-out:
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
+ *   enteredIds                  — fences the device is inside; goes with the registrations it
+ *                                  describes.
+ *   emittedEnterIds             — fences reported entered, plus the userId they belong to.
  *   lastApiFetchLocation        — anchor for the tier-B distance check (rarely updated).
  *   lastMovementTriggerLocation — user's location at the most recent movement-trigger
  *                                  registration; used by boot restore to re-center
@@ -55,6 +58,75 @@ internal interface GeofenceRegionStore {
 
     fun saveRegisteredIds(ids: Set<String>)
     fun getRegisteredIds(): Set<String>
+
+    /** Fences the device is known to be inside. Drives the EXIT guard — see [claimExit]. */
+    fun getEnteredIds(): Set<String>
+
+    /** Records that the device is inside [geofenceId]. Idempotent. */
+    fun recordEntered(geofenceId: String)
+
+    /**
+     * Atomically drops [geofenceId] from the entered set, returning whether it was there, and on
+     * `true` drops the reported-ENTER mark in the same step.
+     *
+     * `false` means no record of the device ever being inside, so the EXIT is a GMS reconciliation
+     * artifact rather than a crossing.
+     */
+    fun claimExit(geofenceId: String): Boolean
+
+    /** Reported-transition counter, read before a sync computes its geometry and passed to [reconcileEnteredIds]. */
+    fun containmentEpoch(): Long
+
+    /**
+     * Prunes the entered set to [registeredIds] and unions in [inside], the fences our own geometry
+     * puts the device within at registration time. Union rather than replace, because [inside] may
+     * come from a stale anchor whose "outside" must not erase real containment.
+     *
+     * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from; a fence whose exit
+     * was claimed after that is dropped, so a departure reported during the sync's GMS await wins
+     * over the older geometry.
+     *
+     * [resetIds] have their carried record dropped rather than pruned and kept, for fences the caller
+     * knows the stored containment no longer describes; [inside] still re-adds them. A fence that
+     * reported an entry after [sinceEpoch] keeps its record — the OS placing the device inside
+     * outranks the caller's older geometry.
+     *
+     * Returns the [resetIds] whose record was actually dropped, so a caller resetting related state
+     * can act on the same decision instead of its own guess.
+     */
+    fun reconcileEnteredIds(
+        registeredIds: Set<String>,
+        inside: Set<String>,
+        sinceEpoch: Long,
+        resetIds: Set<String> = emptySet()
+    ): Set<String>
+
+    /**
+     * Whether containment has ever been recorded. False on an install upgraded from a version that
+     * predates the set, until the first registration seeds it — the EXIT guard defers while it is,
+     * since "empty" and "no data yet" are otherwise indistinguishable.
+     */
+    fun hasContainmentRecord(): Boolean
+
+    /**
+     * Fences reported entered with no EXIT reported since — what the backend currently believes.
+     * Distinct from [getEnteredIds], which tracks where the device *is*: a sync seeds containment
+     * 20-46ms before the OS reports the matching ENTER, so one set would swallow real crossings.
+     *
+     * Scoped to [userId] because a direct A-to-B identify publishes no `ResetEvent`. Set by
+     * [markEnterEmitted], cleared by [claimExit].
+     */
+    fun hasEmittedEnter(userId: String, geofenceId: String): Boolean
+
+    /** Records that an ENTER for [geofenceId] reached the delivery pipeline for [userId]. Idempotent. */
+    fun markEnterEmitted(userId: String, geofenceId: String)
+
+    /**
+     * Drops reported-ENTER marks for fences no longer in [registeredIds]. A fence dropped while the
+     * device is inside never reports the EXIT that would clear its mark, which would then swallow a
+     * genuine revisit.
+     */
+    fun pruneEmittedEnterIds(registeredIds: Set<String>)
 
     /** Device uptime at the last successful OS registration; null if never registered. Drives reboot detection. */
     fun getLastRegistrationUptime(): Long?
@@ -115,6 +187,94 @@ internal class GeofenceRegionStoreImpl(
     override fun getRegisteredIds(): Set<String> =
         readJson(KEY_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
 
+    override fun getEnteredIds(): Set<String> =
+        readJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
+
+    override fun hasContainmentRecord(): Boolean = prefs.read { contains(KEY_ENTERED_IDS) } ?: false
+
+    // The mutators share a lock: each is a read-modify-write, and transitions arrive on the
+    // receiver's coroutine while registration runs on the sync path.
+    override fun recordEntered(geofenceId: String) = synchronized(enteredLock) {
+        val current = getEnteredIds()
+        if (geofenceId !in current) {
+            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current + geofenceId)
+        }
+        // Stamped even when the id is already recorded: a repeat report still says the OS puts the
+        // device inside now, which a sync holding an older fix has to defer to.
+        epoch += 1
+        enterEpochByGeofenceId[geofenceId] = epoch
+    }
+
+    override fun claimExit(geofenceId: String): Boolean = synchronized(enteredLock) {
+        val current = getEnteredIds()
+        if (geofenceId !in current) return@synchronized false
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current - geofenceId)
+        // Same step: a mark stranded by a later failure would silence the next genuine arrival.
+        clearEnterEmitted(geofenceId)
+        // Only a consumed record bumps the epoch; a claim that found nothing is a suspected GMS
+        // artifact and must not block the geometry seed.
+        epoch += 1
+        exitEpochByGeofenceId[geofenceId] = epoch
+        true
+    }
+
+    override fun containmentEpoch(): Long = synchronized(enteredLock) { epoch }
+
+    override fun reconcileEnteredIds(
+        registeredIds: Set<String>,
+        inside: Set<String>,
+        sinceEpoch: Long,
+        resetIds: Set<String>
+    ): Set<String> = synchronized(enteredLock) {
+        val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
+        // An entry reported since the caller's fix describes the geometry being registered now, so
+        // it survives a reset aimed at the geometry it replaced.
+        val dropped = resetIds.filter { (enterEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }.toSet() - stillInside
+        val carried = (getEnteredIds() intersect registeredIds) - dropped
+        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
+        // Bound the maps, after the filters have read them.
+        exitEpochByGeofenceId.keys.retainAll(registeredIds)
+        enterEpochByGeofenceId.keys.retainAll(registeredIds)
+        dropped
+    }
+
+    override fun hasEmittedEnter(userId: String, geofenceId: String): Boolean = synchronized(enteredLock) {
+        if (readEmittedEnterOwner() != userId) return@synchronized false
+        geofenceId in readEmittedEnterIds()
+    }
+
+    override fun markEnterEmitted(userId: String, geofenceId: String) = synchronized(enteredLock) {
+        // One identity owns the set at a time, so a different owner makes it stale — replace, not add.
+        val sameOwner = readEmittedEnterOwner() == userId
+        val current = if (sameOwner) readEmittedEnterIds() else emptySet()
+        if (!sameOwner) {
+            prefs.edit { putString(KEY_EMITTED_ENTER_OWNER, userId) }
+        }
+        if (geofenceId !in current) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current + geofenceId)
+        }
+    }
+
+    private fun readEmittedEnterIds(): Set<String> =
+        readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
+
+    private fun readEmittedEnterOwner(): String? = prefs.read { getString(KEY_EMITTED_ENTER_OWNER, null) }
+
+    private fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
+        val current = readEmittedEnterIds()
+        if (geofenceId in current) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current - geofenceId)
+        }
+    }
+
+    override fun pruneEmittedEnterIds(registeredIds: Set<String>) = synchronized(enteredLock) {
+        val current = readEmittedEnterIds()
+        val retained = current intersect registeredIds
+        if (retained.size != current.size) {
+            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, retained)
+        }
+    }
+
     override fun getLastRegistrationUptime(): Long? = prefs.read {
         if (contains(KEY_LAST_REGISTRATION_UPTIME)) getLong(KEY_LAST_REGISTRATION_UPTIME, 0L) else null
     }
@@ -166,6 +326,9 @@ internal class GeofenceRegionStoreImpl(
             remove(KEY_LAST_API_FETCH_LOCATION)
             remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
             remove(KEY_REGISTERED_IDS)
+            remove(KEY_ENTERED_IDS)
+            remove(KEY_EMITTED_ENTER_IDS)
+            remove(KEY_EMITTED_ENTER_OWNER)
             remove(KEY_LAST_REGISTRATION_UPTIME)
             remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             remove(KEY_LAST_SYNC)
@@ -212,9 +375,21 @@ internal class GeofenceRegionStoreImpl(
         }
     }
 
+    private val enteredLock = Any()
+
+    // Guarded by [enteredLock]. Bumped per reported transition, so a sync can tell which of the two
+    // directions a fence reported most recently against the fix the sync is holding. Per-fence
+    // values are the epoch at which that fence last reported in that direction.
+    private var epoch = 0L
+    private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
+    private val enterEpochByGeofenceId = mutableMapOf<String, Long>()
+
     private companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"
         const val KEY_REGISTERED_IDS = "registered_ids"
+        const val KEY_ENTERED_IDS = "entered_ids"
+        const val KEY_EMITTED_ENTER_IDS = "emitted_enter_ids"
+        const val KEY_EMITTED_ENTER_OWNER = "emitted_enter_owner"
         const val KEY_CACHED_CONFIG = "cached_config"
         const val KEY_LAST_API_FETCH_LOCATION = "last_api_fetch_location"
         const val KEY_LAST_MOVEMENT_TRIGGER_LOCATION = "last_movement_trigger_location"

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -102,6 +103,15 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             "biz-geofence-1",
             "biz-geofence-2"
         )
+        // Default: the device counts as inside every fence, so the EXIT guard is a no-op.
+        // Tests for the guard override.
+        every { mockStore.claimExit(any()) } returns true
+        // Default: containment has been recorded, i.e. not a freshly-upgraded install.
+        every { mockStore.hasContainmentRecord() } returns true
+        // Default: fences monitor both transitions, so the EXIT guard applies. Exit-only fences and
+        // uncached ids are exempt from it and have their own tests.
+        every { mockStore.getCachedRegion(any()) } returns
+            GeofenceRegion("biz-geofence-2", 0.0, 0.0, 100f)
         pendingStore.removeAll()
         receiver = GeofenceBroadcastReceiver()
     }
@@ -598,6 +608,203 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // Both transitions were appended before their schedule attempt.
         pendingStore.loadAll().map { it.geofenceId } shouldBeEqualTo listOf("biz-1", "biz-2")
         coVerify { mockScheduler.schedule(match { it.geofenceId == "biz-2" }) }
+    }
+
+    @Test
+    fun dispatchTransition_givenExitForFenceNeverEntered_expectDroppedAndOsRegistrationKept() = runTest {
+        // GMS reports EXIT for a fence it never reported as entered — its own state
+        // reconciliation, not a crossing. Unlike an orphan ID the registration is still
+        // wanted, so it must NOT be removed from the OS.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
+        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitForExitOnlyFence_expectDeliveredNotDropped() = runTest {
+        // An exit-only fence is registered without ENTER monitoring, so the OS can never report an
+        // ENTER for the guard to record. Applying the guard would drop every one of its EXITs.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns GeofenceRegion(
+            id = "biz-geofence-2",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f,
+            transitionTypes = listOf(GeofenceTransitionType.EXIT)
+        )
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitForUncachedFence_expectDeliveredNotDropped() = runTest {
+        // No cache row means unknown transition types, which can't justify dropping a crossing.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns null
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnmatchedExitOnUpgradedInstall_expectDeliveredNotDropped() = runTest {
+        // Upgrade path: the install predates the entered set, so there is no containment data to
+        // judge against until the first registration seeds it. A fence entered before the upgrade
+        // must still report its EXIT.
+        every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.hasContainmentRecord() } returns false
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenReportedEnterForFenceMonitoringExit_expectDropped() = runTest {
+        every { mockStore.hasEmittedEnter("user-42", "biz-geofence-2") } returns true
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenReportedEnterForEnterOnlyFence_expectDelivered() = runTest {
+        // An enter-only fence never reports an EXIT, so nothing would ever clear its mark. Honouring
+        // the guard here would suppress every arrival after the first for the life of the
+        // registration — the mirror of the exit-only exemption above.
+        every { mockStore.hasEmittedEnter("user-42", "biz-geofence-2") } returns true
+        every { mockStore.getCachedRegion("biz-geofence-2") } returns GeofenceRegion(
+            id = "biz-geofence-2",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f,
+            transitionTypes = listOf(GeofenceTransitionType.ENTER)
+        )
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenConcurrentBroadcastsForSameFence_expectBookkeepingSerialized() = runTest {
+        // Each broadcast is handled on its own scope, so without the lock an ENTER and an EXIT for
+        // the same fence interleave their read-decide-persist: the ENTER reads the mark the EXIT is
+        // about to clear and is dropped, then the EXIT drops containment, leaving the device inside
+        // with no record and its next EXIT dropped too.
+        val inFlight = AtomicInteger()
+        val peakInFlight = AtomicInteger()
+        coEvery { mockScheduler.schedule(any()) } coAnswers {
+            val depth = inFlight.incrementAndGet()
+            peakInFlight.updateAndGet { peak -> maxOf(peak, depth) }
+            delay(100)
+            inFlight.decrementAndGet()
+        }
+
+        val enter = launch {
+            receiver.dispatchTransition(
+                gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+                triggeringGeofenceIds = listOf("biz-1"),
+                latitude = 0.0,
+                longitude = 0.0
+            )
+        }
+        val exit = launch {
+            receiver.dispatchTransition(
+                gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+                triggeringGeofenceIds = listOf("biz-1"),
+                latitude = 0.0,
+                longitude = 0.0
+            )
+        }
+        enter.join()
+        exit.join()
+
+        peakInFlight.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun dispatchTransition_givenEnterTransition_expectContainmentRecorded() = runTest {
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        // Recording the ENTER is what lets the matching EXIT through later.
+        verify { mockStore.recordEntered("biz-geofence-2") }
+    }
+
+    @Test
+    fun dispatchTransition_givenAnonymousEnter_expectContainmentStillRecorded() = runTest {
+        // Containment is physical, so it is tracked even when the event isn't deliverable —
+        // otherwise identifying between a crossing's ENTER and EXIT would lose the EXIT.
+        every { mockSecureUserStore.getUserId() } returns null
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence-2"),
+            latitude = 51.5074,
+            longitude = -0.1278
+        )
+
+        verify { mockStore.recordEntered("biz-geofence-2") }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenMovementTriggerExit_expectGuardNotApplied() = runTest {
+        // The movement trigger is internal plumbing and is never "entered", so running it
+        // through the guard would permanently stall movement-driven refreshes.
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        verify(exactly = 0) { mockStore.claimExit(any()) }
+        verify { mockServices.onMovementTriggerExit(any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceDistanceFilterTest.kt
@@ -87,19 +87,94 @@ class GeofenceDistanceFilterTest : RobolectricTest() {
     }
 
     @Test
-    fun nearest_givenEquallyDistantRegions_expectStableInputOrder() {
-        // Two regions equally distant from origin — Kotlin's sortedBy is stable
-        val first = region("biz-first", 1.0, 0.0)
+    fun nearest_givenEquallyDistantRegions_expectOrderedByIdNotInputOrder() {
+        // Equally distant either side of the origin, supplied in reverse id order: the id tiebreak
+        // must decide, so the result can't depend on the server's response order.
         val second = region("biz-second", -1.0, 0.0)
+        val first = region("biz-first", 1.0, 0.0)
 
-        val result = filter.nearest(listOf(first, second), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
+        val result = filter.nearest(listOf(second, first), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
 
         result.map { it.id } shouldBeEqualTo listOf("biz-first", "biz-second")
+    }
+
+    @Test
+    fun nearest_givenSubMeterDistanceDifference_expectRoundingLetsIdTiebreakDecide() {
+        // Same centre, radii chosen so the boundary distances are 1000.4 m and 1000.2 m — a sub-meter
+        // gap that rounds to the same whole meter. On raw distance "biz-b" would sort first; rounding
+        // makes it a tie so the id decides, which is what keeps the order deterministic.
+        val centreDistance = region("probe", 0.01, 0.0).distanceTo(0.0, 0.0)
+        val a = region("biz-a", 0.01, 0.0, radius = centreDistance - 1000.4f)
+        val b = region("biz-b", 0.01, 0.0, radius = centreDistance - 1000.2f)
+
+        val result = filter.nearest(listOf(a, b), latitude = 0.0, longitude = 0.0, max = 2, maxDistanceMeters = noDistanceCap)
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-a", "biz-b")
+    }
+
+    @Test
+    fun nearest_givenOccupiedRegionAndNearerCenteredRegions_expectOccupiedRegionKeptAndRankedFirst() {
+        // Device sits inside a 5 km region ~2.2 km from its center, so ranking on center distance
+        // would place it 4th and the count budget would evict it — leaving it unmonitored and its
+        // exit unreportable.
+        val occupied = region("biz-occupied", 0.02, 0.0, radius = 5_000f)
+        val small1 = region("biz-small-1", 0.001, 0.0) // ~110 m center, ~10 m edge
+        val small2 = region("biz-small-2", 0.002, 0.0) // ~221 m center, ~121 m edge
+        val small3 = region("biz-small-3", 0.003, 0.0) // ~332 m center, ~232 m edge
+
+        val result = filter.nearest(
+            listOf(small1, small2, small3, occupied),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 3,
+            maxDistanceMeters = noDistanceCap
+        )
+
+        // The occupied region sorts first at edge distance 0; the farthest small region is evicted.
+        result.map { it.id } shouldBeEqualTo listOf("biz-occupied", "biz-small-1", "biz-small-2")
+    }
+
+    @Test
+    fun nearest_givenOccupiedRegionCenterBeyondDistanceCap_expectRegionStillIncluded() {
+        // Center ~5.5 km away with an 8 km radius: the device is inside, but the center falls outside
+        // the 3 km cap, so measuring to the center would filter out a region containing the device.
+        val occupied = region("biz-occupied", 0.05, 0.0, radius = 8_000f)
+        // Control: neither the center (~11 km) nor the boundary (~11 km) is within the cap.
+        val beyond = region("biz-beyond", 0.1, 0.0)
+
+        val result = filter.nearest(
+            listOf(occupied, beyond),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 5,
+            maxDistanceMeters = 3_000f
+        )
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-occupied")
+    }
+
+    @Test
+    fun nearest_givenLargeRegionWithCloserBoundary_expectRankedAheadOfNearerCenteredSmallRegion() {
+        // Applies to regions the device is outside too: a 2 km region centered ~2.2 km away has its
+        // boundary ~211 m off, nearer than a 100 m region centered ~1.1 km away.
+        val bigFar = region("biz-big-far", 0.02, 0.0, radius = 2_000f)
+        val smallNear = region("biz-small-near", 0.01, 0.0)
+
+        val result = filter.nearest(
+            listOf(smallNear, bigFar),
+            latitude = 0.0,
+            longitude = 0.0,
+            max = 2,
+            maxDistanceMeters = noDistanceCap
+        )
+
+        result.map { it.id } shouldBeEqualTo listOf("biz-big-far", "biz-small-near")
     }
 
     private fun region(
         id: String,
         latitude: Double,
-        longitude: Double
-    ) = GeofenceRegion(id = id, latitude = latitude, longitude = longitude, radius = 100f)
+        longitude: Double,
+        radius: Float = 100f
+    ) = GeofenceRegion(id = id, latitude = latitude, longitude = longitude, radius = radius)
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
@@ -124,10 +124,10 @@ class GeofenceManagerTest : RobolectricTest() {
     }
 
     @Test
-    fun replaceGeofences_givenMovementTrigger_expectInitialTriggerEnter() = runTest {
-        // Movement trigger registered with INITIAL_TRIGGER_ENTER so GMS records
-        // state as INSIDE at the new center — without this, prior OUTSIDE state
-        // from the previous EXIT would block future EXITs from firing.
+    fun replaceGeofences_givenMovementTrigger_expectInitialTriggerExit() = runTest {
+        // The trigger evaluates position at register time, so a stale center fires EXIT immediately
+        // and handleMovement re-centers. Device-verified: adding ENTER alongside stops GMS
+        // delivering the trigger's later EXIT entirely.
         grantAllPermissions()
 
         val requestSlot = slot<GeofencingRequest>()
@@ -138,7 +138,7 @@ class GeofenceManagerTest : RobolectricTest() {
             listOf(buildRegion(id = GeofenceConstants.MOVEMENT_TRIGGER_ID))
         )
 
-        requestSlot.captured.initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requestSlot.captured.initialTrigger shouldBeEqualTo GeofencingRequest.INITIAL_TRIGGER_EXIT
     }
 
     @Test
@@ -203,9 +203,9 @@ class GeofenceManagerTest : RobolectricTest() {
         )
 
         requests.size shouldBeEqualTo 2
-        requests[0].initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requests[0].initialTrigger shouldBeEqualTo GeofencingRequest.INITIAL_TRIGGER_EXIT
         requests[0].geofences.first().requestId shouldBeEqualTo GeofenceConstants.MOVEMENT_TRIGGER_ID
-        requests[1].initialTrigger shouldContainFlag GeofencingRequest.INITIAL_TRIGGER_ENTER
+        requests[1].initialTrigger shouldBeEqualTo GeofencingRequest.INITIAL_TRIGGER_ENTER
         requests[1].geofences.first().requestId shouldBeEqualTo "business-1"
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRegionTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRegionTest.kt
@@ -42,16 +42,41 @@ class GeofenceRegionTest : RobolectricTest() {
             (Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
     }
 
+    @Test
+    fun edgeDistanceTo_givenCoordinatesInsideRegion_expectZero() {
+        val region = buildRegion(radius = 5_000f)
+
+        // ~2.2 km from center, well within the radius.
+        region.edgeDistanceTo(0.02, 0.0) shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun edgeDistanceTo_givenCoordinatesOnBoundary_expectZero() {
+        val centerDistance = buildRegion().distanceTo(0.01, 0.0)
+        val region = buildRegion(radius = centerDistance)
+
+        region.edgeDistanceTo(0.01, 0.0) shouldBeEqualTo 0f
+    }
+
+    @Test
+    fun edgeDistanceTo_givenCoordinatesOutsideRegion_expectDistanceLessRadius() {
+        val region = buildRegion(radius = 1_000f)
+        val centerDistance = region.distanceTo(0.05, 0.0)
+
+        region.edgeDistanceTo(0.05, 0.0) shouldBeEqualTo centerDistance - 1_000f
+    }
+
     private fun buildRegion(
         transitionTypes: List<GeofenceTransitionType> = listOf(
             GeofenceTransitionType.ENTER,
             GeofenceTransitionType.EXIT
-        )
+        ),
+        radius: Float = 100f
     ) = GeofenceRegion(
         id = "test-geofence",
         latitude = 0.0,
         longitude = 0.0,
-        radius = 100f,
+        radius = radius,
         transitionTypes = transitionTypes
     )
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -544,6 +545,89 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
         verify(exactly = 0) { store.saveLastMovementTriggerLocation(any()) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationSucceeds_expectContainmentSeededFromGeometryNotFromEnterEvents() = runTest {
+        // Initial-ENTER synthesis is suppressed after a reboot/app update, so no ENTER is emitted
+        // for a fence the device is already inside. Without seeding containment here, that fence's
+        // later genuine EXIT would look unentered and be dropped by the guard.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        val inside = GeofenceRegion("biz-inside", 0.0, 0.0, 500f)
+        val outside = GeofenceRegion("biz-outside", 1.0, 1.0, 100f)
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(inside, outside)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        result.isSuccess shouldBeEqualTo true
+        // Only the fence whose radius actually contains the device is seeded; the far one is not,
+        // so a phantom EXIT for it is still dropped.
+        verify {
+            store.reconcileEnteredIds(
+                registeredIds = any(),
+                inside = setOf("biz-inside"),
+                sinceEpoch = any()
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenExitClaimedWhileRegistering_expectEpochFromBeforeTheAwait() = runTest {
+        // The seed must be judged against the containment state as of this sync's fix, not as of
+        // whenever GMS finished. Registration awaits GMS for seconds, and an EXIT landing in that
+        // window is newer evidence than the geometry.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.containmentEpoch() } returns 5L
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            // A transition claims an exit mid-registration, advancing the epoch.
+            every { store.containmentEpoch() } returns 7L
+            Result.success(Unit)
+        }
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(registeredIds = any(), inside = any(), sinceEpoch = 5L) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationFails_expectContainmentNotSeeded() = runTest {
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.failure(IOException("gms down"))
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Nothing is monitored, so claiming containment would let a later phantom EXIT through.
+        verify(exactly = 0) { store.reconcileEnteredIds(any(), any(), any()) }
+        verify(exactly = 0) { store.pruneEmittedEnterIds(any()) }
+    }
+
+    @Test
+    fun refresh_givenRegistrationSucceeds_expectEmittedEnterPrunedToRegisteredSet() = runTest {
+        // The reported-ENTER marks must be pruned to the same snapshot the registrations are, or a
+        // fence evicted while the device is inside keeps a mark no EXIT will ever clear.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-inside", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        val pruned = slot<Set<String>>()
+        verify { store.pruneEmittedEnterIds(capture(pruned)) }
+        pruned.captured shouldContain "biz-inside"
     }
 
     @Test
@@ -1555,6 +1639,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet() // newly registered
         every { store.getCachedConfig() } returns sampleConfig()
+        // Reconcile seeded containment from this fix's geometry; synthesis follows that, not a
+        // second geometry pass.
+        every { store.getEnteredIds() } returns setOf("biz-1")
         every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
@@ -1568,9 +1655,63 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 timestampSeconds = any(),
                 geofenceName = any(),
                 metadata = any(),
-                geosetIds = any()
+                geosetIds = any(),
+                monitorsExit = true
             )
         }
+    }
+
+    @Test
+    fun refresh_givenNewlyRegisteredEnterOnlyFenceDeviceInside_expectInitialEnterNotLatched() = runTest {
+        // The synthesized ENTER must carry the fence's real monitoring shape: latching an enter-only
+        // fence would suppress every later arrival, since no EXIT can ever release it.
+        val cached = listOf(
+            GeofenceRegion("biz-1", 0.0, 0.0, 100f, transitionTypes = listOf(GeofenceTransitionType.ENTER))
+        )
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getEnteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = false
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenExitClaimedWhileRegistering_expectNoSynthesizedEnter() = runTest {
+        // The device left during the GMS await, so reconcile did not seed the fence. Synthesizing
+        // from this fix's geometry anyway would send an ENTER for a fence we were just told we left,
+        // and the phantom guard would drop its genuine EXIT — an ENTER the backend never balances.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet() // newly registered
+        every { store.getCachedConfig() } returns sampleConfig()
+        // Geometry from the fix says inside; containment says otherwise because the exit was claimed.
+        every { store.getEnteredIds() } returns emptySet()
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1595,7 +1736,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify { manager.replaceGeofences(any(), emptySet()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1617,7 +1758,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1642,7 +1783,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1654,6 +1795,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
         every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
         every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
         coEvery { apiService.fetchGeofences(any()) } returns
             Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
@@ -1669,12 +1811,117 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 timestampSeconds = any(),
                 geofenceName = any(),
                 metadata = any(),
-                geosetIds = any()
+                geosetIds = any(),
+                monitorsExit = any()
             )
         }
     }
 
     @Test
+    fun refresh_givenFenceMovedAwayFromDevice_expectContainmentAndMarkReset() = runTest {
+        // g-1's circle moved while the device was recorded inside the old one. GMS promises no EXIT
+        // for a circle it no longer holds, so carrying the record and the reported-ENTER mark forward
+        // would drop the first genuine arrival at the new circle and deliver its EXIT unmatched.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns setOf("g-1")
+
+        // Device ~1.1 km away: outside the new circle, so the old record cannot be trusted.
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
+        // Mark dropped, so the arrival at the new circle is not mistaken for a repeat.
+        verify { store.pruneEmittedEnterIds(match { "g-1" !in it }) }
+    }
+
+    @Test
+    fun refresh_givenArrivalReportedWhileRegistrationAwaited_expectMarkKeptWithRecord() = runTest {
+        // Same moved circle, but GMS reported an arrival at it while registration was awaited, so the
+        // store keeps the record. The mark has to follow: it belongs to that reported arrival, and
+        // clearing it would let the next report through as a fresh one.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        // Store declines the reset because the arrival is newer than the fix that asked for it.
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns emptySet()
+
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
+        verify { store.pruneEmittedEnterIds(match { "g-1" in it }) }
+    }
+
+    @Test
+    fun refresh_givenFenceReRegisteredWhileDeviceInside_expectRecordAndMarkKept() = runTest {
+        // Radius grew 50 → 100 m with the device inside throughout. Resetting here would let the
+        // synthesized ENTER fire for a visit already reported.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify { store.reconcileEnteredIds(any(), any(), any(), emptySet()) }
+        verify { store.pruneEmittedEnterIds(match { "g-1" in it }) }
+    }
+
+    @Test
+    fun refresh_givenStaleContainmentRecordAndDeviceOutside_expectNoInitialEnter() = runTest {
+        // reconcile carries containment forward for fences that stay registered, so a param-drift
+        // re-add can find a record that outlived the visit. Geometry has to agree before we
+        // synthesize, or we report an arrival somewhere the device left long ago.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1") // stale: carried forward, not current
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        // ~1.1 km north of g-1, far outside its 100 m radius.
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        coVerify(exactly = 0) {
+            transitionEmitter.emit(
+                geofenceId = "g-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = any(),
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = any()
+            )
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun refresh_givenUserChangesDuringRegistration_expectNoInitialEnter() = runTest {
         // clearIdentify rewrites the user store without taking stateMutex, so identity can change
         // while the GMS call is awaited; synthesis must recheck before queueing a delivery row.
@@ -1697,7 +1944,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         gmsGate.complete(Unit)
         refreshJob.join()
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1718,7 +1965,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // ~2.2 km move → local re-rank runs, and the device is inside biz-1 (radius 300 m at 0.02,0.0).
         repository.refresh(latitude = 0.02, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1736,7 +1983,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1755,7 +2002,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1771,7 +2018,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -1791,7 +2038,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.restoreFromCache()
 
-        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     private fun sampleConfig(

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1523,6 +1523,40 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    fun handleMovement_givenHolderOutlastingTheWait_expectSlotLeftFreeForTheNextPass() = runTest {
+        // The wait has to end at its bound and leave the slot usable: the flag is process-scoped and
+        // nothing else clears it, so a pass that gave up while still holding it would silently drop
+        // every later refresh — a worse failure than the stranding the wait exists to prevent.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences(any()) } coAnswers {
+            delay(60.seconds) // outlasts the wait, so the movement pass gives up
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val holder = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent()
+
+        repository.handleMovement(latitude = 0.001, longitude = 0.0)
+        verify(exactly = 1) { logger.logSyncSkipped(match { it.contains("already in progress") }) }
+        holder.join()
+
+        repository.handleMovement(latitude = 0.002, longitude = 0.0)
+
+        // Still one: the second pass took the slot rather than finding it latched.
+        verify(exactly = 1) { logger.logSyncSkipped(match { it.contains("already in progress") }) }
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(0.002, 0.0)) }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
     fun refreshFromLiveFix_givenRefreshHoldingTheSlot_expectRegisteredAroundTheLiveFix() = runTest {
         // Field failure: a cold start's identify refresh took the slot working from the stored
         // anchor, the fix the SDK had asked for arrived 285ms later and was dropped, and the set

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -21,6 +21,8 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
@@ -1432,10 +1434,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun handleMovement_givenSecondCallWhileFirstInFlight_expectSecondDropped() = runTest {
-        // handleMovement and refresh share the same in-flight gate. A movement
-        // EXIT arriving while a refresh is mid-API call must drop fast — same
-        // dedup guarantee.
+    fun handleMovement_givenSecondCallWhileFirstInFlight_expectSerializedNotDropped() = runTest {
+        // Movement passes serialize rather than drop: each carries its own live fix and each has to
+        // re-centre the trigger, so dropping one strands it.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getLastApiFetchLocation() } returns null
         every { store.getCachedConfig() } returns null
@@ -1458,7 +1459,98 @@ class GeofenceRepositoryTest : RobolectricTest() {
         }
 
         maxObservedConcurrency.get() shouldBeEqualTo 1
-        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        coVerify(exactly = 2) { apiService.fetchGeofences(any()) }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun handleMovement_givenRefreshHoldingTheSlot_expectTriggerStillReCentredAtLiveFix() = runTest {
+        // Field failure: a trigger EXIT cold-starts the process, init's refresh takes the slot and
+        // skips (anchored on the registration center, so it measures zero movement), and the movement
+        // pass was dropped — leaving the fired trigger un-recentred, so nothing can fire again.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis()
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        // Cache present, nothing registered: init's pass re-ranks locally, holding the slot.
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            delay(200.milliseconds)
+            Result.success(Unit)
+        }
+        val initPass = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent()
+
+        repository.handleMovement(latitude = 0.001, longitude = 0.0)
+        initPass.join()
+
+        // Re-centred on the movement fix, not the anchor the init pass was using.
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(0.001, 0.0)) }
+        verify(exactly = 0) { logger.logSyncSkipped(match { it.contains("already in progress") }) }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun handleMovement_givenSlowHolderThatRegistersNothing_expectWaitOutlastsIt() = runTest {
+        // The holder can sit in a remote fetch for the HTTP client's whole timeout and then fail,
+        // registering nothing — so it never re-centres the fired trigger on its way out. Waiting only
+        // as long as a local pass would hand that job back to nobody.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → the holder goes remote
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences(any()) } coAnswers {
+            delay(20.seconds)
+            Result.failure(RuntimeException("read timeout"))
+        }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val holder = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent()
+
+        repository.handleMovement(latitude = 0.001, longitude = 0.0)
+        holder.join()
+
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(0.001, 0.0)) }
+        verify(exactly = 0) { logger.logSyncSkipped(match { it.contains("already in progress") }) }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun refreshFromLiveFix_givenRefreshHoldingTheSlot_expectRegisteredAroundTheLiveFix() = runTest {
+        // Field failure: a cold start's identify refresh took the slot working from the stored
+        // anchor, the fix the SDK had asked for arrived 285ms later and was dropped, and the set
+        // was registered 2 km from the device. The arming flag is spent on arrival, so nothing
+        // requested another fix.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → both passes go remote
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { store.getRegisteredIds() } returns emptySet()
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        coEvery { apiService.fetchGeofences(any()) } coAnswers {
+            delay(2.seconds)
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val identifyPass = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent()
+
+        // ~2.2 km from the anchor the holder is using, as in the field log.
+        repository.refreshFromLiveFix(latitude = 0.02, longitude = 0.0)
+        identifyPass.join()
+
+        verify { store.saveLastMovementTriggerLocation(GeofenceLocation(0.02, 0.0)) }
+        verify(exactly = 0) { logger.logSyncSkipped(match { it.contains("already in progress") }) }
     }
 
     // ---------- restoreFromCache (boot path) ----------

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -196,7 +196,7 @@ class GeofenceServicesTest : RobolectricTest() {
     @Test
     fun onLocationAcquired_givenPriorSkipAndUserIdentified_expectRefresh() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
-        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.refreshFromLiveFix(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         // Skip first, then deliver the fix.
@@ -205,13 +205,13 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify { repository.refresh(12.0, 34.0) }
+        coVerify { repository.refreshFromLiveFix(12.0, 34.0) }
     }
 
     @Test
     fun onLocationAcquired_givenExplicitRefreshRequested_expectRefreshWithoutPriorSkip() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
-        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.refreshFromLiveFix(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         // Host-initiated refresh arms the pipeline; the returning fix drives the sync
@@ -220,13 +220,13 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify { repository.refresh(12.0, 34.0) }
+        coVerify { repository.refreshFromLiveFix(12.0, 34.0) }
     }
 
     @Test
     fun onLocationAcquired_givenExplicitRefreshRequested_expectConsumedOnce() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
-        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.refreshFromLiveFix(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onRefreshRequested()
@@ -234,8 +234,8 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 56.0, longitude = 78.0)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { repository.refresh(any(), any()) }
-        coVerify(exactly = 0) { repository.refresh(56.0, 78.0) }
+        coVerify(exactly = 1) { repository.refreshFromLiveFix(any(), any()) }
+        coVerify(exactly = 0) { repository.refreshFromLiveFix(56.0, 78.0) }
     }
 
     @Test
@@ -246,7 +246,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.refreshFromLiveFix(any(), any()) }
         coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
     }
 
@@ -260,7 +260,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.refreshFromLiveFix(any(), any()) }
     }
 
     @Test
@@ -278,7 +278,7 @@ class GeofenceServicesTest : RobolectricTest() {
 
         // Only the initial identify call should reach the repository.
         coVerify(exactly = 1) { repository.refresh(any(), any()) }
-        coVerify(exactly = 0) { repository.refresh(3.0, 4.0) }
+        coVerify(exactly = 0) { repository.refreshFromLiveFix(any(), any()) }
     }
 
     @Test
@@ -296,7 +296,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        coVerify(exactly = 0) { repository.refreshFromLiveFix(any(), any()) }
     }
 
     @Test
@@ -329,6 +329,7 @@ class GeofenceServicesTest : RobolectricTest() {
     fun onForegroundRetry_givenStillNoLocation_expectStaysArmed() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
         coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.refreshFromLiveFix(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         // A retry that still has no anchor must leave the flag up, or the fix it kicks off
@@ -341,7 +342,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify { repository.refresh(12.0, 34.0) }
+        coVerify { repository.refreshFromLiveFix(12.0, 34.0) }
     }
 
     @Test
@@ -378,6 +379,7 @@ class GeofenceServicesTest : RobolectricTest() {
     fun isAwaitingLocation_expectPeekLeavesFlagForTheReturningFix() = runTest(StandardTestDispatcher()) {
         every { secureUserStore.getUserId() } returns "user-1"
         coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        coEvery { repository.refreshFromLiveFix(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
 
         services.onUserIdentified(latitude = null, longitude = null)
@@ -389,7 +391,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onLocationAcquired(latitude = 12.0, longitude = 34.0)
         advanceUntilIdle()
 
-        coVerify { repository.refresh(12.0, 34.0) }
+        coVerify { repository.refreshFromLiveFix(12.0, 34.0) }
         services.isAwaitingLocation() shouldBeEqualTo false
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -115,6 +115,57 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun onMovementTriggerExit_givenUnusableFix_expectSkipAndStayArmed() = runTest(StandardTestDispatcher()) {
+        // NaN, infinite and out-of-range coordinates all make Location.distanceBetween throw, part
+        // way through a sync that has no exception handler above it.
+        val services = servicesWith(this)
+
+        val unusable = listOf(
+            Double.NaN to 2.0,
+            1.0 to Double.NaN,
+            Double.POSITIVE_INFINITY to 2.0,
+            91.0 to 2.0,
+            1.0 to 181.0
+        )
+        unusable.forEach { (lat, lng) ->
+            services.onMovementTriggerExit(latitude = lat, longitude = lng).shouldBeNull()
+        }
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
+        coVerify(exactly = 0) { repository.refresh(any(), any()) }
+        verify(exactly = unusable.size) { logger.logSyncSkippedInvalidLocation(any(), any(), any()) }
+        // Armed like a missing fix, so the next usable one drives a sync.
+        services.isAwaitingLocation() shouldBeEqualTo true
+    }
+
+    @Test
+    fun onMovementTriggerExit_givenRepositoryThrows_expectLoggedAndNotRethrown() = runTest(StandardTestDispatcher()) {
+        // The services scope carries a SupervisorJob and no exception handler, so anything escaping
+        // here would reach the thread's default handler and take the host app down.
+        coEvery { repository.handleMovement(any(), any()) } throws IllegalStateException("boom")
+        val services = servicesWith(this)
+
+        val job = services.onMovementTriggerExit(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        job.shouldNotBeNull()
+        job.isCancelled shouldBeEqualTo false
+        verify { logger.logSyncFailed(match { it?.contains("IllegalStateException") == true }) }
+    }
+
+    @Test
+    fun onUserSignedOut_givenResetThrows_expectLoggedAndNotRethrown() = runTest(StandardTestDispatcher()) {
+        coEvery { repository.reset() } throws IllegalStateException("boom")
+        val services = servicesWith(this)
+
+        services.onUserSignedOut()
+        advanceUntilIdle()
+
+        verify { logger.logSyncFailed(match { it?.contains("IllegalStateException") == true }) }
+    }
+
+    @Test
     fun onMovementTriggerExit_givenPermissionsNotGranted_expectSkipAndLog() = runTest(StandardTestDispatcher()) {
         every { permissionChecker.hasRequiredLocationPermissions() } returns false
         val services = servicesWith(this)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -1,6 +1,7 @@
 package io.customer.geofence
 
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
@@ -28,18 +29,42 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     private val mockScheduler: GeofenceEventScheduler = mockk(relaxed = true)
     private val mockLogger: GeofenceLogger = mockk(relaxed = true)
 
+    // Relaxed default is `hasEmittedEnter = false`, i.e. nothing reported yet — the state every
+    // pre-existing test assumes.
+    private val mockRegionStore: GeofenceRegionStore = mockk(relaxed = true)
+
     private val emitter = GeofenceTransitionEmitter(
         cooldownFilter = mockCooldownFilter,
         pendingStore = mockPendingStore,
         scheduler = mockScheduler,
+        regionStore = mockRegionStore,
         logger = mockLogger
+    )
+
+    /** Defaults describe the common case: an ENTER on a fence monitoring both transitions. */
+    private suspend fun emit(
+        geofenceId: String = "biz-1",
+        transition: Event.GeofenceTransition = Event.GeofenceTransition.ENTER,
+        userId: String = "user-1",
+        geofenceName: String? = null,
+        geosetIds: List<String> = emptyList(),
+        monitorsExit: Boolean = true
+    ): Boolean = emitter.emit(
+        geofenceId = geofenceId,
+        transition = transition,
+        userId = userId,
+        timestampSeconds = 100L,
+        geofenceName = geofenceName,
+        metadata = emptyMap(),
+        geosetIds = geosetIds,
+        monitorsExit = monitorsExit
     )
 
     @Test
     fun emit_givenCooldownSuppresses_expectFalseAndNoPersist() = runTest {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit()
 
         emitted.shouldBeFalse()
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
@@ -52,7 +77,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, "Cafe", emptyMap(), emptyList())
+        val emitted = emit(geofenceName = "Cafe")
 
         emitted.shouldBeTrue()
         verify { mockPendingStore.appendAll(capture(entries)) }
@@ -70,7 +95,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         val entries = slot<List<PendingGeofenceDelivery>>()
 
         // "g1" listed twice → deduped to one entry.
-        emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2", "g1"))
+        emit(geosetIds = listOf("g1", "g2", "g1"))
 
         verify { mockPendingStore.appendAll(capture(entries)) }
         entries.captured.map { it.geosetId } shouldBeEqualTo listOf("g1", "g2")
@@ -86,7 +111,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockPendingStore.appendAll(any()) } returns true
         coEvery { mockScheduler.schedule(match { it.geosetId == "g1" }) } throws RuntimeException("boom")
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), listOf("g1", "g2"))
+        val emitted = emit(geosetIds = listOf("g1", "g2"))
 
         emitted.shouldBeTrue()
         coVerify(exactly = 1) { mockScheduler.schedule(match { it.geosetId == "g2" }) }
@@ -98,10 +123,90 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns false
 
-        val emitted = emitter.emit("biz-1", Event.GeofenceTransition.ENTER, "user-1", 100L, null, emptyMap(), emptyList())
+        val emitted = emit()
 
         emitted.shouldBeFalse()
         verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenEnterAlreadyReported_expectDroppedWithoutSpendingCooldown() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
+
+        val emitted = emit()
+
+        emitted.shouldBeFalse()
+        // Ahead of the cooldown, so the slot stays free for the next genuine transition.
+        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        verify(exactly = 0) { mockPendingStore.appendAll(any()) }
+    }
+
+    @Test
+    fun emit_givenEnterOnlyFenceAlreadyReported_expectDelivered() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        val emitted = emit(monitorsExit = false)
+
+        // GMS never reports an EXIT for this fence, so nothing would ever clear the mark: honouring
+        // it here would suppress every arrival after the first for the life of the registration.
+        emitted.shouldBeTrue()
+    }
+
+    @Test
+    fun emit_givenEnterOnlyFenceDelivered_expectNoMarkRecorded() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit(monitorsExit = false)
+
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
+    }
+
+    @Test
+    fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        val emitted = emit(transition = Event.GeofenceTransition.EXIT)
+
+        // The gate is ENTER-only: an EXIT must never be blocked by it.
+        emitted.shouldBeTrue()
+    }
+
+    @Test
+    fun emit_givenEnterDelivered_expectMarkedReported() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit()
+
+        verify(exactly = 1) { mockRegionStore.markEnterEmitted("user-1", "biz-1") }
+    }
+
+    @Test
+    fun emit_givenEnterPersistFails_expectNotMarkedSoRetryCanDeliver() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns false
+
+        emit()
+
+        // Marking a rolled-back write would suppress the retry and lose the crossing entirely.
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
+    }
+
+    @Test
+    fun emit_givenExitDelivered_expectMarkNotTouchedHere() = runTest {
+        every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit(transition = Event.GeofenceTransition.EXIT)
+
+        // Re-arming belongs to `claimExit`, which runs whether or not delivery gets this far.
+        verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/ModuleGeofenceTest.kt
@@ -4,9 +4,11 @@ import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.location.LocationCoordinates
 import io.customer.location.LocationServices
 import io.customer.location.ModuleLocation
+import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.Test
@@ -17,6 +19,9 @@ class ModuleGeofenceTest {
     private val mockLocationServices: LocationServices = mockk(relaxed = true)
     private val mockLocationModule: ModuleLocation = mockk {
         every { locationServices } returns mockLocationServices
+    }
+    private val identifiedUserStore: SecureUserStore = mockk {
+        every { getUserId() } returns "user-42"
     }
 
     private fun moduleWith(mode: GeofenceLocationMode) =
@@ -41,6 +46,60 @@ class ModuleGeofenceTest {
         moduleWith(GeofenceLocationMode.AUTOMATIC)
             .autoAcquireIfNeeded(mockLocationModule, currentLocation = LocationCoordinates(latitude = 1.0, longitude = 2.0))
 
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenAutomatic_expectArmedAndSilentFetch() {
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo true
+
+        // Arming after the request would race the fix and drop it.
+        verifyOrder {
+            mockServices.onRefreshRequested()
+            mockLocationServices.requestLocationUpdateSilently()
+        }
+    }
+
+    @Test
+    fun refreshOnForeground_givenManual_expectNoFetchOrArm() {
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+
+        moduleWith(GeofenceLocationMode.MANUAL)
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenSyncAlreadyAwaitingLocation_expectDeferredToStuckSyncPath() {
+        val mockServices: GeofenceServices = mockk(relaxed = true) {
+            every { isAwaitingLocation() } returns true
+        }
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, identifiedUserStore, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
+        verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
+    }
+
+    @Test
+    fun refreshOnForeground_givenNoIdentifiedUser_expectNoFetchOrArm() {
+        // Resume before the first identify, and every resume after sign-out. The sync discards a fix
+        // that arrives with nobody identified, so requesting one is spent battery.
+        val mockServices: GeofenceServices = mockk(relaxed = true)
+        val signedOutStore: SecureUserStore = mockk {
+            every { getUserId() } returns null
+        }
+
+        moduleWith(GeofenceLocationMode.AUTOMATIC)
+            .refreshOnForeground(mockServices, signedOutStore, mockLocationModule) shouldBeEqualTo false
+
+        verify(exactly = 0) { mockServices.onRefreshRequested() }
         verify(exactly = 0) { mockLocationServices.requestLocationUpdateSilently() }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -13,7 +13,9 @@ import io.customer.geofence.GeofenceTransitionType
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
@@ -113,6 +115,311 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRegisteredIds(emptySet())
 
         store.getRegisteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun claimExit_givenNeverEntered_expectFalse() {
+        // The phantom-EXIT guard: no containment record means GMS is reconciling its own
+        // state rather than reporting a crossing.
+        store.claimExit("biz-1") shouldBeEqualTo false
+    }
+
+    @Test
+    fun claimExit_givenEntered_expectTrueThenFalseOnSecondCall() {
+        store.recordEntered("biz-1")
+
+        store.claimExit("biz-1") shouldBeEqualTo true
+        // Consumed: a duplicate EXIT for the same crossing doesn't pass twice.
+        store.claimExit("biz-1") shouldBeEqualTo false
+    }
+
+    @Test
+    fun recordEntered_givenCalledTwice_expectSingleEntry() {
+        store.recordEntered("biz-1")
+        store.recordEntered("biz-1")
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenReRegisteredFenceDeviceNoLongerInside_expectRecordDropped() {
+        // The circle moved but kept its ID, so the old record describes somewhere else.
+        store.recordEntered("biz-moved")
+
+        val dropped = store.reconcileEnteredIds(
+            registeredIds = setOf("biz-moved"),
+            inside = emptySet(),
+            sinceEpoch = store.containmentEpoch(),
+            resetIds = setOf("biz-moved")
+        )
+
+        store.getEnteredIds().shouldBeEmpty()
+        // Reported back so the caller resets the matching mark on the same decision.
+        dropped shouldContainSame setOf("biz-moved")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenEnterReportedAfterFixWasTaken_expectRecordKeptDespiteReset() {
+        store.recordEntered("biz-moved")
+        // A sync captures the epoch with its fix, then awaits GMS for seconds.
+        val epochAtFix = store.containmentEpoch()
+
+        // Mid-flight the OS reports an arrival at the circle being registered — our fix said the
+        // device was outside it, GMS says otherwise and is looking at the newer position.
+        store.recordEntered("biz-moved")
+
+        val dropped = store.reconcileEnteredIds(
+            registeredIds = setOf("biz-moved"),
+            inside = emptySet(),
+            sinceEpoch = epochAtFix,
+            resetIds = setOf("biz-moved")
+        )
+
+        // Dropping it here would leave the device inside with no record, so its genuine EXIT would
+        // be discarded as never-entered.
+        store.getEnteredIds() shouldContainSame setOf("biz-moved")
+        dropped.shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenReRegisteredFenceStillInside_expectRecordKept() {
+        // A radius edit made while the device is inside must not manufacture a fresh arrival.
+        store.recordEntered("biz-widened")
+
+        val dropped = store.reconcileEnteredIds(
+            registeredIds = setOf("biz-widened"),
+            inside = setOf("biz-widened"),
+            sinceEpoch = store.containmentEpoch(),
+            resetIds = setOf("biz-widened")
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-widened")
+        // Nothing was dropped, so the caller must not drop the mark either.
+        dropped.shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_expectPrunedToRegisteredAndUnionedWithInside() {
+        store.recordEntered("biz-kept")
+        store.recordEntered("biz-unregistered")
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-kept", "biz-new-inside"),
+            inside = setOf("biz-new-inside"),
+            sinceEpoch = store.containmentEpoch()
+        )
+
+        // "biz-unregistered" pruned, "biz-kept" survives because it is still registered.
+        store.getEnteredIds() shouldContainSame setOf("biz-kept", "biz-new-inside")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenExitClaimedAfterFixWasTaken_expectFenceNotReSeeded() {
+        store.recordEntered("biz-1")
+        // A sync captures the epoch with its fix, then awaits GMS for seconds.
+        val epochAtFix = store.containmentEpoch()
+
+        // Mid-flight the OS reports the departure and the receiver consumes the record.
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // The sync now writes back geometry from the older fix, which still contained the fence.
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        // Resurrecting it would leave the device recorded inside a fence it left, disarming the EXIT
+        // guard for that fence until its next departure.
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenExitClaimedBeforeFixWasTaken_expectFenceSeeded() {
+        // Same fence, opposite order: the departure is already history when the fix is taken, so the
+        // geometry is the newer evidence — e.g. the device drove back in while the process was dead.
+        store.recordEntered("biz-1")
+        store.claimExit("biz-1").shouldBeTrue()
+        val epochAtFix = store.containmentEpoch()
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenUnclaimedExitForSameFence_expectStillSeeded() {
+        // A claim that found no record is a suspected GMS artifact, not a departure. Letting it block
+        // the seed would leave the fence with no containment at all, so its next genuine EXIT would
+        // be dropped as never-entered — the failure the seed exists to prevent.
+        val epochAtFix = store.containmentEpoch()
+
+        store.claimExit("biz-1").shouldBeFalse()
+
+        store.reconcileEnteredIds(
+            registeredIds = setOf("biz-1"),
+            inside = setOf("biz-1"),
+            sinceEpoch = epochAtFix
+        )
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenFenceUnregisteredAfterClaim_expectClaimForgottenSoLaterSeedWorks() {
+        // The claim record is per-fence state that would otherwise accumulate for the life of the
+        // process. Trimming it to the registered set is safe: a fence has to be re-registered before
+        // geometry can seed it again, and by then the old claim is older than any such sync.
+        store.recordEntered("biz-1")
+        val epochAtFix = store.containmentEpoch()
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // Fence drops out of the monitored set, so its claim record is trimmed.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-other"), inside = emptySet(), sinceEpoch = epochAtFix)
+        // Re-registered later with the device inside it, using the same stale epoch.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = setOf("biz-1"), sinceEpoch = epochAtFix)
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun containmentEpoch_givenClaimedExit_expectAdvanced() {
+        store.recordEntered("biz-1")
+        val before = store.containmentEpoch()
+
+        store.claimExit("biz-1")
+
+        (store.containmentEpoch() > before).shouldBeTrue()
+    }
+
+    @Test
+    fun hasContainmentRecord_givenNothingEverRecorded_expectFalse() {
+        // Upgraded install: distinguishable from "recorded, and nothing is entered".
+        store.hasContainmentRecord().shouldBeFalse()
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun hasContainmentRecord_givenReconcileWithNothingInside_expectTrue() {
+        // The first registration seeds the key even when the device is inside nothing, which is what
+        // ends the upgrade grace period.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
+
+        store.hasContainmentRecord().shouldBeTrue()
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenStaleAnchorReportsOutside_expectExistingContainmentPreserved() {
+        // A launch refresh can run off the persisted anchor rather than a live fix. If that
+        // anchor wrongly says "outside", erasing containment would swallow the genuine EXIT.
+        store.recordEntered("biz-1")
+
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun hasEmittedEnter_givenNothingReported_expectFalse() {
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_givenCalledTwice_expectStillReportedAndIdempotent() {
+        store.markEnterEmitted(USER, "biz-1")
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
+    }
+
+    @Test
+    fun claimExit_givenEnterReported_expectMarkClearedWithContainment() {
+        store.recordEntered("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.claimExit("biz-1").shouldBeTrue()
+
+        // Both drop together: the mark can't be left behind for a delivery path that may not run.
+        store.getEnteredIds().shouldBeEmpty()
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun claimExit_givenNeverEntered_expectMarkRetained() {
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.claimExit("biz-1").shouldBeFalse()
+
+        // An unclaimed EXIT is a GMS artifact, not a departure — re-arming on it would let the next
+        // OS re-report of ENTER through as a fresh arrival.
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
+    }
+
+    @Test
+    fun hasEmittedEnter_givenMarkOwnedByAnotherUser_expectFalse() {
+        store.markEnterEmitted(USER, "biz-1")
+
+        // A direct A-to-B identify publishes no ResetEvent, so B reaches a still-registered fence
+        // with A's mark in place. Honouring it would swallow B's first arrival.
+        store.hasEmittedEnter(OTHER_USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_givenNewOwner_expectPreviousUsersMarksDiscarded() {
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.markEnterEmitted(OTHER_USER, "biz-2")
+
+        store.hasEmittedEnter(OTHER_USER, "biz-2").shouldBeTrue()
+        store.hasEmittedEnter(OTHER_USER, "biz-1").shouldBeFalse()
+        // The set belongs to one identity at a time, so A's marks are gone rather than parked.
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun pruneEmittedEnterIds_expectMarksDroppedForUnregisteredFences() {
+        store.markEnterEmitted(USER, "biz-kept")
+        store.markEnterEmitted(USER, "biz-evicted")
+
+        store.pruneEmittedEnterIds(setOf("biz-kept"))
+
+        store.hasEmittedEnter(USER, "biz-kept").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-evicted").shouldBeFalse()
+    }
+
+    @Test
+    fun pruneEmittedEnterIds_givenFenceEvictedWhileInside_expectLaterRevisitNotSuppressed() {
+        // Without the prune the mark outlives the monitoring that would clear it: a fence dropped
+        // from the nearest set while the device is inside never reports its EXIT, so a genuine
+        // revisit months later would be swallowed.
+        store.markEnterEmitted(USER, "biz-1")
+
+        // Evicted from the monitored set — no EXIT is ever delivered for it.
+        store.pruneEmittedEnterIds(setOf("biz-other"))
+        // Re-registered on a later sync when the device comes back into range.
+        store.pruneEmittedEnterIds(setOf("biz-1"))
+
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun markEnterEmitted_expectIndependentOfEnteredSet() {
+        // The two sets answer different questions — where the device is vs. what we have sent — and
+        // the geometry seeding writes only the former. Coupling them would let a sync's reconcile
+        // suppress the OS ENTER that follows it milliseconds later.
+        store.markEnterEmitted(USER, "biz-1")
+
+        store.getEnteredIds().shouldBeEmpty()
+
+        store.reconcileEnteredIds(registeredIds = setOf("biz-2"), inside = setOf("biz-2"), sinceEpoch = store.containmentEpoch())
+
+        store.hasEmittedEnter(USER, "biz-1").shouldBeTrue()
+        store.hasEmittedEnter(USER, "biz-2").shouldBeFalse()
     }
 
     @Test
@@ -273,11 +580,13 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastSyncTimestamp(12_345L)
+        store.recordEntered("biz-1")
 
         store.clearAll()
 
         store.getCachedRegions().shouldBeEmpty()
         store.getRegisteredIds().shouldBeEmpty()
+        store.getEnteredIds().shouldBeEmpty()
         store.getCachedConfig().shouldBeNull()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
@@ -300,6 +609,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedRegions(regions)
         store.saveCachedConfig(config)
         store.saveRegisteredIds(setOf("biz-1"))
+        store.recordEntered("biz-1")
+        store.markEnterEmitted(USER, "biz-1")
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
@@ -310,6 +621,10 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         // User-specific: wiped.
         store.getRegisteredIds().shouldBeEmpty()
+        // Goes with the registrations it describes — sign-out drops those from the OS.
+        store.getEnteredIds().shouldBeEmpty()
+        // The next user must not inherit a suppressed ENTER for a fence they were never told about.
+        store.hasEmittedEnter(USER, "biz-1").shouldBeFalse()
         store.getLastApiFetchLocation().shouldBeNull()
         store.getLastMovementTriggerLocation().shouldBeNull()
         store.getLastRegistrationUptime().shouldBeNull()
@@ -435,6 +750,11 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             maxBusinessGeofences = 19,
             maxMonitoringDistance = 1_000_000f
         )
+    }
+
+    private companion object {
+        private const val USER = "user-1"
+        private const val OTHER_USER = "user-2"
     }
 
     private fun writeRaw(key: String, value: String) {


### PR DESCRIPTION
> [!IMPORTANT]
> **Squash-merge this PR.** All four commits below are `chore`, so a merge commit would put no releasable message on `main` and cut no release at all — silently, with no error. Squashing makes this PR's title the single commit message semantic-release reads, which is why it is a `fix(...)`, and why the title deserves a deliberate read before merging: it becomes the version bump *and* the changelog entry for the whole patch.

### What this is

A release branch collecting post-4.20.0 geofence fixes so one release is cut for all of them rather than one per merge. Nothing here is new work — the diff is exactly the union of the four PRs below, each reviewed and merged on its own.

| PR | What | Reviewed |
|---|---|---|
| #806 | Nearest-set selection ranks by boundary distance instead of centre, so a large region the device is inside is not evicted by nearer centres | Approved |
| #805 | Transitions gated on tracked containment: an EXIT for a region never entered is dropped, and a re-reported ENTER no longer becomes a second arrival | Approved, 4 review rounds + Bugbot |
| #807 | Discovery refreshes from a live fix on foreground entry, and is skipped entirely when no user is identified | Approved |
| #808 | A sync pass carrying the device's real position waits for the in-flight slot instead of being dropped; a stale movement-trigger centre now self-heals | Approved, 2 review rounds + Bugbot |

**Read those four for the reasoning, trade-offs and review history.** This description deliberately doesn't restate them.

### Reviewing this PR

The diff is the concatenation of four already-reviewed changes: 4 commits, 32 files, and `git log main..release-july-launch-fixes` contains nothing but the four squash commits. Everything in it has been through review on the PR it came from, and the discussion lives there.

What is genuinely new at this level is the *combination*. #805 and #808 both edit `GeofenceRepository.kt`, and three pairs interact in ways no sub-PR could show on its own:

- **#807 depends on #808 to be useful on a cold start.** #807 requests a live fix on foreground entry; before #808's third commit that fix's pass was dropped whenever module init still held the sync slot. Both halves of this are in one field log from 5 Aug: at `16:33` the fix was discarded and the set was registered around an anchor 2016 m away for 2 m 24 s; at `16:35` the same device, with the slot free, registered correctly. #808's live-fix commit is what closes the first case.
- **#806 reduces how often #805's mark-prune fires.** #805 drops a region's reported-ENTER mark when it leaves the monitored set, which is what would otherwise let a duplicate arrival through on re-registration. #806 stops evicting regions the device is standing inside, so the occupied-region case that made that prune dangerous now largely doesn't arise. They compound in the same direction.
- **#808's EXIT-only trigger increases re-registration, which #805's guards absorb.** A trigger registered on a stale centre now fires EXIT immediately and re-registers, so initial-ENTER synthesis runs more often. Without #805's redundant-ENTER guard that would mean more duplicate arrivals; with it, the repeats are suppressed. Observed 4 times on the 5 Aug drive, each correctly dropped.
- **Sequential passes over the containment state.** #808 makes a second pass run immediately after a first, so `reconcileEnteredIds` can now run twice in quick succession with different coordinates. #805's epoch mechanism is what keeps that safe: a transition reported between the two passes outranks the older pass's geometry.

### Validation of the combined branch

- Full suite green on the merged branch — **1703 tests, 0 failures** across all 9 CI modules. `apiCheck`, `lintDebug` and ktlint clean; no public API change; no compiler warnings in the touched modules.
- **On-device drive, Pixel 6, 5 Aug (2 h 15 m):** 10/10 movement triggers delivered, 6 complete ENTER/EXIT pairs, **zero false EXITs**, and 4 duplicate arrivals correctly suppressed. The cold-start stranding fix was observed recovering in 1.3 s. That build carried #805, #806, #807 and #808's first two commits.
- **#808's third commit (the live-fix wait) landed after that drive** and was validated by an emulator A/B instead: same seeded state, a fix injected 2 km from the anchor mid-pass. Without it, the fix is discarded and the device ends up monitoring regions 2 km away; with it, the pass waits 2034 ms and re-registers at the live position. The same run shows `app-launch` still dropping while `location-acquired` waits, which is the distinction the change rests on.
- **#805's geometry-drift path** was exercised on the emulator in both directions: a region whose server geometry moves away from the device resets containment and its mark; one that still contains the device keeps both, and the synthesized ENTER is suppressed rather than delivered as a duplicate.
- The 30-second slot wait's give-up branch was forced with a throwaway short-wait build: bounded, logged, returns success, and a following pass still acquires the slot — expiry does not latch the gate.

### Adding to this release

Target this branch, squash-merge, and title it `chore(...)` like the four above — individual titles never reach `main`, so they cannot affect the version. Before this PR merges:

- If anything landing here is a **feature**, retitle this PR to `feat(...)` or a minor ships as a patch.
- Widen this PR's title if the contents stop being geofence-only.
- If `main` moves during the window, merge it into this branch so CI tests what will actually ship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core geofence event delivery, OS registration, and location-driven sync with new persisted state and concurrency; behavior is heavily tested but regressions would affect campaign triggers in the field.
> 
> **Overview**
> **Geofence transition handling** gains persisted *containment* and *reported ENTER* state so GMS reconciliation artifacts are filtered: unmatched EXITs drop (with carve-outs for exit-only fences, uncached regions, and pre-upgrade installs), redundant ENTERs drop when an EXIT-monitored fence was already delivered, and a process-wide mutex serializes per-fence bookkeeping across concurrent broadcasts. Delivery runs through `handleBusinessTransition`, which records ENTER before identity checks and passes `monitorsExit` into the emitter.
> 
> **Discovery and sync** change how regions are chosen and when passes run. Nearest-set selection uses **boundary** distance (`edgeDistanceTo`), meter rounding, and id tie-breaks (aligned with iOS). Movement and **live-fix** sync paths **wait up to ~30s** for the refresh slot via `refreshFromLiveFix` instead of dropping; identify/app-launch still drop on collision. Foreground (automatic mode, identified user) arms a silent fix refresh; acquired locations route to `refreshFromLiveFix`. Registration seeds/reconciles containment with a **containment epoch**, resets state when geometry moves away, and tightens initial-ENTER synthesis to require store + geometry agreement.
> 
> **GMS registration** uses `INITIAL_TRIGGER_EXIT` for the movement trigger (boot restore unified with normal replace). **GeofenceServices** rejects invalid coordinates, and coroutine work is wrapped so sync/reset failures log instead of crashing the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c55a63ae63f6da1685c21f2821f04c3c35b033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->