### PR TITLE
ci: pin semantic-release and changelog preset versions

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -65,9 +65,11 @@ jobs:
         id: semantic-release
         with:
           dry_run: false
-          semantic_version: latest
+          # Pinned: the conventionalcommits preset's 10.x line renders via
+          # conventional-changelog-writer@9, which no released semantic-release ships.
+          semantic_version: 25.0.9
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9.3.1
             @semantic-release/github
             @semantic-release/exec
         env:


### PR DESCRIPTION
Unblocks the 4.20.2 release. `Deploy SDK` failed on the #812 merge ([run 32466371571](https://github.com/customerio/customerio-android/actions/runs/32466371571)) and no tag was created, so nothing shipped.

No Linear ticket — CI hotfix, opened at Rehan's request.

## What broke

`extra_plugins` installed `conventional-changelog-conventionalcommits` **unpinned**. On 2026-06-26 that floated onto the `10.x` line, which swapped Handlebars templates for a JS template API (`@conventional-changelog/template`) requiring `conventional-changelog-writer@9`. No released semantic-release ships writer@9 — 25.0.9 → `release-notes-generator@^14.1.0` → `writer@^8.0.0`, and even `release-notes-generator@15.0.0-beta.1` still pins `^8`. **So bumping semantic-release cannot fix this.**

The mismatch was silent for two months, then turned fatal: `@conventional-changelog/template@1.4.0` (published 2026-08-18 21:37Z) replaced the quiet misrender with a hard `throw`. Nothing in this repo changed — `deploy-sdk.yml` and `.releaserc.json` were last touched in 574326a5 (2026-05-08).

Why one release passed and the next didn't, with identical config: the preset reinstalls unpinned on every run, so each run resolves npm's newest at that moment.

| Release run | When | Newest `@conventional-changelog/template` | Result |
|---|---|---|---|
| 4.20.1 | 2026-08-06 13:04Z | 1.2.1 (1.4.0 didn't exist yet) | notes rendered empty, tag created |
| this failure | 2026-08-21 09:07Z | **1.4.0** | `generateNotes` threw, run aborted |

## Why the tag "failed"

It never got that far. `generateNotes` sits upstream of tagging, so an exception there aborts before `prepare`/`publish`:

```
Completed step "verifyRelease"
Start step "generateNotes"
Failed step "generateNotes"      <- no prepare, no publish, no tag
```

Empty notes never blocked a release — that's why 4.19.0 through 4.20.1 shipped with thin notes. A crashing notes *step* is a different failure entirely.

## The evidence, in our own history

`CHANGELOG.md` records the silent phase precisely — the boundary lands on preset 10.0.0 (2026-06-26):

```
## [4.20.1](…) (2026-08-06)      <- empty
## [4.20.0](…) (2026-07-30)      <- empty
## [4.19.0](…) (2026-07-01)      <- empty
## [4.18.2](…) (2026-06-22)
### Bug Fixes
* scope in-app polling to process lifecycle instead of per-activity (#746) …
```

The GitHub Releases pages for those three look fine only because they were edited by hand after the fact; this file is the unedited machine output.

## The fix

Pin the preset to `9.3.1` and stop `semantic_version` floating.

**Pinning anywhere in 10.x does not work** — every 10.x release carries a caret range that still resolves the broken template: 10.2.1 → `^1.2.1`, 10.3.0 → `^1.3.0`, 10.4.0 → `^1.4.0`. Only `9.3.1` avoids it, having no `@conventional-changelog/template` dependency at all (its sole dep is `compare-func`). `extra_plugins` is a plain npm install list, so npm `overrides` aren't available to force the template version instead.

`9.3.1` is not a guess: it was published 2026-03-29 and 10.0.0 on 2026-06-26, so every release in that window resolved it unpinned — 4.18.0, 4.18.1 and 4.18.2 all rendered correct notes through this exact pipeline. This restores the last known-good combination. Its `templates.js` exports Handlebars template strings (71 `{{` mustaches), which is writer@8's native input; 10.4.0's has zero.

## On hash pinning

Our convention SHA-pins third-party actions (16 of them across the workflows), and this action already complies — `cycjimmy/semantic-release-action@0a51e81a…` is untouched here.

Hashes don't apply to `extra_plugins`, though. Action refs are mutable git tags a publisher can repoint, which is what SHA pinning defends against; npm forbids republishing a version and serves it verified against an integrity hash, so an exact version **is** the immutable equivalent. npm also has no `pkg@sha512-…` install syntax — integrity hashes live in a lockfile, and `extra_plugins` is just an argument list handed to `npm install` at runtime.

The gap worth naming: an exact version pins that package's content, not its transitive tree — exactly the hole that caused this. `9.3.1` sidesteps it structurally, but `semantic_version: 25.0.9` still resolves its own subtree per run. True lockfile-grade pinning means dropping the action for a committed `package.json` + `package-lock.json` and `npm ci && npx semantic-release`, which would also expose these deps to Dependabot. That's a larger change — the action supplies the `new_release_published` / `new_release_version` outputs that the Maven Central and sample-app jobs consume — so it's a reasonable follow-up once 4.20.2 is out, not part of this hotfix.

## What happens on merge

`ci:` doesn't itself trigger a release, but the workflow runs on any push to main and semantic-release analyzes **every commit since the last tag**, not the pushed one. #812's `fix(in-app)` is on main and still untagged, so the range yields a patch. The failed run already proved the analysis:

```
Analyzing commit: fix(in-app): send app identifier header to gist (#812)
  -> The release type for the commit is patch
Analysis of 3 commits complete: patch release
The next release version is 4.20.2
```

Merging this cuts **4.20.2**: `Version.kt` bumped, `CHANGELOG.md` prepended, `chore: prepare for 4.20.2 [skip ci]` pushed, tag `4.20.2` on that commit, GitHub release published, then Maven Central. `ci:` is hidden by the preset, so the release notes will list only the in-app header fix.

Note: re-running the failed run would **not** work — a `push`-event re-run uses the workflow file at that same SHA, still unpinned.

## Test plan

- Workflow YAML parses; the step resolves to `semantic_version: 25.0.9` and preset `9.3.1`.
- Root cause verified against published npm tarballs and registry publish timestamps: the guard string exists only in `@conventional-changelog/template@1.4.0`, not 1.3.0 or 1.2.1, and not in any version of the preset itself.
- **Not verified end-to-end:** npm installs are firewalled in my sandbox, so I could not execute a notes render locally. The 4.20.2 run is the real proof — worth watching `generateNotes` and confirming the notes contain the in-app fix.

## Deliberately not in this PR

`CHANGELOG.md` entries for 4.19.0, 4.20.0 and 4.20.1 stay empty; this fix doesn't backfill history. Happy to do that as a separate PR if we want the changelog whole.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that restores the existing release workflow by pinning dependencies; no application code, security, or data handling is affected.
> 
> **Overview**
> Pins the release workflow's semantic-release tooling to a known-good combination. `semantic_version` is now fixed at `25.0.9` and the `conventional-changelog-conventionalcommits` preset is pinned to `9.3.1` in `extra_plugins`.
> 
> This unblocks the Android SDK release pipeline, which started failing when the unpinned preset resolved to its `10.x` line and pulled in a broken template renderer that crashes the `generateNotes` step before any tag is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40a9ea1f19a7ab27f6937dd20be598c66d7dafdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->