### PR TITLE
feat: support FID based device registration for FCM

### DIFF
--- a/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/io.customer/android/Versions.kt
@@ -4,7 +4,10 @@ object Versions {
     // Android SDK versions
     const val COMPILE_SDK = 36
     const val TARGET_SDK = 36
-    const val MIN_SDK = 21
+
+    // firebase-messaging 25.1+ (required for FID based registration) raised its minimum to API 23,
+    // matching the Firebase wide minSdk bump from June 2025.
+    const val MIN_SDK = 23
 
     // When updating AGP version, make sure to also update workflow: gradle-compatibility-builds
     // and script: update-gradle-compatibility as needed.
@@ -24,7 +27,7 @@ object Versions {
     internal const val DOKKA = "1.9.20"
     internal const val JUNIT_BOM = "5.9.3"
     internal const val ESPRESSO = "3.7.0"
-    internal const val FIREBASE_MESSAGING = "24.1.2"
+    internal const val FIREBASE_MESSAGING = "25.1.2"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "2.0.0"
     internal const val ANDROID_PUBLISH_PLUGIN = "0.1.0"
     internal const val GOOGLE_PLAY_SERVICES_BASE = "18.7.2"

--- a/messagingpush/api/messagingpush.api
+++ b/messagingpush/api/messagingpush.api
@@ -11,6 +11,8 @@ public class io/customer/messagingpush/CustomerIOFirebaseMessagingService : com/
 	public fun onMessageReceived (Lcom/google/firebase/messaging/RemoteMessage;)V
 	public static final fun onNewToken (Landroid/content/Context;Ljava/lang/String;)V
 	public fun onNewToken (Ljava/lang/String;)V
+	public static final fun onRegistered (Landroid/content/Context;Ljava/lang/String;)V
+	public fun onRegistered (Ljava/lang/String;)V
 }
 
 public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion {
@@ -18,6 +20,7 @@ public final class io/customer/messagingpush/CustomerIOFirebaseMessagingService$
 	public final fun onMessageReceived (Landroid/content/Context;Lcom/google/firebase/messaging/RemoteMessage;Z)Z
 	public static synthetic fun onMessageReceived$default (Lio/customer/messagingpush/CustomerIOFirebaseMessagingService$Companion;Landroid/content/Context;Lcom/google/firebase/messaging/RemoteMessage;ZILjava/lang/Object;)Z
 	public final fun onNewToken (Landroid/content/Context;Ljava/lang/String;)V
+	public final fun onRegistered (Landroid/content/Context;Ljava/lang/String;)V
 }
 
 public final class io/customer/messagingpush/MessagingPushModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {

--- a/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/CustomerIOFirebaseMessagingService.kt
@@ -48,6 +48,20 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
             handleNewToken(context = context, token = token)
         }
 
+        /**
+         * Handles the Firebase Installation ID (FID) delivered when the app instance is
+         * registered with FCM. Call this from [FirebaseMessagingService.onRegistered] to
+         * register the FID as the device token when your app has enabled FID based
+         * registration through the `firebase_messaging_installation_id_enabled` manifest flag.
+         *
+         * @param context reference to application context
+         * @param installationId Firebase Installation ID for the current app instance
+         */
+        @JvmStatic
+        fun onRegistered(context: Context, installationId: String) {
+            handleNewToken(context = context, token = installationId)
+        }
+
         private fun handleNewToken(context: Context, token: String) {
             SDKComponent.setupAndroidComponent(context = context)
             eventBus.publish(
@@ -70,8 +84,13 @@ open class CustomerIOFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
+    @Deprecated("Deprecated by FCM in favor of onRegistered")
     override fun onNewToken(token: String) {
         handleNewToken(context = this, token = token)
+    }
+
+    override fun onRegistered(installationId: String) {
+        handleNewToken(context = this, token = installationId)
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {

--- a/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/di/DiGraphMessagingPush.kt
@@ -3,6 +3,7 @@
 package io.customer.messagingpush.di
 
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.messagingpush.AsyncPushDeliveryTracker
@@ -44,6 +45,7 @@ internal val AndroidSDKComponent.fcmTokenProvider: DeviceTokenProvider
             context = applicationContext,
             googleApiAvailabilityProvider = { GoogleApiAvailability.getInstance() },
             firebaseMessagingProvider = { FirebaseMessaging.getInstance() },
+            firebaseInstallationsProvider = { FirebaseInstallations.getInstance() },
             pushLogger = SDKComponent.pushLogger
         )
     }

--- a/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/provider/FCMTokenProviderImpl.kt
@@ -1,8 +1,10 @@
 package io.customer.messagingpush.provider
 
 import android.content.Context
+import android.content.pm.PackageManager
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.messagingpush.logger.PushNotificationLogger
 import javax.inject.Provider
@@ -22,6 +24,7 @@ internal class FCMTokenProviderImpl(
     private val context: Context,
     private val googleApiAvailabilityProvider: Provider<GoogleApiAvailability>,
     private val firebaseMessagingProvider: Provider<FirebaseMessaging>,
+    private val firebaseInstallationsProvider: Provider<FirebaseInstallations>,
     private val pushLogger: PushNotificationLogger
 ) : DeviceTokenProvider {
 
@@ -42,6 +45,24 @@ internal class FCMTokenProviderImpl(
         }
     }
 
+    /**
+     * FCM deprecated registration tokens in favor of registration based on the Firebase
+     * Installation ID (FID). Host apps opt in through the manifest metadata flag below,
+     * which also makes the legacy token APIs throw. Mirror the flag here so we fetch the
+     * identifier through whichever registration mode the host app is in.
+     */
+    private fun isInstallationIdRegistrationEnabled(): Boolean {
+        return try {
+            val applicationInfo = context.packageManager.getApplicationInfo(
+                context.packageName,
+                PackageManager.GET_META_DATA
+            )
+            applicationInfo.metaData?.getBoolean(METADATA_INSTALLATION_ID_ENABLED, false) ?: false
+        } catch (exception: Throwable) {
+            false
+        }
+    }
+
     override fun getCurrentToken(onComplete: (String?) -> Unit) {
         pushLogger.obtainingTokenStarted()
         try {
@@ -50,20 +71,66 @@ internal class FCMTokenProviderImpl(
                 return
             }
 
-            firebaseMessagingProvider.get().token.addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    val existingDeviceToken = task.result
-                    pushLogger.obtainingTokenSuccess(existingDeviceToken)
-
-                    onComplete(existingDeviceToken)
-                } else {
-                    pushLogger.obtainingTokenFailed(task.exception)
-                    onComplete(null)
-                }
+            if (isInstallationIdRegistrationEnabled()) {
+                getInstallationId(onComplete)
+            } else {
+                getRegistrationToken(onComplete)
             }
         } catch (exception: Throwable) {
             pushLogger.obtainingTokenFailed(exception)
             onComplete(null)
         }
+    }
+
+    /**
+     * Legacy registration flow. [FirebaseMessaging.getToken] is deprecated but remains the
+     * only working API while the host app has not enabled FID based registration.
+     */
+    @Suppress("DEPRECATION")
+    private fun getRegistrationToken(onComplete: (String?) -> Unit) {
+        firebaseMessagingProvider.get().token.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val existingDeviceToken = task.result
+                pushLogger.obtainingTokenSuccess(existingDeviceToken)
+
+                onComplete(existingDeviceToken)
+            } else {
+                pushLogger.obtainingTokenFailed(task.exception)
+                onComplete(null)
+            }
+        }
+    }
+
+    /**
+     * FID registration flow. [FirebaseMessaging.register] makes sure the FCM backend knows
+     * about this app instance, then the FID is read from Firebase Installations and used as
+     * the device token.
+     */
+    private fun getInstallationId(onComplete: (String?) -> Unit) {
+        firebaseMessagingProvider.get().register().addOnCompleteListener { registerTask ->
+            if (!registerTask.isSuccessful) {
+                pushLogger.obtainingTokenFailed(registerTask.exception)
+                onComplete(null)
+                return@addOnCompleteListener
+            }
+
+            firebaseInstallationsProvider.get().id.addOnCompleteListener { idTask ->
+                if (idTask.isSuccessful) {
+                    val installationId = idTask.result
+                    pushLogger.obtainingTokenSuccess(installationId)
+
+                    onComplete(installationId)
+                } else {
+                    pushLogger.obtainingTokenFailed(idTask.exception)
+                    onComplete(null)
+                }
+            }
+        }
+    }
+
+    internal companion object {
+        // Manifest metadata flag defined by the FCM SDK. Setting it to true switches the
+        // host app to FID based registration and disables getToken()/deleteToken().
+        internal const val METADATA_INSTALLATION_ID_ENABLED = "firebase_messaging_installation_id_enabled"
     }
 }

