### PR TITLE
chore(core): log uncaught SDK coroutine failures instead of crashing the host

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
@@ -18,7 +18,9 @@ class SdkScopeProvider(private val dispatchers: DispatchersProvider) : ScopeProv
     // Last-resort net: an exception escaping a coroutine on an SDK scope would crash the
     // host app. This only logs and drops — call sites still own their error handling.
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        SDKComponent.logger.error("Uncaught exception in SDK coroutine", throwable = throwable)
+        // Exception spelled into the message: custom log dispatchers (wrapper SDKs) receive only
+        // the message string, not the throwable.
+        SDKComponent.logger.error("Uncaught exception in SDK coroutine: $throwable", throwable = throwable)
     }
 
     override val eventBusScope: CoroutineScope

--- a/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/util/ScopeProvider.kt
@@ -1,5 +1,7 @@
 package io.customer.sdk.core.util
 
+import io.customer.sdk.core.di.SDKComponent
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 
@@ -12,14 +14,21 @@ interface ScopeProvider {
 }
 
 class SdkScopeProvider(private val dispatchers: DispatchersProvider) : ScopeProvider {
+
+    // Last-resort net: an exception escaping a coroutine on an SDK scope would crash the
+    // host app. This only logs and drops — call sites still own their error handling.
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        SDKComponent.logger.error("Uncaught exception in SDK coroutine", throwable = throwable)
+    }
+
     override val eventBusScope: CoroutineScope
-        get() = CoroutineScope(dispatchers.default + SupervisorJob())
+        get() = CoroutineScope(dispatchers.default + SupervisorJob() + exceptionHandler)
     override val lifecycleListenerScope: CoroutineScope
-        get() = CoroutineScope(dispatchers.default + SupervisorJob())
+        get() = CoroutineScope(dispatchers.default + SupervisorJob() + exceptionHandler)
     override val inAppLifecycleScope: CoroutineScope
-        get() = CoroutineScope(dispatchers.default + SupervisorJob())
+        get() = CoroutineScope(dispatchers.default + SupervisorJob() + exceptionHandler)
     override val locationScope: CoroutineScope
-        get() = CoroutineScope(dispatchers.default + SupervisorJob())
+        get() = CoroutineScope(dispatchers.default + SupervisorJob() + exceptionHandler)
     override val geofenceScope: CoroutineScope
-        get() = CoroutineScope(dispatchers.default + SupervisorJob())
+        get() = CoroutineScope(dispatchers.default + SupervisorJob() + exceptionHandler)
 }

--- a/core/src/test/java/io/customer/sdk/core/util/SdkScopeProviderTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/SdkScopeProviderTest.kt
@@ -42,7 +42,14 @@ class SdkScopeProviderTest : JUnit5Test() {
             scope.launch { throw IllegalStateException("uncaught SDK failure") }.join()
         }
 
-        verify(exactly = scopes.size) { mockLogger.error(any(), any(), any<IllegalStateException>()) }
+        // Message must carry the exception itself: custom log dispatchers only receive the string.
+        verify(exactly = scopes.size) {
+            mockLogger.error(
+                match { it.contains("IllegalStateException") && it.contains("uncaught SDK failure") },
+                any(),
+                any<IllegalStateException>()
+            )
+        }
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/core/util/SdkScopeProviderTest.kt
+++ b/core/src/test/java/io/customer/sdk/core/util/SdkScopeProviderTest.kt
@@ -1,0 +1,58 @@
+package io.customer.sdk.core.util
+
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.JUnit5Test
+import io.customer.commontest.util.DispatchersProviderStub
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class SdkScopeProviderTest : JUnit5Test() {
+
+    private val mockLogger: Logger = mockk(relaxed = true)
+    private val scopeProvider = SdkScopeProvider(DispatchersProviderStub())
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency<Logger>(mockLogger)
+                    }
+                }
+            }
+        )
+    }
+
+    @Test
+    fun allScopes_givenCoroutineThrows_expectLoggedNotCrashed() = runTest {
+        val scopes = listOf(
+            scopeProvider.eventBusScope,
+            scopeProvider.lifecycleListenerScope,
+            scopeProvider.inAppLifecycleScope,
+            scopeProvider.locationScope,
+            scopeProvider.geofenceScope
+        )
+
+        scopes.forEach { scope ->
+            scope.launch { throw IllegalStateException("uncaught SDK failure") }.join()
+        }
+
+        verify(exactly = scopes.size) { mockLogger.error(any(), any(), any<IllegalStateException>()) }
+    }
+
+    @Test
+    fun scope_givenCoroutineThrows_expectSiblingCoroutinesUnaffected() = runTest {
+        val scope = scopeProvider.geofenceScope
+        var siblingRan = false
+
+        scope.launch { throw IllegalStateException("uncaught SDK failure") }.join()
+        scope.launch { siblingRan = true }.join()
+
+        siblingRan.shouldBeTrue()
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -197,6 +197,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence foreground flush complete: $count transition(s) handed off this run", tag = TAG)
     }
 
