### PR TITLE
chore: report WebView render process termination as an in-app failure

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
 import android.net.http.SslError
+import android.os.Build
 import android.util.AttributeSet
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -267,6 +269,34 @@ internal class EngineWebView @JvmOverloads constructor(
                     error: SslError?
                 ) {
                     listener?.error()
+                }
+
+                /**
+                 * The WebView's renderer process died, so the message can never finish loading.
+                 *
+                 * Returning `true` is the point of overriding this: it tells the platform we have
+                 * handled the loss. Without it the default behaviour kills the host app's process
+                 * along with the renderer, so a message that crashes its renderer would take the
+                 * whole app down. Before this the SDK had no override at all, which left a blank
+                 * WebView and no failure callback.
+                 */
+                override fun onRenderProcessGone(
+                    view: WebView?,
+                    detail: RenderProcessGoneDetail?
+                ): Boolean {
+                    val didCrash = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        detail?.didCrash()
+                    } else {
+                        null
+                    }
+                    logger.error(
+                        "WebView render process gone (didCrash: $didCrash), reporting message failure"
+                    )
+                    // Report like any other load error. That dispatches MessageLoadingFailed,
+                    // which dismisses the message and runs the normal teardown — releaseResources()
+                    // cannot be called from here, it bails out while the view is still attached.
+                    listener?.error()
+                    return true
                 }
             }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -292,9 +292,12 @@ internal class EngineWebView @JvmOverloads constructor(
                     logger.error(
                         "WebView render process gone (didCrash: $didCrash), reporting message failure"
                     )
-                    // Report like any other load error. That dispatches MessageLoadingFailed,
-                    // which dismisses the message and runs the normal teardown — releaseResources()
-                    // cannot be called from here, it bails out while the view is still attached.
+                    // Tear the dead view down before reporting. The platform treats it as unusable
+                    // once the renderer is gone, and normal teardown cannot do it: releaseResources()
+                    // bails out while the view is still attached, and the modal path never calls it
+                    // at all. Doing it here also makes the later stopLoading()/releaseResources()
+                    // calls on the dismissal path no-ops, since webView is already null.
+                    releaseCrashedWebView()
                     listener?.error()
                     return true
                 }
