### PR TITLE
chore: emit Java-compatible default methods from messaginginapp interfaces

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -280,9 +280,9 @@ public final class io/customer/messaginginapp/type/InAppMessageKt {
 
 public abstract interface class io/customer/messaginginapp/type/InboxEventListener {
 	public abstract fun messageActionTaken (Lio/customer/messaginginapp/gist/data/model/InboxMessage;Ljava/lang/String;Ljava/lang/String;)Z
-	public abstract fun messageDismissed (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
-	public abstract fun messageOpened (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
-	public abstract fun messageShown (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public fun messageDismissed (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public fun messageOpened (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
+	public fun messageShown (Lio/customer/messaginginapp/gist/data/model/InboxMessage;)V
 }
 
 public final class io/customer/messaginginapp/type/InboxEventListener$DefaultImpls {
@@ -320,7 +320,6 @@ public abstract class io/customer/messaginginapp/ui/core/BaseInlineInAppMessageV
 	protected abstract fun getPlatformDelegate ()Lio/customer/messaginginapp/ui/bridge/InAppPlatformDelegate;
 	protected fun onAttachedToWindow ()V
 	protected fun onDetachedFromWindow ()V
-	public fun onViewSizeChanged (II)V
 	public final fun setActionListener (Lio/customer/messaginginapp/type/InlineMessageActionListener;)V
 	public final fun setElementId (Ljava/lang/String;)V
 }

--- a/messaginginapp/build.gradle
+++ b/messaginginapp/build.gradle
@@ -1,4 +1,5 @@
 import io.customer.android.Dependencies
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'com.android.library'
@@ -13,6 +14,22 @@ customerIoPublish {
 apply from: "${rootDir}/scripts/android-config.gradle"
 apply from: "${rootDir}/scripts/codecov-android.gradle"
 apply from: "${rootDir}/scripts/android-module-testing.gradle"
+
+// Emit real Java default methods for interface members that declare a body, instead of Kotlin's
+// default `DefaultImpls`-only shape. Without this, a defaulted member is still `abstract` in the
+// bytecode, so every Java class implementing one of our public listeners is forced to override it —
+// adding an optional callback would be a source-breaking change for Java hosts.
+//
+// `all-compatibility` (rather than `all`) also keeps generating the `DefaultImpls` shims, so code
+// already compiled against the previous shape continues to link. Dropping to `all` would remove
+// them and break binary compatibility.
+tasks.withType(KotlinCompile).all {
+    kotlinOptions {
+        freeCompilerArgs += [
+                '-Xjvm-default=all-compatibility',
+        ]
+    }
+}
 
 android {
     namespace 'io.customer.messaginginapp'


### PR DESCRIPTION
## MBL-2310 · Android stack — step 1 of 4

| Step | PR | |
| --- | --- | --- |
| **1** | **#823 — `chore:` emit Java-compatible default methods from messaginginapp interfaces** | **← you are here** |
| 2 | #826 — `chore:` report WebView render process termination as an in-app failure |  |
| 3 | #827 — `chore:` classify and log in-app message failures internally |  |
| 4 | #828 — `fix:` surface the failure reason on `errorWithMessage` | cuts the Android release |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**iOS mirror:** customerio/customerio-ios#1231 → customerio/customerio-ios#1237 → customerio/customerio-ios#1238. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Build-config only: turns on `-Xjvm-default=all-compatibility` for `messaginginapp` so interface members that declare a body compile to real Java default methods.

Groundwork for MBL-2310. Landing it on its own keeps the ABI change reviewable in isolation.

### Why

Kotlin's default mode compiles a defaulted interface member into an `abstract` method plus a `DefaultImpls` shim, so Java classes implementing our public listeners are still forced to override it. Adding an optional callback to `InAppEventListener` would therefore be source-breaking for Java hosts. `all-compatibility` (rather than `all`) emits the Java default methods *and* keeps the `DefaultImpls` shims, so already-compiled code still links.

### API diff

Two hunks, both expected:

- `InboxEventListener`'s three defaulted members flip `public abstract fun` -> `public fun`, and `InboxEventListener$DefaultImpls` is retained.
- `BaseInlineInAppMessageView.onViewSizeChanged` disappears. It was never declared on that class — it was a synthetic bridge to the `internal` `InAppMessageViewCallback` default. With a real default method on the interface the bridge is no longer emitted.

### Verification

Built and consumed as a **published artifact**, not from source — `IS_DEVELOPMENT=true ./gradlew publishToMavenLocal` then `assembleDebug -PcioSDKVersion=local`, confirmed with 0 `:messaginginapp:` source tasks and `io.customer.android:messaging-in-app:local` on the runtime classpath.

- `samples/java_layout` (Java, implements `InAppEventListener`) builds green against the published aar with **no source changes** — before and after.
- `javap` on the published aar: `InAppMessageViewCallback.onViewSizeChanged` is now `public default`, `BaseInlineInAppMessageView` still implements the interface, so calls compiled against the old shape still resolve.
- All `DefaultImpls` shims retained: `InboxEventListener`, `InAppMessageViewCallback`, `InlineInAppMessageViewCallback`, `ModalInAppMessageViewCallback`, `InAppPlatformDelegate`.
- `./gradlew :messaginginapp:testDebugUnitTest` green.
