### PR TITLE
fix(in-app): guard modal sizing against viewport-dependent message height

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessageReducer.kt
@@ -105,7 +105,7 @@ internal val inAppMessagingReducer: Reducer<InAppMessagingState> = { state, acti
 
         is InAppMessagingAction.EngineAction.MessageLoadingFailed -> state.withMessageDismissed(
             message = action.message,
-            shouldMarkAsShown = false
+            shouldMarkAsShown = action.shouldMarkMessageAsShown()
         )
 
         is InAppMessagingAction.LoadMessage ->

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
@@ -25,7 +25,16 @@ internal sealed class InAppMessagingAction {
 
     sealed class EngineAction {
         data class Tap(val message: Message, val route: String, val name: String, val action: String) : InAppMessagingAction()
-        data class MessageLoadingFailed(val message: Message) : InAppMessagingAction()
+
+        /**
+         * @param suppressRetry when true, the message is marked as shown so it is not fetched and
+         * displayed again. Use it only when the failure is a property of the message itself and
+         * retrying can never succeed; a transient load failure should stay retryable.
+         */
+        data class MessageLoadingFailed(
+            val message: Message,
+            val suppressRetry: Boolean = false
+        ) : InAppMessagingAction()
     }
 
     sealed class InboxAction(open val message: InboxMessage) : InAppMessagingAction() {
@@ -48,6 +57,12 @@ internal fun InAppMessagingAction.shouldMarkMessageAsShown(): Boolean {
         is InAppMessagingAction.DismissMessage -> {
             // Mark the message as shown if it's persistent and should be logged and dismissed via close action only
             message.gistProperties.persistent && shouldLog && viaCloseAction
+        }
+
+        is InAppMessagingAction.EngineAction.MessageLoadingFailed -> {
+            // Persistent messages are not marked as shown when displayed, so a failure that can
+            // never succeed has to mark them here or the message is fetched and shown again forever.
+            suppressRetry
         }
 
         else -> false

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -54,6 +54,10 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
         logger.debug("[InApp][$type] $message")
     }
 
+    protected fun logViewError(message: String) {
+        logger.error("[InApp][$type] $message")
+    }
+
     /**
      * Attaches a new EngineWebView instance to the view hierarchy if not already attached.
      * Initializes the delegate, sets its alpha and listener, and adds it to the view.

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
@@ -1,26 +1,21 @@
 package io.customer.messaginginapp.ui.controller
 
-import androidx.annotation.VisibleForTesting
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppPlatformDelegate
 import io.customer.messaginginapp.ui.bridge.ModalInAppMessageViewCallback
-import io.customer.sdk.core.di.SDKComponent
 
 internal class ModalInAppMessageViewController(
     viewDelegate: InAppHostViewDelegate,
-    platformDelegate: InAppPlatformDelegate
+    platformDelegate: InAppPlatformDelegate,
+    /** Injectable so tests can drive the guard's clock instead of sleeping. */
+    private val sizePolicy: ModalSizePolicy = ModalSizePolicy()
 ) : InAppMessageViewController<ModalInAppMessageViewCallback>(
     type = "Modal",
     viewDelegate = viewDelegate,
     platformDelegate = platformDelegate
 ) {
-    private val logger = SDKComponent.logger
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal val sizePolicy: ModalSizePolicy = ModalSizePolicy()
-
     init {
         attachEngineWebView()
     }
@@ -35,18 +30,29 @@ internal class ModalInAppMessageViewController(
 
     override fun onRouteLoaded(message: Message, route: String) {
         engineWebViewDelegate?.setAlpha(1.0F)
-        // Only start judging reported heights once the message is on screen. While it loads the
-        // WebView is still detached and legitimately measures zero.
+        // Start judging reported heights from the point the message is handed over for display.
+        // Heights measured before this belong to a WebView that may not be laid out yet, and the
+        // policy additionally requires the collapsed reports to span real time so the ones that
+        // arrive while the modal is still being laid out cannot fail a healthy message.
         sizePolicy.arm()
         super.onRouteLoaded(message, route)
     }
 
     override fun onWebViewSizeUpdated(widthInDp: Double, heightInDp: Double) {
+        val message = currentMessage
+        if (message == null) {
+            // Without a message there is nothing to fail, and consuming a verdict we cannot act on
+            // would disable the guard for the rest of this message's life.
+            super.onWebViewSizeUpdated(widthInDp, heightInDp)
+            return
+        }
+
         when (val verdict = sizePolicy.onHeightReported(heightInDp)) {
-            is ModalSizeVerdict.Degenerate -> failCollapsedMessage()
+            is ModalSizeVerdict.Degenerate -> failCollapsedMessage(message)
 
             is ModalSizeVerdict.ViewportDependent -> {
-                logViewportDependentHeight(verdict.deltaInDp)
+                logViewportDependentHeight(message, verdict.deltaInDp)
+                sizePolicy.onViewportDependentHandled()
                 super.onWebViewSizeUpdated(widthInDp, heightInDp)
             }
 
@@ -57,25 +63,34 @@ internal class ModalInAppMessageViewController(
     /**
      * The message is displayed but collapsed, so it covers the screen and swallows touches without
      * ever showing anything. Failing it dismisses the overlay and tells the host app why.
+     *
+     * [InAppMessagingAction.EngineAction.MessageLoadingFailed.suppressRetry] is required here: a
+     * message whose CSS cannot resolve will collapse again every time, and persistent messages are
+     * never marked as shown when displayed, so without it the message would be fetched and shown
+     * again indefinitely.
      */
-    private fun failCollapsedMessage() {
-        val message = currentMessage ?: return
-        logger.error(
-            "In-app message ${message.messageId} reported a collapsed height " +
-                "(<= ${ModalSizePolicy.DEGENERATE_MAX_DP.toInt()}dp) for " +
-                "${ModalSizePolicy.SAMPLE_COUNT} consecutive updates, so it can never become " +
-                "visible while still blocking the screen. Dismissing it. $VIEWPORT_HEIGHT_HINT"
+    private fun failCollapsedMessage(message: Message) {
+        logViewError(
+            "Message ${message.messageId} reported a collapsed height " +
+                "(<= ${sizePolicy.degenerateMaxDp.toInt()}dp) for ${sizePolicy.sampleCount} " +
+                "consecutive updates over ${sizePolicy.degenerateMinElapsedMs}ms, so it can never " +
+                "become visible while still blocking the screen. Dismissing it and not retrying it. " +
+                VIEWPORT_HEIGHT_HINT
         )
         inAppMessagingManager.dispatch(
-            InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
+            InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                message = message,
+                suppressRetry = true
+            )
         )
+        sizePolicy.onDegenerateHandled()
     }
 
-    private fun logViewportDependentHeight(deltaInDp: Double) {
-        logger.error(
-            "In-app message ${currentMessage?.messageId} keeps growing by ${deltaInDp}dp per " +
-                "update, so its height tracks the WebView height instead of its content. It will " +
-                "be clamped to the screen and its content may not be positioned as designed. " +
+    private fun logViewportDependentHeight(message: Message, deltaInDp: Double) {
+        logViewError(
+            "Message ${message.messageId} keeps growing by ${deltaInDp}dp per update, so its " +
+                "height tracks the WebView height instead of its content. It will grow until the " +
+                "layout can grow no further, and its content may not be positioned as designed. " +
                 VIEWPORT_HEIGHT_HINT
         )
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalInAppMessageViewController.kt
@@ -1,9 +1,12 @@
 package io.customer.messaginginapp.ui.controller
 
+import androidx.annotation.VisibleForTesting
 import io.customer.messaginginapp.gist.data.model.Message
+import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppPlatformDelegate
 import io.customer.messaginginapp.ui.bridge.ModalInAppMessageViewCallback
+import io.customer.sdk.core.di.SDKComponent
 
 internal class ModalInAppMessageViewController(
     viewDelegate: InAppHostViewDelegate,
@@ -13,6 +16,11 @@ internal class ModalInAppMessageViewController(
     viewDelegate = viewDelegate,
     platformDelegate = platformDelegate
 ) {
+    private val logger = SDKComponent.logger
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val sizePolicy: ModalSizePolicy = ModalSizePolicy()
+
     init {
         attachEngineWebView()
     }
@@ -27,7 +35,49 @@ internal class ModalInAppMessageViewController(
 
     override fun onRouteLoaded(message: Message, route: String) {
         engineWebViewDelegate?.setAlpha(1.0F)
+        // Only start judging reported heights once the message is on screen. While it loads the
+        // WebView is still detached and legitimately measures zero.
+        sizePolicy.arm()
         super.onRouteLoaded(message, route)
+    }
+
+    override fun onWebViewSizeUpdated(widthInDp: Double, heightInDp: Double) {
+        when (val verdict = sizePolicy.onHeightReported(heightInDp)) {
+            is ModalSizeVerdict.Degenerate -> failCollapsedMessage()
+
+            is ModalSizeVerdict.ViewportDependent -> {
+                logViewportDependentHeight(verdict.deltaInDp)
+                super.onWebViewSizeUpdated(widthInDp, heightInDp)
+            }
+
+            is ModalSizeVerdict.Apply -> super.onWebViewSizeUpdated(widthInDp, heightInDp)
+        }
+    }
+
+    /**
+     * The message is displayed but collapsed, so it covers the screen and swallows touches without
+     * ever showing anything. Failing it dismisses the overlay and tells the host app why.
+     */
+    private fun failCollapsedMessage() {
+        val message = currentMessage ?: return
+        logger.error(
+            "In-app message ${message.messageId} reported a collapsed height " +
+                "(<= ${ModalSizePolicy.DEGENERATE_MAX_DP.toInt()}dp) for " +
+                "${ModalSizePolicy.SAMPLE_COUNT} consecutive updates, so it can never become " +
+                "visible while still blocking the screen. Dismissing it. $VIEWPORT_HEIGHT_HINT"
+        )
+        inAppMessagingManager.dispatch(
+            InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
+        )
+    }
+
+    private fun logViewportDependentHeight(deltaInDp: Double) {
+        logger.error(
+            "In-app message ${currentMessage?.messageId} keeps growing by ${deltaInDp}dp per " +
+                "update, so its height tracks the WebView height instead of its content. It will " +
+                "be clamped to the screen and its content may not be positioned as designed. " +
+                VIEWPORT_HEIGHT_HINT
+        )
     }
 
     override fun bootstrapped() {
@@ -43,5 +93,13 @@ internal class ModalInAppMessageViewController(
         logViewEvent("Clearing resources for empty messageId")
         detachEngineWebView()
         currentMessage = null
+    }
+
+    private companion object {
+        const val VIEWPORT_HEIGHT_HINT: String =
+            "This usually means the message HTML derives its own height from the viewport " +
+                "(height: 100vh or height: 100% on html/body). The SDK sizes the WebView to the " +
+                "height the message reports, so a viewport based height can never resolve; give " +
+                "the message a content driven height instead."
     }
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalSizePolicy.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalSizePolicy.kt
@@ -1,0 +1,139 @@
+package io.customer.messaginginapp.ui.controller
+
+import kotlin.math.abs
+
+/**
+ * Outcome of inspecting a height reported by the message renderer for a modal message.
+ */
+internal sealed interface ModalSizeVerdict {
+    /**
+     * Height looks sane; apply it as usual.
+     */
+    data class Apply(val heightInDp: Double) : ModalSizeVerdict
+
+    /**
+     * Height has stayed collapsed for [ModalSizePolicy.SAMPLE_COUNT] consecutive reports, so the
+     * message can never become visible. The modal is still on screen blocking touches, so the
+     * caller is expected to fail the message rather than keep waiting.
+     */
+    object Degenerate : ModalSizeVerdict
+
+    /**
+     * Reported height is growing by a constant amount per report, which means the message sizes
+     * itself from the WebView height that the SDK derives from it. The height is still applied
+     * (the container clamps it), but the caller should surface the cause once.
+     */
+    data class ViewportDependent(
+        val heightInDp: Double,
+        val deltaInDp: Double
+    ) : ModalSizeVerdict
+}
+
+/**
+ * Detects message HTML whose height cannot be resolved by the SDK's content-sizing contract.
+ *
+ * The renderer reports the message's content height roughly once per second and the SDK sizes the
+ * WebView to it. When the message CSS instead derives its own height from the viewport (for example
+ * `height: 100vh` or `height: 100%` on `html`/`body`) the two are mutually recursive and there is no
+ * useful fixed point:
+ *
+ * - reported == container: every value is a fixed point, including zero. The WebView starts at zero,
+ *   so the message stays collapsed forever behind a full screen, touch blocking overlay.
+ * - reported == container + constant: the height grows by that constant on every report until the
+ *   container clamps it, and the message renders at full screen with its content pinned to the top.
+ *
+ * This class is deliberately free of Android dependencies so the decision logic can be unit tested
+ * directly. It is only used for modal messages: inline messages legitimately report a zero height to
+ * collapse themselves.
+ */
+internal class ModalSizePolicy(
+    private val degenerateMaxDp: Double = DEGENERATE_MAX_DP,
+    private val sampleCount: Int = SAMPLE_COUNT
+) {
+    private val samples = ArrayDeque<Double>()
+
+    /**
+     * Heights reported before the message is displayed are not evaluated: the WebView is still
+     * detached and legitimately measures zero while it loads.
+     */
+    private var isArmed: Boolean = false
+    private var hasReportedDegenerate: Boolean = false
+    private var hasReportedViewportDependent: Boolean = false
+
+    /**
+     * Starts evaluating reported heights. Called once the message is displayed.
+     */
+    fun arm() {
+        isArmed = true
+        samples.clear()
+    }
+
+    fun onHeightReported(heightInDp: Double): ModalSizeVerdict {
+        if (!isArmed) return ModalSizeVerdict.Apply(heightInDp)
+
+        samples.addLast(heightInDp)
+        while (samples.size > sampleCount) {
+            samples.removeFirst()
+        }
+
+        if (!hasReportedDegenerate && isCollapsed()) {
+            hasReportedDegenerate = true
+            return ModalSizeVerdict.Degenerate
+        }
+
+        val delta = constantGrowthDelta()
+        if (!hasReportedViewportDependent && delta != null) {
+            hasReportedViewportDependent = true
+            return ModalSizeVerdict.ViewportDependent(heightInDp = heightInDp, deltaInDp = delta)
+        }
+
+        return ModalSizeVerdict.Apply(heightInDp)
+    }
+
+    /**
+     * True when every recent report is too small to show anything. A single small report is not
+     * enough: a multi step message can momentarily measure small while switching steps.
+     */
+    private fun isCollapsed(): Boolean {
+        return samples.size >= sampleCount && samples.all { it <= degenerateMaxDp }
+    }
+
+    /**
+     * Returns the shared delta when recent reports grow by the same positive amount each time,
+     * otherwise null. A message whose height legitimately settles while images and fonts load grows
+     * by irregular amounts, so requiring a constant delta avoids flagging it.
+     */
+    private fun constantGrowthDelta(): Double? {
+        if (samples.size < sampleCount) return null
+
+        val heights = samples.toList()
+        val first = heights[1] - heights[0]
+        if (first <= 0.0) return null
+
+        for (index in 2 until heights.size) {
+            val delta = heights[index] - heights[index - 1]
+            if (abs(delta - first) > DELTA_TOLERANCE_DP) return null
+        }
+        return first
+    }
+
+    companion object {
+        /**
+         * Heights at or below this are treated as collapsed. No message can render usable content in
+         * this space, and it covers the values seen in the field: zero, and the few points left by a
+         * collapsed default body margin.
+         */
+        const val DEGENERATE_MAX_DP: Double = 20.0
+
+        /**
+         * Reports needed before a verdict is returned. The renderer reports about once per second.
+         */
+        const val SAMPLE_COUNT: Int = 4
+
+        /**
+         * Growth deltas are compared with a small tolerance because reported heights are rounded
+         * from CSS pixels.
+         */
+        private const val DELTA_TOLERANCE_DP: Double = 0.5
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalSizePolicy.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/ModalSizePolicy.kt
@@ -9,93 +9,119 @@ internal sealed interface ModalSizeVerdict {
     /**
      * Height looks sane; apply it as usual.
      */
-    data class Apply(val heightInDp: Double) : ModalSizeVerdict
+    object Apply : ModalSizeVerdict
 
     /**
-     * Height has stayed collapsed for [ModalSizePolicy.SAMPLE_COUNT] consecutive reports, so the
-     * message can never become visible. The modal is still on screen blocking touches, so the
-     * caller is expected to fail the message rather than keep waiting.
+     * Height has stayed collapsed for long enough that the message can never become visible. The
+     * modal is still on screen blocking touches, so the caller is expected to fail the message
+     * rather than keep waiting.
      */
     object Degenerate : ModalSizeVerdict
 
     /**
      * Reported height is growing by a constant amount per report, which means the message sizes
-     * itself from the WebView height that the SDK derives from it. The height is still applied
-     * (the container clamps it), but the caller should surface the cause once.
+     * itself from the WebView height that the SDK derives from it. The height is still applied, but
+     * the caller should surface the cause once.
      */
-    data class ViewportDependent(
-        val heightInDp: Double,
-        val deltaInDp: Double
-    ) : ModalSizeVerdict
+    data class ViewportDependent(val deltaInDp: Double) : ModalSizeVerdict
 }
 
 /**
  * Detects message HTML whose height cannot be resolved by the SDK's content-sizing contract.
  *
- * The renderer reports the message's content height roughly once per second and the SDK sizes the
- * WebView to it. When the message CSS instead derives its own height from the viewport (for example
- * `height: 100vh` or `height: 100%` on `html`/`body`) the two are mutually recursive and there is no
- * useful fixed point:
+ * The renderer reports the message's content height and the SDK sizes the WebView to it. When the
+ * message CSS instead derives its own height from the viewport (for example `height: 100vh` or
+ * `height: 100%` on `html`/`body`) the two are mutually recursive and there is no useful fixed point:
  *
  * - reported == container: every value is a fixed point, including zero. The WebView starts at zero,
  *   so the message stays collapsed forever behind a full screen, touch blocking overlay.
  * - reported == container + constant: the height grows by that constant on every report until the
- *   container clamps it, and the message renders at full screen with its content pinned to the top.
+ *   layout can grow no further.
  *
  * This class is deliberately free of Android dependencies so the decision logic can be unit tested
  * directly. It is only used for modal messages: inline messages legitimately report a zero height to
  * collapse themselves.
  */
 internal class ModalSizePolicy(
-    private val degenerateMaxDp: Double = DEGENERATE_MAX_DP,
-    private val sampleCount: Int = SAMPLE_COUNT
+    val degenerateMaxDp: Double = DEGENERATE_MAX_DP,
+    val sampleCount: Int = SAMPLE_COUNT,
+    val degenerateMinElapsedMs: Long = DEGENERATE_MIN_ELAPSED_MS,
+    private val currentTimeMillis: () -> Long = { System.currentTimeMillis() }
 ) {
-    private val samples = ArrayDeque<Double>()
+    private val samples = ArrayDeque<Sample>()
 
     /**
-     * Heights reported before the message is displayed are not evaluated: the WebView is still
-     * detached and legitimately measures zero while it loads.
+     * Heights reported before the message is displayed are not evaluated: the WebView may still be
+     * unlaid out and legitimately measure zero.
      */
     private var isArmed: Boolean = false
     private var hasReportedDegenerate: Boolean = false
     private var hasReportedViewportDependent: Boolean = false
 
     /**
-     * Starts evaluating reported heights. Called once the message is displayed.
+     * Starts evaluating reported heights. Idempotent: repeat calls are ignored rather than discarding
+     * progress, so callers that fire on every display state emission do not need to guard it, and the
+     * instance can never be left half-reset.
      */
     fun arm() {
+        if (isArmed) return
+
         isArmed = true
         samples.clear()
+        hasReportedDegenerate = false
+        hasReportedViewportDependent = false
     }
 
     fun onHeightReported(heightInDp: Double): ModalSizeVerdict {
-        if (!isArmed) return ModalSizeVerdict.Apply(heightInDp)
+        if (!isArmed) return ModalSizeVerdict.Apply
 
-        samples.addLast(heightInDp)
+        samples.addLast(Sample(heightInDp = heightInDp, timestampMs = currentTimeMillis()))
         while (samples.size > sampleCount) {
             samples.removeFirst()
         }
 
         if (!hasReportedDegenerate && isCollapsed()) {
-            hasReportedDegenerate = true
             return ModalSizeVerdict.Degenerate
         }
 
         val delta = constantGrowthDelta()
         if (!hasReportedViewportDependent && delta != null) {
-            hasReportedViewportDependent = true
-            return ModalSizeVerdict.ViewportDependent(heightInDp = heightInDp, deltaInDp = delta)
+            return ModalSizeVerdict.ViewportDependent(deltaInDp = delta)
         }
 
-        return ModalSizeVerdict.Apply(heightInDp)
+        return ModalSizeVerdict.Apply
     }
 
     /**
-     * True when every recent report is too small to show anything. A single small report is not
-     * enough: a multi step message can momentarily measure small while switching steps.
+     * Confirms the caller acted on [ModalSizeVerdict.Degenerate] so it is not reported again. Kept
+     * separate from [onHeightReported] so a verdict the caller cannot act on yet does not silently
+     * disable the guard.
+     */
+    fun onDegenerateHandled() {
+        hasReportedDegenerate = true
+    }
+
+    /**
+     * Confirms the caller acted on [ModalSizeVerdict.ViewportDependent] so it is not reported again.
+     */
+    fun onViewportDependentHandled() {
+        hasReportedViewportDependent = true
+    }
+
+    /**
+     * True when every recent report is too small to show anything *and* they span enough time to
+     * rule out a transient.
+     *
+     * Both conditions matter. `sizeChanged` is documented elsewhere in this module as arriving
+     * multiple times, and the renderer also reports on every window resize, so a burst of collapsed
+     * reports can arrive within milliseconds while the message is merely still being laid out.
      */
     private fun isCollapsed(): Boolean {
-        return samples.size >= sampleCount && samples.all { it <= degenerateMaxDp }
+        if (samples.size < sampleCount) return false
+        if (samples.any { it.heightInDp > degenerateMaxDp }) return false
+
+        val elapsed = samples.last().timestampMs - samples.first().timestampMs
+        return elapsed >= degenerateMinElapsedMs
     }
 
     /**
@@ -104,9 +130,9 @@ internal class ModalSizePolicy(
      * by irregular amounts, so requiring a constant delta avoids flagging it.
      */
     private fun constantGrowthDelta(): Double? {
-        if (samples.size < sampleCount) return null
+        if (samples.size < sampleCount || samples.size < MIN_SAMPLES_FOR_GROWTH) return null
 
-        val heights = samples.toList()
+        val heights = samples.map { it.heightInDp }
         val first = heights[1] - heights[0]
         if (first <= 0.0) return null
 
@@ -117,6 +143,8 @@ internal class ModalSizePolicy(
         return first
     }
 
+    private data class Sample(val heightInDp: Double, val timestampMs: Long)
+
     companion object {
         /**
          * Heights at or below this are treated as collapsed. No message can render usable content in
@@ -126,9 +154,20 @@ internal class ModalSizePolicy(
         const val DEGENERATE_MAX_DP: Double = 20.0
 
         /**
-         * Reports needed before a verdict is returned. The renderer reports about once per second.
+         * Reports needed before a collapsed verdict is possible.
          */
         const val SAMPLE_COUNT: Int = 4
+
+        /**
+         * How long the collapsed reports must span. The renderer polls about once per second, so
+         * this clears a burst of reports triggered by layout without waiting much beyond the poll.
+         */
+        const val DEGENERATE_MIN_ELAPSED_MS: Long = 2500
+
+        /**
+         * At least two heights are needed to compute a delta at all.
+         */
+        private const val MIN_SAMPLES_FOR_GROWTH: Int = 2
 
         /**
          * Growth deltas are compared with a small tolerance because reported heights are rounded

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalMessageViewControllerTest.kt
@@ -43,13 +43,29 @@ class ModalMessageViewControllerTest : JUnitTest() {
         every { viewDelegate.createEngineWebViewInstance() } returns engineWebViewDelegate
     }
 
-    private fun createViewController(): ModalInAppMessageViewController {
+    /** Lets size-guard tests advance time without sleeping. */
+    private class FakeClock(var nowMs: Long = 0L)
+
+    private val clock = FakeClock()
+
+    private fun createViewController(
+        sizePolicy: ModalSizePolicy = ModalSizePolicy(currentTimeMillis = { clock.nowMs })
+    ): ModalInAppMessageViewController {
         val platformDelegate: InAppPlatformDelegate = mockk(relaxed = true)
         val instance = ModalInAppMessageViewController(
             platformDelegate = platformDelegate,
-            viewDelegate = viewDelegate
+            viewDelegate = viewDelegate,
+            sizePolicy = sizePolicy
         )
         return spyk(instance)
+    }
+
+    /** Reports a collapsed height often enough, and over enough time, to trip the guard. */
+    private fun ModalInAppMessageViewController.reportCollapsedHeightUntilGuardTrips() {
+        repeat(ModalSizePolicy.SAMPLE_COUNT) {
+            sizeChanged(width = 320.0, height = 0.0)
+            clock.nowMs += 1000L
+        }
     }
 
     @Test
@@ -114,18 +130,44 @@ class ModalMessageViewControllerTest : JUnitTest() {
     }
 
     @Test
-    fun sizeChanged_givenHeightStaysCollapsedAfterDisplay_expectMessageFailed() {
+    fun sizeChanged_givenHeightStaysCollapsedAfterDisplay_expectMessageFailedWithRetrySuppressed() {
         val controller = createViewController()
         val givenMessage = createInAppMessage()
         controller.currentMessage = givenMessage
         controller.routeLoaded(String.random)
 
         // A collapsed modal covers the screen and swallows touches without showing anything.
-        repeat(ModalSizePolicy.SAMPLE_COUNT) { controller.sizeChanged(width = 320.0, height = 0.0) }
+        controller.reportCollapsedHeightUntilGuardTrips()
+
+        // suppressRetry marks the message as shown; without it a persistent message would be
+        // fetched and displayed again forever.
+        assertCalledOnce {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    message = givenMessage,
+                    suppressRetry = true
+                )
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenPersistentMessageStaysCollapsed_expectRetrySuppressed() {
+        val controller = createViewController()
+        // Persistent messages are never marked as shown when displayed, so they are the case that
+        // would loop if the failure did not suppress retries.
+        val givenMessage = createInAppMessage(persistent = true)
+        controller.currentMessage = givenMessage
+        controller.routeLoaded(String.random)
+
+        controller.reportCollapsedHeightUntilGuardTrips()
 
         assertCalledOnce {
             inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    message = givenMessage,
+                    suppressRetry = true
+                )
             )
         }
     }
@@ -139,11 +181,15 @@ class ModalMessageViewControllerTest : JUnitTest() {
 
         repeat(ModalSizePolicy.SAMPLE_COUNT * 3) {
             controller.sizeChanged(width = 320.0, height = 0.0)
+            clock.nowMs += 1000L
         }
 
         assertCalledOnce {
             inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    message = givenMessage,
+                    suppressRetry = true
+                )
             )
         }
     }
@@ -153,14 +199,60 @@ class ModalMessageViewControllerTest : JUnitTest() {
         val controller = createViewController()
         controller.currentMessage = createInAppMessage()
 
-        // While the message loads the WebView is detached and legitimately measures zero.
+        // While the message loads the WebView may be unlaid out and legitimately measures zero.
         repeat(ModalSizePolicy.SAMPLE_COUNT * 2) {
             controller.sizeChanged(width = 0.0, height = 0.0)
+            clock.nowMs += 1000L
         }
 
         verify(exactly = 0) {
             inAppMessagingManager.dispatch(
                 ofType<InAppMessagingAction.EngineAction.MessageLoadingFailed>()
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenCollapsedHeightBurstAfterDisplay_expectNoFailure() {
+        val controller = createViewController()
+        controller.currentMessage = createInAppMessage()
+        controller.routeLoaded(String.random)
+
+        // Reports arrive in bursts while the modal is still being laid out. Failing on report count
+        // alone would destroy a healthy message here.
+        repeat(ModalSizePolicy.SAMPLE_COUNT * 3) {
+            controller.sizeChanged(width = 320.0, height = 0.0)
+            clock.nowMs += 5L
+        }
+
+        verify(exactly = 0) {
+            inAppMessagingManager.dispatch(
+                ofType<InAppMessagingAction.EngineAction.MessageLoadingFailed>()
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenNoCurrentMessage_expectGuardNotConsumed() {
+        val controller = createViewController()
+        controller.currentMessage = createInAppMessage()
+        controller.routeLoaded(String.random)
+        controller.currentMessage = null
+
+        // Verdicts that cannot be acted on must not disable the guard...
+        controller.reportCollapsedHeightUntilGuardTrips()
+
+        val givenMessage = createInAppMessage()
+        controller.currentMessage = givenMessage
+        controller.reportCollapsedHeightUntilGuardTrips()
+
+        // ...so the guard still fires once a message is available again.
+        assertCalledOnce {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    message = givenMessage,
+                    suppressRetry = true
+                )
             )
         }
     }
@@ -175,6 +267,7 @@ class ModalMessageViewControllerTest : JUnitTest() {
 
         repeat(ModalSizePolicy.SAMPLE_COUNT) {
             controller.sizeChanged(width = 320.0, height = 382.0)
+            clock.nowMs += 1000L
         }
 
         verify(exactly = ModalSizePolicy.SAMPLE_COUNT) {
@@ -196,9 +289,10 @@ class ModalMessageViewControllerTest : JUnitTest() {
         controller.routeLoaded(String.random)
 
         // Viewport dependent height: the reported value tracks the WebView height. The message
-        // still renders (clamped by the container), so it must not be failed.
+        // still renders, so it must not be failed.
         listOf(704.0, 736.0, 768.0, 800.0).forEach {
             controller.sizeChanged(width = 320.0, height = it)
+            clock.nowMs += 1000L
         }
 
         verify(exactly = 4) { viewCallback.onViewSizeChanged(any(), any()) }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalMessageViewControllerTest.kt
@@ -17,6 +17,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import io.mockk.verify
 import io.mockk.verifyOrder
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
@@ -110,6 +111,102 @@ class ModalMessageViewControllerTest : JUnitTest() {
 
         controller.currentRoute shouldBeEqualTo givenRoute
         assertNoInteractions(engineWebViewDelegate, inAppMessagingManager)
+    }
+
+    @Test
+    fun sizeChanged_givenHeightStaysCollapsedAfterDisplay_expectMessageFailed() {
+        val controller = createViewController()
+        val givenMessage = createInAppMessage()
+        controller.currentMessage = givenMessage
+        controller.routeLoaded(String.random)
+
+        // A collapsed modal covers the screen and swallows touches without showing anything.
+        repeat(ModalSizePolicy.SAMPLE_COUNT) { controller.sizeChanged(width = 320.0, height = 0.0) }
+
+        assertCalledOnce {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenHeightStaysCollapsedAfterDisplay_expectMessageFailedOnlyOnce() {
+        val controller = createViewController()
+        val givenMessage = createInAppMessage()
+        controller.currentMessage = givenMessage
+        controller.routeLoaded(String.random)
+
+        repeat(ModalSizePolicy.SAMPLE_COUNT * 3) {
+            controller.sizeChanged(width = 320.0, height = 0.0)
+        }
+
+        assertCalledOnce {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenCollapsedHeightBeforeDisplay_expectNoFailure() {
+        val controller = createViewController()
+        controller.currentMessage = createInAppMessage()
+
+        // While the message loads the WebView is detached and legitimately measures zero.
+        repeat(ModalSizePolicy.SAMPLE_COUNT * 2) {
+            controller.sizeChanged(width = 0.0, height = 0.0)
+        }
+
+        verify(exactly = 0) {
+            inAppMessagingManager.dispatch(
+                ofType<InAppMessagingAction.EngineAction.MessageLoadingFailed>()
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenResolvedHeightAfterDisplay_expectSizeForwardedAndNoFailure() {
+        val controller = createViewController()
+        val viewCallback = mockk<ModalInAppMessageViewCallback>(relaxed = true)
+        controller.currentMessage = createInAppMessage()
+        controller.viewCallback = viewCallback
+        controller.routeLoaded(String.random)
+
+        repeat(ModalSizePolicy.SAMPLE_COUNT) {
+            controller.sizeChanged(width = 320.0, height = 382.0)
+        }
+
+        verify(exactly = ModalSizePolicy.SAMPLE_COUNT) {
+            viewCallback.onViewSizeChanged(any(), any())
+        }
+        verify(exactly = 0) {
+            inAppMessagingManager.dispatch(
+                ofType<InAppMessagingAction.EngineAction.MessageLoadingFailed>()
+            )
+        }
+    }
+
+    @Test
+    fun sizeChanged_givenHeightGrowsByConstantAfterDisplay_expectSizeStillAppliedAndNoFailure() {
+        val controller = createViewController()
+        val viewCallback = mockk<ModalInAppMessageViewCallback>(relaxed = true)
+        controller.currentMessage = createInAppMessage()
+        controller.viewCallback = viewCallback
+        controller.routeLoaded(String.random)
+
+        // Viewport dependent height: the reported value tracks the WebView height. The message
+        // still renders (clamped by the container), so it must not be failed.
+        listOf(704.0, 736.0, 768.0, 800.0).forEach {
+            controller.sizeChanged(width = 320.0, height = it)
+        }
+
+        verify(exactly = 4) { viewCallback.onViewSizeChanged(any(), any()) }
+        verify(exactly = 0) {
+            inAppMessagingManager.dispatch(
+                ofType<InAppMessagingAction.EngineAction.MessageLoadingFailed>()
+            )
+        }
     }
 
     @Test

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalSizePolicyTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalSizePolicyTest.kt
@@ -5,134 +5,228 @@ import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 
 class ModalSizePolicyTest {
-    private fun armedPolicy(): ModalSizePolicy = ModalSizePolicy().apply { arm() }
+    /** Renderer polls roughly once per second. */
+    private val pollIntervalMs = 1000L
 
-    private fun ModalSizePolicy.report(vararg heights: Double): List<ModalSizeVerdict> =
-        heights.map { onHeightReported(it) }
+    private class FakeClock(var nowMs: Long = 0L)
 
-    @Test
-    fun heightReported_givenNotArmed_expectHeightAlwaysApplied() {
-        val policy = ModalSizePolicy()
+    private fun policy(
+        clock: FakeClock,
+        sampleCount: Int = ModalSizePolicy.SAMPLE_COUNT
+    ): ModalSizePolicy = ModalSizePolicy(
+        sampleCount = sampleCount,
+        currentTimeMillis = { clock.nowMs }
+    )
 
-        // Zero heights while the message is still loading must not be judged.
-        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    private fun armedPolicy(clock: FakeClock): ModalSizePolicy =
+        policy(clock).apply { arm() }
 
-        verdicts.forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+    /** Reports each height, advancing the clock by [stepMs] between reports. */
+    private fun ModalSizePolicy.report(
+        clock: FakeClock,
+        vararg heights: Double,
+        stepMs: Long = 1000L
+    ): List<ModalSizeVerdict> = heights.mapIndexed { index, height ->
+        if (index > 0) clock.nowMs += stepMs
+        onHeightReported(height)
     }
 
     @Test
-    fun heightReported_givenCollapsedAtZero_expectDegenerateOnceSampleCountReached() {
-        val policy = armedPolicy()
+    fun heightReported_givenNotArmed_expectHeightAlwaysApplied() {
+        val clock = FakeClock()
+        val policy = policy(clock)
 
-        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0)
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
+    }
+
+    @Test
+    fun heightReported_givenCollapsedAtZeroOverTime_expectDegenerate() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0, 0.0)
 
         verdicts.take(ModalSizePolicy.SAMPLE_COUNT - 1)
-            .forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+            .forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
         verdicts.last() shouldBeEqualTo ModalSizeVerdict.Degenerate
     }
 
     @Test
     fun heightReported_givenCollapsedAtCollapsedMargin_expectDegenerate() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
         // iOS reported 8.0 in the field: a body margin left over from an otherwise empty document.
-        val verdicts = policy.report(8.0, 8.0, 8.0, 8.0)
+        val verdicts = policy.report(clock, 8.0, 8.0, 8.0, 8.0)
 
         verdicts.last() shouldBeEqualTo ModalSizeVerdict.Degenerate
     }
 
     @Test
-    fun heightReported_givenStaysCollapsed_expectDegenerateReportedOnlyOnce() {
-        val policy = armedPolicy()
+    fun heightReported_givenCollapsedBurstWithinMilliseconds_expectNoDegenerate() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
-        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        // sizeChanged arrives in bursts (it also fires on every window resize), so a healthy
+        // message still being laid out can emit several collapsed reports back to back.
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, stepMs = 5L)
 
-        verdicts.count { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo 1
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
+    }
+
+    @Test
+    fun heightReported_givenCollapsedBurstThenResolves_expectNoDegenerate() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0, 380.0, stepMs = 10L)
+
+        verdicts.none { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo true
+    }
+
+    @Test
+    fun heightReported_givenDegenerateNotHandled_expectVerdictRepeated() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+
+        // The caller may be unable to act yet; the guard must not disable itself.
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        verdicts.count { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo 3
+    }
+
+    @Test
+    fun heightReported_givenDegenerateHandled_expectNotReportedAgain() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+        policy.report(clock, 0.0, 0.0, 0.0, 0.0)
+
+        policy.onDegenerateHandled()
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0)
+
+        verdicts.none { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo true
     }
 
     @Test
     fun heightReported_givenCollapsedThenResolves_expectNoDegenerate() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
-        // A couple of empty measurements before the content settles is normal.
-        val verdicts = policy.report(0.0, 0.0, 380.0, 380.0)
+        val verdicts = policy.report(clock, 0.0, 0.0, 380.0, 380.0)
 
         verdicts.none { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo true
-        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Apply(380.0)
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Apply
     }
 
     @Test
     fun heightReported_givenConstantGrowth_expectViewportDependentWithDelta() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
         // Observed on device: the height climbs by the body padding on every report.
-        val verdicts = policy.report(704.0, 736.0, 768.0, 800.0)
+        val verdicts = policy.report(clock, 704.0, 736.0, 768.0, 800.0)
 
         val verdict = verdicts.last()
         verdict.shouldBeInstanceOf<ModalSizeVerdict.ViewportDependent>()
         (verdict as ModalSizeVerdict.ViewportDependent).deltaInDp shouldBeEqualTo 32.0
-        verdict.heightInDp shouldBeEqualTo 800.0
     }
 
     @Test
-    fun heightReported_givenConstantGrowthContinues_expectViewportDependentReportedOnlyOnce() {
-        val policy = armedPolicy()
+    fun heightReported_givenViewportDependentHandled_expectNotReportedAgain() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+        policy.report(clock, 704.0, 736.0, 768.0, 800.0)
 
-        val verdicts = policy.report(704.0, 736.0, 768.0, 800.0, 832.0, 864.0, 896.0)
+        policy.onViewportDependentHandled()
+        val verdicts = policy.report(clock, 832.0, 864.0, 896.0)
 
-        verdicts.count { it is ModalSizeVerdict.ViewportDependent } shouldBeEqualTo 1
+        verdicts.none { it is ModalSizeVerdict.ViewportDependent } shouldBeEqualTo true
     }
 
     @Test
     fun heightReported_givenTallConstantHeight_expectAppliedAndNotFlagged() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
-        // A message legitimately taller than the screen reports a constant height; the container
-        // clamps it. That must not be mistaken for a runaway.
-        val verdicts = policy.report(1200.0, 1200.0, 1200.0, 1200.0, 1200.0)
+        // A message legitimately taller than the screen reports a constant height. That must not be
+        // mistaken for a runaway.
+        val verdicts = policy.report(clock, 1200.0, 1200.0, 1200.0, 1200.0, 1200.0)
 
-        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply(1200.0) }
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
     }
 
     @Test
     fun heightReported_givenIrregularGrowthWhileLoading_expectAppliedAndNotFlagged() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
         // Images and fonts settling produce uneven growth, which is not a runaway.
-        val verdicts = policy.report(200.0, 300.0, 380.0, 382.0, 382.0)
+        val verdicts = policy.report(clock, 200.0, 300.0, 380.0, 382.0, 382.0)
 
-        verdicts.none { it is ModalSizeVerdict.ViewportDependent } shouldBeEqualTo true
-        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Apply(382.0)
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
     }
 
     @Test
     fun heightReported_givenNormalStableHeight_expectAppliedVerbatim() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
-        val verdicts = policy.report(382.0, 382.0, 382.0, 382.0)
+        val verdicts = policy.report(clock, 382.0, 382.0, 382.0, 382.0)
 
-        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply(382.0) }
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
     }
 
     @Test
     fun heightReported_givenShrinkingHeight_expectAppliedAndNotFlagged() {
-        val policy = armedPolicy()
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
 
         // Going back to a shorter step is a normal multi step transition.
-        val verdicts = policy.report(500.0, 468.0, 436.0, 404.0)
+        val verdicts = policy.report(clock, 500.0, 468.0, 436.0, 404.0)
 
-        verdicts.forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply }
     }
 
     @Test
-    fun arm_givenRearmed_expectEarlierSamplesDiscarded() {
-        val policy = armedPolicy()
-        policy.report(0.0, 0.0, 0.0)
+    fun arm_givenCalledRepeatedly_expectProgressPreserved() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+
+        // Callers may arm on every display state emission. Re-arming must not discard samples, or
+        // the guard could be reset forever and never reach a verdict.
+        val verdicts = listOf(0.0, 0.0, 0.0, 0.0).mapIndexed { index, height ->
+            if (index > 0) clock.nowMs += 1000L
+            policy.arm()
+            policy.onHeightReported(height)
+        }
+
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Degenerate
+    }
+
+    @Test
+    fun arm_givenCalledAfterHandling_expectLatchNotSilentlyReset() {
+        val clock = FakeClock()
+        val policy = armedPolicy(clock)
+        policy.report(clock, 0.0, 0.0, 0.0, 0.0)
+        policy.onDegenerateHandled()
 
         policy.arm()
-        val verdict = policy.onHeightReported(0.0)
+        val verdicts = policy.report(clock, 0.0, 0.0, 0.0)
 
-        // Only one sample since re-arming, so no verdict can be reached yet.
-        verdict shouldBeEqualTo ModalSizeVerdict.Apply(0.0)
+        // Already handled, so it stays handled: no duplicate failures for the same message.
+        verdicts.none { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo true
+    }
+
+    @Test
+    fun heightReported_givenSampleCountOfOne_expectNoCrash() {
+        val clock = FakeClock()
+        val policy = policy(clock, sampleCount = 1).apply { arm() }
+
+        // Computing a growth delta needs two samples; a single sample must not index out of bounds.
+        val verdicts = policy.report(clock, 500.0, 600.0)
+
+        verdicts.size shouldBeEqualTo 2
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalSizePolicyTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/ModalSizePolicyTest.kt
@@ -1,0 +1,138 @@
+package io.customer.messaginginapp.ui.controller
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class ModalSizePolicyTest {
+    private fun armedPolicy(): ModalSizePolicy = ModalSizePolicy().apply { arm() }
+
+    private fun ModalSizePolicy.report(vararg heights: Double): List<ModalSizeVerdict> =
+        heights.map { onHeightReported(it) }
+
+    @Test
+    fun heightReported_givenNotArmed_expectHeightAlwaysApplied() {
+        val policy = ModalSizePolicy()
+
+        // Zero heights while the message is still loading must not be judged.
+        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        verdicts.forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+    }
+
+    @Test
+    fun heightReported_givenCollapsedAtZero_expectDegenerateOnceSampleCountReached() {
+        val policy = armedPolicy()
+
+        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0)
+
+        verdicts.take(ModalSizePolicy.SAMPLE_COUNT - 1)
+            .forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Degenerate
+    }
+
+    @Test
+    fun heightReported_givenCollapsedAtCollapsedMargin_expectDegenerate() {
+        val policy = armedPolicy()
+
+        // iOS reported 8.0 in the field: a body margin left over from an otherwise empty document.
+        val verdicts = policy.report(8.0, 8.0, 8.0, 8.0)
+
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Degenerate
+    }
+
+    @Test
+    fun heightReported_givenStaysCollapsed_expectDegenerateReportedOnlyOnce() {
+        val policy = armedPolicy()
+
+        val verdicts = policy.report(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        verdicts.count { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo 1
+    }
+
+    @Test
+    fun heightReported_givenCollapsedThenResolves_expectNoDegenerate() {
+        val policy = armedPolicy()
+
+        // A couple of empty measurements before the content settles is normal.
+        val verdicts = policy.report(0.0, 0.0, 380.0, 380.0)
+
+        verdicts.none { it == ModalSizeVerdict.Degenerate } shouldBeEqualTo true
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Apply(380.0)
+    }
+
+    @Test
+    fun heightReported_givenConstantGrowth_expectViewportDependentWithDelta() {
+        val policy = armedPolicy()
+
+        // Observed on device: the height climbs by the body padding on every report.
+        val verdicts = policy.report(704.0, 736.0, 768.0, 800.0)
+
+        val verdict = verdicts.last()
+        verdict.shouldBeInstanceOf<ModalSizeVerdict.ViewportDependent>()
+        (verdict as ModalSizeVerdict.ViewportDependent).deltaInDp shouldBeEqualTo 32.0
+        verdict.heightInDp shouldBeEqualTo 800.0
+    }
+
+    @Test
+    fun heightReported_givenConstantGrowthContinues_expectViewportDependentReportedOnlyOnce() {
+        val policy = armedPolicy()
+
+        val verdicts = policy.report(704.0, 736.0, 768.0, 800.0, 832.0, 864.0, 896.0)
+
+        verdicts.count { it is ModalSizeVerdict.ViewportDependent } shouldBeEqualTo 1
+    }
+
+    @Test
+    fun heightReported_givenTallConstantHeight_expectAppliedAndNotFlagged() {
+        val policy = armedPolicy()
+
+        // A message legitimately taller than the screen reports a constant height; the container
+        // clamps it. That must not be mistaken for a runaway.
+        val verdicts = policy.report(1200.0, 1200.0, 1200.0, 1200.0, 1200.0)
+
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply(1200.0) }
+    }
+
+    @Test
+    fun heightReported_givenIrregularGrowthWhileLoading_expectAppliedAndNotFlagged() {
+        val policy = armedPolicy()
+
+        // Images and fonts settling produce uneven growth, which is not a runaway.
+        val verdicts = policy.report(200.0, 300.0, 380.0, 382.0, 382.0)
+
+        verdicts.none { it is ModalSizeVerdict.ViewportDependent } shouldBeEqualTo true
+        verdicts.last() shouldBeEqualTo ModalSizeVerdict.Apply(382.0)
+    }
+
+    @Test
+    fun heightReported_givenNormalStableHeight_expectAppliedVerbatim() {
+        val policy = armedPolicy()
+
+        val verdicts = policy.report(382.0, 382.0, 382.0, 382.0)
+
+        verdicts.forEach { it shouldBeEqualTo ModalSizeVerdict.Apply(382.0) }
+    }
+
+    @Test
+    fun heightReported_givenShrinkingHeight_expectAppliedAndNotFlagged() {
+        val policy = armedPolicy()
+
+        // Going back to a shorter step is a normal multi step transition.
+        val verdicts = policy.report(500.0, 468.0, 436.0, 404.0)
+
+        verdicts.forEach { it.shouldBeInstanceOf<ModalSizeVerdict.Apply>() }
+    }
+
+    @Test
+    fun arm_givenRearmed_expectEarlierSamplesDiscarded() {
+        val policy = armedPolicy()
+        policy.report(0.0, 0.0, 0.0)
+
+        policy.arm()
+        val verdict = policy.onHeightReported(0.0)
+
+        // Only one sample since re-arming, so no verdict can be reached yet.
+        verdict shouldBeEqualTo ModalSizeVerdict.Apply(0.0)
+    }
+}


### PR DESCRIPTION
### Bug

Modal in-app messages are sized to the content height the renderer reports (about once a second). If a message's CSS instead takes its height from the viewport — `height: 100vh`, or `height: 100%` on `html`/`body` — the two are mutually recursive and the height never resolves:

- **Collapsed:** reported == container, so zero is a fixed point. The WebView starts at zero, so the message stays at zero forever behind a full-screen overlay that shows nothing and swallows every touch (back still exits on Android).
- **Runaway:** reported == container + constant, so the height grows by that constant on every report until the container clamps it, rendering full-screen with content pinned to the top.

Reproduced on device: `411.0 x 0.0` repeating with `layoutParams.height` at literally `0px`; and `96 → 704 → 736 → … → 947` settling at screen height + 32.

### Fix

`ModalSizePolicy` recognises both shapes from the reported heights alone, so it needs no knowledge of the container:

| Reported | Verdict | Behaviour |
| --- | --- | --- |
| collapsed (≤ 20dp) × 4 | degenerate | fail the message → overlay dismissed, host gets `onError` |
| constant positive delta × 4 | viewport-dependent | keep applying (container clamps, so rendering unchanged) + log the cause once |
| tall but constant | apply | unchanged — a legitimately tall message |
| irregular growth | apply | unchanged — height still settling while images/fonts load |

Requiring a *constant* delta is what keeps a normal message that grows while loading from being flagged.

Scoped to modal messages — inline legitimately passes `heightInDp = 0.0` to collapse itself, so the guard lives in `ModalInAppMessageViewController` rather than the shared base.

### Notes

- Both paths log a diagnostic naming the likely CSS cause; a blank overlay is otherwise very hard to diagnose.
- The failure passes `suppressRetry: true`, which marks the message as shown so it is not fetched again. This is required rather than optional: `shouldMarkMessageAsShown` is **false for persistent messages** at display time, so without it a persistent collapsed message would be re-shown indefinitely. Transient load failures keep the default `suppressRetry = false` and stay retryable.
- The impression logged at display stays counted — the overlay did display, and correcting it would need new metric semantics.
- Policy and tests mirror the iOS counterpart so the two SDKs cannot drift.

### Tests

`messaginginapp`: 536 tests, 0 failures (12 new policy + 5 new controller). Inline's 19 tests unchanged. ktlint + `lintDebug` clean.

Ref: MBL-2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
