### PR TITLE
fix(push): render live notifications delivered to a cold process

### DIFF
--- a/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/LiveNotificationHandler.kt
@@ -15,6 +15,8 @@ import io.customer.messagingpush.activity.NotificationClickReceiverActivity
 import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
 import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.di.pushModuleConfig
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationBrandingSerializer
 import io.customer.messagingpush.livenotification.LiveNotificationDismissReceiver
 import io.customer.messagingpush.livenotification.template.TemplateAssets
 import io.customer.messagingpush.livenotification.template.TemplateRegistry
@@ -153,9 +155,20 @@ internal class LiveNotificationHandler(
         }
 
         val activityType = bundle.getString(NOTIFICATION_TYPE_KEY)
-        if (activityType == null || activityType !in SDKComponent.pushModuleConfig.liveNotificationTypes) {
-            SDKComponent.logger.debug(
-                "Live notification type '$activityType' is not enabled; ignoring activity '$activityId'."
+        val enabledTypes = enabledActivityTypes()
+        if (activityType == null || activityType !in enabledTypes) {
+            // Escalated from debug: reaching here means Customer.io delivered a live notification
+            // for a type this app doesn't render, which is a misconfiguration the customer needs to
+            // see. error is the only level visible at the SDK's default log level.
+            SDKComponent.logger.error(
+                if (enabledTypes.isEmpty()) {
+                    "Live notification type '$activityType' is not enabled; ignoring activity " +
+                        "'$activityId'. This app has never enabled live notifications — enable the " +
+                        "type via MessagingPushModuleConfig if it should render."
+                } else {
+                    "Live notification type '$activityType' is not enabled; ignoring activity " +
+                        "'$activityId'. Enabled types are $enabledTypes."
+                }
             )
             return
         }
@@ -221,7 +234,7 @@ internal class LiveNotificationHandler(
 
         val template = TemplateRegistry.find(activityType)
         val data = extractData(bundle)
-        val branding = SDKComponent.pushModuleConfig.liveNotificationBranding
+        val branding = branding(context)
         // Branding overrides the status-bar icon for live notifications only.
         val effectiveSmallIcon = branding?.smallIcon ?: smallIcon
 
@@ -337,6 +350,34 @@ internal class LiveNotificationHandler(
         // (local); the tracked activity type is intentionally kept (not cleared) so a
         // subsequent logout can still cancel an ended-but-still-visible notification.
     }
+
+    /**
+     * The activity types this app renders, falling back to the persisted opt-in when the module
+     * config carries none.
+     *
+     * A cold process — one Android started solely to deliver an FCM message — never runs
+     * `CustomerIO.initialize`, so the push module isn't registered and [pushModuleConfig] resolves
+     * to its defaults. The resulting empty set is ambiguous: it means both "this app never enabled
+     * live notifications" and "this app did, but this process hasn't loaded that yet". The persisted
+     * copy tells them apart, so a push delivered after ordinary process death still renders.
+     *
+     * A populated config always wins, so *disabling* a type takes effect immediately in a running
+     * process rather than waiting for the persisted copy to be rewritten, and an app that never
+     * enabled the feature keeps ignoring these pushes.
+     */
+    private fun enabledActivityTypes(): Set<String> =
+        SDKComponent.pushModuleConfig.liveNotificationTypes
+            .ifEmpty { SDKComponent.liveNotificationStore.enabledActivityTypes() }
+
+    /**
+     * Branding for this render, falling back to the persisted copy in a cold process for the same
+     * reason as [enabledActivityTypes] — otherwise a cold render would drop the branded small icon
+     * and logo, visibly changing an ongoing notification a warm process had already posted.
+     */
+    private fun branding(context: Context): LiveNotificationBranding? =
+        SDKComponent.pushModuleConfig.liveNotificationBranding
+            ?: SDKComponent.liveNotificationStore.brandingJson()
+                ?.let { LiveNotificationBrandingSerializer.decode(context, it) }
 
     private fun buildSdkNotification(
         context: Context,

--- a/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/ModuleMessagingPushFCM.kt
@@ -9,9 +9,11 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import io.customer.messagingpush.di.fcmTokenProvider
 import io.customer.messagingpush.di.liveNotificationManager
 import io.customer.messagingpush.di.liveNotificationRegistrar
+import io.customer.messagingpush.di.liveNotificationStore
 import io.customer.messagingpush.di.pushDeliveryFlusher
 import io.customer.messagingpush.di.pushLogger
 import io.customer.messagingpush.di.pushTrackingUtil
+import io.customer.messagingpush.livenotification.LiveNotificationBrandingSerializer
 import io.customer.messagingpush.livenotification.LiveNotificationData
 import io.customer.messagingpush.livenotification.ULID
 import io.customer.messagingpush.logger.PushNotificationLogger
@@ -42,6 +44,7 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         get() = MODULE_NAME
 
     override fun initialize() {
+        persistLiveNotificationConfig()
         // Live notifications are opt-in; start before requesting the token so the
         // registrar observes the resulting RegisterDeviceTokenEvent.
         if (moduleConfig.liveNotificationTypes.isNotEmpty()) {
@@ -50,6 +53,34 @@ class ModuleMessagingPushFCM @JvmOverloads constructor(
         getCurrentFcmToken()
         subscribeToLifecycleEvents()
         observeProcessForeground()
+    }
+
+    /**
+     * Mirrors the live-notification opt-in (enabled types + branding) into persistent storage so a
+     * cold process can render.
+     *
+     * Android starts a process solely to deliver an FCM message; no app code runs there, so
+     * `CustomerIO.initialize` never executes and the push module is never registered. The render
+     * gate then reads an empty enabled-types set from the default module config, which is ambiguous
+     * — "never opted in" and "opted in, not loaded yet" look identical — and every live notification
+     * delivered after ordinary process death is dropped. Worse, a dropped `end` strands an ongoing
+     * notification that isn't user-dismissible before Android 14.
+     *
+     * Written on *every* initialization, including when nothing is enabled: that is how un-enabling
+     * a type, or the feature, propagates to the next cold process. Deliberately outside the
+     * registrar's non-empty guard below for the same reason.
+     */
+    private fun persistLiveNotificationConfig() {
+        val store = SDKComponent.liveNotificationStore
+        store.setEnabledActivityTypes(moduleConfig.liveNotificationTypes)
+        store.setBrandingJson(
+            moduleConfig.liveNotificationBranding?.let { branding ->
+                LiveNotificationBrandingSerializer.encode(
+                    context = SDKComponent.android().applicationContext,
+                    branding = branding
+                )
+            }
+        )
     }
 
     /**

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationBrandingSerializer.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationBrandingSerializer.kt
@@ -1,0 +1,155 @@
+package io.customer.messagingpush.livenotification
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.Uri
+import io.customer.sdk.core.di.SDKComponent
+import org.json.JSONObject
+
+/**
+ * Persists [LiveNotificationBranding] so a cold process — one Android started solely to deliver an
+ * FCM message, where `CustomerIO.initialize` never ran — renders with the same branding a warm
+ * process would use. Without it a cold render silently falls back to the app's manifest icon and no
+ * logo, visibly changing an ongoing notification halfway through its life.
+ *
+ * Resource **names** are stored rather than resource ids: ids are assigned at build time and are not
+ * stable across app updates, so a persisted id can resolve to an unrelated drawable after an
+ * upgrade. The resource *type* is stored alongside the name because a small icon is frequently a
+ * `mipmap` (app launcher icons) rather than a `drawable`, and it is resolved against the *current*
+ * package at decode time so a persisted entry survives any package-name change.
+ *
+ * Neither direction throws: anything unrepresentable or unresolvable degrades to "no branding" for
+ * that field, because failing a render is strictly worse than rendering it unbranded.
+ */
+internal object LiveNotificationBrandingSerializer {
+
+    fun encode(context: Context, branding: LiveNotificationBranding): String? = runCatching {
+        JSONObject().apply {
+            put(KEY_COMPANY_NAME, branding.companyName)
+            put(KEY_ACCENT_COLOR, branding.accentColor)
+            branding.smallIcon
+                ?.let { resourceToJson(context, it) }
+                ?.let { put(KEY_SMALL_ICON, it) }
+            encodeLogo(context, branding.logo)?.let { put(KEY_LOGO, it) }
+        }.toString()
+    }.getOrElse { cause ->
+        SDKComponent.logger.error(
+            "Failed to persist live notification branding: ${cause.message}"
+        )
+        null
+    }
+
+    fun decode(context: Context, json: String): LiveNotificationBranding? = runCatching {
+        val root = JSONObject(json)
+        LiveNotificationBranding(
+            companyName = root.optString(KEY_COMPANY_NAME),
+            accentColor = root.getInt(KEY_ACCENT_COLOR),
+            smallIcon = root.optJSONObject(KEY_SMALL_ICON)?.let { resourceFromJson(context, it) },
+            logo = root.optJSONObject(KEY_LOGO)?.let { decodeLogo(context, it) }
+        )
+    }.getOrElse { cause ->
+        SDKComponent.logger.error(
+            "Failed to read persisted live notification branding; rendering unbranded: ${cause.message}"
+        )
+        null
+    }
+
+    private fun encodeLogo(context: Context, logo: LiveNotificationAsset?): JSONObject? = when (logo) {
+        null -> null
+        is LiveNotificationAsset.Drawable -> resourceToJson(context, logo.resId)
+            ?.put(KEY_LOGO_KIND, LOGO_DRAWABLE)
+
+        is LiveNotificationAsset.RemoteUrl -> JSONObject()
+            .put(KEY_LOGO_KIND, LOGO_REMOTE_URL)
+            .put(KEY_LOGO_VALUE, logo.url)
+
+        is LiveNotificationAsset.Resource -> JSONObject()
+            .put(KEY_LOGO_KIND, LOGO_RESOURCE_URI)
+            .put(KEY_LOGO_VALUE, logo.uri.toString())
+
+        // Raw bytes are unbounded, and SharedPreferences is the wrong place for an image payload.
+        // A cold render simply has no logo; every other branding field still applies.
+        is LiveNotificationAsset.Bytes -> {
+            SDKComponent.logger.debug(
+                "Live notification branding logo is raw bytes; it will not be available after " +
+                    "process death. Use a bundled drawable or a remote URL to keep it."
+            )
+            null
+        }
+    }
+
+    private fun decodeLogo(context: Context, json: JSONObject): LiveNotificationAsset? =
+        when (val kind = json.optString(KEY_LOGO_KIND)) {
+            LOGO_DRAWABLE -> resourceFromJson(context, json)?.let(LiveNotificationAsset::Drawable)
+            LOGO_REMOTE_URL -> json.optString(KEY_LOGO_VALUE)
+                .takeIf { it.isNotBlank() }
+                ?.let(LiveNotificationAsset::RemoteUrl)
+
+            LOGO_RESOURCE_URI -> json.optString(KEY_LOGO_VALUE)
+                .takeIf { it.isNotBlank() }
+                ?.let { LiveNotificationAsset.Resource(Uri.parse(it)) }
+
+            else -> {
+                SDKComponent.logger.debug("Unknown persisted live notification logo kind '$kind'; ignoring.")
+                null
+            }
+        }
+
+    /**
+     * `resId` -> `{package, type, entry}`, or null when the id doesn't resolve to a named resource.
+     *
+     * The package is recorded because branding may legitimately point at a resource outside the
+     * app's own package (a framework or library drawable), and the type because a small icon is
+     * frequently a `mipmap` (launcher icons) rather than a `drawable`.
+     */
+    private fun resourceToJson(context: Context, resId: Int): JSONObject? = runCatching {
+        JSONObject()
+            .put(KEY_RES_PKG, context.resources.getResourcePackageName(resId))
+            .put(KEY_RES_TYPE, context.resources.getResourceTypeName(resId))
+            .put(KEY_RES_ENTRY, context.resources.getResourceEntryName(resId))
+    }.getOrElse { cause ->
+        SDKComponent.logger.debug(
+            "Live notification branding resource $resId has no resolvable name; not persisting it: ${cause.message}"
+        )
+        null
+    }
+
+    /**
+     * `{package, type, entry}` -> `resId`, or null when the resource no longer resolves (renamed or
+     * removed by an app update since it was persisted).
+     */
+    @SuppressLint("DiscouragedApi")
+    private fun resourceFromJson(context: Context, json: JSONObject): Int? {
+        val type = json.optString(KEY_RES_TYPE).takeIf { it.isNotBlank() } ?: return null
+        val entry = json.optString(KEY_RES_ENTRY).takeIf { it.isNotBlank() } ?: return null
+        // Try the package the resource was compiled into first — branding may point at a framework
+        // or library resource, not an app one — then the app's current package, which covers both an
+        // entry persisted before the package was recorded and an app whose package name changed.
+        val packages = listOfNotNull(
+            json.optString(KEY_RES_PKG).takeIf { it.isNotBlank() },
+            context.packageName
+        ).distinct()
+        // getIdentifier is discouraged, but resolving a persisted name is exactly what it is for —
+        // the same mechanism Context.getDrawableByName already uses for push payload icons. It
+        // documents 0 (not Resources.ID_NULL, which is API 29+) for "no such resource".
+        return packages.firstNotNullOfOrNull { pkg ->
+            context.resources.getIdentifier(entry, type, pkg).takeUnless { it == 0 }
+        }
+    }
+
+    private const val KEY_COMPANY_NAME = "companyName"
+    private const val KEY_ACCENT_COLOR = "accentColor"
+    private const val KEY_SMALL_ICON = "smallIcon"
+    private const val KEY_LOGO = "logo"
+
+    private const val KEY_RES_PKG = "resPkg"
+    private const val KEY_RES_TYPE = "resType"
+    private const val KEY_RES_ENTRY = "resEntry"
+
+    private const val KEY_LOGO_KIND = "kind"
+    private const val KEY_LOGO_VALUE = "value"
+
+    private const val LOGO_DRAWABLE = "drawable"
+    private const val LOGO_REMOTE_URL = "remoteUrl"
+    private const val LOGO_RESOURCE_URI = "resourceUri"
+}

--- a/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/livenotification/LiveNotificationStore.kt
@@ -7,11 +7,53 @@ import java.util.concurrent.TimeUnit
 /**
  * Persistent live-notification state (dedicated SharedPreferences file):
  * per-`activity_type` registration signatures, per-`activity_id` last-seen
- * timestamps for the out-of-order guard, and per-`activity_id` activity types.
+ * timestamps for the out-of-order guard, per-`activity_id` activity types, and the
+ * app-wide opt-in (enabled activity types + branding) that a cold process needs to
+ * render at all.
  */
 internal class LiveNotificationStore(context: Context) {
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    // --- App-wide config (survives process death) ---
+
+    /**
+     * The activity types this app last enabled, or an empty set if it never enabled any.
+     *
+     * Read in a cold process — one Android started solely to deliver an FCM message, where no app
+     * code ran and so `CustomerIO.initialize` never registered the push module. Without this, the
+     * module config falls back to its defaults and an empty enabled-types set is ambiguous: it
+     * means both "this app never opted in" (ignore the push) and "this app opted in, but this
+     * process hasn't loaded that yet" (render the push). Persisting the opt-in separates the two.
+     */
+    fun enabledActivityTypes(): Set<String> =
+        // SharedPreferences owns the instance it returns, so copy instead of retaining it.
+        prefs.getStringSet(ENABLED_TYPES_KEY, null)?.toSet().orEmpty()
+
+    /** Replaces (never merges) the persisted opt-in. An empty set removes the entry. */
+    fun setEnabledActivityTypes(types: Set<String>) {
+        prefs.edit {
+            if (types.isEmpty()) {
+                remove(ENABLED_TYPES_KEY)
+            } else {
+                putStringSet(ENABLED_TYPES_KEY, types)
+            }
+        }
+    }
+
+    /** The serialized branding last configured, or null when the app configured none. */
+    fun brandingJson(): String? = prefs.getString(BRANDING_KEY, null)
+
+    /** Replaces the persisted branding. Null or blank removes the entry. */
+    fun setBrandingJson(json: String?) {
+        prefs.edit {
+            if (json.isNullOrBlank()) {
+                remove(BRANDING_KEY)
+            } else {
+                putString(BRANDING_KEY, json)
+            }
+        }
+    }
 
     /**
      * One-time cleanup for the namespace rename: drops registration signatures
@@ -177,6 +219,14 @@ internal class LiveNotificationStore(context: Context) {
 
     companion object {
         private const val PREFS_NAME = "io.customer.messagingpush.live_notifications"
+
+        // App-wide entries, deliberately unprefixed. Every sweep in this class
+        // ([trimStaleTimestamps], [clearAllActivities], [clearRegistrations]) filters on one of the
+        // per-activity prefixes below, so neither TTL reclamation nor logout can clear these — which
+        // is intended: an app-wide opt-in is not user-scoped.
+        private const val ENABLED_TYPES_KEY = "enabled_types"
+        private const val BRANDING_KEY = "branding"
+
         private const val REG_PREFIX = "reg:"
         private const val TS_PREFIX = "ts:"
         private const val TYPE_PREFIX = "type:"

--- a/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationColdProcessTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/LiveNotificationColdProcessTest.kt
@@ -1,0 +1,151 @@
+package io.customer.messagingpush
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.graphics.Color
+import android.os.Bundle
+import io.customer.commontest.extensions.assertCalledNever
+import io.customer.commontest.extensions.attachToSDKComponent
+import io.customer.messagingpush.di.liveNotificationStore
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationBrandingSerializer
+import io.customer.messagingpush.livenotification.LiveNotificationType
+import io.customer.messagingpush.livenotification.template.TemplateRegistry
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.core.di.SDKComponent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Rendering in a **cold process** — one Android started solely to deliver an FCM message, where no
+ * app code ran and `CustomerIO.initialize` never registered the push module.
+ *
+ * The distinguishing setup is what these tests *don't* do: unlike [LiveNotificationHandlerTest] they
+ * never call `attachToSDKComponent()`, so `SDKComponent.pushModuleConfig` resolves to
+ * [MessagingPushModuleConfig.default] exactly as it does in a real cold process. Everything the
+ * render needs must therefore come from [io.customer.messagingpush.livenotification.LiveNotificationStore].
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationColdProcessTest : IntegrationTest() {
+
+    private val notificationManager: NotificationManager = mockk(relaxed = true)
+    private val channelId = "live-notifications"
+
+    private fun newBundle(
+        activityId: String = "live-act-1",
+        event: String = "start",
+        activityType: String? = TemplateRegistry.SEGMENTS
+    ): Bundle = Bundle().apply {
+        putString(LiveNotificationHandler.CIO_INSTANCE_ID_KEY, activityId)
+        putString(LiveNotificationHandler.EVENT_KEY, event)
+        if (activityType != null) {
+            putString(LiveNotificationHandler.NOTIFICATION_TYPE_KEY, activityType)
+        }
+        // Minimal renderable content for either built-in template.
+        val data = JSONObject().apply {
+            put("status", "Out for delivery")
+            put("title", "Out for delivery")
+        }
+        for (key in data.keys()) putString(key, data.get(key).toString())
+    }
+
+    private fun invoke(bundle: Bundle) {
+        LiveNotificationHandler(bundle).handle(
+            context = contextMock,
+            deliveryId = "delivery-id-1",
+            deliveryToken = "delivery-token-1",
+            smallIcon = 0,
+            tintColor = null,
+            channelId = channelId,
+            notificationManager = notificationManager
+        )
+    }
+
+    @Test
+    fun handle_givenPersistedOptInAndNoModuleConfig_rendersNotification() {
+        // The regression: before the persisted opt-in existed, the empty default config made this
+        // push indistinguishable from one sent to an app that never enabled live notifications, and
+        // it was dropped silently.
+        SDKComponent.liveNotificationStore.setEnabledActivityTypes(setOf(TemplateRegistry.SEGMENTS))
+
+        invoke(newBundle())
+
+        verify { notificationManager.notify("live-act-1", any<Int>(), any<Notification>()) }
+    }
+
+    @Test
+    fun handle_givenNoPersistedOptInAndNoModuleConfig_dropsNotification() {
+        // Unchanged behaviour for an app that genuinely never enabled live notifications: an
+        // unsolicited push must never render.
+        invoke(newBundle())
+
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
+    fun handle_givenPopulatedConfigExcludingType_dropsEvenWhenPersistedSetContainsIt() {
+        // A populated config always wins, so *disabling* a type takes effect immediately in a
+        // running process instead of waiting for the persisted copy to be rewritten.
+        SDKComponent.liveNotificationStore.setEnabledActivityTypes(setOf(TemplateRegistry.SEGMENTS))
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder()
+                .enableLiveNotificationTypes(LiveNotificationType.COUNTDOWN_TIMER)
+                .build()
+        ).attachToSDKComponent()
+
+        invoke(newBundle(activityType = TemplateRegistry.SEGMENTS))
+
+        assertCalledNever {
+            notificationManager.notify(any<String>(), any<Int>(), any<Notification>())
+        }
+    }
+
+    @Test
+    fun handle_givenColdProcessEnd_postsTerminalStateRatherThanStrandingIt() {
+        // The worst symptom of the drop: an `end` delivered to a cold process left the ongoing
+        // notification a previous process posted on screen forever — and an ongoing notification is
+        // not user-dismissible before Android 14, so there was no way to clear it.
+        SDKComponent.liveNotificationStore.setEnabledActivityTypes(setOf(TemplateRegistry.SEGMENTS))
+
+        invoke(newBundle(event = "end"))
+
+        verify { notificationManager.notify("live-act-1", any<Int>(), any<Notification>()) }
+    }
+
+    @Test
+    fun handle_givenPersistedBranding_appliesItToAColdRender() {
+        // Branding lives in the same in-memory config as the enabled types, so without persisting it
+        // a cold render would swap the branded status-bar icon for the app's manifest icon halfway
+        // through an ongoing notification's life.
+        val brandedSmallIcon = android.R.drawable.ic_dialog_info
+        val store = SDKComponent.liveNotificationStore
+        store.setEnabledActivityTypes(setOf(TemplateRegistry.SEGMENTS))
+        store.setBrandingJson(
+            LiveNotificationBrandingSerializer.encode(
+                context = contextMock,
+                branding = LiveNotificationBranding(
+                    companyName = "Acme",
+                    accentColor = Color.RED,
+                    smallIcon = brandedSmallIcon
+                )
+            )
+        )
+        val posted = slot<Notification>()
+        every { notificationManager.notify(any<String>(), any<Int>(), capture(posted)) } returns Unit
+
+        invoke(newBundle())
+
+        // The legacy int `icon` field mirrors the resId passed to setSmallIcon.
+        @Suppress("DEPRECATION")
+        posted.captured.icon shouldBeEqualTo brandedSmallIcon
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -1,5 +1,6 @@
 package io.customer.messagingpush
 
+import android.graphics.Color
 import androidx.work.Operation
 import androidx.work.WorkManager
 import com.google.common.util.concurrent.Futures
@@ -10,6 +11,10 @@ import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.commontest.extensions.random
 import io.customer.commontest.util.DispatchersProviderStub
 import io.customer.messagingpush.di.fcmTokenProvider
+import io.customer.messagingpush.di.liveNotificationStore
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationBrandingSerializer
+import io.customer.messagingpush.livenotification.LiveNotificationType
 import io.customer.messagingpush.logger.PushNotificationLogger
 import io.customer.messagingpush.provider.DeviceTokenProvider
 import io.customer.messagingpush.store.PendingPushDeliveryMetric
@@ -26,7 +31,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -79,6 +88,48 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
         ModuleMessagingPushFCM.foregroundObserver = null
         eventBus.removeAllSubscriptions()
         super.teardown()
+    }
+
+    @Test
+    fun initialize_givenLiveNotificationsEnabled_persistsOptInForColdProcesses() {
+        // A process Android starts solely to deliver an FCM message runs no app code, so the module
+        // config is unavailable there. Mirroring the opt-in into storage at init is what lets such a
+        // process tell "never enabled" apart from "not loaded yet" and render at all.
+        val givenBranding = LiveNotificationBranding(
+            companyName = "Acme",
+            accentColor = Color.RED,
+            smallIcon = android.R.drawable.ic_dialog_info
+        )
+
+        ModuleMessagingPushFCM(
+            MessagingPushModuleConfig.Builder()
+                .enableLiveNotificationTypes(LiveNotificationType.SEGMENTS)
+                .setLiveNotificationBranding(givenBranding)
+                .build()
+        ).initialize()
+
+        val store = SDKComponent.liveNotificationStore
+        store.enabledActivityTypes() shouldContainSame setOf(LiveNotificationType.SEGMENTS.identifier)
+        LiveNotificationBrandingSerializer.decode(
+            contextMock,
+            requireNotNull(store.brandingJson())
+        ) shouldBeEqualTo givenBranding
+    }
+
+    @Test
+    fun initialize_givenLiveNotificationsNotEnabled_clearsPersistedOptIn() {
+        // The persist runs on every init, outside the registrar's non-empty guard: that is how
+        // un-enabling a type — or the whole feature — reaches the next cold process. Left stale, the
+        // persisted copy would keep rendering pushes the app no longer wants.
+        val store = SDKComponent.liveNotificationStore
+        store.setEnabledActivityTypes(setOf(LiveNotificationType.SEGMENTS.identifier))
+        store.setBrandingJson("""{"companyName":"Acme","accentColor":1}""")
+
+        // `module` is built with the default config, which enables nothing.
+        module.initialize()
+
+        store.enabledActivityTypes().shouldBeEmpty()
+        store.brandingJson().shouldBeNull()
     }
 
     @Test

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationBrandingSerializerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationBrandingSerializerTest.kt
@@ -1,0 +1,169 @@
+package io.customer.messagingpush.livenotification
+
+import android.graphics.Color
+import android.net.Uri
+import io.customer.messagingpush.testutils.core.IntegrationTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Round-trip coverage for the branding a cold process reads back. The resource-name indirection is
+ * the point: resource ids are build-time values, so persisting ids would resolve to an unrelated
+ * drawable after an app update.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class LiveNotificationBrandingSerializerTest : IntegrationTest() {
+
+    // Any resource that genuinely exists in the test APK, so getResourceEntryName/getIdentifier
+    // have something real to round-trip.
+    private val realResId: Int
+        get() = android.R.drawable.ic_dialog_info
+
+    private fun encodeThenDecode(branding: LiveNotificationBranding): LiveNotificationBranding? =
+        LiveNotificationBrandingSerializer.encode(contextMock, branding)
+            ?.let { LiveNotificationBrandingSerializer.decode(contextMock, it) }
+
+    @Test
+    fun encodeDecode_givenScalarFieldsOnly_roundTrips() {
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(companyName = "Acme", accentColor = Color.RED)
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.companyName shouldBeEqualTo "Acme"
+        decoded.accentColor shouldBeEqualTo Color.RED
+        decoded.smallIcon.shouldBeNull()
+        decoded.logo.shouldBeNull()
+    }
+
+    @Test
+    fun encodeDecode_givenSmallIcon_roundTripsAsResourceName() {
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(
+                companyName = "Acme",
+                accentColor = Color.BLUE,
+                smallIcon = realResId
+            )
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.smallIcon shouldBeEqualTo realResId
+    }
+
+    @Test
+    fun encodeDecode_givenDrawableLogo_roundTrips() {
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(
+                companyName = "Acme",
+                accentColor = Color.BLUE,
+                logo = LiveNotificationAsset.Drawable(realResId)
+            )
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.logo shouldBeEqualTo LiveNotificationAsset.Drawable(realResId)
+    }
+
+    @Test
+    fun encodeDecode_givenRemoteUrlLogo_roundTrips() {
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(
+                companyName = "Acme",
+                accentColor = Color.BLUE,
+                logo = LiveNotificationAsset.RemoteUrl("https://example.com/logo.png")
+            )
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.logo shouldBeEqualTo LiveNotificationAsset.RemoteUrl("https://example.com/logo.png")
+    }
+
+    @Test
+    fun encodeDecode_givenResourceUriLogo_roundTrips() {
+        val uri = Uri.parse("content://media/external/images/media/42")
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(
+                companyName = "Acme",
+                accentColor = Color.BLUE,
+                logo = LiveNotificationAsset.Resource(uri)
+            )
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.logo shouldBeEqualTo LiveNotificationAsset.Resource(uri)
+    }
+
+    @Test
+    fun encode_givenBytesLogo_dropsLogoAndKeepsEverythingElse() {
+        // Raw bytes are unbounded; SharedPreferences is the wrong home for an image payload. The
+        // cold render loses the logo but keeps the rest of the branding.
+        val decoded = encodeThenDecode(
+            LiveNotificationBranding(
+                companyName = "Acme",
+                accentColor = Color.GREEN,
+                smallIcon = realResId,
+                logo = LiveNotificationAsset.Bytes(byteArrayOf(1, 2, 3))
+            )
+        )
+
+        decoded.shouldNotBeNull()
+        decoded.logo.shouldBeNull()
+        decoded.companyName shouldBeEqualTo "Acme"
+        decoded.accentColor shouldBeEqualTo Color.GREEN
+        decoded.smallIcon shouldBeEqualTo realResId
+    }
+
+    @Test
+    fun decode_givenResourceTheAppNoLongerShips_yieldsNullAssetNotCrash() {
+        // Simulates a drawable renamed or removed by an app update after branding was persisted.
+        val json = JSONObject()
+            .put("companyName", "Acme")
+            .put("accentColor", Color.RED)
+            .put(
+                "smallIcon",
+                JSONObject().put("resType", "drawable").put("resEntry", "cio_no_such_drawable")
+            )
+            .put(
+                "logo",
+                JSONObject()
+                    .put("kind", "drawable")
+                    .put("resType", "drawable")
+                    .put("resEntry", "cio_no_such_drawable")
+            )
+            .toString()
+
+        val decoded = LiveNotificationBrandingSerializer.decode(contextMock, json)
+
+        decoded.shouldNotBeNull()
+        decoded.smallIcon.shouldBeNull()
+        decoded.logo.shouldBeNull()
+        decoded.companyName shouldBeEqualTo "Acme"
+    }
+
+    @Test
+    fun decode_givenUnknownLogoKind_ignoresLogo() {
+        val json = JSONObject()
+            .put("companyName", "Acme")
+            .put("accentColor", Color.RED)
+            .put("logo", JSONObject().put("kind", "something-a-newer-sdk-wrote"))
+            .toString()
+
+        val decoded = LiveNotificationBrandingSerializer.decode(contextMock, json)
+
+        decoded.shouldNotBeNull()
+        decoded.logo.shouldBeNull()
+    }
+
+    @Test
+    fun decode_givenMalformedOrIncompleteJson_returnsNullWithoutThrowing() {
+        LiveNotificationBrandingSerializer.decode(contextMock, "not json").shouldBeNull()
+        LiveNotificationBrandingSerializer.decode(contextMock, "").shouldBeNull()
+        // accentColor is required; a truncated entry must degrade to unbranded, not throw.
+        LiveNotificationBrandingSerializer.decode(contextMock, """{"companyName":"Acme"}""").shouldBeNull()
+    }
+}

--- a/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/livenotification/LiveNotificationStoreTest.kt
@@ -17,6 +17,61 @@ internal class LiveNotificationStoreTest : IntegrationTest() {
     private val store by lazy { LiveNotificationStore(contextMock) }
 
     @Test
+    fun enabledActivityTypes_roundTripsAndClearsWhenEmpty() {
+        store.enabledActivityTypes().shouldBeEmpty()
+
+        store.setEnabledActivityTypes(setOf("type.a", "type.b"))
+        store.enabledActivityTypes() shouldContainSame setOf("type.a", "type.b")
+
+        // Replace, never merge.
+        store.setEnabledActivityTypes(setOf("type.c"))
+        store.enabledActivityTypes() shouldContainSame setOf("type.c")
+
+        // An app that stops enabling every type must not look opted in to the next cold process.
+        store.setEnabledActivityTypes(emptySet())
+        store.enabledActivityTypes().shouldBeEmpty()
+    }
+
+    @Test
+    fun brandingJson_roundTripsAndClearsWhenNullOrBlank() {
+        store.brandingJson().shouldBeNull()
+
+        store.setBrandingJson("""{"companyName":"Acme"}""")
+        store.brandingJson() shouldBeEqualTo """{"companyName":"Acme"}"""
+
+        store.setBrandingJson(null)
+        store.brandingJson().shouldBeNull()
+
+        store.setBrandingJson("   ")
+        store.brandingJson().shouldBeNull()
+    }
+
+    @Test
+    fun appWideEntries_surviveEverySweep() {
+        // `enabled_types` and `branding` are app-wide and deliberately unprefixed, so no sweep in
+        // the store may reclaim them: TTL reclamation would lose the opt-in for a device that
+        // simply hasn't received a push in a while, and logout would lose it for the next user.
+        val now = 10_000_000_000L
+        val ttl = 1_000L
+        store.setEnabledActivityTypes(setOf("type.a"))
+        store.setBrandingJson("""{"companyName":"Acme"}""")
+        store.setLastTimestamp("old", 1L, now = now - ttl - 1)
+        store.setActivityType("old", "type.a", now = now - ttl - 1)
+        store.markEnded("old", now = now - ttl - 1)
+        store.setRegistrationSignature("type.a", "tok|user")
+
+        store.trimStaleTimestamps(ttlMs = ttl, now = now)
+        store.clearAllActivities()
+        store.clearRegistrations()
+
+        store.enabledActivityTypes() shouldContainSame setOf("type.a")
+        store.brandingJson() shouldBeEqualTo """{"companyName":"Acme"}"""
+        // Sanity: the sweeps did run.
+        store.activityType("old").shouldBeNull()
+        store.registrationSignature("type.a").shouldBeNull()
+    }
+
+    @Test
     fun registrationSignature_setGetClear() {
         store.registrationSignature("type-a").shouldBeNull()
 


### PR DESCRIPTION
Live notifications delivered after ordinary process death were silently dropped, and a dropped `end` left an ongoing notification stranded on screen (not user-dismissible before Android 14).

A process Android starts solely to deliver an FCM message runs no app code, so `CustomerIO.initialize` never registers the push module and the render gate reads an empty enabled-types set off the default config — indistinguishable from an app that never opted in. This persists the opt-in (enabled types + branding) at initialization and falls back to it when the config carries none; a populated config still wins, so disabling a type still takes effect immediately. Branding round-trips resource *names*, since ids are build-time values a later app update can reassign. The remaining not-enabled drop moves from `debug` to `error`, so a real misconfiguration is visible at the default log level.

Custom callback-rendered types still need an initialized process to render — the host callback exists only in memory — and are handled as a follow-up. They do get the `end` fix, so nothing strands.

### Testing
- `:messagingpush:testDebugUnitTest` green, including new cold-process coverage (`LiveNotificationColdProcessTest`) that never registers the module, so the config resolves to its defaults exactly as in a real cold process.
- `:messagingpush:apiCheck` green and `messagingpush/api/messagingpush.api` unchanged — everything added is `internal`.
- Device verification pending: `adb shell am kill` (not force-stop, which blocks FCM delivery and would pass for the wrong reason), then drive an `update` and an `end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)