### PR TITLE
chore(geofence): trust geometry only from live fixes and stamp epochs with the fix

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -120,6 +120,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence sync skipped: last successful sync is still within the freshness window", tag = TAG)
     }
 
+    fun logContainmentJudged(insideCount: Int) {
+        logger.debug("Judged containment from the live fix: inside $insideCount region(s)", tag = TAG)
+    }
+
     fun logGeofencingError(errorCode: Int) {
         logger.error("OS reported geofencing error (code=$errorCode); see GeofenceStatusCodes for meaning", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -214,12 +214,28 @@ internal class GeofenceRepositoryImpl(
     private fun osStateWiped(): Boolean = osStateWipedByReboot() || osStateWipedByAppUpdate()
 
     /**
-     * How far a pass's geometry can be trusted. [LIVE] is a fix the OS delivered for this pass — it
-     * may seed containment, reset moved-circle records and synthesize initial ENTERs. [ANCHOR] is
-     * stored coordinates describing where the device once was, so it may only rank and prune; the
-     * next LIVE pass owns the reseed.
+     * How far a pass's geometry can be trusted.
+     *
+     * [LIVE] and [MOVEMENT] both carry a real fix, so either may seed containment, reset
+     * moved-circle records and synthesize initial ENTERs. [ANCHOR] is stored coordinates describing
+     * where the device once was, so it may only rank and prune; the next real fix owns the reseed.
      */
-    private enum class FixSource { LIVE, ANCHOR }
+    private enum class FixSource {
+        /** A fix requested for this pass. */
+        LIVE,
+
+        /** Stored coordinates from the last registration, or the OS location cache. */
+        ANCHOR,
+
+        /** The fix the OS delivered with a movement trigger, because the device moved. */
+        MOVEMENT;
+
+        /** An anchor proves nothing about where the device is now, so it may not judge containment. */
+        val trustsGeometry: Boolean get() = this != ANCHOR
+
+        /** True when the OS produced this fix by observing the device, not when we asked for it. */
+        val isOsObserved: Boolean get() = this == MOVEMENT
+    }
 
     /**
      * Takes the in-flight slot for a pass that can't be dropped, waiting for the holder instead.
@@ -265,16 +281,16 @@ internal class GeofenceRepositoryImpl(
                 movedBeyondFetchRadius(distanceFromAnchor, config)
             // The triggering fix is the OS's own, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
-                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch, FixSource.LIVE)
+                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch, FixSource.MOVEMENT)
                 if (remote.isFailure) {
                     // The trigger already fired, and a failed pass never re-centres it — leaving it
                     // where the device just exited, so nothing can fire again. Re-rank to re-arm it.
                     logger.logMovementRearmedAfterFailedRefresh()
-                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.LIVE)
+                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.MOVEMENT)
                 }
                 remote
             } else {
-                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.LIVE)
+                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.MOVEMENT)
             }
         } finally {
             releaseRefreshSlot()
@@ -497,7 +513,7 @@ internal class GeofenceRepositoryImpl(
                         .toSet()
                     // Without a record the later genuine EXIT looks unentered and gets dropped, but
                     // an anchor would seed a place the device left days ago — so it judges nothing.
-                    val insideIds = insideNow.takeIf { fixSource == FixSource.LIVE }
+                    val insideIds = insideNow.takeIf { fixSource.trustsGeometry }
                     // A moved circle keeps its ID, so its record and mark can describe a fence that
                     // no longer exists, and the mark then suppresses GMS's own arrival at the new
                     // one. An anchor may retire evidence it can't vouch for; it just may not seed.
@@ -530,10 +546,15 @@ internal class GeofenceRepositoryImpl(
                 }
             }
             // An anchor inside a fence proves nothing about where the device is now, so a record
-            // carried across a geometry edit must not become a fresh arrival. A wipe re-registers
-            // every fence with INITIAL_TRIGGER_ENTER, so GMS re-reports these itself and the
-            // backstop is redundant exactly when its inputs are least trustworthy.
-            if (registrationResult.isSuccess && fixSource == FixSource.LIVE && !osStateWasWiped) {
+            // carried across a geometry edit must not become a fresh arrival. After a wipe a
+            // requested fix may also describe a stretch we never observed, so synthesis defers to
+            // the re-registration's own INITIAL_TRIGGER_ENTER — but only for a fix we asked for. A
+            // movement fix is the OS's own, produced because the device just moved, so no wipe can
+            // have made it stale, and suppressing it here would drop the backstop on the one path
+            // that exists because that callback gets missed.
+            val maySynthesize = fixSource.trustsGeometry &&
+                (fixSource.isOsObserved || !osStateWasWiped)
+            if (registrationResult.isSuccess && maySynthesize) {
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -465,6 +465,9 @@ internal class GeofenceRepositoryImpl(
             // override here (unlike the registration diff): a reboot re-registers with
             // INITIAL_TRIGGER_ENTER, so the OS re-reports these itself.
             val unchangedRegistered = unchangedRegisteredIds(nearest)
+            // Snapshotted for the same reason: a successful registration stamps uptime and package
+            // update time, which is what clears the wipe signals this reads.
+            val osStateWasWiped = osStateWiped()
             // Registered before this pass but not cache-equal: the ID survived a geometry edit.
             val previouslyRegistered = store.getRegisteredIds()
             val reRegisteredIds = nearest.map { it.id }
@@ -530,7 +533,7 @@ internal class GeofenceRepositoryImpl(
             // carried across a geometry edit must not become a fresh arrival. A wipe re-registers
             // every fence with INITIAL_TRIGGER_ENTER, so GMS re-reports these itself and the
             // backstop is redundant exactly when its inputs are least trustworthy.
-            if (registrationResult.isSuccess && fixSource == FixSource.LIVE && !osStateWiped()) {
+            if (registrationResult.isSuccess && fixSource == FixSource.LIVE && !osStateWasWiped) {
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -558,13 +558,7 @@ internal class GeofenceRepositoryImpl(
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {
-                    emitInitialEnters(
-                        candidates = nearest,
-                        newIds = nearest.map { it.id }.toSet() - unchangedRegistered,
-                        userId = userId,
-                        latitude = latitude,
-                        longitude = longitude
-                    )
+                    emitInitialEnters(nearest, unchangedRegistered, userId, latitude, longitude)
                 } else {
                     logger.logSyncSkipped("user changed during refresh — initial-enter synthesis skipped")
                 }
@@ -577,10 +571,13 @@ internal class GeofenceRepositoryImpl(
      * Judges containment from a fix whose registration is already current.
      *
      * The anchor pass that made the inputs look fresh could not judge geometry, so without this the
-     * live fix queued behind it is discarded and the entered set stays unseeded: the receiver then
-     * reads a genuine EXIT as unmatched and drops it, and an `INITIAL_TRIGGER_ENTER` GMS dropped for
-     * a fence that pass registered stays lost. Registration and the cache are left alone — this only
-     * decides where the device is.
+     * live fix queued behind it is discarded and the entered set stays unseeded — the receiver then
+     * reads a genuine EXIT as unmatched and drops it. Registration and the cache are left alone.
+     *
+     * Seeding only. Synthesis stays tied to a pass that registers: this one runs on every foreground
+     * fix, and an exact point check on a fix that can be 100 m out would fabricate an arrival near a
+     * boundary, then leave a mark that swallows the real one. A wrong seed is the fail-open
+     * direction — it lets an EXIT through — so it does not carry that cost.
      */
     private suspend fun reconcileContainment(
         userId: String,
@@ -603,40 +600,29 @@ internal class GeofenceRepositoryImpl(
                 .filter { it.distanceTo(latitude, longitude) <= it.radius }
                 .map { it.id }
                 .toSet()
-            val containedBefore = store.getEnteredIds()
             store.reconcileEnteredIds(
                 registeredIds = registeredIds,
                 inside = insideNow,
                 sinceEpoch = containmentEpoch
             )
             logger.logContainmentJudged(insideNow.size)
-            // Only where the record is new: a fence we already knew we were inside has had its
-            // arrival reported, and an enter-only one carries no mark to stop this repeating. No
-            // wipe gate — refreshAction routes a wiped install to LOCAL, so this pass never sees one.
-            emitInitialEnters(
-                candidates = monitored,
-                newIds = insideNow - containedBefore,
-                userId = userId,
-                latitude = latitude,
-                longitude = longitude
-            )
             Result.success(Unit)
         }
     }
 
     /**
-     * Synthesizes an ENTER for each fence in [newIds] the device is already inside — GMS's
+     * Synthesizes an ENTER for each newly-registered fence the device is already inside — GMS's
      * `INITIAL_TRIGGER_ENTER` unreliably drops this for a region added around a stationary device.
-     * [newIds] is what this pass has a reason to check: newly registered where it registered,
-     * newly contained where the registration was already current. Cooldown-deduped, so a real GMS
-     * ENTER and this one collapse to one event.
+     * "New" = not in [unchangedRegisteredIds]: brand-new fences and re-added param changes fire,
+     * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
+     * collapse to one event.
      *
      * Requires the stored containment record and this fix's geometry to agree — reconcile carries a
      * record forward for a still-registered fence, so it can outlive the visit.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
-        newIds: Set<String>,
+        unchangedRegisteredIds: Set<String>,
         userId: String,
         latitude: Double,
         longitude: Double
@@ -644,12 +630,12 @@ internal class GeofenceRepositoryImpl(
         val timestamp = clock.currentTimeSeconds()
         val contained = store.getEnteredIds()
         candidates.forEach { region ->
-            val isNew = region.id in newIds
+            val newlyRegistered = region.id !in unchangedRegisteredIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
             // Both: a carried-forward record can outlive the visit, and geometry alone ignores an
             // EXIT reported while GMS was awaited.
             val insideNow = region.distanceTo(latitude, longitude) <= region.radius
-            if (!isNew || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
+            if (!newlyRegistered || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
             logger.logInitialEnterInside(region.id)
             transitionEmitter.emit(
                 geofenceId = region.id,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -138,7 +138,7 @@ internal class GeofenceRepositoryImpl(
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, fixSource)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
-                    Result.success(Unit)
+                    reconcileContainment(userId, latitude, longitude, containmentEpoch, fixSource)
                 }
             }
         } finally {
@@ -558,7 +558,13 @@ internal class GeofenceRepositoryImpl(
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {
-                    emitInitialEnters(nearest, unchangedRegistered, userId, latitude, longitude)
+                    emitInitialEnters(
+                        candidates = nearest,
+                        newIds = nearest.map { it.id }.toSet() - unchangedRegistered,
+                        userId = userId,
+                        latitude = latitude,
+                        longitude = longitude
+                    )
                 } else {
                     logger.logSyncSkipped("user changed during refresh — initial-enter synthesis skipped")
                 }
@@ -568,18 +574,69 @@ internal class GeofenceRepositoryImpl(
     }
 
     /**
-     * Synthesizes an ENTER for each newly-registered fence the device is already inside — GMS's
+     * Judges containment from a fix whose registration is already current.
+     *
+     * The anchor pass that made the inputs look fresh could not judge geometry, so without this the
+     * live fix queued behind it is discarded and the entered set stays unseeded: the receiver then
+     * reads a genuine EXIT as unmatched and drops it, and an `INITIAL_TRIGGER_ENTER` GMS dropped for
+     * a fence that pass registered stays lost. Registration and the cache are left alone — this only
+     * decides where the device is.
+     */
+    private suspend fun reconcileContainment(
+        userId: String,
+        latitude: Double,
+        longitude: Double,
+        containmentEpoch: Long,
+        fixSource: FixSource
+    ): Result<Unit> {
+        if (!fixSource.trustsGeometry) return Result.success(Unit)
+        return stateMutex.withLock {
+            // As in registerNearestAndPersist: a sign-out during the pass must not have this write
+            // reinstate the departing user's containment.
+            if (secureUserStore.getUserId() != userId) {
+                logger.logSyncSkipped("user changed during refresh")
+                return@withLock Result.success(Unit)
+            }
+            val registeredIds = store.getRegisteredIds()
+            val monitored = store.getCachedRegions().filter { it.id in registeredIds }
+            val insideNow = monitored
+                .filter { it.distanceTo(latitude, longitude) <= it.radius }
+                .map { it.id }
+                .toSet()
+            val containedBefore = store.getEnteredIds()
+            store.reconcileEnteredIds(
+                registeredIds = registeredIds,
+                inside = insideNow,
+                sinceEpoch = containmentEpoch
+            )
+            logger.logContainmentJudged(insideNow.size)
+            // Only where the record is new: a fence we already knew we were inside has had its
+            // arrival reported, and an enter-only one carries no mark to stop this repeating. No
+            // wipe gate — refreshAction routes a wiped install to LOCAL, so this pass never sees one.
+            emitInitialEnters(
+                candidates = monitored,
+                newIds = insideNow - containedBefore,
+                userId = userId,
+                latitude = latitude,
+                longitude = longitude
+            )
+            Result.success(Unit)
+        }
+    }
+
+    /**
+     * Synthesizes an ENTER for each fence in [newIds] the device is already inside — GMS's
      * `INITIAL_TRIGGER_ENTER` unreliably drops this for a region added around a stationary device.
-     * "New" = not in [unchangedRegisteredIds]: brand-new fences and re-added param changes fire,
-     * an unchanged re-register stays silent. Cooldown-deduped, so a real GMS ENTER and this one
-     * collapse to one event.
+     * [newIds] is what this pass has a reason to check: newly registered where it registered,
+     * newly contained where the registration was already current. Cooldown-deduped, so a real GMS
+     * ENTER and this one collapse to one event.
      *
      * Requires the stored containment record and this fix's geometry to agree — reconcile carries a
      * record forward for a still-registered fence, so it can outlive the visit.
      */
     private suspend fun emitInitialEnters(
         candidates: List<GeofenceRegion>,
-        unchangedRegisteredIds: Set<String>,
+        newIds: Set<String>,
         userId: String,
         latitude: Double,
         longitude: Double
@@ -587,12 +644,12 @@ internal class GeofenceRepositoryImpl(
         val timestamp = clock.currentTimeSeconds()
         val contained = store.getEnteredIds()
         candidates.forEach { region ->
-            val newlyRegistered = region.id !in unchangedRegisteredIds
+            val isNew = region.id in newIds
             val monitorsEnter = GeofenceTransitionType.ENTER in region.transitionTypes
             // Both: a carried-forward record can outlive the visit, and geometry alone ignores an
             // EXIT reported while GMS was awaited.
             val insideNow = region.distanceTo(latitude, longitude) <= region.radius
-            if (!newlyRegistered || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
+            if (!isNew || !monitorsEnter || region.id !in contained || !insideNow) return@forEach
             logger.logInitialEnterInside(region.id)
             transitionEmitter.emit(
                 geofenceId = region.id,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -33,10 +33,9 @@ internal interface GeofenceRepository {
 
     /**
      * [refresh] for a just-acquired fix, which waits for an in-flight sync instead of dropping.
-     * The two run the same pass; they differ only in what a collision costs. Identify and
-     * app-launch collide constantly and share one anchor, so dropping loses nothing — but this
-     * caller holds the device's real position while the sync in flight is working from a stored
-     * anchor that can be kilometres stale, and the fix is consumed whether or not it is used.
+     * Identify and app-launch collide constantly and share one anchor, so dropping loses nothing;
+     * this caller holds the device's real position and the fix is consumed either way. Like the
+     * movement trigger, it carries a real fix and is trusted accordingly — see [FixSource].
      */
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     suspend fun refreshFromLiveFix(latitude: Double, longitude: Double): Result<Unit>
@@ -95,24 +94,33 @@ internal class GeofenceRepositoryImpl(
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
+        val containmentEpoch = store.containmentEpoch()
         if (!tryTakeRefreshSlot()) {
             logger.logSyncSkipped("refresh already in progress")
             return Result.success(Unit)
         }
-        return runRefresh(latitude, longitude)
+        return runRefresh(latitude, longitude, FixSource.ANCHOR, containmentEpoch)
     }
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refreshFromLiveFix(latitude: Double, longitude: Double): Result<Unit> {
+        // Captured with the fix, before the slot wait: a transition reported while this pass queues
+        // is newer evidence than the fix and must outrank its geometry.
+        val containmentEpoch = store.containmentEpoch()
         if (!awaitRefreshSlot()) {
             logger.logSyncSkipped("refresh already in progress after waiting")
             return Result.success(Unit)
         }
-        return runRefresh(latitude, longitude)
+        return runRefresh(latitude, longitude, FixSource.LIVE, containmentEpoch)
     }
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-    private suspend fun runRefresh(latitude: Double, longitude: Double): Result<Unit> {
+    private suspend fun runRefresh(
+        latitude: Double,
+        longitude: Double,
+        fixSource: FixSource,
+        containmentEpoch: Long
+    ): Result<Unit> {
         try {
             val userId = secureUserStore.getUserId()
             if (userId.isNullOrBlank()) {
@@ -121,19 +129,13 @@ internal class GeofenceRepositoryImpl(
             }
 
             val config = store.getCachedConfigOrFallback()
-            // Captured with the coordinates: an exit claimed mid-sync must beat this fix's geometry.
-            val containmentEpoch = store.containmentEpoch()
             // Decided under stateMutex so a concurrent sign-out reset can't wipe state right
             // after this reads pre-wipe freshness/registrations and SKIPs — that would leave
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
             val action = stateMutex.withLock { refreshAction(LocationCoordinates(latitude, longitude), config) }
-            // A launch/identify refresh runs with the persisted anchor, which a reboot or app update
-            // can leave pointing at a stale position — containment can't be trusted, so no synthesis
-            // this pass (mirrors restoreFromCache). Drops once registration re-stamps.
-            val emitInitialEnter = !osStateWiped()
             return when (action) {
-                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, containmentEpoch, emitInitialEnter)
-                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, emitInitialEnter = emitInitialEnter)
+                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, containmentEpoch, fixSource)
+                RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, fixSource)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()
                     Result.success(Unit)
@@ -212,6 +214,14 @@ internal class GeofenceRepositoryImpl(
     private fun osStateWiped(): Boolean = osStateWipedByReboot() || osStateWipedByAppUpdate()
 
     /**
+     * How far a pass's geometry can be trusted. [LIVE] is a fix the OS delivered for this pass — it
+     * may seed containment, reset moved-circle records and synthesize initial ENTERs. [ANCHOR] is
+     * stored coordinates describing where the device once was, so it may only rank and prune; the
+     * next LIVE pass owns the reseed.
+     */
+    private enum class FixSource { LIVE, ANCHOR }
+
+    /**
      * Takes the in-flight slot for a pass that can't be dropped, waiting for the holder instead.
      * For a movement pass, the OS holds a fired trigger in the outside state, so returning without
      * re-centring it stops discovery until the next app open, reboot or update; for a live fix, the
@@ -233,6 +243,8 @@ internal class GeofenceRepositoryImpl(
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun handleMovement(latitude: Double, longitude: Double): Result<Unit> {
+        // Before the slot wait, as in [refreshFromLiveFix].
+        val containmentEpoch = store.containmentEpoch()
         if (!awaitRefreshSlot()) {
             logger.logSyncSkipped("refresh already in progress after waiting")
             return Result.success(Unit)
@@ -246,25 +258,23 @@ internal class GeofenceRepositoryImpl(
 
             val anchor = store.getLastApiFetchLocation()
             val config = store.getCachedConfigOrFallback()
-            val containmentEpoch = store.containmentEpoch()
             val distanceFromAnchor = anchor?.distanceTo(latitude, longitude) ?: 0f
             // No anchor yet (first EXIT after install / clearAll / sign-out) bootstraps from the server.
             // Otherwise, a non-remote move always re-ranks locally — that's the floor for any EXIT.
             val needsRemoteFetch = anchor == null ||
                 movedBeyondFetchRadius(distanceFromAnchor, config)
-            // Initial-enter synthesis stays on here (unlike refresh): containment is judged against
-            // the OS's live triggering fix, so a reboot/app-update wipe can't make it stale.
+            // The triggering fix is the OS's own, so a reboot/app-update wipe can't make it stale.
             return if (needsRemoteFetch) {
-                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch)
+                val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch, FixSource.LIVE)
                 if (remote.isFailure) {
                     // The trigger already fired, and a failed pass never re-centres it — leaving it
                     // where the device just exited, so nothing can fire again. Re-rank to re-arm it.
                     logger.logMovementRearmedAfterFailedRefresh()
-                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
+                    performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.LIVE)
                 }
                 remote
             } else {
-                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch)
+                performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, FixSource.LIVE)
             }
         } finally {
             releaseRefreshSlot()
@@ -303,9 +313,8 @@ internal class GeofenceRepositoryImpl(
             cachedConfig = cachedConfig,
             containmentEpoch = store.containmentEpoch(),
             register = manager::replaceGeofencesForBootRestore,
-            // No initial-enter on boot restore: the cached anchor may be stale if the device moved
-            // while off, so containment can't be trusted.
-            emitInitialEnter = false
+            // The cached location may be stale if the device moved while off.
+            fixSource = FixSource.ANCHOR
         )
     }
 
@@ -315,7 +324,7 @@ internal class GeofenceRepositoryImpl(
         latitude: Double,
         longitude: Double,
         containmentEpoch: Long,
-        emitInitialEnter: Boolean = true
+        fixSource: FixSource
     ): Result<Unit> {
         // The device location lets the backend return the nearby set; the request carries no user
         // identity, so it isn't attributable to a user.
@@ -341,7 +350,7 @@ internal class GeofenceRepositoryImpl(
                     regions = regions,
                     config = config,
                     containmentEpoch = containmentEpoch,
-                    emitInitialEnter = emitInitialEnter,
+                    fixSource = fixSource,
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
                     // a null parse must not clobber a previously cached value.
@@ -367,8 +376,8 @@ internal class GeofenceRepositoryImpl(
         longitude: Double,
         cachedConfig: GeofenceConfig,
         containmentEpoch: Long,
-        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
-        emitInitialEnter: Boolean = true
+        fixSource: FixSource,
+        register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff
     ): Result<Unit> = registerNearestAndPersist(
         userId = userId,
         latitude = latitude,
@@ -377,7 +386,7 @@ internal class GeofenceRepositoryImpl(
         config = cachedConfig,
         containmentEpoch = containmentEpoch,
         register = register,
-        emitInitialEnter = emitInitialEnter
+        fixSource = fixSource
     )
 
     /**
@@ -422,9 +431,9 @@ internal class GeofenceRepositoryImpl(
         regions: List<GeofenceRegion>,
         config: GeofenceConfig,
         containmentEpoch: Long,
+        fixSource: FixSource,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
-        onRegistered: () -> Unit = {},
-        emitInitialEnter: Boolean = true
+        onRegistered: () -> Unit = {}
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
         val nearest = distanceFilter.nearest(
@@ -453,8 +462,8 @@ internal class GeofenceRepositoryImpl(
                 return@withLock Result.success(Unit)
             }
             // Synthesis baseline, snapshotted before register/persist mutate the store. No reboot
-            // override here (unlike the registration diff): callers disable synthesis outright
-            // while the reboot flag is up — the anchor can predate the reboot.
+            // override here (unlike the registration diff): a reboot re-registers with
+            // INITIAL_TRIGGER_ENTER, so the OS re-reports these itself.
             val unchangedRegistered = unchangedRegisteredIds(nearest)
             // Registered before this pass but not cache-equal: the ID survived a geometry edit.
             val previouslyRegistered = store.getRegisteredIds()
@@ -480,16 +489,19 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
-                    // Seed containment from our own geometry: synthesis is suppressed after a
-                    // reboot or app update, and without a record the later genuine EXIT looks
-                    // unentered and gets dropped.
-                    val insideIds = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
-                        .map { it.id }
-                        .toSet()
-                    // A moved circle keeps its ID, so containment and the reported-ENTER mark can
-                    // describe where the fence used to be. Reset both, but only once the new geometry
-                    // agrees the device is out, or trimming a radius manufactures a second arrival.
-                    val movedAwayIds = reRegisteredIds - insideIds
+                    // Without a record the later genuine EXIT looks unentered and gets dropped, but
+                    // an anchor would seed a place the device left days ago — so it judges nothing.
+                    val insideIds = if (fixSource == FixSource.LIVE) {
+                        nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
+                            .map { it.id }
+                            .toSet()
+                    } else {
+                        null
+                    }
+                    // A moved circle keeps its ID, so its record can describe where the fence used
+                    // to be. Reset only once live geometry agrees the device is out: an anchor's
+                    // "outside" proves nothing, and a radius trim must not manufacture an arrival.
+                    val movedAwayIds = insideIds?.let { reRegisteredIds - it }.orEmpty()
                     val resetApplied = store.reconcileEnteredIds(
                         registeredIds = idsToSave,
                         inside = insideIds,
@@ -517,7 +529,9 @@ internal class GeofenceRepositoryImpl(
                     logger.logSyncSucceeded(nearest.size, movementTriggerRegistered = monitoringEnabled)
                 }
             }
-            if (registrationResult.isSuccess && emitInitialEnter) {
+            // An anchor inside a fence proves nothing about where the device is now, so a record
+            // carried across a geometry edit must not become a fresh arrival.
+            if (registrationResult.isSuccess && fixSource == FixSource.LIVE) {
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -489,19 +489,16 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    val insideNow = nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
+                        .map { it.id }
+                        .toSet()
                     // Without a record the later genuine EXIT looks unentered and gets dropped, but
                     // an anchor would seed a place the device left days ago — so it judges nothing.
-                    val insideIds = if (fixSource == FixSource.LIVE) {
-                        nearest.filter { it.distanceTo(latitude, longitude) <= it.radius }
-                            .map { it.id }
-                            .toSet()
-                    } else {
-                        null
-                    }
-                    // A moved circle keeps its ID, so its record can describe where the fence used
-                    // to be. Reset only once live geometry agrees the device is out: an anchor's
-                    // "outside" proves nothing, and a radius trim must not manufacture an arrival.
-                    val movedAwayIds = insideIds?.let { reRegisteredIds - it }.orEmpty()
+                    val insideIds = insideNow.takeIf { fixSource == FixSource.LIVE }
+                    // A moved circle keeps its ID, so its record and mark can describe a fence that
+                    // no longer exists, and the mark then suppresses GMS's own arrival at the new
+                    // one. An anchor may retire evidence it can't vouch for; it just may not seed.
+                    val movedAwayIds = reRegisteredIds - insideNow
                     val resetApplied = store.reconcileEnteredIds(
                         registeredIds = idsToSave,
                         inside = insideIds,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -527,8 +527,10 @@ internal class GeofenceRepositoryImpl(
                 }
             }
             // An anchor inside a fence proves nothing about where the device is now, so a record
-            // carried across a geometry edit must not become a fresh arrival.
-            if (registrationResult.isSuccess && fixSource == FixSource.LIVE) {
+            // carried across a geometry edit must not become a fresh arrival. A wipe re-registers
+            // every fence with INITIAL_TRIGGER_ENTER, so GMS re-reports these itself and the
+            // backstop is redundant exactly when its inputs are least trustworthy.
+            if (registrationResult.isSuccess && fixSource == FixSource.LIVE && !osStateWiped()) {
                 // Identity can change during the awaited GMS call, and reset doesn't clear pending
                 // delivery rows — never queue a synthetic ENTER for a signed-out/switched user.
                 if (secureUserStore.getUserId() == userId) {

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -79,8 +79,11 @@ internal interface GeofenceRegionStore {
 
     /**
      * Prunes the entered set to [registeredIds] and unions in [inside], the fences our own geometry
-     * puts the device within at registration time. Union rather than replace, because [inside] may
-     * come from a stale anchor whose "outside" must not erase real containment.
+     * puts the device within at registration time. Union rather than replace, because a fix can miss
+     * containment the OS already reported.
+     *
+     * A null [inside] is a pass with no live fix: it prunes only, and leaves the entered set absent
+     * if it was — key-absence is the upgrade grace [hasContainmentRecord] reads.
      *
      * [sinceEpoch] is [containmentEpoch] as of the fix [inside] was derived from; a fence whose exit
      * was claimed after that is dropped, so a departure reported during the sync's GMS await wins
@@ -96,15 +99,15 @@ internal interface GeofenceRegionStore {
      */
     fun reconcileEnteredIds(
         registeredIds: Set<String>,
-        inside: Set<String>,
+        inside: Set<String>?,
         sinceEpoch: Long,
         resetIds: Set<String> = emptySet()
     ): Set<String>
 
     /**
      * Whether containment has ever been recorded. False on an install upgraded from a version that
-     * predates the set, until the first registration seeds it — the EXIT guard defers while it is,
-     * since "empty" and "no data yet" are otherwise indistinguishable.
+     * predates the set, until the first pass holding a live fix judges it — the EXIT guard defers
+     * while it is, since "empty" and "no data yet" are otherwise indistinguishable.
      */
     fun hasContainmentRecord(): Boolean
 
@@ -227,16 +230,21 @@ internal class GeofenceRegionStoreImpl(
 
     override fun reconcileEnteredIds(
         registeredIds: Set<String>,
-        inside: Set<String>,
+        inside: Set<String>?,
         sinceEpoch: Long,
         resetIds: Set<String>
     ): Set<String> = synchronized(enteredLock) {
-        val stillInside = inside.filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
+        val stillInside = inside.orEmpty().filter { (exitEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }
         // An entry reported since the caller's fix describes the geometry being registered now, so
         // it survives a reset aimed at the geometry it replaced.
         val dropped = resetIds.filter { (enterEpochByGeofenceId[it] ?: 0L) <= sinceEpoch }.toSet() - stillInside
-        val carried = (getEnteredIds() intersect registeredIds) - dropped
-        writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
+        // A live fix ends the grace even when it finds nothing inside — that is a real reading of
+        // "not in any fence". A prune-only pass creating the key would instead arm the EXIT guard
+        // off an anchor and drop crossings that predate any record.
+        if (inside != null || hasContainmentRecord()) {
+            val carried = (getEnteredIds() intersect registeredIds) - dropped
+            writeJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER, carried + stillInside)
+        }
         // Bound the maps, after the filters have read them.
         exitEpochByGeofenceId.keys.retainAll(registeredIds)
         enterEpochByGeofenceId.keys.retainAll(registeredIds)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceContainmentRealStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceContainmentRealStoreTest.kt
@@ -1,0 +1,126 @@
+package io.customer.geofence
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.api.GeofenceApiService
+import io.customer.geofence.store.GeofenceRegionStoreImpl
+import io.customer.sdk.core.util.Clock
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The containment-only pass against the real [GeofenceRegionStoreImpl] rather than a stub of it.
+ * [GeofenceRepositoryTest] models reconcile's semantics by hand, so it cannot show that this path
+ * arms the guard the receiver actually reads — only the real store's epoch filter and key-absence
+ * grace can.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeofenceContainmentRealStoreTest : RobolectricTest() {
+
+    private lateinit var store: GeofenceRegionStoreImpl
+    private lateinit var repository: GeofenceRepositoryImpl
+
+    private val manager: GeofenceManager = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val clock: Clock = mockk(relaxed = true)
+    private val packageInfo: GeofencePackageInfo = mockk { every { lastUpdateTimeMs() } returns null }
+
+    private val fence = GeofenceRegion("biz-1", 0.0, 0.0, 100f)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { argument(ApplicationArgument(applicationMock)) })
+        store = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+        store.clearAll()
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.elapsedRealtime() } returns 10_000L
+        every { clock.currentTimeMillis() } returns System.currentTimeMillis()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        repository = GeofenceRepositoryImpl(
+            apiService = mockk<GeofenceApiService>(relaxed = true),
+            store = store,
+            distanceFilter = GeofenceDistanceFilter(),
+            manager = manager,
+            secureUserStore = secureUserStore,
+            cooldownFilter = mockk(relaxed = true),
+            transitionEmitter = mockk(relaxed = true),
+            clock = clock,
+            packageInfo = packageInfo,
+            logger = mockk(relaxed = true)
+        )
+        // State a successful anchor pass leaves behind: registered and stamped, containment unjudged.
+        store.saveCachedRegions(listOf(fence))
+        store.saveCachedConfig(sampleConfig())
+        store.setLastSyncTimestamp(System.currentTimeMillis())
+        store.saveRegisteredIds(setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, fence.id))
+        store.saveLastMovementTriggerLocation(GeofenceLocation(0.0, 0.0))
+        store.setLastRegistrationUptime(clock.elapsedRealtime())
+    }
+
+    @Test
+    fun anchorOnlyState_expectGuardStillDeferring() {
+        // Control: with no live fix yet the key is absent, so the receiver's guard fails open.
+        store.hasContainmentRecord().shouldBeFalse()
+        store.claimExit(fence.id).shouldBeFalse()
+    }
+
+    @Test
+    fun liveFixOnFreshInputs_expectGuardArmedAndGenuineExitClaimable() = runTest {
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        // Discriminator: SKIP registers nothing. Without this the assertions below also pass on a
+        // LOCAL pass, which seeds through a different code path entirely.
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        store.getEnteredIds() shouldContainSame setOf(fence.id)
+        store.hasContainmentRecord().shouldBeTrue()
+        // The guarantee the receiver depends on: a genuine departure is matched, not read as phantom.
+        store.claimExit(fence.id).shouldBeTrue()
+    }
+
+    @Test
+    fun liveFixOutsideEveryFence_expectRecordCreatedEmpty() = runTest {
+        // ~555m out: a real reading of "inside nothing" must still end the grace.
+        repository.refreshFromLiveFix(latitude = 0.005, longitude = 0.0)
+
+        store.getEnteredIds() shouldBeEqualTo emptySet()
+        store.hasContainmentRecord().shouldBeTrue()
+    }
+
+    @Test
+    fun exitClaimedBeforeTheFix_expectTheFixReseeds() = runTest {
+        // The epoch contract, which GeofenceRepositoryTest's hand-written stub does not model. A
+        // departure that predates the fix is older evidence, so the fix re-seeds; only one claimed
+        // after the epoch this pass captured would outrank it (covered in GeofenceRegionStoreTest).
+        store.recordEntered(fence.id)
+        store.claimExit(fence.id).shouldBeTrue()
+
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        store.getEnteredIds() shouldContainSame setOf(fence.id)
+    }
+
+    private fun sampleConfig() = GeofenceConfig(
+        localRefreshTriggerRadius = 1_000f,
+        remoteFetchRefreshTriggerRadius = 5_000f,
+        remoteFetchRefreshExpiry = 86_400_000L,
+        duplicateEventsExpiry = 3_600_000L,
+        maxBusinessGeofences = 19,
+        maxMonitoringDistance = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
+    )
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -2086,7 +2086,11 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { secureUserStore.getUserId() } returns "user-42"
         every { clock.currentTimeMillis() } returns 200_000_000_000L
         every { clock.elapsedRealtime() } returns 1_000L
-        every { store.getLastRegistrationUptime() } returns 900_000L // uptime regressed -> rebooted
+        // Stateful, because the pass stamps this key mid-flight: a fixed stub would keep reporting
+        // "wiped" after the write that clears it and pass whether or not the guard reads it in time.
+        var storedUptime: Long? = 900_000L // uptime regressed -> rebooted
+        every { store.getLastRegistrationUptime() } answers { storedUptime }
+        every { store.setLastRegistrationUptime(any()) } answers { storedUptime = firstArg() }
         every { store.getLastSyncTimestamp() } returns 1_000L
         every { store.getRegisteredIds() } returns emptySet()
         every { store.getEnteredIds() } returns setOf("g-1")

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -577,7 +577,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenAnchorInsideAFence_expectNoSeedingNoResetNoSynthesis() = runTest {
+    fun refresh_givenAnchorInsideAFence_expectNoSeedingNoSynthesis() = runTest {
         // refresh() runs off the persisted anchor — where the device once was. Seeding containment
         // or synthesizing an ENTER from it would resurrect an exited visit or report an arrival at
         // a place the device left days ago. Anchor passes only rank and prune.
@@ -2075,6 +2075,36 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
         // Mark dropped, so the arrival at the new circle is not mistaken for a repeat.
+        verify { store.pruneEmittedEnterIds(match { "g-1" !in it }) }
+    }
+
+    @Test
+    fun refresh_givenFenceMovedAwayFromAnchor_expectContainmentAndMarkReset() = runTest {
+        // Same moved circle, judged off the anchor. The record and mark describe a circle GMS no
+        // longer holds, so keeping them swallows the first arrival at the new one — GMS's own
+        // report, not the synthesis backstop an anchor pass gives up. Retiring them seeds nothing.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns setOf("g-1")
+
+        repository.refresh(latitude = 0.01, longitude = 0.0)
+
+        verify {
+            store.reconcileEnteredIds(
+                registeredIds = any(),
+                inside = null,
+                sinceEpoch = any(),
+                resetIds = setOf("g-1")
+            )
+        }
         verify { store.pruneEmittedEnterIds(match { "g-1" !in it }) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1848,10 +1848,50 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
     @Test
     fun handleMovement_givenNewlyRegisteredFenceDeviceInside_expectInitialEnterEmitted() = runTest {
-        // The movement trigger fires on the OS's own fix, so a movement pass is LIVE like
+        // The movement trigger fires on the OS's own fix, so a movement pass trusts geometry like
         // refreshFromLiveFix: it must still seed and synthesize, not just rank and prune.
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet() // newly registered
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getEnteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.handleMovement(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = true
+            )
+        }
+    }
+
+    /**
+     * A wipe suppresses synthesis for a fix we requested, because it may describe a stretch we never
+     * observed. The movement trigger's fix is the OS's own, produced because the device just moved,
+     * so no wipe can have made it stale — and this is the path the backstop exists for, since the
+     * INITIAL_TRIGGER_ENTER it defers to is the callback that gets missed.
+     */
+    @Test
+    fun handleMovement_givenOsStateWiped_expectInitialEnterStillEmitted() = runTest {
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.elapsedRealtime() } returns 1_000L
+        // Stateful: the pass stamps this key mid-flight, and a fixed stub would keep reporting
+        // "wiped" after the write that clears it.
+        var storedUptime: Long? = 900_000L // uptime regressed -> rebooted
+        every { store.getLastRegistrationUptime() } answers { storedUptime }
+        every { store.setLastRegistrationUptime(any()) } answers { storedUptime = firstArg() }
         every { store.getCachedRegions() } returns cached
         every { store.getRegisteredIds() } returns emptySet() // newly registered
         every { store.getCachedConfig() } returns sampleConfig()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -2402,6 +2402,12 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.getLastMovementTriggerLocation() } answers { movementLocation }
         every { store.saveLastMovementTriggerLocation(any()) } answers { movementLocation = firstArg() }
         every { store.getEnteredIds() } answers { enteredIds.orEmpty() }
+        every { store.claimExit(any()) } answers {
+            val id = firstArg<String>()
+            val wasInside = id in enteredIds.orEmpty()
+            enteredIds = enteredIds?.minus(id)
+            wasInside
+        }
         every { store.reconcileEnteredIds(any(), any(), any(), any()) } answers {
             val registered = firstArg<Set<String>>()
             val inside = secondArg<Set<String>?>()
@@ -2445,6 +2451,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
         repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+        // The genuine departure clears the record, as the receiver's EXIT path does.
+        store.claimExit("biz-1") shouldBeEqualTo true
+        store.getEnteredIds().shouldBeEmpty()
         repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
         store.getEnteredIds() shouldContainSame setOf("biz-1")

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -2079,6 +2079,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refreshFromLiveFix_givenOsStateWiped_expectNoInitialEnter() = runTest {
+        // A reboot or app update re-registers every fence with INITIAL_TRIGGER_ENTER, so GMS reports
+        // the arrival itself. Synthesizing as well only adds a second source of truth at the moment
+        // the stored record is least likely to describe where the device actually is.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { clock.elapsedRealtime() } returns 1_000L
+        every { store.getLastRegistrationUptime() } returns 900_000L // uptime regressed -> rebooted
+        every { store.getLastSyncTimestamp() } returns 1_000L
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
     fun refresh_givenFenceMovedAwayFromAnchor_expectContainmentAndMarkReset() = runTest {
         // Same moved circle, judged off the anchor. The record and mark describe a circle GMS no
         // longer holds, so keeping them swallows the first arrival at the new one — GMS's own

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -550,7 +550,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenRegistrationSucceeds_expectContainmentSeededFromGeometryNotFromEnterEvents() = runTest {
+    fun refreshFromLiveFix_givenRegistrationSucceeds_expectContainmentSeededFromGeometryNotFromEnterEvents() = runTest {
         // Initial-ENTER synthesis is suppressed after a reboot/app update, so no ENTER is emitted
         // for a fence the device is already inside. Without seeding containment here, that fence's
         // later genuine EXIT would look unentered and be dropped by the guard.
@@ -562,7 +562,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(inside, outside)
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
-        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
+        val result = repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
         result.isSuccess shouldBeEqualTo true
         // Only the fence whose radius actually contains the device is seeded; the far one is not,
@@ -572,6 +572,65 @@ class GeofenceRepositoryTest : RobolectricTest() {
                 registeredIds = any(),
                 inside = setOf("biz-inside"),
                 sinceEpoch = any()
+            )
+        }
+    }
+
+    @Test
+    fun refresh_givenAnchorInsideAFence_expectNoSeedingNoResetNoSynthesis() = runTest {
+        // refresh() runs off the persisted anchor — where the device once was. Seeding containment
+        // or synthesizing an ENTER from it would resurrect an exited visit or report an arrival at
+        // a place the device left days ago. Anchor passes only rank and prune.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        val inside = GeofenceRegion("biz-inside", 0.0, 0.0, 500f)
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse(maxBusinessGeofences = 5))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(inside)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        result.isSuccess shouldBeEqualTo true
+        verify {
+            store.reconcileEnteredIds(
+                registeredIds = any(),
+                inside = null,
+                sinceEpoch = any(),
+                resetIds = emptySet()
+            )
+        }
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun refreshFromLiveFix_givenTransitionWhileQueuedForTheSlot_expectEpochFromBeforeTheWait() = runTest {
+        // The epoch belongs to the fix, so it has to be read before the slot wait. A crossing
+        // reported while this pass queues behind a holder postdates the fix; reading the epoch
+        // after the wait would fold that crossing into the baseline and let the seed overrule it.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.containmentEpoch() } returns 3L
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(GeofenceRegion("biz-1", 0.0, 0.0, 500f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        coEvery { apiService.fetchGeofences(any()) } coAnswers {
+            // The holder occupies the slot; a transition lands while the live-fix pass queues.
+            delay(20.seconds)
+            every { store.containmentEpoch() } returns 9L
+            Result.success(sampleResponse(maxBusinessGeofences = 5))
+        }
+
+        val holder = launch { repository.refresh(latitude = 0.0, longitude = 0.0) }
+        runCurrent()
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+        holder.join()
+
+        verify {
+            store.reconcileEnteredIds(
+                registeredIds = any(),
+                inside = setOf("biz-1"),
+                sinceEpoch = 3L,
+                resetIds = any()
             )
         }
     }
@@ -1756,7 +1815,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     // ---------- initial enter-when-inside (synthesized; GMS INITIAL_TRIGGER_ENTER is unreliable) ----------
 
     @Test
-    fun refresh_givenNewlyRegisteredFenceDeviceInside_expectInitialEnterEmitted() = runTest {
+    fun refreshFromLiveFix_givenNewlyRegisteredFenceDeviceInside_expectInitialEnterEmitted() = runTest {
         // Fresh cache but OS regs wiped → local re-register; the fence is newly registered and the
         // device sits inside it → synthesize the ENTER GMS may have dropped.
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
@@ -1771,7 +1830,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
-        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) {
             transitionEmitter.emit(
@@ -1788,7 +1847,37 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenNewlyRegisteredEnterOnlyFenceDeviceInside_expectInitialEnterNotLatched() = runTest {
+    fun handleMovement_givenNewlyRegisteredFenceDeviceInside_expectInitialEnterEmitted() = runTest {
+        // The movement trigger fires on the OS's own fix, so a movement pass is LIVE like
+        // refreshFromLiveFix: it must still seed and synthesize, not just rank and prune.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getCachedRegions() } returns cached
+        every { store.getRegisteredIds() } returns emptySet() // newly registered
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastApiFetchLocation() } returns GeofenceLocation(0.0, 0.0)
+        every { store.getEnteredIds() } returns setOf("biz-1")
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.handleMovement(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = true
+            )
+        }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenNewlyRegisteredEnterOnlyFenceDeviceInside_expectInitialEnterNotLatched() = runTest {
         // The synthesized ENTER must carry the fence's real monitoring shape: latching an enter-only
         // fence would suppress every later arrival, since no EXIT can ever release it.
         val cached = listOf(
@@ -1803,7 +1892,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
-        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) {
             transitionEmitter.emit(
@@ -1913,7 +2002,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenRegisteredFenceParamsChangedDeviceInside_expectInitialEnter() = runTest {
+    fun refreshFromLiveFix_givenRegisteredFenceParamsChangedDeviceInside_expectInitialEnter() = runTest {
         // Server grew g-1's radius (50 → 100 m): the fence is re-added to GMS, so it synthesizes
         // like a new fence when the device is inside the new geometry.
         every { secureUserStore.getUserId() } returns "user-42"
@@ -1927,7 +2016,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
         coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
 
-        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
         coVerify(exactly = 1) {
             transitionEmitter.emit(
@@ -1944,7 +2033,28 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenFenceMovedAwayFromDevice_expectContainmentAndMarkReset() = runTest {
+    fun refresh_givenRegisteredFenceParamsChangedAnchorInside_expectNoInitialEnter() = runTest {
+        // Same geometry edit, but the pass runs off the anchor. The record was carried forward from
+        // an older visit and the anchor still reads "inside", so synthesis would fire an arrival on
+        // two pieces of stale evidence — days after the device may have left.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.currentTimeMillis() } returns 200_000_000_000L
+        every { store.getLastSyncTimestamp() } returns 1_000L // stale → remote fetch
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("g-1", 0.0, 0.0, 50f))
+        every { store.getRegisteredIds() } returns setOf("g-1")
+        every { store.getEnteredIds() } returns setOf("g-1")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3)) // g-1 at (0,0) radius 100
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } answers { firstArg() }
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenFenceMovedAwayFromDevice_expectContainmentAndMarkReset() = runTest {
         // g-1's circle moved while the device was recorded inside the old one. GMS promises no EXIT
         // for a circle it no longer holds, so carrying the record and the reported-ENTER mark forward
         // would drop the first genuine arrival at the new circle and deliver its EXIT unmatched.
@@ -1961,7 +2071,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns setOf("g-1")
 
         // Device ~1.1 km away: outside the new circle, so the old record cannot be trusted.
-        repository.refresh(latitude = 0.01, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.01, longitude = 0.0)
 
         verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
         // Mark dropped, so the arrival at the new circle is not mistaken for a repeat.
@@ -1969,7 +2079,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenArrivalReportedWhileRegistrationAwaited_expectMarkKeptWithRecord() = runTest {
+    fun refreshFromLiveFix_givenArrivalReportedWhileRegistrationAwaited_expectMarkKeptWithRecord() = runTest {
         // Same moved circle, but GMS reported an arrival at it while registration was awaited, so the
         // store keeps the record. The mark has to follow: it belongs to that reported arrival, and
         // clearing it would let the next report through as a fresh one.
@@ -1986,7 +2096,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Store declines the reset because the arrival is newer than the fix that asked for it.
         every { store.reconcileEnteredIds(any(), any(), any(), any()) } returns emptySet()
 
-        repository.refresh(latitude = 0.01, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.01, longitude = 0.0)
 
         verify { store.reconcileEnteredIds(any(), any(), any(), setOf("g-1")) }
         verify { store.pruneEmittedEnterIds(match { "g-1" in it }) }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -2419,10 +2419,10 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refreshFromLiveFix_givenAnchorPassMadeInputsFresh_expectContainmentJudgedAndEnterEmitted() = runTest {
+    fun refreshFromLiveFix_givenAnchorPassMadeInputsFresh_expectContainmentJudged() = runTest {
         // Cold start registers from the anchor, which stamps every freshness input, so the live fix
-        // behind it takes SKIP. It still owns the reseed: otherwise nothing ever judges containment,
-        // the arrival GMS dropped stays lost, and the receiver reads the later EXIT as unmatched.
+        // behind it takes SKIP. It still owns the reseed: otherwise nothing ever judges containment
+        // and the receiver reads the eventual genuine EXIT as unmatched.
         val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         statefulStore(cached)
 
@@ -2433,45 +2433,22 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         verify { logger.logSyncSkippedFresh() }
         store.getEnteredIds() shouldContainSame setOf("biz-1")
-        coVerify(exactly = 1) {
-            transitionEmitter.emit(
-                geofenceId = "biz-1",
-                transition = Event.GeofenceTransition.ENTER,
-                userId = "user-42",
-                timestampSeconds = any(),
-                geofenceName = any(),
-                metadata = any(),
-                geosetIds = any(),
-                monitorsExit = true
-            )
-        }
     }
 
     @Test
-    fun refreshFromLiveFix_givenContainmentAlreadyJudged_expectNoSecondEnter() = runTest {
-        // Foreground entry takes a fix on every resume. An enter-only fence never reports the EXIT
-        // that clears its mark, so nothing downstream would stop a repeat — only the record does.
-        val cached = listOf(
-            GeofenceRegion("biz-1", 0.0, 0.0, 100f, transitionTypes = listOf(GeofenceTransitionType.ENTER))
-        )
+    fun refreshFromLiveFix_givenRecordClearedByAnExit_expectReseedButNoSynthesizedEnter() = runTest {
+        // The chain this pass must not open: a real EXIT clears the record and the mark, then a
+        // foreground fix reading a hair inside re-seeds. Synthesizing there would fabricate an
+        // arrival and re-arm the mark, which would then swallow the user's real next one.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
         statefulStore(cached)
 
         repository.refresh(latitude = 0.0, longitude = 0.0)
         repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
         repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
 
-        coVerify(exactly = 1) {
-            transitionEmitter.emit(
-                geofenceId = "biz-1",
-                transition = any(),
-                userId = any(),
-                timestampSeconds = any(),
-                geofenceName = any(),
-                metadata = any(),
-                geosetIds = any(),
-                monitorsExit = any()
-            )
-        }
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -2505,18 +2482,6 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         reconciledInside shouldBeEqualTo listOf(null, setOf("biz-1"))
         store.getEnteredIds() shouldContainSame setOf("biz-1")
-        coVerify(exactly = 0) {
-            transitionEmitter.emit(
-                geofenceId = "biz-2",
-                transition = any(),
-                userId = any(),
-                timestampSeconds = any(),
-                geofenceName = any(),
-                metadata = any(),
-                geosetIds = any(),
-                monitorsExit = any()
-            )
-        }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -2373,6 +2373,182 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
     }
 
+    // ---------- live fix arriving behind an anchor pass ----------
+
+    /**
+     * Wires the keys an anchor pass writes and the pass behind it reads back, so a live fix that
+     * follows one takes SKIP for the real reason rather than a stubbed one.
+     */
+    private fun statefulStore(
+        cached: List<GeofenceRegion>,
+        preRegistered: Set<String> = emptySet()
+    ): List<Set<String>?> {
+        val reconciledInside = mutableListOf<Set<String>?>()
+        var registeredIds = preRegistered
+        // Null models key-absence, which is what `hasContainmentRecord` reads.
+        var enteredIds: Set<String>? = null
+        // Stand in for the registering pass that [preRegistered] represents.
+        var registrationUptime: Long? = 10_000L.takeIf { preRegistered.isNotEmpty() }
+        var movementLocation: GeofenceLocation? = GeofenceLocation(0.0, 0.0).takeIf { preRegistered.isNotEmpty() }
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { clock.elapsedRealtime() } returns 10_000L
+        every { store.getCachedRegions() } returns cached
+        every { store.getCachedConfig() } returns sampleConfig()
+        every { store.getLastSyncTimestamp() } returns System.currentTimeMillis() - 60_000L
+        every { store.getRegisteredIds() } answers { registeredIds }
+        every { store.saveRegisteredIds(any()) } answers { registeredIds = firstArg() }
+        every { store.getLastRegistrationUptime() } answers { registrationUptime }
+        every { store.setLastRegistrationUptime(any()) } answers { registrationUptime = firstArg() }
+        every { store.getLastMovementTriggerLocation() } answers { movementLocation }
+        every { store.saveLastMovementTriggerLocation(any()) } answers { movementLocation = firstArg() }
+        every { store.getEnteredIds() } answers { enteredIds.orEmpty() }
+        every { store.reconcileEnteredIds(any(), any(), any(), any()) } answers {
+            val registered = firstArg<Set<String>>()
+            val inside = secondArg<Set<String>?>()
+            reconciledInside += inside
+            enteredIds = if (inside == null) {
+                enteredIds?.intersect(registered)
+            } else {
+                enteredIds.orEmpty().intersect(registered) + inside
+            }
+            emptySet()
+        }
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns cached
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        return reconciledInside
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenAnchorPassMadeInputsFresh_expectContainmentJudgedAndEnterEmitted() = runTest {
+        // Cold start registers from the anchor, which stamps every freshness input, so the live fix
+        // behind it takes SKIP. It still owns the reseed: otherwise nothing ever judges containment,
+        // the arrival GMS dropped stays lost, and the receiver reads the later EXIT as unmatched.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        statefulStore(cached)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+        store.getEnteredIds().shouldBeEmpty()
+
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        verify { logger.logSyncSkippedFresh() }
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = Event.GeofenceTransition.ENTER,
+                userId = "user-42",
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = true
+            )
+        }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenContainmentAlreadyJudged_expectNoSecondEnter() = runTest {
+        // Foreground entry takes a fix on every resume. An enter-only fence never reports the EXIT
+        // that clears its mark, so nothing downstream would stop a repeat — only the record does.
+        val cached = listOf(
+            GeofenceRegion("biz-1", 0.0, 0.0, 100f, transitionTypes = listOf(GeofenceTransitionType.ENTER))
+        )
+        statefulStore(cached)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        coVerify(exactly = 1) {
+            transitionEmitter.emit(
+                geofenceId = "biz-1",
+                transition = any(),
+                userId = any(),
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = any()
+            )
+        }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenFreshInputsAndDeviceOutside_expectNoEnterAndRecordWritten() = runTest {
+        // The record is written even with nothing inside: that write is what lets the EXIT guard
+        // stop deferring, and geometry that puts the device outside must not invent an arrival.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val reconciledInside = statefulStore(cached)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+        // ~555m: outside the 100m fence, inside both refresh radii, so the pass still takes SKIP.
+        repository.refreshFromLiveFix(latitude = 0.005, longitude = 0.0)
+
+        // Null from the anchor's registering pass, then the live fix's own empty judgement.
+        reconciledInside shouldBeEqualTo listOf(null, emptySet())
+        coVerify(exactly = 0) { transitionEmitter.emit(any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenCachedFenceNotRegistered_expectItLeftOutOfTheJudgement() = runTest {
+        // The cache holds more than the OS monitors. Recording a visit to a fence GMS never got
+        // would report an arrival nothing can ever balance with an EXIT.
+        val registered = GeofenceRegion("biz-1", 0.0, 0.0, 100f)
+        val unregistered = GeofenceRegion("biz-2", 0.0, 0.0, 100f)
+        val cached = listOf(registered, unregistered)
+        val reconciledInside = statefulStore(cached)
+        every { distanceFilter.nearest(cached, any(), any(), any(), any()) } returns listOf(registered)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        reconciledInside shouldBeEqualTo listOf(null, setOf("biz-1"))
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+        coVerify(exactly = 0) {
+            transitionEmitter.emit(
+                geofenceId = "biz-2",
+                transition = any(),
+                userId = any(),
+                timestampSeconds = any(),
+                geofenceName = any(),
+                metadata = any(),
+                geosetIds = any(),
+                monitorsExit = any()
+            )
+        }
+    }
+
+    @Test
+    fun refreshFromLiveFix_givenUserSignedOutDuringThePass_expectContainmentLeftUnjudged() = runTest {
+        // The slot wait and the action decision both release before this writes, so a sign-out can
+        // land in between; seeding then would hand the next user the previous one's containment.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val reconciledInside = statefulStore(cached, preRegistered = setOf("biz-1"))
+        every { secureUserStore.getUserId() } returnsMany listOf("user-42", null)
+
+        repository.refreshFromLiveFix(latitude = 0.0, longitude = 0.0)
+
+        verify { logger.logSyncSkippedFresh() }
+        reconciledInside.shouldBeEmpty()
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun refresh_givenAnchorPassOnFreshInputs_expectContainmentLeftUnjudged() = runTest {
+        // An anchor describes where the device used to be. A SKIP on one must judge nothing — the
+        // absent record is what keeps the EXIT guard deferring rather than dropping a real departure.
+        val cached = listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val reconciledInside = statefulStore(cached)
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        verify(exactly = 1) { logger.logSyncSkippedFresh() }
+        reconciledInside shouldBeEqualTo listOf(null)
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
     private fun sampleConfig(
         remoteFetchRefreshExpiry: Long = 86_400_000L,
         maxMonitoringDistance: Float = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -304,9 +304,18 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun hasContainmentRecord_givenReconcileWithNothingInside_expectTrue() {
-        // The first registration seeds the key even when the device is inside nothing, which is what
-        // ends the upgrade grace period.
+    fun hasContainmentRecord_givenPruneOnlyReconcile_expectGracePreserved() {
+        // An upgraded install has no key; a pass with no live fix (null inside) must not create one,
+        // or the EXIT guard arms off an anchor and drops crossings that predate any record.
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = null, sinceEpoch = store.containmentEpoch())
+
+        store.hasContainmentRecord().shouldBeFalse()
+    }
+
+    @Test
+    fun hasContainmentRecord_givenLiveFixInsideNothing_expectGraceEnded() {
+        // "Inside nothing" from a live fix is a real reading, so it ends the grace and arms the EXIT
+        // guard — otherwise a user who never enters a fence never gets phantom EXITs filtered.
         store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
 
         store.hasContainmentRecord().shouldBeTrue()
@@ -314,12 +323,32 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun reconcileEnteredIds_givenStaleAnchorReportsOutside_expectExistingContainmentPreserved() {
-        // A launch refresh can run off the persisted anchor rather than a live fix. If that
-        // anchor wrongly says "outside", erasing containment would swallow the genuine EXIT.
+    fun hasContainmentRecord_givenReconcileSeedsContainment_expectGraceEnded() {
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = setOf("biz-1"), sinceEpoch = store.containmentEpoch())
+
+        store.hasContainmentRecord().shouldBeTrue()
+        store.getEnteredIds() shouldBeEqualTo setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenFixReportsOutsideARecordedFence_expectContainmentPreserved() {
+        // Union, not replace: a fix taken at the edge of a circle can read "outside" for a fence the
+        // OS already reported entered, and erasing the record would swallow the genuine EXIT.
         store.recordEntered("biz-1")
 
         store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = emptySet(), sinceEpoch = store.containmentEpoch())
+
+        store.getEnteredIds() shouldContainSame setOf("biz-1")
+    }
+
+    @Test
+    fun reconcileEnteredIds_givenPruneOnlyPassWithExistingRecord_expectRecordCarried() {
+        // The grace only covers a missing key. Once a record exists, a prune-only pass still writes:
+        // it has to drop fences that left the registered set.
+        store.recordEntered("biz-1")
+        store.recordEntered("biz-2")
+
+        store.reconcileEnteredIds(registeredIds = setOf("biz-1"), inside = null, sinceEpoch = store.containmentEpoch())
 
         store.getEnteredIds() shouldContainSame setOf("biz-1")
     }


### PR DESCRIPTION
Part of: [MBL-2319](https://linear.app/customerio/issue/MBL-2319/improve-geofence-transition-reliability)

## Stack

- 👉 [#824 trust geometry only from live fixes](https://github.com/customerio/customerio-android/pull/824)
- [#832 qualify a fix before letting it judge containment](https://github.com/customerio/customerio-android/pull/832)
- [#833 polygon wire contract and geometry foundation](https://github.com/customerio/customerio-android/pull/833)

## Problem

A sync pass does not always run from a fix the OS just gave us. `refresh()` —
identify, app-launch, foreground retry — and boot restore run from the
**persisted anchor**: the last registration centre, or the OS location cache.
That is where the device *was*, and it can be arbitrarily stale. The SDK treated
it as trustworthy geometry, which breaks in both directions.

**It fabricates arrivals.** Containment was seeded by testing the pass's
coordinates against each fence, and an initial ENTER was synthesized for anything
the device landed inside. With an anchor, "inside" only means the device was once
there. The trigger is a customer rolling out new fences: every user whose stored
anchor happens to sit inside one gets an arrival on their next launch.

**It also swallows real ones.** Synthesis was gated on
`emitInitialEnter = !osStateWiped()`, suppressed after a reboot or app update
because the anchor could not be trusted then. But the seeding ran anyway from that
same untrusted anchor, so later passes saw the fence as already occupied and
stayed quiet. The genuine arrival is never reported until the user leaves and
comes back.

Gating on OS-state-wiped was the wrong axis. The question is not whether GMS was
reset, it is whether the pass is holding a real fix.

## Change

`FixSource { LIVE, ANCHOR, MOVEMENT }` is threaded through the pass.

| | source | containment seed | moved-circle reset | initial-ENTER synthesis |
|---|---|---|---|---|
| **LIVE** | requested silent fix | yes | yes | yes, unless OS state was wiped |
| **MOVEMENT** | movement-trigger EXIT | yes | yes | yes |
| **ANCHOR** | `refresh()`, boot restore | no | yes | no |

A movement fix is the OS's own, produced because the device moved, so no wipe can have staled
it — and that is the path the backstop exists for, since the `INITIAL_TRIGGER_ENTER` it would
otherwise defer to is the callback that gets missed.

An anchor pass ranks and prunes, and may retire a record it can no longer vouch for —
but it never seeds one. Synthesis keeps the `!osStateWiped()` condition it had before
this branch: a reboot or app update re-registers every fence with
`INITIAL_TRIGGER_ENTER`, so GMS re-reports those arrivals itself, and the backstop is
redundant exactly when the stored record is least likely to be true.

Two supporting changes.

**The containment epoch moves to before the slot wait.** It belongs to the fix, so
a crossing reported while a pass queues behind a holder outranks that pass's
geometry instead of being folded into its baseline.

**`reconcileEnteredIds(inside:)` becomes nullable**, to keep two cases apart that
`emptySet()` used to conflate:

- `null` — this pass has no live fix and cannot judge containment.
- `emptySet()` — a live fix looked and found the device inside nothing.

That distinction matters because key-absence of `entered_ids` is the upgrade grace
`hasContainmentRecord()` reads, and the unmatched-EXIT guard defers while the grace
holds. So a prune-only pass must not create the key — arming the guard off an
anchor would drop the genuine EXIT of anyone upgrading from 4.20.0, which tracked
no containment at all. A live fix must create it even when nothing is inside, since
that is a real reading; otherwise a user who has never been inside a fence never
arms the guard and the phantom EXITs it exists to filter come back.

## Behaviour notes

**An anchor pass no longer seeds containment; the next live fix does.** An anchor pass that
registers a new fence around a genuinely stationary device does not seed containment or
synthesize its ENTER — it cannot tell "inside" from "was once inside". GMS registers business
fences with `INITIAL_TRIGGER_ENTER` and reports that arrival itself, so synthesis is only the
backstop for when GMS drops it.

The part that is easy to miss is that `entered_ids` has **two** readers. Besides
`emitInitialEnters`, the unmatched-EXIT guard reads it as
`!claimExit(id) && hasContainmentRecord()`. So deferring the seed defers both: until a live fix
judges, a dropped `INITIAL_TRIGGER_ENTER` has no backstop, and the later genuine EXIT reads as a
phantom.

**The EXIT guard is armed by the next live fix — including one that changes no registration.**
A successful anchor pass stamps the sync timestamp, the movement location, the registration uptime
and the package update time, so the live fix that follows on a cold start reaches `refreshAction`
and takes `SKIP`. `SKIP` now runs a containment-only pass for any fix that trusts geometry: no
fetch, no registration, just the judgement the anchor could not make. Raised by @Shahroz16; an
earlier revision of this section argued the loss was permanent, which was wrong.

**That pass seeds; it does not synthesize.** It runs on every foreground fix in AUTOMATIC, so
synthesizing there would move the backstop from "at registration" to "at every resume", decided by
an exact point check on a fix this path measures at 100 m indoors. Near a boundary that fabricates
an ENTER *and* arms the emitted mark, and since reconcile carries a record for a still-registered
fence, the record is sticky: the user's real next arrival is then dropped as
`isRedundantEnter` and only its EXIT gets through. A wrong seed has no equivalent cost — it can
only let an EXIT through, which is the direction this path already fails open in. So the
synthesis backstop stays tied to a pass that registers, and a dropped `INITIAL_TRIGGER_ENTER` for
an anchor-registered fence stays lost; GMS reports that arrival itself, and synthesis only ever
covered the case where it does not.

**The grace is now wider than upgrades.** `clearUserScopedState` removes
`entered_ids`, so a sign-out re-enters the grace too, as does a `readJson`
parse-failure wipe. Until the next live pass, an unmatched EXIT is delivered rather
than dropped — fail-open, and correct when we genuinely have no record. The root
cause is that `hasContainmentRecord()` answers "does this install track
containment?" by testing a *user-scoped* key; a dedicated marker that survives
sign-out would decouple them. Left out of this PR deliberately — candidate
follow-up on the same ticket.

## Review follow-ups

Findings from @Shahroz16's review, all fixed here.

**Fixed here — a stale arrival mark survives a geometry edit.** Gating the
moved-circle reset on a live fix means an anchor pass never clears the mark, so a
fence re-registered with new geometry keeps saying "already reported". GMS fires
`INITIAL_TRIGGER_ENTER` for the new circle, the emitter drops it as `isRedundantEnter`,
and the first arrival at the edited geometry is swallowed — its later EXIT then arrives
unmatched. That is a regression this PR introduces, and it breaks GMS's own report
rather than the backstop, so it is fixed here.

The gate was too broad. An anchor cannot be trusted to *create* evidence: seeding
containment or synthesizing an ENTER invents an arrival with no OS event behind it. A
reset only removes a record, and the record it removes describes a circle GMS no longer
holds. **An anchor may retire evidence it can no longer vouch for; it just may not
seed.**

So `movedAwayIds` is computed from the pass's own geometry on every pass, while the
containment seed and the synthesis stay live-only. That restores exactly what 4.20.1 and
4.20.2 already do for this decision, and `reconcileEnteredIds` still declines any reset a
fence has outranked with a newer reported arrival.

One case survives, unchanged from 4.20.2: an anchor that wrongly reads "inside the new
circle" keeps the mark and still swallows that arrival. It needs the anchor to be wrong,
not merely stale, and no reset can do better without a fix to judge against.

**Fixed here — synthesis after a reboot or app update (58f70e2e, corrected by dbbf329c).**
Gating synthesis on `FixSource` dropped the `emitInitialEnter = !osStateWiped()` condition it
replaced, so a live fix arriving post-wipe synthesized an ENTER where no pass previously did.
That is the one path this branch opened rather than narrowed, so the condition is restored.

Worth reading as two commits: the first put the condition back at the call site, where it was
a **no-op** — a successful registration stamps uptime and package update time, and those two
writes are exactly what make the wipe detectors return false, so the guard always saw "not
wiped". Caught by Bugbot. The second snapshots the value before the registration block, next
to the synthesis baseline, which is snapshotted for the same reason. The test had passed
because a fixed mock stub returned "wiped" regardless of the write; it is stateful now and
fails against the first commit. Movement
passes reached synthesis through the old parameter default rather than the guard, so they
lose it here too; the window is the gap between a wipe and the first successful
registration, which boot restore performs.

**Fix quality — shipped as #832.** Raised by @Shahroz16. The 11–31 m figures first cited here
were GMS `triggeringLocation` callbacks recorded during a drive, not the
`getCurrentLocation(PRIORITY_LOW_POWER)` this path uses, which reports 100 m on every fix
indoors; and `getCurrentLocation` does return cached fixes, measured to 124 s. #832 carries the
fix's monotonic timestamp through and runs no pass for a fix older than 5 minutes. It does not
gate on accuracy: a margin on the inside test silences the indoor backstop, and a margin on
retirement keeps a stale mark that swallows the next arrival, so containment stays the exact
point check this PR uses.

Net effect of this branch on that surface is still a narrowing: anchor passes used to seed
containment too, and only live ones can now.

## Upgrade path

No migration needed. No key added, renamed or removed, and no serialized schema
change — the only persistence delta is whether one existing
`writeJson(KEY_ENTERED_IDS, …)` runs.

- **From 4.20.1 / 4.20.2** (`entered_ids` present): reconcile still carries
  `enteredIds ∩ registeredIds`, so containment survives and the guard stays armed.
  Synthesis was already suppressed on an app update. The upgrade pass is identical.
- **From 4.20.0** (key absent, and it had no EXIT guard at all): the grace holds and
  the guard fails open — 4.20.0's own behaviour. GMS's `INITIAL_TRIGGER_ENTER`
  re-report creates the key within seconds for any fence the device is standing in.
  Inside no fence, the guard arms at the first live pass that does work: the first
  movement-trigger EXIT, or 24 h staleness.
- **Better in one case**: 4.20.1 wrote `[]` from a possibly-wrong anchor, arming the
  guard on a guess and then dropping that upgrader's genuine EXIT. Now delivered.
- **Rollback safe**: 4.20.1 handles an absent key and recreates it unconditionally.

## Verification

Emulator differential on a Pixel 10 Pro AVD against a real workspace (8 fences
around Bahria Town Lahore). Anchor seeded inside fence 5, location provider removed
so only the anchor could drive a pass:

| | before | after |
|---|---|---|
| `entered_ids` after an anchor-only relaunch | `["5"]` | absent |
| ENTER delivered | none | none |

The old build silently records "inside fence 5" with no event — the swallowed
arrival. Positive control on the new build: a live fix inside fence 5 registers,
records containment and delivers the ENTER.

Field verification of the anchor path rides the polygon drive.

## Test plan

- Anchor pass: nothing seeded, no moved-away resets, no synthesis; registration and
  pruning still happen.
- Anchor pass with a carried record and a re-registered fence: still no synthesis, but the
  record and mark of a circle that moved away are reset.
- Live pass: all three still happen. Movement passes are live too.
- Live pass just after a reboot: registers and seeds, but synthesizes nothing.
- Epoch: a transition landing while the pass is queued for the slot, and one landing
  during the GMS await, both outrank the pass's geometry.
- Fresh-input live pass: `SKIP` judges containment and emits nothing — including after an EXIT
  cleared the record, which is the chain a synthesizing SKIP would open. An anchor `SKIP` judges
  nothing; a sign-out mid-pass writes nothing; a cached-but-unregistered fence is left out.
- Grace: prune-only leaves `entered_ids` absent; a live fix inside nothing creates
  it; a prune-only pass with an existing record still prunes.
- 429 tests / 0 failures; ktlint, apiCheck and `lintDebug` green.
- Each new guard was mutation-tested — inverted in isolation to confirm a test fails.
  Two tests were passing for the wrong reason and were rewritten; re-applying the gate
  above fails the review-follow-up test and nothing else.











