### PR TITLE
ci: keep all sample app builds in one PR comment

### DIFF
--- a/.github/actions/update-sample-app-comment/action.yml
+++ b/.github/actions/update-sample-app-comment/action.yml
@@ -1,0 +1,35 @@
+name: Update sample app builds PR comment
+description: Create or rewrite the single PR comment that lists the latest sample app builds.
+
+inputs:
+  status:
+    description: "Markdown placed under the heading. Either a progress message or the list of built apps."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Find existing sample builds comment
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+      id: existing-comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: <!-- sample app builds -->
+
+    - name: Create or update sample builds comment
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        comment-id: ${{ steps.existing-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          <!-- sample app builds -->
+          # Sample app builds 📱
+
+          Below you will find the list of the latest versions of the sample apps. It's recommended to always download the latest builds of the sample apps to accurately test the pull request.
+
+          ---
+          ${{ inputs.status }}
+
+          Commit ${{ github.event.pull_request.head.sha }} · [CI run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+        edit-mode: replace

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -17,32 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # to be able to comment on PR
-    outputs:
-      comment-id: ${{ steps.create-comment.outputs.comment-id }}
     steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        id: existing-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <!-- sample app builds -->
+      - uses: actions/checkout@v4 # required to use the local action below
 
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        id: create-comment
+      # Claims the comment early so it shows builds are on the way. The build workflow rewrites it with results.
+      - uses: ./.github/actions/update-sample-app-comment
         with:
-          comment-id: ${{ steps.existing-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- sample app builds --> 
-            # Sample app builds 📱
-            
-            Below you will find the list of the latest versions of the sample apps. It's recommended to always download the latest builds of the sample apps to accurately test the pull request. 
-            
-            ---
-            ${{ steps.build.outputs.build-log }}
-          edit-mode: replace # replace the existing comment with new content since we are creating new builds
+          status: "⏳ Building the sample apps..."
 
   build-sample-apps:
     if: ${{ always() }} # do not skip running this step if update-pr-comment does not run

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -9,6 +9,9 @@ on:
         required: false
         default: false
 
+env:
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
 jobs:
   build_sample_apps:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         sample-app:
           # List all sample apps you want to have compiled.
           # List item is name of directory inside of "samples" directory for the corresponding app to compile.
+          # Adding an app here? Add a matching line to "outputs" below so it shows up in the PR comment too.
           - "java_layout"
           - "kotlin_compose"
         include: # Add additional variables to each sample app build: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
@@ -32,9 +36,12 @@ jobs:
             cio-siteid-secret-key: "CUSTOMERIO_KOTLIN_WORKSPACE_SITE_ID"
             firebase-app-id-secret-key: "SAMPLE_APPS_KOTLIN_FIREBASE_APP_ID"
 
+    # Matrix legs share one outputs map, so each app needs its own key to avoid overwriting the others.
+    outputs:
+      java_layout: ${{ steps.build-result.outputs.java_layout }}
+      kotlin_compose: ${{ steps.build-result.outputs.kotlin_compose }}
+
     name: Building app...${{ matrix.sample-app }}
-    permissions:
-      pull-requests: write # comment on pull request with build information
     steps:
       - name: Check out code with conditional fetch-depth
         uses: actions/checkout@v4
@@ -176,23 +183,50 @@ jobs:
           sdk_version: ${{ env.APP_SDK_BUILD_VERSION }}
           slack_webhook_url: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
 
-      - name: Update sample builds PR comment with build information
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        with:
-          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          # the variables APP_BUILD_NUMBER, APP_VERSION_STRING are created when fastlane runs "build".
-          body: |
-            * ${{ matrix.sample-app }}: `${{ env.APP_VERSION_STRING }} (${{ env.APP_BUILD_NUMBER }})`
-          edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds.
+      # Reporting a result instead of commenting here stops parallel apps clobbering each other's edits.
+      - name: Record build result for the PR comment
+        id: build-result
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          SAMPLE_APP: ${{ matrix.sample-app }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          if [[ "$JOB_STATUS" == "success" ]]; then
+            # the variables APP_BUILD_NUMBER, APP_VERSION_STRING are created when fastlane runs "build".
+            result="* $SAMPLE_APP: \`$APP_VERSION_STRING ($APP_BUILD_NUMBER)\`"
+          else
+            result="* $SAMPLE_APP: Build failed. See [CI job logs]($RUN_URL) to determine the issue and try re-building."
+          fi
+          echo "$SAMPLE_APP=$result" >> "$GITHUB_OUTPUT"
 
-      - name: Update sample builds PR comment with build failure message
-        if: ${{ failure() }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+  update_pr_comment:
+    name: Update sample builds PR comment
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [ build_sample_apps ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # comment on pull request with build information
+    steps:
+      - uses: actions/checkout@v4 # required to use the local action below
+
+      - name: Build the list of sample app builds
+        id: build-log
+        shell: bash
+        env:
+          BUILD_RESULTS: ${{ toJSON(needs.build_sample_apps.outputs) }}
+        run: |
+          # Sorted by app name for a stable order; apps that reported nothing (cancelled) are dropped.
+          build_log="$(jq -r 'to_entries | sort_by(.key) | map(.value) | map(select(. != "")) | join("\n")' <<< "$BUILD_RESULTS" 2>/dev/null || true)"
+          if [[ -z "$build_log" ]]; then
+            build_log="No sample app builds were produced. See [CI job logs]($RUN_URL)."
+          fi
+          {
+            echo "build-log<<GITHUB_OUTPUT_EOF"
+            echo "$build_log"
+            echo "GITHUB_OUTPUT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/update-sample-app-comment
         with:
-          comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            * ${{ matrix.sample-app }}: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building.
-          edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds.
+          status: ${{ steps.build-log.outputs.build-log }}


### PR DESCRIPTION
## Problem

Every push to a PR added **new** sample-app comments instead of updating the existing one. PR #805 accumulated 26 of them (2 per push × 13 pushes).

The comment steps lived in `reusable_build_sample_apps.yml` and read:

```yaml
comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
```

`update-pr-comment` is a job in the **caller** (`build-sample-apps.yml`). Inside a reusable workflow, `needs` only resolves jobs declared in that same file, so this was always an empty string — and `create-or-update-comment` with no `comment-id` creates a new comment. The reusable workflow never accepted the id as an input, so it could not have worked.

For reference, `customerio-flutter` does not hit this: its equivalent job sits in the same file as the one that creates the comment, so `needs` resolves.

## Fix

Each app now reports its result as a job output, and one job renders them all into a single comment with `edit-mode: replace`.

This also fixes two problems that a straight `comment-id` passthrough would have left behind:

- **Parallel append race** — `edit-mode: append` is a read-modify-write, and both apps append concurrently. On #805 they finished within the same second twice.
- **Duplicate lines on re-run** — re-running one failed app appended a second line for it rather than replacing the first.

Ordering is now stable (sorted by app name) instead of depending on which app finished first.

## Notes

- Matrix legs share a single `outputs` map, so each app needs its own key. It sits directly under the matrix list with a pointer comment. The rendering job reads `toJSON(needs.build_sample_apps.outputs)` and is app-agnostic — adding an app never touches it.
- Comment text now lives only in `.github/actions/update-sample-app-comment`, shared by the in-progress placeholder and the final result, so the heading/intro/footer exist in one place.
- The failure comment is now guarded to `pull_request`. It previously ran on any `failure()`, so a failed `push`/`release` build tried to comment with an empty issue-number.
- `pull-requests: write` moved off the build jobs onto the only job that comments.

## Testing

The comment on this PR is the test: it was pushed to several times, and the result is one comment throughout.

Rendering logic was also dry-run against every shape the outputs map can take — both apps succeeding, one failing, one cancelled with an empty value, an empty map, and null outputs — plus a hypothetical third app to confirm it needs no rendering changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and comment formatting changes; no application runtime, auth, or data handling.
> 
> **Overview**
> **Fixes duplicate sample-app PR comments** by stopping matrix jobs from appending to the same comment (which also raced when apps finished together) and by no longer relying on a `comment-id` from the caller job that reusable workflows could not see.
> 
> Adds **`.github/actions/update-sample-app-comment`**, which finds the `<!-- sample app builds -->` comment and **replaces** its body (placeholder or final list). `build-sample-apps.yml` uses it early with “Building…”; the reusable workflow posts the finished list.
> 
> In **`reusable_build_sample_apps.yml`**, each matrix leg records success/failure as a **named job output**; a new **`update_pr_comment`** job sorts those lines with `jq` and writes one comment. **`pull-requests: write`** moves to that job only, and failure messaging is limited to **`pull_request`** events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9f6d9fd3180c12494e4ba9c172d4a7630e7ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->