--- a/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/provider/FCMTokenProviderTest.kt
@@ -1,14 +1,19 @@
 package io.customer.messagingpush.provider
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Bundle
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.tasks.OnCompleteListener
 import com.google.android.gms.tasks.Task
+import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import io.customer.commontest.core.JUnit5Test
 import io.customer.commontest.extensions.assertCalledOnce
 import io.customer.messagingpush.logger.PushNotificationLogger
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -18,20 +23,46 @@ import org.junit.jupiter.api.Test
 class FCMTokenProviderTest : JUnit5Test() {
 
     private val mockContext = mockk<Context>()
+    private val mockPackageManager = mockk<PackageManager>()
     private val mockGoogleApiAvailability = mockk<GoogleApiAvailability>()
     private val mockFirebaseMessaging = mockk<FirebaseMessaging>()
+    private val mockFirebaseInstallations = mockk<FirebaseInstallations>()
     private val mockPushLogger = mockk<PushNotificationLogger>(relaxed = true)
 
     private val tokenProvider: DeviceTokenProvider = FCMTokenProviderImpl(
         mockContext,
         { mockGoogleApiAvailability },
         { mockFirebaseMessaging },
+        { mockFirebaseInstallations },
         mockPushLogger
     )
+
+    private fun mockInstallationIdRegistration(enabled: Boolean?) {
+        val applicationInfo = mockk<ApplicationInfo>()
+        applicationInfo.metaData = enabled?.let { value ->
+            mockk<Bundle> {
+                every { getBoolean(FCMTokenProviderImpl.METADATA_INSTALLATION_ID_ENABLED, false) } returns value
+            }
+        }
+        every { mockContext.packageName } returns "io.customer.test"
+        every { mockPackageManager.getApplicationInfo("io.customer.test", PackageManager.GET_META_DATA) } returns applicationInfo
+        every { mockContext.packageManager } returns mockPackageManager
+    }
+
+    @Suppress("DEPRECATION")
+    private fun mockRegistrationTokenTask(): Pair<Task<String>, CapturingSlot<OnCompleteListener<String>>> {
+        val task = mockk<Task<String>>(relaxed = true)
+        val taskSlot = slot<OnCompleteListener<String>>()
+        every { mockFirebaseMessaging.getToken() } returns task
+        every { task.addOnCompleteListener(capture(taskSlot)) } returns task
+        return task to taskSlot
+    }
 
     @Test
     fun test_getCurrentToken_givenPlayServicesAvailable_logSuccess() {
         every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = null)
+        mockRegistrationTokenTask()
 
         tokenProvider.getCurrentToken { }
 
@@ -66,14 +97,12 @@ class FCMTokenProviderTest : JUnit5Test() {
     @Test
     fun test_getCurrentToken_givenObtainingTokenSuccessful() {
         every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = false)
 
         val token = "fcm-token"
-        val task = mockk<Task<String>>(relaxed = true)
-        val taskSlot = slot<OnCompleteListener<String>>()
+        val (task, taskSlot) = mockRegistrationTokenTask()
         every { task.isSuccessful } returns true
         every { task.result } returns token
-        every { mockFirebaseMessaging.getToken() } returns task
-        every { task.addOnCompleteListener(capture(taskSlot)) } returns task
 
         var result: String? = null
         tokenProvider.getCurrentToken { result = it }
@@ -87,14 +116,12 @@ class FCMTokenProviderTest : JUnit5Test() {
     @Test
     fun test_getCurrentToken_givenObtainingTokenNotSuccessful() {
         every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = false)
 
-        val task = mockk<Task<String>>(relaxed = true)
         val exception = IllegalStateException()
-        val taskSlot = slot<OnCompleteListener<String>>()
+        val (task, taskSlot) = mockRegistrationTokenTask()
         every { task.isSuccessful } returns false
         every { task.exception } returns exception
-        every { mockFirebaseMessaging.getToken() } returns task
-        every { task.addOnCompleteListener(capture(taskSlot)) } returns task
 
         var result: String? = null
         tokenProvider.getCurrentToken { result = it }
@@ -106,8 +133,10 @@ class FCMTokenProviderTest : JUnit5Test() {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun test_getCurrentToken_givenObtainingTokenThrows() {
         every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = false)
 
         val exception = IllegalStateException()
         every { mockFirebaseMessaging.getToken() } throws exception
@@ -118,5 +147,135 @@ class FCMTokenProviderTest : JUnit5Test() {
         assertCalledOnce { mockPushLogger.obtainingTokenStarted() }
         assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
         result shouldBeEqualTo null
+    }
+
+    @Test
+    fun test_getCurrentToken_givenManifestFlagMissing_useRegistrationToken() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = null)
+
+        val token = "fcm-token"
+        val (task, taskSlot) = mockRegistrationTokenTask()
+        every { task.isSuccessful } returns true
+        every { task.result } returns token
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        taskSlot.captured.onComplete(task)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenSuccess(token) }
+        result shouldBeEqualTo token
+    }
+
+    @Test
+    fun test_getCurrentToken_givenInstallationIdEnabled_registerAndReturnInstallationId() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = true)
+
+        val installationId = "firebase-installation-id"
+        val registerTask = mockk<Task<Void>>(relaxed = true)
+        val registerSlot = slot<OnCompleteListener<Void>>()
+        every { registerTask.isSuccessful } returns true
+        every { mockFirebaseMessaging.register() } returns registerTask
+        every { registerTask.addOnCompleteListener(capture(registerSlot)) } returns registerTask
+
+        val idTask = mockk<Task<String>>(relaxed = true)
+        val idSlot = slot<OnCompleteListener<String>>()
+        every { idTask.isSuccessful } returns true
+        every { idTask.result } returns installationId
+        every { mockFirebaseInstallations.id } returns idTask
+        every { idTask.addOnCompleteListener(capture(idSlot)) } returns idTask
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        registerSlot.captured.onComplete(registerTask)
+        idSlot.captured.onComplete(idTask)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenStarted() }
+        assertCalledOnce { mockPushLogger.obtainingTokenSuccess(installationId) }
+        result shouldBeEqualTo installationId
+    }
+
+    @Test
+    fun test_getCurrentToken_givenInstallationIdEnabled_registerNotSuccessful() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = true)
+
+        val exception = IllegalStateException()
+        val registerTask = mockk<Task<Void>>(relaxed = true)
+        val registerSlot = slot<OnCompleteListener<Void>>()
+        every { registerTask.isSuccessful } returns false
+        every { registerTask.exception } returns exception
+        every { mockFirebaseMessaging.register() } returns registerTask
+        every { registerTask.addOnCompleteListener(capture(registerSlot)) } returns registerTask
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        registerSlot.captured.onComplete(registerTask)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun test_getCurrentToken_givenInstallationIdEnabled_obtainingInstallationIdNotSuccessful() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = true)
+
+        val registerTask = mockk<Task<Void>>(relaxed = true)
+        val registerSlot = slot<OnCompleteListener<Void>>()
+        every { registerTask.isSuccessful } returns true
+        every { mockFirebaseMessaging.register() } returns registerTask
+        every { registerTask.addOnCompleteListener(capture(registerSlot)) } returns registerTask
+
+        val exception = IllegalStateException()
+        val idTask = mockk<Task<String>>(relaxed = true)
+        val idSlot = slot<OnCompleteListener<String>>()
+        every { idTask.isSuccessful } returns false
+        every { idTask.exception } returns exception
+        every { mockFirebaseInstallations.id } returns idTask
+        every { idTask.addOnCompleteListener(capture(idSlot)) } returns idTask
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        registerSlot.captured.onComplete(registerTask)
+        idSlot.captured.onComplete(idTask)
+
+        assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun test_getCurrentToken_givenInstallationIdEnabled_registerThrows() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        mockInstallationIdRegistration(enabled = true)
+
+        val exception = IllegalStateException()
+        every { mockFirebaseMessaging.register() } throws exception
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+
+        assertCalledOnce { mockPushLogger.obtainingTokenFailed(exception) }
+        result shouldBeEqualTo null
+    }
+
+    @Test
+    fun test_getCurrentToken_givenManifestLookupThrows_useRegistrationToken() {
+        every { mockGoogleApiAvailability.isGooglePlayServicesAvailable(mockContext) } returns ConnectionResult.SUCCESS
+        every { mockContext.packageName } returns "io.customer.test"
+        every { mockContext.packageManager } returns mockPackageManager
+        every { mockPackageManager.getApplicationInfo("io.customer.test", PackageManager.GET_META_DATA) } throws PackageManager.NameNotFoundException()
+
+        val token = "fcm-token"
+        val (task, taskSlot) = mockRegistrationTokenTask()
+        every { task.isSuccessful } returns true
+        every { task.result } returns token
+
+        var result: String? = null
+        tokenProvider.getCurrentToken { result = it }
+        taskSlot.captured.onComplete(task)
+
+        result shouldBeEqualTo token
     }
 }

