### PR TITLE
chore(geofence): make the emitted-mark write atomic and bound GMS awaits

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -32,6 +32,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.error("Failed to remove geofences: $message", tag = TAG)
     }
 
+    fun logGmsCallTimedOut(description: String) {
+        logger.error("GMS $description gave no callback before the deadline — treating as failed; Play Services may be updating or unresponsive", tag = TAG)
+    }
+
     fun logMissingPermission(permission: String) {
         logger.error("Cannot register geofences: $permission not granted. Host app must request this permission.", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
@@ -225,7 +225,9 @@ internal class GeofenceManager(
     }
 
     private companion object {
-        // Generous against the millisecond norm, and inside the receiver's 8s goAsync budget.
+        // Per call, generous against the millisecond norm. A pass chains up to four (remove and
+        // re-add movement, add business, roll back), so a wedged GMS can still outlast the
+        // receiver's 8s goAsync budget — the join there is best-effort and the refresh continues.
         val GMS_CALL_TIMEOUT = 5.seconds
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceManager.kt
@@ -9,8 +9,12 @@ import androidx.annotation.RequiresPermission
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingClient
 import com.google.android.gms.location.GeofencingRequest
+import java.util.concurrent.TimeoutException
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 
 /** Wraps GeofencingClient to register/remove geofences with the OS. */
 internal class GeofenceManager(
@@ -137,7 +141,7 @@ internal class GeofenceManager(
             return Result.failure(e)
         }
 
-        return suspendCancellableCoroutine { cont ->
+        return awaitGmsCall("addGeofences") { cont ->
             try {
                 client.addGeofences(request, pendingIntent)
                     .addOnSuccessListener {
@@ -159,7 +163,7 @@ internal class GeofenceManager(
     suspend fun removeGeofencesByIds(ids: List<String>): Result<Unit> {
         if (ids.isEmpty()) return Result.success(Unit)
 
-        return suspendCancellableCoroutine { cont ->
+        return awaitGmsCall("removeGeofences") { cont ->
             try {
                 client.removeGeofences(ids)
                     .addOnSuccessListener {
@@ -180,7 +184,7 @@ internal class GeofenceManager(
     }
 
     suspend fun clearAll(): Result<Unit> {
-        return suspendCancellableCoroutine { cont ->
+        return awaitGmsCall("removeGeofences (all)") { cont ->
             client.removeGeofences(pendingIntent)
                 .addOnSuccessListener {
                     if (!cont.isActive) return@addOnSuccessListener
@@ -196,6 +200,21 @@ internal class GeofenceManager(
         }
     }
 
+    /**
+     * A Task never calls back when Play Services is mid-update, and the caller holds the refresh
+     * slot — so an unbounded await wedges every later sync. Safe here unlike around the slot CAS:
+     * nothing holds a resource on the result, so a late success just becomes a spurious failure.
+     */
+    private suspend fun awaitGmsCall(
+        description: String,
+        block: (CancellableContinuation<Result<Unit>>) -> Unit
+    ): Result<Unit> =
+        withTimeoutOrNull(GMS_CALL_TIMEOUT) { suspendCancellableCoroutine(block) }
+            ?: run {
+                logger.logGmsCallTimedOut(description)
+                Result.failure(TimeoutException("GMS $description gave no callback within $GMS_CALL_TIMEOUT"))
+            }
+
     private fun GeofenceRegion.toGmsGeofence(): Geofence {
         return Geofence.Builder()
             .setRequestId(id)
@@ -203,5 +222,10 @@ internal class GeofenceManager(
             .setTransitionTypes(toGmsTransitionTypes())
             .setExpirationDuration(GeofenceConstants.GEOFENCE_EXPIRATION_NEVER)
             .build()
+    }
+
+    private companion object {
+        // Generous against the millisecond norm, and inside the receiver's 8s goAsync budget.
+        val GMS_CALL_TIMEOUT = 5.seconds
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -247,11 +247,13 @@ internal class GeofenceRegionStoreImpl(
         // One identity owns the set at a time, so a different owner makes it stale — replace, not add.
         val sameOwner = readEmittedEnterOwner() == userId
         val current = if (sameOwner) readEmittedEnterIds() else emptySet()
-        if (!sameOwner) {
-            prefs.edit { putString(KEY_EMITTED_ENTER_OWNER, userId) }
-        }
-        if (geofenceId !in current) {
-            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current + geofenceId)
+        if (sameOwner && geofenceId in current) return@synchronized
+        // One commit: a death between separate writes leaves the new owner holding the old set.
+        prefs.edit {
+            if (!sameOwner) {
+                putString(KEY_EMITTED_ENTER_OWNER, userId)
+            }
+            putString(KEY_EMITTED_ENTER_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, current + geofenceId))
         }
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -208,9 +208,14 @@ internal class GeofenceRegionStoreImpl(
     override fun claimExit(geofenceId: String): Boolean = synchronized(enteredLock) {
         val current = getEnteredIds()
         if (geofenceId !in current) return@synchronized false
-        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, current - geofenceId)
-        // Same step: a mark stranded by a later failure would silence the next genuine arrival.
-        clearEnterEmitted(geofenceId)
+        val marks = readEmittedEnterIds()
+        // One commit: a mark stranded by a torn write would silence the next genuine arrival.
+        prefs.edit {
+            putString(KEY_ENTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, current - geofenceId))
+            if (geofenceId in marks) {
+                putString(KEY_EMITTED_ENTER_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, marks - geofenceId))
+            }
+        }
         // Only a consumed record bumps the epoch; a claim that found nothing is a suspected GMS
         // artifact and must not block the geometry seed.
         epoch += 1
@@ -261,13 +266,6 @@ internal class GeofenceRegionStoreImpl(
         readJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER) ?: emptySet()
 
     private fun readEmittedEnterOwner(): String? = prefs.read { getString(KEY_EMITTED_ENTER_OWNER, null) }
-
-    private fun clearEnterEmitted(geofenceId: String) = synchronized(enteredLock) {
-        val current = readEmittedEnterIds()
-        if (geofenceId in current) {
-            writeJson(KEY_EMITTED_ENTER_IDS, ID_SET_SERIALIZER, current - geofenceId)
-        }
-    }
 
     override fun pruneEmittedEnterIds(registeredIds: Set<String>) = synchronized(enteredLock) {
         val current = readEmittedEnterIds()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import java.util.concurrent.TimeoutException
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
@@ -360,6 +361,18 @@ class GeofenceManagerTest : RobolectricTest() {
         grantPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
     }
 
+    @Test
+    fun replaceGeofences_givenGmsTaskNeverCallsBack_expectTimeoutFailureInsteadOfIndefiniteSuspend() = runTest {
+        // A Task that never resolves previously suspended the await for the life of the process.
+        grantAllPermissions()
+        every { client.addGeofences(any<GeofencingRequest>(), any()) } returns silentTask()
+
+        val result = manager.replaceGeofences(listOf(buildRegion(id = "business-1")))
+
+        result.isFailure.shouldBeTrue()
+        (result.exceptionOrNull() is TimeoutException).shouldBeTrue()
+    }
+
     // -- Helpers: GMS Task stubs --
 
     private fun stubClientAddSuccess(requestSlot: CapturingSlot<GeofencingRequest>? = null) {
@@ -388,6 +401,14 @@ class GeofenceManagerTest : RobolectricTest() {
     private fun stubClientRemoveByPendingIntentSuccess() {
         val task = immediateSuccessTask<Void>()
         every { client.removeGeofences(any<PendingIntent>()) } returns task
+    }
+
+    /** Registers listeners but never invokes them — a Task that never resolves. */
+    private fun <T> silentTask(): Task<T> {
+        val task = mockk<Task<T>>()
+        every { task.addOnSuccessListener(any()) } returns task
+        every { task.addOnFailureListener(any()) } returns task
+        return task
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceManagerTest.kt
@@ -346,6 +346,38 @@ class GeofenceManagerTest : RobolectricTest() {
         verify { receiverToggle.setEnabled(false) }
     }
 
+    @Test
+    fun replaceGeofences_givenGmsTaskNeverCallsBack_expectTimeoutFailureInsteadOfIndefiniteSuspend() = runTest {
+        // A Task that never resolves previously suspended the await for the life of the process.
+        grantAllPermissions()
+        every { client.addGeofences(any<GeofencingRequest>(), any()) } returns silentTask()
+
+        val result = manager.replaceGeofences(listOf(buildRegion(id = "business-1")))
+
+        result.isFailure.shouldBeTrue()
+        (result.exceptionOrNull() is TimeoutException).shouldBeTrue()
+    }
+
+    @Test
+    fun removeGeofencesByIds_givenGmsTaskNeverCallsBack_expectTimeoutFailure() = runTest {
+        every { client.removeGeofences(any<List<String>>()) } returns silentTask()
+
+        val result = manager.removeGeofencesByIds(listOf("business-1"))
+
+        result.isFailure.shouldBeTrue()
+        (result.exceptionOrNull() is TimeoutException).shouldBeTrue()
+    }
+
+    @Test
+    fun clearAll_givenGmsTaskNeverCallsBack_expectTimeoutFailure() = runTest {
+        every { client.removeGeofences(any<PendingIntent>()) } returns silentTask()
+
+        val result = manager.clearAll()
+
+        result.isFailure.shouldBeTrue()
+        (result.exceptionOrNull() is TimeoutException).shouldBeTrue()
+    }
+
     // -- Helpers: permission --
 
     private fun grantPermission(permission: String) {
@@ -359,18 +391,6 @@ class GeofenceManagerTest : RobolectricTest() {
     private fun grantAllPermissions() {
         grantPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         grantPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-    }
-
-    @Test
-    fun replaceGeofences_givenGmsTaskNeverCallsBack_expectTimeoutFailureInsteadOfIndefiniteSuspend() = runTest {
-        // A Task that never resolves previously suspended the await for the life of the process.
-        grantAllPermissions()
-        every { client.addGeofences(any<GeofencingRequest>(), any()) } returns silentTask()
-
-        val result = manager.replaceGeofences(listOf(buildRegion(id = "business-1")))
-
-        result.isFailure.shouldBeTrue()
-        (result.exceptionOrNull() is TimeoutException).shouldBeTrue()
     }
 
     // -- Helpers: GMS Task stubs --


### PR DESCRIPTION
https://linear.app/customerio/issue/MBL-2319/improve-geofence-transition-reliability

Two ways an interrupted operation could strand geofence state. Neither changes
the events the SDK emits; both remove a way the existing behaviour can be lost.

### The emitted-ENTER mark could be persisted under the wrong owner

`markEnterEmitted` wrote the mark's owner and its id set as two separate prefs
commits. A process death between them persists the new owner alongside the
previous user's id set. Owner scoping then reads those marks as the new user's,
silencing their first arrival at every fence in the set — and the next mark
write carries the stale ids forward, so the contamination outlives the crash
that caused it.

Both keys now go in a single editor block, which is one atomic file write, so
the owner can never be persisted apart from the set it owns.
Replace-on-owner-change and idempotency semantics are unchanged.

`claimExit` had the same window over the same two keys — it consumed the
containment record and cleared the mark in two commits, so a torn write strands
the mark and the next genuine arrival is dropped by the redundant-ENTER guard.
Its single caller is inlined so both keys land in one commit. (Review follow-up.)

### A GMS call that never calls back suspended the sync pipeline for the process lifetime

`addGeofences`, `removeGeofences` and `clearAll` awaited their GMS Task with an
unbounded `suspendCancellableCoroutine`. GMS normally calls back in
milliseconds, but a Task never resolves at all when Play Services is mid-update
or has crashed. Every caller holds the refresh slot — and `reset()` waits on
`stateMutex` behind it — so one unresolved Task wedged every later sync for the
life of the process.

Each await now carries a 5s deadline and fails the call instead, landing in the
retry paths a real GMS failure already uses. 5s is generous against the
millisecond norm and fits inside the broadcast receiver's own 8s `goAsync`
budget, so on the movement-refresh path the deadline can still fire before the
receiver gives up waiting.

`withTimeoutOrNull` is safe in this position, unlike around the refresh-slot
CAS: nothing holds a resource on the block's return value, so a deadline racing
a late GMS success only converts it into a spurious failure, and the cancelled
continuation makes the late callback a no-op through the existing `isActive`
guards.

### Test plan

- New `replaceGeofences_givenGmsTaskNeverCallsBack_expectTimeoutFailureInsteadOfIndefiniteSuspend`,
  using a Task that registers listeners and never invokes them; asserts the call
  fails with `TimeoutException` rather than suspending. `runTest` virtual time
  makes the deadline instant.
- `removeGeofencesByIds` and `clearAll` share the deadline helper and now have
  their own timeout tests.
- No new test for the atomic writes: the semantics it preserves are already
  covered by `markEnterEmitted_givenNewOwner_expectPreviousUsersMarksDiscarded`
  and `markEnterEmitted_givenCalledTwice_expectStillReportedAndIdempotent`, and
  the atomicity itself is by construction — `GeofenceRegionStoreImpl` builds its
  prefs from `context`, so reaching the crash window from a test would mean
  adding an injection seam used by nothing else. The semantics `claimExit`
  preserves are covered by `claimExit_givenEnterReported_expectMarkClearedWithContainment`
  and `claimExit_givenNeverEntered_expectMarkRetained`.
- 409 tests / 0 failures, ktlint and apiCheck green.

### Stack

```
feature/geofence-polygons
└── mbl-2319-geofence-atomic-mark-and-bounded-awaits   ← this PR
```