+    fun logAsyncDeliveryFailed(geofenceId: String, transitionName: String, message: String?) {
+        logger.error("Geofence '$geofenceId' $transitionName: async delivery failed unexpectedly; left in pending store for the foreground flush — $message", tag = TAG)
+    }
+
     fun logSchedulerFailed(geofenceId: String, transitionName: String, message: String?) {
         logger.error("Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; left in pending store for the foreground flush — $message", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -18,6 +18,7 @@ import io.customer.sdk.core.module.CustomerIOModule
 import io.customer.sdk.core.util.HandlerMainThreadPoster
 import io.customer.sdk.core.util.MainThreadPoster
 import io.customer.sdk.data.store.SecureUserStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
@@ -179,6 +180,10 @@ class ModuleGeofence @JvmOverloads constructor(
                                 if (!refreshOnForeground(sdkAndroid.geofenceServices, sdkAndroid.secureUserStore, locationModule)) {
                                     retrySyncAwaitingLocation(sdkAndroid, locationModule)
                                 }
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Throwable) {
+                                SDKComponent.geofenceLogger.logSyncFailed("foreground refresh failed: ${e.message}")
                             } finally {
                                 foregroundScope.cancel()
                             }
@@ -205,6 +210,12 @@ class ModuleGeofence @JvmOverloads constructor(
                         )
                         autoAcquireIfNeeded(locationModule, anchor)
                     }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    // Keystore/prefs reads can throw on some OEMs; log instead of relying on
+                    // the scope's last-resort handler so the failure is attributable.
+                    SDKComponent.geofenceLogger.logSyncFailed("app-launch refresh failed: ${e.message}")
                 } finally {
                     // One-shot: geofenceScope mints a fresh scope per access, so cancel it once
                     // the launch read completes rather than leaking its Job.
@@ -268,6 +279,10 @@ class ModuleGeofence @JvmOverloads constructor(
                     longitude = anchor?.longitude
                 )
                 autoAcquireIfNeeded(locationModule, anchor)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                SDKComponent.geofenceLogger.logSyncFailed("foreground retry failed: ${e.message}")
             } finally {
                 retryScope.cancel()
             }

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
@@ -11,6 +11,7 @@ import io.customer.sdk.core.util.Iso8601TimestampFormatter
 import io.customer.sdk.data.store.PendingDeliveryStore
 import io.customer.sdk.data.store.sendRemoveOnSuccess
 import io.customer.sdk.util.EventNames
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -85,8 +86,16 @@ internal class AsyncGeofenceEventTracker(
             return
         }
         CoroutineScope(dispatcher.background).launch {
-            pendingStore.sendRemoveOnSuccess(entry) {
-                tracker.trackEvent(entry)
+            try {
+                pendingStore.sendRemoveOnSuccess(entry) {
+                    tracker.trackEvent(entry)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Ad-hoc scope with no exception handler — an escape would crash the host.
+                // The entry stays in the store, so the foreground flush retries it.
+                logger.logAsyncDeliveryFailed(entry.geofenceId, entry.transition.name, e.message)
             }
         }
     }

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -69,6 +69,19 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
+    fun trackEvent_givenStoreThrows_expectLoggedNotCrashed() = runTest {
+        // The fire-and-forget scope has no exception handler — an escaping throw
+        // would crash the host. The entry stays in store for the foreground flush.
+        val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 11L, "user-42", transitionId = "tid-5")
+        every { mockStore.loadAll() } throws IllegalStateException("corrupt store")
+
+        asyncTracker.trackEvent(entry)
+
+        verify { mockLogger.logAsyncDeliveryFailed("biz-5", "ENTER", "corrupt store") }
+        coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
+    }
+
+    @Test
     fun trackEvent_givenFailure_expectEntryKeptForFlush() = runTest {
         val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42", transitionId = "tid-4")
         every { mockStore.loadAll() } returns listOf(entry)


### PR DESCRIPTION
## What

An exception escaping a coroutine launched on an SDK scope currently crashes the host app. This adds a last-resort `CoroutineExceptionHandler` to all five `SdkScopeProvider` scopes that logs the failure and drops it, plus attributable catches at the launch sites that need their own handling.

## Changes

- **`SdkScopeProvider` (core)**: every scope now carries a shared `CoroutineExceptionHandler` that logs via `SDKComponent.logger`. Cancellation is unaffected (coroutines never route `CancellationException` to handlers).
- **`ModuleGeofence`**: the foreground-hook, app-launch, and retry launches catch and log with the failing operation's name, so a failure is attributable instead of falling to the scope's generic log. `CancellationException` is rethrown.
- **`AsyncGeofenceEventTracker`**: the fire-and-forget delivery launch runs on an ad-hoc `CoroutineScope` that has **no** handler at all — an escaping throw crashed the host outright. Now caught and logged; the entry stays in the pending store, so the existing foreground flush retries delivery.

## Behavior

No logic change on success paths. Failure paths that previously crashed the host now log; async delivery failures additionally keep the entry for the existing retry path. Worst case of the backstop itself: an exception that would have crashed the app is logged and dropped — call sites still own their real error handling.

## Testing

- New `SdkScopeProviderTest`: all five scopes log-not-crash, and a failed coroutine doesn't affect siblings on the same scope.
- New `AsyncGeofenceEventTrackerTest` case: store throw is logged, entry kept, no crash.
- Full suite: 3406 tests / 0 failures (debug + release, all modules), `apiCheck` and ktlint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)