--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId "io.customer.android.sample.java_layout"
-        minSdk 21
+        minSdk 23
         targetSdk 36
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Closes #756

## What

Firebase Cloud Messaging deprecated its registration token APIs in firebase-messaging 25.1.0 in favor of registering app instances by Firebase Installation ID (FID). This PR adds FID support to the messaging push module while keeping the existing token behavior for apps that have not opted in.

FID registration is opt-in through a manifest flag in the host app:

```xml
<meta-data android:name="firebase_messaging_installation_id_enabled" android:value="true" />
```

Enabling the flag makes the legacy token APIs throw, so an app that opts in is broken with the SDK as it is today: `FirebaseMessaging.getToken()` returns a failed task and no device token is ever registered.

## API replacements

| Deprecated | Replacement |
| --- | --- |
| `FirebaseMessaging.getToken()` | `FirebaseMessaging.register()` + FID from Firebase Installations |
| `FirebaseMessagingService.onNewToken(String)` | `FirebaseMessagingService.onRegistered(String)` |
| `FirebaseMessaging.deleteToken()` | `FirebaseMessaging.unregister()` (not used by the SDK) |

## How

- `FCMTokenProviderImpl` reads the same manifest flag FCM uses to pick the registration mode. With the flag enabled it calls `register()` to make sure the FCM backend knows about the app instance, then reads the FID from Firebase Installations and uses it as the device token. Without the flag it keeps the existing `getToken()` flow, which stays the only working API for apps that have not opted in.
- `CustomerIOFirebaseMessagingService` overrides `onRegistered()` and treats the delivered FID like a refreshed token. A static `onRegistered(context, installationId)` helper mirrors the existing `onNewToken(context, token)` one for apps that use their own messaging service.
- `firebase-messaging` updated from 24.1.2 to 25.1.2, which is where the new registration APIs live. `FirebaseInstallations` comes in transitively from firebase-messaging, no new dependency.
- Unit tests cover both registration modes: flag missing, flag disabled, flag enabled with success and failure of `register()` and of the FID lookup, and manifest lookup failures falling back to the token flow.