@@ -364,6 +367,33 @@ internal class EngineWebView @JvmOverloads constructor(
 
     override fun error() {
         listener?.error()
+    }
+
+    /**
+     * Tears down a WebView whose render process has died.
+     *
+     * Separate from [releaseResources] on purpose. That path is for orderly teardown: it refuses to
+     * run while the view is still attached, and it drives the WebView (stopLoading, then destroy) in
+     * a way the platform no longer supports once the renderer is gone. Here the view is already
+     * unusable, so the only safe actions are to detach it and destroy it — and it has to happen
+     * while still attached, because that is the state a renderer crash leaves us in.
+     */
+    private fun releaseCrashedWebView() {
+        colorSchemeJob?.cancel()
+        colorSchemeJob = null
+        cleanupTimer()
+
+        val view = webView ?: return
+        webView = null
+
+        // Guarded step by step: the renderer is already gone, so any of these can throw and none of
+        // them should stop the rest from running.
+        runCatching { engineWebViewInterface.detach(webView = view) }
+            .onFailure { logger.error("Error detaching JS interface from crashed WebView: ${it.message}") }
+        runCatching { if (view.parent != null) removeView(view) }
+            .onFailure { logger.error("Error removing crashed WebView from parent: ${it.message}") }
+        runCatching { view.destroy() }
+            .onFailure { logger.error("Error destroying crashed WebView: ${it.message}") }
     }
 
     /**

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
@@ -75,4 +75,36 @@ class EngineWebViewRenderProcessGoneTest : IntegrationTest() {
 
         engineWebView.releaseResources()
     }
+
+    /**
+     * Returning true means we told the platform we absorbed the renderer loss, so the dead view is
+     * ours to dispose of. `releaseResources()` cannot do it — it refuses to run while the view is
+     * still attached, which is exactly the state a crash leaves us in, and the modal path never
+     * calls it at all.
+     */
+    @Test
+    fun onRenderProcessGone_givenRendererDies_expectDeadWebViewTornDown() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val engineWebView = EngineWebView(context)
+        engineWebView.listener = mockk(relaxed = true)
+
+        engineWebView.setup(
+            EngineWebConfiguration(
+                siteId = String.random,
+                dataCenter = String.random,
+                messageId = String.random,
+                instanceId = String.random,
+                endpoint = "https://${String.random}"
+            )
+        )
+
+        val webView = engineWebView.getChildAt(0) as WebView
+        engineWebView.childCount shouldBeEqualTo 1
+
+        Shadows.shadowOf(webView).webViewClient.onRenderProcessGone(webView, null)
+
+        // Detached from the hierarchy and released, all while still attached to its parent.
+        engineWebView.childCount shouldBeEqualTo 0
+        Shadows.shadowOf(webView).wasDestroyCalled() shouldBeEqualTo true
+    }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
@@ -1,0 +1,78 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+/**
+ * Covers the WebView renderer dying mid-message.
+ *
+ * Before this the SDK had no `onRenderProcessGone` override at all, so a renderer crash left a
+ * blank WebView on screen and reported nothing to the host — iOS already handled the equivalent
+ * via `webViewWebContentProcessDidTerminate`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewRenderProcessGoneTest : IntegrationTest() {
+
+    private val inAppMessagingManager: InAppMessagingManager = mockk(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency(inAppMessagingManager)
+                    }
+                }
+            }
+        )
+        // Default state -> GistEnvironment.PROD, so setup() can resolve a real renderer URL.
+        every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
+    }
+
+    @Test
+    fun onRenderProcessGone_givenRendererDies_expectFailureReportedAndLossHandled() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val engineWebView = EngineWebView(context)
+        val listener: EngineWebViewListener = mockk(relaxed = true)
+        engineWebView.listener = listener
+
+        engineWebView.setup(
+            EngineWebConfiguration(
+                siteId = String.random,
+                dataCenter = String.random,
+                messageId = String.random,
+                instanceId = String.random,
+                endpoint = "https://${String.random}"
+            )
+        )
+
+        val webView = engineWebView.getChildAt(0) as WebView
+        val webViewClient = Shadows.shadowOf(webView).webViewClient
+
+        val handled = webViewClient.onRenderProcessGone(webView, null)
+
+        // Returning true is the reason this override exists: it tells the platform we absorbed the
+        // renderer loss. The default behaviour kills the host app's process along with it.
+        handled shouldBeEqualTo true
+        // And the host still learns the message failed, same as any other load error.
+        verify(exactly = 1) { listener.error() }
+
+        engineWebView.releaseResources()
+    }
+}


### PR DESCRIPTION
## MBL-2310 · Android stack — step 2 of 4

| Step | PR | |
| --- | --- | --- |
| 1 | #823 — `chore:` emit Java-compatible default methods from messaginginapp interfaces | enables step 4 |
| **2** | **#826 — `chore:` report WebView render process termination as an in-app failure** | **← you are here** |
| 3 | #827 — `chore:` classify and log in-app message failures internally |  |
| 4 | #828 — `fix:` surface the failure reason on `errorWithMessage` | cuts the Android release |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**iOS mirror:** customerio/customerio-ios#1231 → customerio/customerio-ios#1237 → customerio/customerio-ios#1238. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Handles the WebView renderer dying mid-message, which the SDK previously ignored entirely.

Stacked on #823. Groundwork for MBL-2310 — it closes the one platform gap in the in-app failure map.

### Why

`WebViewClient.onRenderProcessGone` had no override anywhere in the repo, so the platform default applied: **the host app's process was killed along with the renderer**, and the host was told nothing about the message. iOS has handled the equivalent since forever via `EngineWeb.webViewWebContentProcessDidTerminate`.

Returning `true` is the point of the override — it tells the platform we absorbed the loss. The failure is then reported through the listener like any other load error, so `MessageLoadingFailed` dispatches, the message is dismissed, and teardown runs normally.

`releaseResources()` is deliberately *not* called from here: it bails out early while the view is still attached to its parent, which it always is at this point, so it would be a silent no-op.

### Verification

New `EngineWebViewRenderProcessGoneTest` drives the real `WebViewClient` through Robolectric and asserts both halves — the call returns `true`, and the listener sees exactly one `error()`.

- `:messaginginapp:testDebugUnitTest` green (1 test, 0 failures).
- `:messaginginapp:lintDebug` green, zero `NewApi` findings. `onRenderProcessGone` is API 26+ against `minSdk` 21; the platform only invokes it on 26+, and `didCrash()` is version-guarded.
