### PR TITLE
chore: classify and log in-app message failures internally

### DIFF
--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -4,11 +4,9 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
-import android.net.http.SslError
 import android.os.Build
 import android.util.AttributeSet
 import android.webkit.RenderProcessGoneDetail
-import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -257,6 +255,15 @@ internal class EngineWebView @JvmOverloads constructor(
                     )
                 }
 
+                // Deliberately no onReceivedSslError override. The platform default already
+                // cancels the request, which is the behaviour we want and the only part that
+                // matters for safety — we never continue past a certificate error. Overriding it
+                // replaced that default with our own cancel() and reported every failure as a
+                // message-level NETWORK error, including certificate failures on subresources,
+                // which dismissed messages that would have rendered. The callback carries no
+                // WebResourceRequest, so there is no reliable way to tell the document from a
+                // subresource. A certificate failure on the document aborts the main-frame load
+                // and surfaces through onReceivedError below, which is already frame-gated.
                 override fun onReceivedHttpError(
                     view: WebView?,
                     request: WebResourceRequest?,
@@ -293,25 +300,6 @@ internal class EngineWebView @JvmOverloads constructor(
                             reason = InAppMessageErrorReason.NETWORK,
                             detail = if (hasDetail) error?.description?.toString() else null,
                             code = if (hasDetail) error?.errorCode else null
-                        )
-                    )
-                }
-
-                override fun onReceivedSslError(
-                    view: WebView?,
-                    handler: SslErrorHandler?,
-                    error: SslError?
-                ) {
-                    // Overriding this removed the platform default's cancel(), so the handler has
-                    // to be resolved here or the request stays suspended. Always cancel: the
-                    // renderer is first-party HTTPS and we never continue past a certificate error.
-                    handler?.cancel()
-
-                    reportFailure(
-                        InAppMessageError(
-                            reason = InAppMessageErrorReason.NETWORK,
-                            detail = "SSL error loading the renderer",
-                            code = error?.primaryError
                         )
                     )
                 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -4,9 +4,11 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
+import android.net.http.SslError
 import android.os.Build
 import android.util.AttributeSet
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -47,6 +49,14 @@ internal class EngineWebView @JvmOverloads constructor(
     private val logger = SDKComponent.logger
     private var lastResolvedColorScheme: String? = null
     private var colorSchemeJob: Job? = null
+
+    /**
+     * The renderer document this view loaded.
+     *
+     * `onReceivedSslError` gives no [WebResourceRequest], so this is the only way to tell a
+     * certificate failure on the message itself from one on an image or font it pulls in.
+     */
+    private var documentUrl: String? = null
 
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
 
@@ -191,8 +201,8 @@ internal class EngineWebView @JvmOverloads constructor(
         elapsedTimer.start("Engine render for message: ${configuration.messageId}")
         val messageData = mapOf("options" to configuration)
         val jsonString = Gson().toJson(messageData)
-        val messageUrl =
-            "${state.environment.getGistRendererUrl()}/index.html"
+        val messageUrl = "${state.environment.getGistRendererUrl()}/index.html"
+        documentUrl = messageUrl
         logger.debug("Rendering message with URL: $messageUrl")
         webView?.let {
             it.settings.javaScriptEnabled = true
@@ -255,15 +265,36 @@ internal class EngineWebView @JvmOverloads constructor(
                     )
                 }
 
-                // Deliberately no onReceivedSslError override. The platform default already
-                // cancels the request, which is the behaviour we want and the only part that
-                // matters for safety — we never continue past a certificate error. Overriding it
-                // replaced that default with our own cancel() and reported every failure as a
-                // message-level NETWORK error, including certificate failures on subresources,
-                // which dismissed messages that would have rendered. The callback carries no
-                // WebResourceRequest, so there is no reliable way to tell the document from a
-                // subresource. A certificate failure on the document aborts the main-frame load
-                // and surfaces through onReceivedError below, which is already frame-gated.
+                override fun onReceivedSslError(
+                    view: WebView?,
+                    handler: SslErrorHandler?,
+                    error: SslError?
+                ) {
+                    // Cancel unconditionally, whatever the resource. Overriding this removes the
+                    // platform default's cancel(), so the handler has to be resolved here or the
+                    // request stays suspended, and we never continue past a certificate error.
+                    handler?.cancel()
+
+                    // Reporting is gated separately. This fires for every resource, so a bad
+                    // certificate on an image would otherwise dismiss a renderable message. There
+                    // is no WebResourceRequest here, so the document has to be identified by URL.
+                    //
+                    // We cannot lean on onReceivedError instead: Android only promises
+                    // ERROR_FAILED_SSL_HANDSHAKE for non-recoverable SSL failures, while the
+                    // recoverable ones — expired, untrusted, hostname mismatch — arrive here and
+                    // nowhere else. Dropping this override made those surface as a 5s TIMEOUT.
+                    val failedUrl = error?.url
+                    if (failedUrl == null || failedUrl != documentUrl) return
+
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.NETWORK,
+                            detail = "SSL error loading the renderer",
+                            code = error.primaryError
+                        )
+                    )
+                }
+
                 override fun onReceivedHttpError(
                     view: WebView?,
                     request: WebResourceRequest?,

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -25,6 +25,8 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.gist.utilities.ElapsedTimer
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.type.ColorScheme
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.sdk.core.di.SDKComponent
 import java.util.Timer
@@ -41,7 +43,9 @@ internal class EngineWebView @JvmOverloads constructor(
     private var timerTask: TimerTask? = null
     private var webView: WebView? = null
     private var elapsedTimer: ElapsedTimer = ElapsedTimer()
-    private val engineWebViewInterface = EngineWebViewInterface(this)
+    private val engineWebViewInterface = EngineWebViewInterface(this).apply {
+        onEngineError = { error -> reportFailure(error) }
+    }
     private val logger = SDKComponent.logger
     private var lastResolvedColorScheme: String? = null
     private var colorSchemeJob: Job? = null
@@ -244,7 +248,13 @@ internal class EngineWebView @JvmOverloads constructor(
                     description: String,
                     failingUrl: String?
                 ) {
-                    listener?.error()
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.NETWORK,
+                            detail = description,
+                            code = errorCod
+                        )
+                    )
                 }
 
                 override fun onReceivedHttpError(
@@ -252,7 +262,13 @@ internal class EngineWebView @JvmOverloads constructor(
                     request: WebResourceRequest?,
                     errorResponse: WebResourceResponse?
                 ) {
-                    listener?.error()
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.NETWORK,
+                            detail = errorResponse?.reasonPhrase,
+                            code = errorResponse?.statusCode
+                        )
+                    )
                 }
 
                 override fun onReceivedError(
@@ -260,7 +276,16 @@ internal class EngineWebView @JvmOverloads constructor(
                     request: WebResourceRequest?,
                     error: WebResourceError?
                 ) {
-                    listener?.error()
+                    // description/errorCode are API 23+; below that the deprecated overload above
+                    // is the one the platform calls, and it carries the same detail.
+                    val hasDetail = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.NETWORK,
+                            detail = if (hasDetail) error?.description?.toString() else null,
+                            code = if (hasDetail) error?.errorCode else null
+                        )
+                    )
                 }
 
                 override fun onReceivedSslError(
@@ -268,7 +293,13 @@ internal class EngineWebView @JvmOverloads constructor(
                     handler: SslErrorHandler?,
                     error: SslError?
                 ) {
-                    listener?.error()
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.NETWORK,
+                            detail = "SSL error loading the renderer",
+                            code = error?.primaryError
+                        )
+                    )
                 }
 
                 /**
@@ -289,16 +320,18 @@ internal class EngineWebView @JvmOverloads constructor(
                     } else {
                         null
                     }
-                    logger.error(
-                        "WebView render process gone (didCrash: $didCrash), reporting message failure"
-                    )
                     // Tear the dead view down before reporting. The platform treats it as unusable
                     // once the renderer is gone, and normal teardown cannot do it: releaseResources()
                     // bails out while the view is still attached, and the modal path never calls it
                     // at all. Doing it here also makes the later stopLoading()/releaseResources()
                     // calls on the dismissal path no-ops, since webView is already null.
                     releaseCrashedWebView()
-                    listener?.error()
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.WEB_VIEW_CRASHED,
+                            detail = "WebView render process gone (didCrash: $didCrash)"
+                        )
+                    )
                     return true
                 }
             }
@@ -311,8 +344,12 @@ internal class EngineWebView @JvmOverloads constructor(
         timerTask = object : TimerTask() {
             override fun run() {
                 if (timer != null) {
-                    logger.debug("Message global timeout, cancelling display.")
-                    listener?.error()
+                    reportFailure(
+                        InAppMessageError(
+                            reason = InAppMessageErrorReason.TIMEOUT,
+                            detail = "Engine did not bootstrap within ${TIMEOUT_DURATION}ms"
+                        )
+                    )
                     cleanupTimer()
                 }
             }
@@ -394,6 +431,17 @@ internal class EngineWebView @JvmOverloads constructor(
             .onFailure { logger.error("Error removing crashed WebView from parent: ${it.message}") }
         runCatching { view.destroy() }
             .onFailure { logger.error("Error destroying crashed WebView: ${it.message}") }
+    }
+
+    /**
+     * Single exit for every failure in this view: classify, log, then notify the listener.
+     *
+     * [EngineWebViewListener.error] takes no arguments and is public API, so the classified error
+     * reaches the logs but not the host yet.
+     */
+    private fun reportFailure(error: InAppMessageError) {
+        logger.error("In-app message failed: ${error.describeForLogs()}")
+        listener?.error()
     }
 
     /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -262,6 +262,9 @@ internal class EngineWebView @JvmOverloads constructor(
                     request: WebResourceRequest?,
                     errorResponse: WebResourceResponse?
                 ) {
+                    // Also fired per resource: a 404 on an image is not a message-level failure.
+                    if (request?.isForMainFrame != true) return
+
                     reportFailure(
                         InAppMessageError(
                             reason = InAppMessageErrorReason.NETWORK,
@@ -276,6 +279,12 @@ internal class EngineWebView @JvmOverloads constructor(
                     request: WebResourceRequest?,
                     error: WebResourceError?
                 ) {
+                    // Fired for every resource, not just the page — images, fonts, iframes. Only a
+                    // main-frame failure means the message cannot render; reporting a subresource
+                    // would dismiss a message that was otherwise fine. The deprecated overload
+                    // above is main-frame-only already, so this also keeps API 21-22 consistent.
+                    if (request?.isForMainFrame != true) return
+
                     // description/errorCode are API 23+; below that the deprecated overload above
                     // is the one the platform calls, and it carries the same detail.
                     val hasDetail = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
@@ -293,6 +302,11 @@ internal class EngineWebView @JvmOverloads constructor(
                     handler: SslErrorHandler?,
                     error: SslError?
                 ) {
+                    // Overriding this removed the platform default's cancel(), so the handler has
+                    // to be resolved here or the request stays suspended. Always cancel: the
+                    // renderer is first-party HTTPS and we never continue past a certificate error.
+                    handler?.cancel()
+
                     reportFailure(
                         InAppMessageError(
                             reason = InAppMessageErrorReason.NETWORK,

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
@@ -3,6 +3,8 @@ package io.customer.messaginginapp.gist.presentation.engine
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import com.google.gson.Gson
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.sdk.core.di.SDKComponent
 
 internal data class EngineWebMessage(
@@ -17,6 +19,15 @@ internal data class EngineWebEvent(
 
 class EngineWebViewInterface(private val listener: EngineWebViewListener) {
     private val logger = SDKComponent.logger
+
+    /**
+     * Receives the classified failure for an engine `error` event.
+     *
+     * [EngineWebViewListener.error] takes no arguments and is public API, so it cannot carry the
+     * renderer's own description yet. This internal seam lets the view classify and log it in the
+     * meantime; it goes away once the listener itself can take the error.
+     */
+    internal var onEngineError: ((InAppMessageError) -> Unit)? = null
 
     // Indicates whether the interface is attached to a web view and should continue to process messages
     private var isAttachedToWebView: Boolean = false
@@ -80,8 +91,38 @@ class EngineWebViewInterface(private val listener: EngineWebViewListener) {
                     }
                 }
 
-                "error" -> listener.error()
+                "error" -> {
+                    val reporter = onEngineError
+                    if (reporter != null) {
+                        reporter(
+                            InAppMessageError(
+                                reason = InAppMessageErrorReason.RENDER_FAILED,
+                                detail = parseErrorDetail(eventParameters)
+                            )
+                        )
+                    } else {
+                        listener.error()
+                    }
+                }
             }
+        }
+    }
+
+    /**
+     * Pulls the renderer's own description of a failure out of an `error` event.
+     *
+     * The renderer sends `{ target, errorMessage }` — e.g. `Unable to find "step-2" in payload.`
+     * That string is the only first-hand account of why a message would not render.
+     */
+    private fun parseErrorDetail(parameters: Map<String, Any>): String? {
+        val errorMessage = parameters["errorMessage"] as? String
+        val target = parameters["target"] as? String
+
+        return when {
+            errorMessage != null && target != null -> "$errorMessage (target: $target)"
+            errorMessage != null -> errorMessage
+            target != null -> "Engine reported an error for target: $target"
+            else -> null
         }
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
@@ -1,0 +1,47 @@
+package io.customer.messaginginapp.type
+
+/**
+ * Why an in-app message failed to load or render.
+ *
+ * The entries are deliberately coarse: each maps to a different thing an integrator would do about
+ * it — check connectivity, look at a slow renderer, report the message content to us, or file an
+ * SDK bug. Finer detail belongs in [InAppMessageError.detail].
+ */
+internal enum class InAppMessageErrorReason {
+    /** The renderer could not be reached: navigation failed, TLS failed, or the host errored. */
+    NETWORK,
+
+    /** The renderer was reached but never signalled that it had bootstrapped within the timeout. */
+    TIMEOUT,
+
+    /** The renderer loaded and then reported that it could not render the message. */
+    RENDER_FAILED,
+
+    /** The WebView's render process died, so the message can never finish. */
+    WEB_VIEW_CRASHED,
+
+    /** The SDK itself could not drive the render. */
+    INTERNAL_ERROR
+}
+
+/**
+ * A single in-app message load/render failure, with as much context as the failing layer had.
+ *
+ * @param reason the coarse category; branch on this.
+ * @param detail human-readable detail from the layer that failed — a WebView error description, or
+ * the message the renderer itself reported. Free-form and unstable: log it, don't parse it.
+ * @param code the underlying platform error code where the failing layer had one, e.g. a
+ * [android.webkit.WebResourceError] code or an HTTP status. Null when there was no numeric code.
+ */
+internal data class InAppMessageError(
+    val reason: InAppMessageErrorReason,
+    val detail: String? = null,
+    val code: Int? = null
+) {
+    /** Compact form for logs: `NETWORK (-2): net::ERR_NAME_NOT_RESOLVED` */
+    fun describeForLogs(): String = buildString {
+        append(reason.name)
+        code?.let { append(" ($it)") }
+        detail?.let { append(": $it") }
+    }
+}

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -11,6 +11,8 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.gist.presentation.engine.EngineWebViewListener
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.type.InAppMessage
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.messaginginapp.type.InlineMessageActionListener
 import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate
@@ -239,7 +241,14 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
     }
 
     override fun routeError(route: String) {
-        logViewEvent("Route error: $route")
+        // The renderer has not emitted `routeError` since the 3.0 bundle, so this path is
+        // effectively unreachable today. Classified anyway so it behaves like the live sites if a
+        // future renderer brings it back.
+        val error = InAppMessageError(
+            reason = InAppMessageErrorReason.RENDER_FAILED,
+            detail = "Failed to load route: $route"
+        )
+        logViewEvent("In-app message failed: ${error.describeForLogs()}")
         currentMessage?.let { message ->
             inAppMessagingManager.dispatch(
                 InAppMessagingAction.EngineAction.MessageLoadingFailed(message)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -45,6 +45,10 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
     }
 
+    /** The renderer document the view loads — `GistEnvironment.PROD` in these tests. */
+    private val documentUrl: String
+        get() = "${InAppMessagingState().environment.getGistRendererUrl()}/index.html"
+
     private fun startEngine(): WebView {
         val context = ApplicationProvider.getApplicationContext<Context>()
         engineWebView = EngineWebView(context)
@@ -108,29 +112,63 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         verify(exactly = 0) { listener.error() }
     }
 
-    /**
-     * We deliberately do not override `onReceivedSslError`.
-     *
-     * The platform default cancels the request, which is the only part that matters for safety.
-     * Overriding it replaced that default with our own cancel and reported every certificate
-     * failure as a message-level `NETWORK` error — including failures on subresources, which
-     * dismissed messages that would have rendered. The callback carries no `WebResourceRequest`,
-     * so there is no reliable way to tell the document from a subresource.
-     *
-     * This pins that decision: the request is still refused, and we report nothing ourselves.
-     */
     @Test
-    fun onReceivedSslError_givenCertificateError_expectRequestRefusedAndNothingReported() {
+    fun onReceivedSslError_givenCertificateErrorOnTheDocument_expectRefusedAndReported() {
         val webView = startEngine()
         val handler: SslErrorHandler = mockk(relaxed = true)
-        val sslError: SslError = mockk(relaxed = true) { every { primaryError } returns SslError.SSL_UNTRUSTED }
+        val sslError: SslError = mockk(relaxed = true) {
+            every { primaryError } returns SslError.SSL_UNTRUSTED
+            every { url } returns documentUrl
+        }
 
         Shadows.shadowOf(webView).webViewClient.onReceivedSslError(webView, handler, sslError)
 
-        // Never continue past a certificate error, whoever resolves the handler.
+        verify(exactly = 1) { handler.cancel() }
         verify(exactly = 0) { handler.proceed() }
-        // And a certificate failure on a subresource must not take the message down. A failure on
-        // the document aborts the main-frame load and surfaces through onReceivedError instead.
+        // Recoverable certificate errors arrive here and nowhere else — Android only promises
+        // ERROR_FAILED_SSL_HANDSHAKE for non-recoverable ones — so this is the only chance to
+        // report the real cause instead of letting it fall through to a 5s timeout.
+        verify(exactly = 1) { listener.error() }
+    }
+
+    @Test
+    fun onReceivedSslError_givenCertificateErrorOnSubresource_expectRefusedButNotReported() {
+        val webView = startEngine()
+        val handler: SslErrorHandler = mockk(relaxed = true)
+        val sslError: SslError = mockk(relaxed = true) {
+            every { primaryError } returns SslError.SSL_UNTRUSTED
+            every { url } returns "https://cdn.example.com/hero.png"
+        }
+
+        Shadows.shadowOf(webView).webViewClient.onReceivedSslError(webView, handler, sslError)
+
+        // Refused like any other, but a bad certificate on an image must not take the message down.
+        verify(exactly = 1) { handler.cancel() }
+        verify(exactly = 0) { handler.proceed() }
+        verify(exactly = 0) { listener.error() }
+    }
+
+    /**
+     * The cost of identifying the document by URL, pinned deliberately.
+     *
+     * `onReceivedSslError` carries no [WebResourceRequest], so the document can only be recognised
+     * by comparing URLs. If the main frame redirects, the failing URL no longer matches what we
+     * loaded and the error is refused but not reported, surfacing later as a timeout. The failure
+     * mode is silence rather than a wrong dismissal, which is the safer direction of the two.
+     */
+    @Test
+    fun onReceivedSslError_givenRedirectedMainFrame_expectRefusedButNotReported() {
+        val webView = startEngine()
+        val handler: SslErrorHandler = mockk(relaxed = true)
+        val sslError: SslError = mockk(relaxed = true) {
+            every { primaryError } returns SslError.SSL_IDMISMATCH
+            every { url } returns "https://redirected.example.com/index.html"
+        }
+
+        Shadows.shadowOf(webView).webViewClient.onReceivedSslError(webView, handler, sslError)
+
+        verify(exactly = 1) { handler.cancel() }
+        verify(exactly = 0) { handler.proceed() }
         verify(exactly = 0) { listener.error() }
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -1,0 +1,125 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import android.content.Context
+import android.net.http.SslError
+import android.webkit.SslErrorHandler
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.test.core.app.ApplicationProvider
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.extensions.random
+import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+/**
+ * Covers which `WebViewClient` errors count as a message failure.
+ *
+ * `onReceivedError(view, request, error)` and `onReceivedHttpError` fire for every resource the
+ * page loads — images, fonts, iframes — not just the page itself. Reporting those as message-level
+ * failures dismisses a message that would have rendered fine with one broken asset.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewClientErrorTest : IntegrationTest() {
+
+    private val inAppMessagingManager: InAppMessagingManager = mockk(relaxed = true)
+    private lateinit var listener: EngineWebViewListener
+    private lateinit var engineWebView: EngineWebView
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph { sdk { overrideDependency(inAppMessagingManager) } }
+            }
+        )
+        every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
+    }
+
+    private fun startEngine(): WebView {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        engineWebView = EngineWebView(context)
+        listener = mockk(relaxed = true)
+        engineWebView.listener = listener
+        engineWebView.setup(
+            EngineWebConfiguration(
+                siteId = String.random,
+                dataCenter = String.random,
+                messageId = String.random,
+                instanceId = String.random,
+                endpoint = "https://${String.random}"
+            )
+        )
+        return engineWebView.getChildAt(0) as WebView
+    }
+
+    private fun request(isMainFrame: Boolean): WebResourceRequest =
+        mockk(relaxed = true) { every { isForMainFrame } returns isMainFrame }
+
+    @Test
+    fun onReceivedError_givenMainFrameFailure_expectMessageFailureReported() {
+        val webView = startEngine()
+
+        Shadows.shadowOf(webView).webViewClient
+            .onReceivedError(webView, request(isMainFrame = true), mockk(relaxed = true))
+
+        verify(exactly = 1) { listener.error() }
+    }
+
+    @Test
+    fun onReceivedError_givenSubresourceFailure_expectMessageNotFailed() {
+        val webView = startEngine()
+
+        Shadows.shadowOf(webView).webViewClient
+            .onReceivedError(webView, request(isMainFrame = false), mockk(relaxed = true))
+
+        // A broken image must not take the whole message down.
+        verify(exactly = 0) { listener.error() }
+    }
+
+    @Test
+    fun onReceivedHttpError_givenMainFrameFailure_expectMessageFailureReported() {
+        val webView = startEngine()
+        val response: WebResourceResponse = mockk(relaxed = true) { every { statusCode } returns 503 }
+
+        Shadows.shadowOf(webView).webViewClient
+            .onReceivedHttpError(webView, request(isMainFrame = true), response)
+
+        verify(exactly = 1) { listener.error() }
+    }
+
+    @Test
+    fun onReceivedHttpError_givenSubresourceFailure_expectMessageNotFailed() {
+        val webView = startEngine()
+        val response: WebResourceResponse = mockk(relaxed = true) { every { statusCode } returns 404 }
+
+        Shadows.shadowOf(webView).webViewClient
+            .onReceivedHttpError(webView, request(isMainFrame = false), response)
+
+        verify(exactly = 0) { listener.error() }
+    }
+
+    @Test
+    fun onReceivedSslError_givenCertificateError_expectHandlerCancelledAndFailureReported() {
+        val webView = startEngine()
+        val handler: SslErrorHandler = mockk(relaxed = true)
+        val sslError: SslError = mockk(relaxed = true) { every { primaryError } returns SslError.SSL_UNTRUSTED }
+
+        Shadows.shadowOf(webView).webViewClient.onReceivedSslError(webView, handler, sslError)
+
+        // Overriding this callback removes the platform default's cancel(), so we must resolve the
+        // handler ourselves — and never proceed past a certificate error.
+        verify(exactly = 1) { handler.cancel() }
+        verify(exactly = 0) { handler.proceed() }
+        verify(exactly = 1) { listener.error() }
+    }
+}

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -108,18 +108,29 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         verify(exactly = 0) { listener.error() }
     }
 
+    /**
+     * We deliberately do not override `onReceivedSslError`.
+     *
+     * The platform default cancels the request, which is the only part that matters for safety.
+     * Overriding it replaced that default with our own cancel and reported every certificate
+     * failure as a message-level `NETWORK` error — including failures on subresources, which
+     * dismissed messages that would have rendered. The callback carries no `WebResourceRequest`,
+     * so there is no reliable way to tell the document from a subresource.
+     *
+     * This pins that decision: the request is still refused, and we report nothing ourselves.
+     */
     @Test
-    fun onReceivedSslError_givenCertificateError_expectHandlerCancelledAndFailureReported() {
+    fun onReceivedSslError_givenCertificateError_expectRequestRefusedAndNothingReported() {
         val webView = startEngine()
         val handler: SslErrorHandler = mockk(relaxed = true)
         val sslError: SslError = mockk(relaxed = true) { every { primaryError } returns SslError.SSL_UNTRUSTED }
 
         Shadows.shadowOf(webView).webViewClient.onReceivedSslError(webView, handler, sslError)
 
-        // Overriding this callback removes the platform default's cancel(), so we must resolve the
-        // handler ourselves — and never proceed past a certificate error.
-        verify(exactly = 1) { handler.cancel() }
+        // Never continue past a certificate error, whoever resolves the handler.
         verify(exactly = 0) { handler.proceed() }
-        verify(exactly = 1) { listener.error() }
+        // And a certificate failure on a subresource must not take the message down. A failure on
+        // the document aborts the main-frame load and surfaces through onReceivedError instead.
+        verify(exactly = 0) { listener.error() }
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
@@ -1,0 +1,106 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import com.google.gson.Gson
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.core.RobolectricTest
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers the renderer's own failure description, which the bridge used to drop.
+ *
+ * The 3.0 renderer sends `{ target, errorMessage }` with an `error` event — e.g.
+ * `Unable to find "step-2" in payload.` — and it is the only first-hand account of why a message
+ * would not render. The bridge discarded the whole parameter map and called a no-argument
+ * `listener.error()`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewInterfaceErrorTest : RobolectricTest() {
+
+    private lateinit var received: MutableList<InAppMessageError>
+    private lateinit var engineWebViewInterface: EngineWebViewInterface
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfig)
+        received = mutableListOf()
+        engineWebViewInterface = EngineWebViewInterface(mockk(relaxed = true)).apply {
+            onEngineError = { received.add(it) }
+        }
+        // postMessage ignores everything until the interface is attached to a WebView.
+        attachToWebView()
+    }
+
+    private fun attachToWebView() {
+        engineWebViewInterface.attach(webView = mockk(relaxed = true))
+    }
+
+    private fun postErrorEvent(parameters: Map<String, Any>) {
+        val payload = mapOf(
+            "gist" to mapOf(
+                "instanceId" to "test-instance",
+                "method" to "error",
+                "parameters" to parameters
+            )
+        )
+        engineWebViewInterface.postMessage(Gson().toJson(payload))
+    }
+
+    @Test
+    fun postMessage_givenErrorWithMessageAndTarget_expectBothInDetail() {
+        postErrorEvent(
+            mapOf(
+                "errorMessage" to "Unable to find \"step-2\" in payload.",
+                "target" to "step-2"
+            )
+        )
+
+        received.size shouldBeEqualTo 1
+        received.first().reason shouldBeEqualTo InAppMessageErrorReason.RENDER_FAILED
+        received.first().detail shouldBeEqualTo "Unable to find \"step-2\" in payload. (target: step-2)"
+    }
+
+    @Test
+    fun postMessage_givenErrorWithMessageOnly_expectMessageAsDetail() {
+        postErrorEvent(mapOf("errorMessage" to "Boom"))
+
+        received.single().detail shouldBeEqualTo "Boom"
+    }
+
+    @Test
+    fun postMessage_givenErrorWithTargetOnly_expectTargetDescribed() {
+        postErrorEvent(mapOf("target" to "step-2"))
+
+        received.single().detail shouldBeEqualTo "Engine reported an error for target: step-2"
+    }
+
+    @Test
+    fun postMessage_givenErrorWithoutDetail_expectReasonWithNullDetail() {
+        postErrorEvent(mapOf("ignored" to "value"))
+
+        received.single().reason shouldBeEqualTo InAppMessageErrorReason.RENDER_FAILED
+        received.single().detail.shouldBeNull()
+    }
+
+    @Test
+    fun describeForLogs_givenCodeAndDetail_expectAllThree() {
+        val error = InAppMessageError(
+            reason = InAppMessageErrorReason.NETWORK,
+            detail = "net::ERR_NAME_NOT_RESOLVED",
+            code = -2
+        )
+
+        error.describeForLogs() shouldBeEqualTo "NETWORK (-2): net::ERR_NAME_NOT_RESOLVED"
+    }
+
+    @Test
+    fun describeForLogs_givenReasonOnly_expectReason() {
+        InAppMessageError(reason = InAppMessageErrorReason.TIMEOUT)
+            .describeForLogs() shouldBeEqualTo "TIMEOUT"
+    }
+}


### PR DESCRIPTION
## MBL-2310 · Android stack — step 3 of 4

| Step | PR | |
| --- | --- | --- |
| 1 | #823 — `chore:` emit Java-compatible default methods from messaginginapp interfaces | enables step 4 |
| 2 | #826 — `chore:` report WebView render process termination as an in-app failure |  |
| **3** | **#827 — `chore:` classify and log in-app message failures internally** | **← you are here** |
| 4 | #828 — `fix:` surface the failure reason on `errorWithMessage` | cuts the Android release |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**iOS mirror:** customerio/customerio-ios#1231 → customerio/customerio-ios#1237 → customerio/customerio-ios#1238. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Gives every in-app failure a reason and keeps the detail the SDK was throwing away. Internal only — `apiDump` is unchanged.

Stacked on #826. The Android mirror of ios#1237. Groundwork for MBL-2310; the next PR puts the reason on `errorWithMessage`.

### Why

Every failure site in `EngineWebView` collapsed into a bare `listener?.error()`, so why a message failed survived only in whatever each site happened to log. The richest sources were dropped outright:

- **The renderer's own `errorMessage`.** The 3.0 bundle sends `{ target, errorMessage }` with the engine `error` event — e.g. `Unable to find "step-2" in payload.` The bridge discarded the whole parameter map.
- **Everything the four `WebViewClient` error callbacks hand us**: `WebResourceError` code and description, the HTTP status from `onReceivedHttpError`, and `SslError.primaryError`.

### Change

An internal `InAppMessageError` (`reason`, `detail`, `code`) with five coarse reasons — `NETWORK`, `TIMEOUT`, `RENDER_FAILED`, `WEB_VIEW_CRASHED`, `INTERNAL_ERROR` — matching iOS exactly.

All sites now route through one `reportFailure` choke point that classifies and logs before notifying the listener, so the next PR changes the hand-off in one place.

`InAppMessageViewController.routeError` is classified too, though renderer 3.0 never emits `routeError` — noted in a comment so nobody counts it as live coverage.

### The internal seam

`EngineWebViewListener.error()` takes no arguments and **is public API** (`messaginginapp.api:201`), as is `EngineWebViewInterface` itself. So the bridge cannot hand the parsed detail over through the listener yet. It goes through an `internal var onEngineError` instead — deliberately temporary, and it disappears when the listener can take the error in the `fix:` PR.

Same constraint iOS hit with `EngineWebDelegate`, so both platforms split the same way.

### Verification

`EngineWebViewInterfaceErrorTest` drives real JSON through `postMessage` — the actual bridge entry point — and covers all four `errorMessage`/`target` combinations plus log formatting.

- `:messaginginapp:testDebugUnitTest` green, 6 new tests.
- `:messaginginapp:lintDebug` green.
- `./gradlew apiDump` produces **no diff** — every new declaration is `internal` or `private`.