## Breaking change: minSdk 21 to 23

firebase-messaging 25.1+ requires minSdk 23 (Firebase raised the minimum across all its Android libraries in June 2025), so this bumps the SDK minimum from API 21 to API 23. The commit carries a `BREAKING CHANGE` footer so semantic-release treats it as a major bump. If we want to keep minSdk 21 for now, the alternative is staying on firebase-messaging 24.x, which caps us to a partial FID implementation without `register()`/`onRegistered()`.

## Notes for review

- Delivering pushes to a device registered by FID requires FID sends on the delivery side (the `fid` field in the FCM HTTP v1 API / Admin SDKs). Until that is in place end to end, customers should keep the flag disabled; nothing changes for them with this PR.
- FCM invokes `onRegistered()` with the identifier its registration store holds, so the service callback stays authoritative if a device ever falls back to legacy registration internally (very old Google Play services). The provider path and the callback path both publish `RegisterDeviceTokenEvent`, same as before.
- `messagingpush.api` regenerated with `apiDump`; `apiCheck`, ktlint, Android lint, and the unit test suites for all nine modules pass locally. The java_layout sample needed the same minSdk bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking minSdk bump and push device identity changes when FID mode is enabled; delivery must support FID sends end-to-end. Legacy apps without the manifest flag should see unchanged token behavior.
> 
> **Overview**
> Adds **Firebase Installation ID (FID)** registration for FCM alongside the legacy token flow, and bumps **firebase-messaging** to **25.1.2** with **minSdk 23** (from 21).
> 
> When the host app sets manifest metadata `firebase_messaging_installation_id_enabled`, `FCMTokenProviderImpl` uses `FirebaseMessaging.register()` and the FID from Firebase Installations instead of deprecated `getToken()`. Without the flag, behavior stays on the legacy token path. `CustomerIOFirebaseMessagingService` adds `onRegistered()` (and a static helper) so FID updates publish the same `RegisterDeviceTokenEvent` as `onNewToken`.
> 
> Public API surface grows via regenerated `messagingpush.api`. Unit tests cover both registration modes, failures, and manifest lookup fallback. The java_layout sample aligns with minSdk 23.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95367775e064a2243b6a8c0478543c471536096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->