### PR TITLE
fix: surface the failure reason on in-app error callback

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -31,6 +31,7 @@ public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer
 	public static final fun instance ()Lio/customer/messaginginapp/ModuleMessagingInApp;
 	public fun onAction (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun onError (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	public fun onError (Lio/customer/messaginginapp/gist/data/model/Message;Lio/customer/messaginginapp/type/InAppMessageError;)V
 	public fun onMessageCancelled (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public fun onMessageDismissed (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
@@ -184,9 +185,14 @@ public abstract interface class io/customer/messaginginapp/gist/presentation/Gis
 	public abstract fun embedMessage (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;)V
 	public abstract fun onAction (Lio/customer/messaginginapp/gist/data/model/Message;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun onError (Lio/customer/messaginginapp/gist/data/model/Message;)V
+	public fun onError (Lio/customer/messaginginapp/gist/data/model/Message;Lio/customer/messaginginapp/type/InAppMessageError;)V
 	public abstract fun onMessageCancelled (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public abstract fun onMessageDismissed (Lio/customer/messaginginapp/gist/data/model/Message;)V
 	public abstract fun onMessageShown (Lio/customer/messaginginapp/gist/data/model/Message;)V
+}
+
+public final class io/customer/messaginginapp/gist/presentation/GistListener$DefaultImpls {
+	public static fun onError (Lio/customer/messaginginapp/gist/presentation/GistListener;Lio/customer/messaginginapp/gist/data/model/Message;Lio/customer/messaginginapp/type/InAppMessageError;)V
 }
 
 public final class io/customer/messaginginapp/gist/presentation/GistModalActivity$Companion {
@@ -201,11 +207,16 @@ public final class io/customer/messaginginapp/gist/presentation/engine/EngineWeb
 public abstract interface class io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener {
 	public abstract fun bootstrapped ()V
 	public abstract fun error ()V
+	public fun error (Lio/customer/messaginginapp/type/InAppMessageError;)V
 	public abstract fun routeChanged (Ljava/lang/String;)V
 	public abstract fun routeError (Ljava/lang/String;)V
 	public abstract fun routeLoaded (Ljava/lang/String;)V
 	public abstract fun sizeChanged (DD)V
 	public abstract fun tap (Ljava/lang/String;Ljava/lang/String;Z)V
+}
+
+public final class io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener$DefaultImpls {
+	public static fun error (Lio/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener;Lio/customer/messaginginapp/type/InAppMessageError;)V
 }
 
 public final class io/customer/messaginginapp/gist/utilities/ElapsedTimer {
@@ -250,9 +261,14 @@ public final class io/customer/messaginginapp/type/ColorScheme : java/lang/Enum 
 
 public abstract interface class io/customer/messaginginapp/type/InAppEventListener {
 	public abstract fun errorWithMessage (Lio/customer/messaginginapp/type/InAppMessage;)V
+	public fun errorWithMessage (Lio/customer/messaginginapp/type/InAppMessage;Lio/customer/messaginginapp/type/InAppMessageError;)V
 	public abstract fun messageActionTaken (Lio/customer/messaginginapp/type/InAppMessage;Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun messageDismissed (Lio/customer/messaginginapp/type/InAppMessage;)V
 	public abstract fun messageShown (Lio/customer/messaginginapp/type/InAppMessage;)V
+}
+
+public final class io/customer/messaginginapp/type/InAppEventListener$DefaultImpls {
+	public static fun errorWithMessage (Lio/customer/messaginginapp/type/InAppEventListener;Lio/customer/messaginginapp/type/InAppMessage;Lio/customer/messaginginapp/type/InAppMessageError;)V
 }
 
 public final class io/customer/messaginginapp/type/InAppMessage {
@@ -272,6 +288,34 @@ public final class io/customer/messaginginapp/type/InAppMessage {
 }
 
 public final class io/customer/messaginginapp/type/InAppMessage$Companion {
+}
+
+public final class io/customer/messaginginapp/type/InAppMessageError {
+	public fun <init> (Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;)Lio/customer/messaginginapp/type/InAppMessageError;
+	public static synthetic fun copy$default (Lio/customer/messaginginapp/type/InAppMessageError;Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/customer/messaginginapp/type/InAppMessageError;
+	public final fun describeForLogs ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/Integer;
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getReason ()Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/customer/messaginginapp/type/InAppMessageErrorReason : java/lang/Enum {
+	public static final field INTERNAL_ERROR Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static final field NETWORK Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static final field RENDER_FAILED Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static final field TIMEOUT Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static final field WEB_VIEW_CRASHED Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/customer/messaginginapp/type/InAppMessageErrorReason;
+	public static fun values ()[Lio/customer/messaginginapp/type/InAppMessageErrorReason;
 }
 
 public final class io/customer/messaginginapp/type/InAppMessageKt {

--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -298,7 +298,6 @@ public final class io/customer/messaginginapp/type/InAppMessageError {
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun copy (Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;)Lio/customer/messaginginapp/type/InAppMessageError;
 	public static synthetic fun copy$default (Lio/customer/messaginginapp/type/InAppMessageError;Lio/customer/messaginginapp/type/InAppMessageErrorReason;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/customer/messaginginapp/type/InAppMessageError;
-	public final fun describeForLogs ()Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCode ()Ljava/lang/Integer;
 	public final fun getDetail ()Ljava/lang/String;

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ModuleMessagingInApp.kt
@@ -14,6 +14,8 @@ import io.customer.messaginginapp.inbox.VisualInbox
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.type.InAppMessage
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.messaginginapp.type.InboxEventListener
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.subscribe
@@ -151,8 +153,18 @@ class ModuleMessagingInApp(
     override fun onMessageCancelled(message: Message) {}
 
     override fun onError(message: Message) {
-        logger.error("Error occurred on message: $message")
-        moduleConfig.eventListener?.errorWithMessage(InAppMessage.getFromGistMessage(message))
+        onError(
+            message = message,
+            error = InAppMessageError(reason = InAppMessageErrorReason.INTERNAL_ERROR)
+        )
+    }
+
+    override fun onError(message: Message, error: InAppMessageError) {
+        logger.error("Error occurred on message: $message — ${error.describeForLogs()}")
+        moduleConfig.eventListener?.errorWithMessage(
+            InAppMessage.getFromGistMessage(message),
+            error
+        )
     }
 
     override fun onAction(message: Message, currentRoute: String, action: String, name: String) {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/GistSdk.kt
@@ -11,6 +11,7 @@ import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.state.ModalMessageState
 import io.customer.messaginginapp.store.InAppPreferenceStore
 import io.customer.messaginginapp.type.ColorScheme
+import io.customer.messaginginapp.type.InAppMessageError
 import io.customer.sdk.core.di.SDKComponent
 
 internal interface GistProvider {
@@ -96,5 +97,12 @@ interface GistListener {
     fun onMessageDismissed(message: Message)
     fun onMessageCancelled(message: Message)
     fun onError(message: Message)
+
+    /**
+     * Called when a message fails to load or render, with the reason it failed.
+     *
+     * Defaulted so implementations written against the reason-less callback keep compiling.
+     */
+    fun onError(message: Message, error: InAppMessageError) = onError(message)
     fun onAction(message: Message, currentRoute: String, action: String, name: String)
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -56,6 +56,12 @@ internal class EngineWebView @JvmOverloads constructor(
      */
     private var documentUrl: String? = null
 
+    /**
+     * Set once the first failure is reported. An engine renders one message, so it fails at most
+     * once.
+     */
+    private var hasReportedFailure = false
+
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
 
     private val state: InAppMessagingState
@@ -472,6 +478,15 @@ internal class EngineWebView @JvmOverloads constructor(
      * Single exit for every failure in this view: classify, then notify the listener.
      */
     private fun reportFailure(error: InAppMessageError) {
+        // First failure wins, and the latch — not the cancel — is what makes that deterministic.
+        // The bootstrap TimerTask runs independently of the WebView callbacks, so cancelling the
+        // timer alone still races with a task that has already started. Without this the host could
+        // be told NETWORK and then TIMEOUT about the same message, the second overwriting the real
+        // cause. Mirrors the same guard on iOS.
+        if (hasReportedFailure) return
+        hasReportedFailure = true
+        cleanupTimer()
+
         val listener = this.listener
         if (listener == null) {
             // Nothing downstream will see this one, so it has to be logged here. The timeout timer

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -472,11 +472,16 @@ internal class EngineWebView @JvmOverloads constructor(
      * Single exit for every failure in this view: classify, then notify the listener.
      */
     private fun reportFailure(error: InAppMessageError) {
-        // Not logged here any more. In the previous step this log was the only place the
-        // classification surfaced, because the listener could not carry it. Now that it can, the
-        // controller logs the same failure with the message id and route attached, so logging in
-        // both places would double up on every failure.
-        listener?.error(error)
+        val listener = this.listener
+        if (listener == null) {
+            // Nothing downstream will see this one, so it has to be logged here. The timeout timer
+            // can still fire after the view is detached and the listener cleared.
+            logger.error("In-app message failed with no listener attached: ${error.describeForLogs()}")
+            return
+        }
+        // Deliberately not logged on this path: the controller logs the same failure straight after,
+        // with the message id and route attached, so logging here too would double up on every one.
+        listener.error(error)
     }
 
     /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -43,9 +43,7 @@ internal class EngineWebView @JvmOverloads constructor(
     private var timerTask: TimerTask? = null
     private var webView: WebView? = null
     private var elapsedTimer: ElapsedTimer = ElapsedTimer()
-    private val engineWebViewInterface = EngineWebViewInterface(this).apply {
-        onEngineError = { error -> reportFailure(error) }
-    }
+    private val engineWebViewInterface = EngineWebViewInterface(this)
     private val logger = SDKComponent.logger
     private var lastResolvedColorScheme: String? = null
     private var colorSchemeJob: Job? = null
@@ -439,6 +437,10 @@ internal class EngineWebView @JvmOverloads constructor(
         listener?.error()
     }
 
+    override fun error(error: InAppMessageError) {
+        reportFailure(error)
+    }
+
     /**
      * Tears down a WebView whose render process has died.
      *
@@ -468,13 +470,10 @@ internal class EngineWebView @JvmOverloads constructor(
 
     /**
      * Single exit for every failure in this view: classify, log, then notify the listener.
-     *
-     * [EngineWebViewListener.error] takes no arguments and is public API, so the classified error
-     * reaches the logs but not the host yet.
      */
     private fun reportFailure(error: InAppMessageError) {
         logger.error("In-app message failed: ${error.describeForLogs()}")
-        listener?.error()
+        listener?.error(error)
     }
 
     /**

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -469,10 +469,13 @@ internal class EngineWebView @JvmOverloads constructor(
     }
 
     /**
-     * Single exit for every failure in this view: classify, log, then notify the listener.
+     * Single exit for every failure in this view: classify, then notify the listener.
      */
     private fun reportFailure(error: InAppMessageError) {
-        logger.error("In-app message failed: ${error.describeForLogs()}")
+        // Not logged here any more. In the previous step this log was the only place the
+        // classification surfaced, because the listener could not carry it. Now that it can, the
+        // controller logs the same failure with the message id and route attached, so logging in
+        // both places would double up on every failure.
         listener?.error(error)
     }
 

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebView.kt
@@ -31,6 +31,7 @@ import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.sdk.core.di.SDKComponent
 import java.util.Timer
 import java.util.TimerTask
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Job
 
 internal class EngineWebView @JvmOverloads constructor(
@@ -59,8 +60,13 @@ internal class EngineWebView @JvmOverloads constructor(
     /**
      * Set once the first failure is reported. An engine renders one message, so it fails at most
      * once.
+     *
+     * Atomic because three threads reach [reportFailure]: the bootstrap [TimerTask] on the timer's
+     * own thread, renderer errors on the WebView's JS bridge thread, and [WebViewClient] callbacks
+     * on the UI thread. A plain read-then-write lets two of them both observe false and both
+     * notify, and a non-volatile field gives no guarantee the write is ever seen by the others.
      */
-    private var hasReportedFailure = false
+    private val hasReportedFailure = AtomicBoolean(false)
 
     private val inAppMessagingManager = SDKComponent.inAppMessagingManager
 
@@ -482,9 +488,9 @@ internal class EngineWebView @JvmOverloads constructor(
         // The bootstrap TimerTask runs independently of the WebView callbacks, so cancelling the
         // timer alone still races with a task that has already started. Without this the host could
         // be told NETWORK and then TIMEOUT about the same message, the second overwriting the real
-        // cause. Mirrors the same guard on iOS.
-        if (hasReportedFailure) return
-        hasReportedFailure = true
+        // cause. The compare-and-set has to be atomic because those callers are on different
+        // threads; iOS can use a plain flag only because everything there is on the main thread.
+        if (!hasReportedFailure.compareAndSet(false, true)) return
         cleanupTimer()
 
         val listener = this.listener

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
@@ -49,6 +49,18 @@ class EngineWebViewInterface(private val listener: EngineWebViewListener) {
 
         logger.debug("Received event from WebView: $event")
 
+        // Handled before the parameters guard below: a failure has to reach the host even when the
+        // renderer sends no detail with it. Every other event is meaningless without its parameters.
+        if (event.gist.method == "error") {
+            listener.error(
+                InAppMessageError(
+                    reason = InAppMessageErrorReason.RENDER_FAILED,
+                    detail = event.gist.parameters?.let(::parseErrorDetail)
+                )
+            )
+            return
+        }
+
         event.gist.parameters?.let { eventParameters ->
             when (event.gist.method) {
                 "bootstrapped" -> listener.bootstrapped()
@@ -81,13 +93,6 @@ class EngineWebViewInterface(private val listener: EngineWebViewListener) {
                         }
                     }
                 }
-
-                "error" -> listener.error(
-                    InAppMessageError(
-                        reason = InAppMessageErrorReason.RENDER_FAILED,
-                        detail = parseErrorDetail(eventParameters)
-                    )
-                )
             }
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterface.kt
@@ -20,15 +20,6 @@ internal data class EngineWebEvent(
 class EngineWebViewInterface(private val listener: EngineWebViewListener) {
     private val logger = SDKComponent.logger
 
-    /**
-     * Receives the classified failure for an engine `error` event.
-     *
-     * [EngineWebViewListener.error] takes no arguments and is public API, so it cannot carry the
-     * renderer's own description yet. This internal seam lets the view classify and log it in the
-     * meantime; it goes away once the listener itself can take the error.
-     */
-    internal var onEngineError: ((InAppMessageError) -> Unit)? = null
-
     // Indicates whether the interface is attached to a web view and should continue to process messages
     private var isAttachedToWebView: Boolean = false
 
@@ -91,19 +82,12 @@ class EngineWebViewInterface(private val listener: EngineWebViewListener) {
                     }
                 }
 
-                "error" -> {
-                    val reporter = onEngineError
-                    if (reporter != null) {
-                        reporter(
-                            InAppMessageError(
-                                reason = InAppMessageErrorReason.RENDER_FAILED,
-                                detail = parseErrorDetail(eventParameters)
-                            )
-                        )
-                    } else {
-                        listener.error()
-                    }
-                }
+                "error" -> listener.error(
+                    InAppMessageError(
+                        reason = InAppMessageErrorReason.RENDER_FAILED,
+                        detail = parseErrorDetail(eventParameters)
+                    )
+                )
             }
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewListener.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.gist.presentation.engine
 
+import io.customer.messaginginapp.type.InAppMessageError
+
 interface EngineWebViewListener {
     fun bootstrapped()
     fun tap(name: String, action: String, system: Boolean)
@@ -8,4 +10,11 @@ interface EngineWebViewListener {
     fun routeLoaded(route: String)
     fun sizeChanged(width: Double, height: Double)
     fun error()
+
+    /**
+     * Called when a message fails to load or render, with the reason it failed.
+     *
+     * Defaulted so implementations written against the reason-less callback keep compiling.
+     */
+    fun error(error: InAppMessageError) = error()
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingAction.kt
@@ -5,6 +5,7 @@ import io.customer.messaginginapp.gist.data.model.InboxMessage
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.MessagePosition
 import io.customer.messaginginapp.type.ColorScheme
+import io.customer.messaginginapp.type.InAppMessageError
 
 internal sealed class InAppMessagingAction {
     data class Initialize(val siteId: String, val dataCenter: String, val environment: GistEnvironment, val colorScheme: ColorScheme = ColorScheme.AUTO) : InAppMessagingAction()
@@ -25,7 +26,10 @@ internal sealed class InAppMessagingAction {
 
     sealed class EngineAction {
         data class Tap(val message: Message, val route: String, val name: String, val action: String) : InAppMessagingAction()
-        data class MessageLoadingFailed(val message: Message) : InAppMessagingAction()
+        data class MessageLoadingFailed(
+            val message: Message,
+            val error: InAppMessageError
+        ) : InAppMessagingAction()
     }
 
     sealed class InboxAction(open val message: InboxMessage) : InAppMessagingAction() {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/state/InAppMessagingMiddlewares.kt
@@ -341,7 +341,7 @@ internal fun gistListenerMiddleware(gistListener: GistListener?) = middleware<In
         }
 
         is InAppMessagingAction.EngineAction.MessageLoadingFailed -> {
-            gistListener?.onError(action.message)
+            gistListener?.onError(action.message, action.error)
         }
 
         is InAppMessagingAction.EngineAction.Tap -> {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppEventListener.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppEventListener.kt
@@ -4,5 +4,15 @@ interface InAppEventListener {
     fun messageShown(message: InAppMessage)
     fun messageDismissed(message: InAppMessage)
     fun errorWithMessage(message: InAppMessage)
+
+    /**
+     * Called when an in-app message fails to load or render, with the reason it failed.
+     *
+     * Prefer this over [errorWithMessage]. Branch on [InAppMessageError.reason];
+     * [InAppMessageError.detail] is diagnostic text meant for logs, not for parsing.
+     *
+     * Defaulted so listeners written before the reason existed keep compiling and keep working.
+     */
+    fun errorWithMessage(message: InAppMessage, error: InAppMessageError) = errorWithMessage(message)
     fun messageActionTaken(message: InAppMessage, actionValue: String, actionName: String)
 }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
@@ -38,8 +38,12 @@ data class InAppMessageError(
     val detail: String? = null,
     val code: Int? = null
 ) {
-    /** Compact form for logs: `NETWORK (-2): net::ERR_NAME_NOT_RESOLVED` */
-    fun describeForLogs(): String = buildString {
+    /**
+     * Compact form for logs: `NETWORK (-2): net::ERR_NAME_NOT_RESOLVED`
+     *
+     * Internal: hosts should read [reason], [detail] and [code] rather than depend on this format.
+     */
+    internal fun describeForLogs(): String = buildString {
         append(reason.name)
         code?.let { append(" ($it)") }
         detail?.let { append(": $it") }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
@@ -7,7 +7,7 @@ package io.customer.messaginginapp.type
  * it — check connectivity, look at a slow renderer, report the message content to us, or file an
  * SDK bug. Finer detail belongs in [InAppMessageError.detail].
  */
-internal enum class InAppMessageErrorReason {
+enum class InAppMessageErrorReason {
     /** The renderer could not be reached: navigation failed, TLS failed, or the host errored. */
     NETWORK,
 
@@ -33,7 +33,7 @@ internal enum class InAppMessageErrorReason {
  * @param code the underlying platform error code where the failing layer had one, e.g. a
  * [android.webkit.WebResourceError] code or an HTTP status. Null when there was no numeric code.
  */
-internal data class InAppMessageError(
+data class InAppMessageError(
     val reason: InAppMessageErrorReason,
     val detail: String? = null,
     val code: Int? = null

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/InAppMessageError.kt
@@ -6,6 +6,10 @@ package io.customer.messaginginapp.type
  * The entries are deliberately coarse: each maps to a different thing an integrator would do about
  * it — check connectivity, look at a slow renderer, report the message content to us, or file an
  * SDK bug. Finer detail belongs in [InAppMessageError.detail].
+ *
+ * **Keep a fallback branch when you switch on this.** More reasons may be added in future releases,
+ * and an exhaustive `when` expression over this enum will stop compiling when that happens. An
+ * `else ->` branch keeps your listener building across SDK upgrades.
  */
 enum class InAppMessageErrorReason {
     /** The renderer could not be reached: navigation failed, TLS failed, or the host errored. */
@@ -29,7 +33,9 @@ enum class InAppMessageErrorReason {
  *
  * @param reason the coarse category; branch on this.
  * @param detail human-readable detail from the layer that failed — a WebView error description, or
- * the message the renderer itself reported. Free-form and unstable: log it, don't parse it.
+ * the message the renderer itself reported. Free-form, unstable, and partly renderer-supplied, so
+ * treat it as **local diagnostics only**: write it to your logs, don't parse it, and don't forward
+ * it verbatim to analytics or crash reporting. Branch on [reason] instead.
  * @param code the underlying platform error code where the failing layer had one, e.g. a
  * [android.webkit.WebResourceError] code or an HTTP status. Null when there was no numeric code.
  */

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/ui/controller/InAppMessageViewController.kt
@@ -248,12 +248,7 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
             reason = InAppMessageErrorReason.RENDER_FAILED,
             detail = "Failed to load route: $route"
         )
-        logViewEvent("In-app message failed: ${error.describeForLogs()}")
-        currentMessage?.let { message ->
-            inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
-            )
-        }
+        this.error(error)
     }
 
     final override fun routeLoaded(route: String) {
@@ -274,10 +269,25 @@ internal abstract class InAppMessageViewController<ViewCallback : InAppMessageVi
     }
 
     override fun error() {
-        logViewEvent("Error loading engine for message: ${currentMessage?.messageId} on route: $currentRoute")
+        // Only reachable from an implementation that predates the classified callback. EngineWebView
+        // always classifies, so treat an unlabelled failure as an SDK-side gap rather than inventing
+        // a cause.
+        error(
+            InAppMessageError(
+                reason = InAppMessageErrorReason.INTERNAL_ERROR,
+                detail = "Engine reported a failure with no reason"
+            )
+        )
+    }
+
+    override fun error(error: InAppMessageError) {
+        logViewEvent(
+            "In-app message ${currentMessage?.messageId} failed on route $currentRoute: " +
+                error.describeForLogs()
+        )
         currentMessage?.let { message ->
             inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(message, error)
             )
         }
     }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.assertNoInteractions
@@ -352,9 +354,14 @@ class InAppMessagingStoreTest : IntegrationTest() {
         initializeAndSetUser()
         val message = createInAppMessage(queueId = "1")
 
-        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(message))
+        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(message, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)))
 
-        verify { inAppEventListener.errorWithMessage(InAppMessage.getFromGistMessage(message)) }
+        verify {
+            inAppEventListener.errorWithMessage(
+                InAppMessage.getFromGistMessage(message),
+                InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)
+            )
+        }
     }
 
     @Test
@@ -378,9 +385,14 @@ class InAppMessagingStoreTest : IntegrationTest() {
         initializeAndSetUser()
         val message = createInAppMessage(queueId = "1")
 
-        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(message))
+        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(message, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)))
 
-        verify { inAppEventListener.errorWithMessage(InAppMessage.getFromGistMessage(message)) }
+        verify {
+            inAppEventListener.errorWithMessage(
+                InAppMessage.getFromGistMessage(message),
+                InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)
+            )
+        }
     }
 
     @Test

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/InAppMessagingStoreTest.kt
@@ -1,7 +1,5 @@
 package io.customer.messaginginapp
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.core.TestConstants
 import io.customer.commontest.extensions.assertNoInteractions
@@ -20,6 +18,8 @@ import io.customer.messaginginapp.testutils.extension.pageRuleContains
 import io.customer.messaginginapp.testutils.extension.pageRuleEquals
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.messaginginapp.type.InAppMessage
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.model.Region
 import io.mockk.Called

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -76,7 +76,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         Shadows.shadowOf(webView).webViewClient
             .onReceivedError(webView, request(isMainFrame = true), mockk(relaxed = true))
 
-        verify(exactly = 1) { listener.error() }
+        verify(exactly = 1) { listener.error(any()) }
     }
 
     @Test
@@ -87,6 +87,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
             .onReceivedError(webView, request(isMainFrame = false), mockk(relaxed = true))
 
         // A broken image must not take the whole message down.
+        verify(exactly = 0) { listener.error(any()) }
         verify(exactly = 0) { listener.error() }
     }
 
@@ -98,7 +99,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         Shadows.shadowOf(webView).webViewClient
             .onReceivedHttpError(webView, request(isMainFrame = true), response)
 
-        verify(exactly = 1) { listener.error() }
+        verify(exactly = 1) { listener.error(any()) }
     }
 
     @Test
@@ -109,6 +110,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         Shadows.shadowOf(webView).webViewClient
             .onReceivedHttpError(webView, request(isMainFrame = false), response)
 
+        verify(exactly = 0) { listener.error(any()) }
         verify(exactly = 0) { listener.error() }
     }
 
@@ -169,6 +171,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
 
         verify(exactly = 1) { handler.cancel() }
         verify(exactly = 0) { handler.proceed() }
+        verify(exactly = 0) { listener.error(any()) }
         verify(exactly = 0) { listener.error() }
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -130,7 +130,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         // Recoverable certificate errors arrive here and nowhere else — Android only promises
         // ERROR_FAILED_SSL_HANDSHAKE for non-recoverable ones — so this is the only chance to
         // report the real cause instead of letting it fall through to a 5s timeout.
-        verify(exactly = 1) { listener.error() }
+        verify(exactly = 1) { listener.error(any()) }
     }
 
     @Test
@@ -147,6 +147,7 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         // Refused like any other, but a bad certificate on an image must not take the message down.
         verify(exactly = 1) { handler.cancel() }
         verify(exactly = 0) { handler.proceed() }
+        verify(exactly = 0) { listener.error(any()) }
         verify(exactly = 0) { listener.error() }
     }
 

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewClientErrorTest.kt
@@ -14,9 +14,13 @@ import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.state.InAppMessagingState
 import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -174,5 +178,28 @@ class EngineWebViewClientErrorTest : IntegrationTest() {
         verify(exactly = 0) { handler.proceed() }
         verify(exactly = 0) { listener.error(any()) }
         verify(exactly = 0) { listener.error() }
+    }
+
+    /**
+     * An engine renders one message, so it fails at most once.
+     *
+     * The bootstrap `TimerTask` runs independently of the WebView callbacks, so a real failure
+     * followed by a delayed teardown could report `NETWORK` and then a second `TIMEOUT`, the latter
+     * overwriting the true cause. Cancelling the timer alone is not enough — it races with a task
+     * that has already started — so the latch is the guard and the cancel is belt-and-braces.
+     */
+    @Test
+    fun reportFailure_givenSecondFailure_expectOnlyTheFirstReported() {
+        val webView = startEngine()
+        val client = Shadows.shadowOf(webView).webViewClient
+        val captured = slot<InAppMessageError>()
+
+        // A network failure on the document, then the renderer dying underneath it.
+        client.onReceivedError(webView, request(isMainFrame = true), mockk(relaxed = true))
+        client.onRenderProcessGone(webView, null)
+
+        verify(exactly = 1) { listener.error(capture(captured)) }
+        // The first cause is the true one; anything after it is a consequence.
+        captured.captured.reason shouldBeEqualTo InAppMessageErrorReason.NETWORK
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewConcurrentFailureTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewConcurrentFailureTest.kt
@@ -1,0 +1,117 @@
+package io.customer.messaginginapp.gist.presentation.engine
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers the first-failure latch under concurrency.
+ *
+ * Three threads reach `reportFailure`: the bootstrap `TimerTask` on the timer's own thread,
+ * renderer errors on the WebView's JS bridge thread, and `WebViewClient` callbacks on the UI
+ * thread. The latch started life as a plain `var` read-then-write, mirroring iOS — but iOS only
+ * ever touches it from the main thread, so the plain flag was safe there and not here. Two callers
+ * could both read false and both notify, handing the host two different reasons for one message.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EngineWebViewConcurrentFailureTest : IntegrationTest() {
+
+    private val inAppMessagingManager: InAppMessagingManager = mockk(relaxed = true)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                diGraph {
+                    sdk {
+                        overrideDependency(inAppMessagingManager)
+                    }
+                }
+            }
+        )
+        every { inAppMessagingManager.getCurrentState() } returns InAppMessagingState()
+    }
+
+    /**
+     * Records every failure the host is told about, from whichever thread delivers it.
+     */
+    private class RecordingListener : EngineWebViewListener {
+        val delivered = CopyOnWriteArrayList<InAppMessageError>()
+
+        override fun error(error: InAppMessageError) {
+            delivered.add(error)
+        }
+
+        override fun error() = Unit
+        override fun bootstrapped() = Unit
+        override fun tap(name: String, action: String, system: Boolean) = Unit
+        override fun routeChanged(newRoute: String) = Unit
+        override fun routeError(route: String) = Unit
+        override fun routeLoaded(route: String) = Unit
+        override fun sizeChanged(width: Double, height: Double) = Unit
+    }
+
+    @Test
+    fun reportFailure_givenSimultaneousFailures_expectExactlyOneReachesHost() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // A single pass can win the race by luck, so repeat over fresh engines and assert on the
+        // whole run. Against a plain read-then-write flag this fails well inside the first few.
+        val engines = 40
+        val threadsPerEngine = 8
+        val duplicated = mutableListOf<List<InAppMessageError>>()
+
+        repeat(engines) {
+            val engineWebView = EngineWebView(context)
+            val listener = RecordingListener()
+            engineWebView.listener = listener
+
+            // Every thread waits here, so they contend on the latch rather than arriving in turn.
+            val barrier = CyclicBarrier(threadsPerEngine)
+            val threads = (0 until threadsPerEngine).map { index ->
+                Thread {
+                    barrier.await(10, TimeUnit.SECONDS)
+                    engineWebView.error(
+                        InAppMessageError(
+                            reason = reasons[index % reasons.size],
+                            detail = "failure from thread $index"
+                        )
+                    )
+                }
+            }
+
+            threads.forEach(Thread::start)
+            threads.forEach { it.join(TimeUnit.SECONDS.toMillis(10)) }
+
+            if (listener.delivered.size != 1) {
+                duplicated.add(listener.delivered.toList())
+            }
+        }
+
+        // An engine renders one message, so the host hears about one failure — never a real cause
+        // followed by a second thread's TIMEOUT overwriting it.
+        duplicated shouldBeEqualTo emptyList()
+    }
+
+    private companion object {
+        val reasons = listOf(
+            InAppMessageErrorReason.TIMEOUT,
+            InAppMessageErrorReason.NETWORK,
+            InAppMessageErrorReason.RENDER_FAILED,
+            InAppMessageErrorReason.WEB_VIEW_CRASHED
+        )
+    }
+}

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
@@ -103,6 +103,28 @@ class EngineWebViewInterfaceErrorTest : RobolectricTest() {
         received.single().detail.shouldBeNull()
     }
 
+    /**
+     * The renderer always sends `{ target, errorMessage }` today, but a failure must still reach the
+     * host if it ever arrives bare. iOS already behaves this way — its `error` case sits outside any
+     * parameters guard — so dropping it here would put the two platforms out of step on the one path
+     * this work exists to protect.
+     */
+    @Test
+    fun postMessage_givenErrorWithNoParametersAtAll_expectStillReported() {
+        val payload = mapOf(
+            "gist" to mapOf(
+                "instanceId" to "test-instance",
+                "method" to "error"
+            )
+        )
+
+        engineWebViewInterface.postMessage(Gson().toJson(payload))
+
+        received.size shouldBeEqualTo 1
+        received.single().reason shouldBeEqualTo InAppMessageErrorReason.RENDER_FAILED
+        received.single().detail.shouldBeNull()
+    }
+
     @Test
     fun postMessage_givenError_expectClassifiedOverloadUsedNotTheReasonLessOne() {
         postErrorEvent(mapOf("errorMessage" to "Boom"))

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
@@ -23,7 +23,9 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class EngineWebViewInterfaceErrorTest : RobolectricTest() {
 
-    /// Captures what the bridge hands to the listener, which is the real production path.
+    /**
+     * Captures what the bridge hands to the listener, which is the real production path.
+     */
     private class RecordingListener : EngineWebViewListener {
         val received = mutableListOf<InAppMessageError>()
         var reasonLessCallCount = 0

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewInterfaceErrorTest.kt
@@ -23,15 +23,29 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class EngineWebViewInterfaceErrorTest : RobolectricTest() {
 
-    private lateinit var received: MutableList<InAppMessageError>
+    /// Captures what the bridge hands to the listener, which is the real production path.
+    private class RecordingListener : EngineWebViewListener {
+        val received = mutableListOf<InAppMessageError>()
+        var reasonLessCallCount = 0
+
+        override fun bootstrapped() {}
+        override fun tap(name: String, action: String, system: Boolean) {}
+        override fun routeChanged(newRoute: String) {}
+        override fun routeError(route: String) {}
+        override fun routeLoaded(route: String) {}
+        override fun sizeChanged(width: Double, height: Double) {}
+        override fun error() { reasonLessCallCount++ }
+        override fun error(error: InAppMessageError) { received.add(error) }
+    }
+
+    private lateinit var listener: RecordingListener
     private lateinit var engineWebViewInterface: EngineWebViewInterface
+    private val received: MutableList<InAppMessageError> get() = listener.received
 
     override fun setup(testConfig: TestConfig) {
         super.setup(testConfig)
-        received = mutableListOf()
-        engineWebViewInterface = EngineWebViewInterface(mockk(relaxed = true)).apply {
-            onEngineError = { received.add(it) }
-        }
+        listener = RecordingListener()
+        engineWebViewInterface = EngineWebViewInterface(listener)
         // postMessage ignores everything until the interface is attached to a WebView.
         attachToWebView()
     }
@@ -85,6 +99,15 @@ class EngineWebViewInterfaceErrorTest : RobolectricTest() {
 
         received.single().reason shouldBeEqualTo InAppMessageErrorReason.RENDER_FAILED
         received.single().detail.shouldBeNull()
+    }
+
+    @Test
+    fun postMessage_givenError_expectClassifiedOverloadUsedNotTheReasonLessOne() {
+        postErrorEvent(mapOf("errorMessage" to "Boom"))
+
+        received.size shouldBeEqualTo 1
+        // The reason-less callback exists only for source compatibility; the SDK must not use it.
+        listener.reasonLessCallCount shouldBeEqualTo 0
     }
 
     @Test

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
@@ -9,6 +9,8 @@ import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.messaginginapp.testutils.core.IntegrationTest
 import io.mockk.every
 import io.mockk.mockk
@@ -70,8 +72,13 @@ class EngineWebViewRenderProcessGoneTest : IntegrationTest() {
         // Returning true is the reason this override exists: it tells the platform we absorbed the
         // renderer loss. The default behaviour kills the host app's process along with it.
         handled shouldBeEqualTo true
-        // And the host still learns the message failed, same as any other load error.
-        verify(exactly = 1) { listener.error() }
+        // And the host still learns the message failed, same as any other load error — carrying
+        // the reason, not a bare notification.
+        verify(exactly = 1) {
+            listener.error(
+                match<InAppMessageError> { it.reason == InAppMessageErrorReason.WEB_VIEW_CRASHED }
+            )
+        }
 
         engineWebView.releaseResources()
     }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/gist/presentation/engine/EngineWebViewRenderProcessGoneTest.kt
@@ -9,9 +9,9 @@ import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.gist.data.model.engine.EngineWebConfiguration
 import io.customer.messaginginapp.state.InAppMessagingManager
 import io.customer.messaginginapp.state.InAppMessagingState
+import io.customer.messaginginapp.testutils.core.IntegrationTest
 import io.customer.messaginginapp.type.InAppMessageError
 import io.customer.messaginginapp.type.InAppMessageErrorReason
-import io.customer.messaginginapp.testutils.core.IntegrationTest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
@@ -1,7 +1,5 @@
 package io.customer.messaginginapp.state
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.gist.data.model.GistProperties
@@ -9,6 +7,8 @@ import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.gist.data.model.MessagePosition
 import io.customer.messaginginapp.testutils.core.JUnitTest
 import io.customer.messaginginapp.testutils.extension.createInboxMessage
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessageReducerTest.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.state
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.gist.data.model.GistProperties
@@ -220,7 +222,7 @@ class InAppMessageReducerTest : JUnitTest() {
             shownMessageQueueIds = emptySet()
         )
 
-        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
+        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED))
         val resultState = inAppMessagingReducer(startingState, dismissAction)
 
         assertTrue(resultState.shownMessageQueueIds.isEmpty())
@@ -240,7 +242,7 @@ class InAppMessageReducerTest : JUnitTest() {
             shownMessageQueueIds = emptySet()
         )
 
-        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage)
+        val dismissAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message = testMessage, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED))
         val resultState = inAppMessagingReducer(startingState, dismissAction)
 
         assertTrue(resultState.shownMessageQueueIds.isEmpty())

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.state
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.random
@@ -148,10 +150,15 @@ class InAppMessagingMiddlewaresTest : JUnitTest() {
         val message = createMessage(elementId = elementId)
 
         val middleware = gistListenerMiddleware(mockGistListener)
-        val action = InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
+        val action = InAppMessagingAction.EngineAction.MessageLoadingFailed(message, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED))
         middleware(store)(nextFn)(action)
 
-        verify { mockGistListener.onError(message) }
+        verify {
+            mockGistListener.onError(
+                message,
+                InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)
+            )
+        }
 
         verify { nextFn(action) }
     }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InAppMessagingMiddlewaresTest.kt
@@ -1,7 +1,5 @@
 package io.customer.messaginginapp.state
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.random
@@ -12,6 +10,8 @@ import io.customer.messaginginapp.state.MessageBuilderMock.createMessage
 import io.customer.messaginginapp.testutils.core.JUnitTest
 import io.customer.messaginginapp.testutils.extension.createInAppMessage
 import io.customer.messaginginapp.testutils.extension.createInboxMessage
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.util.Logger

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InlineMessageStateTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InlineMessageStateTest.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.state
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.state.MessageBuilderMock.createMessage
 import io.customer.messaginginapp.testutils.core.JUnitTest
@@ -122,7 +124,7 @@ class InlineMessageStateTest : JUnitTest() {
             queuedInlineMessagesState = queuedState
         )
 
-        val loadingFailedAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message)
+        val loadingFailedAction = InAppMessagingAction.EngineAction.MessageLoadingFailed(message, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED))
         val resultState = inAppMessagingReducer(initialState, loadingFailedAction)
 
         val messageState = resultState.queuedInlineMessagesState.getMessage(elementId)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/state/InlineMessageStateTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/state/InlineMessageStateTest.kt
@@ -1,10 +1,10 @@
 package io.customer.messaginginapp.state
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.extensions.random
 import io.customer.messaginginapp.state.MessageBuilderMock.createMessage
 import io.customer.messaginginapp.testutils.core.JUnitTest
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/InAppMessagingIntegrationUtil.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/InAppMessagingIntegrationUtil.kt
@@ -1,12 +1,12 @@
 package io.customer.messaginginapp.ui
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.extensions.flushCoroutines
 import io.customer.commontest.util.ScopeProviderStub
 import io.customer.messaginginapp.gist.data.model.Message
 import io.customer.messaginginapp.state.InAppMessagingAction
 import io.customer.messaginginapp.state.InAppMessagingManager
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 
 object InAppMessagingIntegrationUtil {
     internal fun Message.testMatchAndEmbed(

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/InAppMessagingIntegrationUtil.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/InAppMessagingIntegrationUtil.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.ui
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.extensions.flushCoroutines
 import io.customer.commontest.util.ScopeProviderStub
 import io.customer.messaginginapp.gist.data.model.Message
@@ -57,7 +59,7 @@ object InAppMessagingIntegrationUtil {
         manager: InAppMessagingManager,
         scopeProvider: ScopeProviderStub
     ) {
-        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(this))
+        manager.dispatch(InAppMessagingAction.EngineAction.MessageLoadingFailed(this, InAppMessageError(reason = InAppMessageErrorReason.RENDER_FAILED)))
             .flushCoroutines(scopeProvider.inAppLifecycleScope)
     }
 }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
@@ -1,5 +1,7 @@
 package io.customer.messaginginapp.ui.controller
 
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.assertCalledNever
@@ -353,7 +355,13 @@ class InAppMessageViewControllerTest : JUnitTest() {
 
         verifyOrder {
             inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    givenMessage,
+                    InAppMessageError(
+                        reason = InAppMessageErrorReason.RENDER_FAILED,
+                        detail = "Failed to load route: Error loading message"
+                    )
+                )
             )
         }
     }
@@ -472,11 +480,37 @@ class InAppMessageViewControllerTest : JUnitTest() {
         val givenMessage = createInAppMessage()
         controller.setMessageAndRouteForTest(message = givenMessage, route = String.random)
 
+        val givenError = InAppMessageError(
+            reason = InAppMessageErrorReason.NETWORK,
+            detail = "net::ERR_NAME_NOT_RESOLVED",
+            code = -2
+        )
+
+        controller.error(givenError)
+
+        verifyOrder {
+            inAppMessagingManager.dispatch(
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage, givenError)
+            )
+        }
+    }
+
+    @Test
+    fun engineListener_givenUnclassifiedEngineError_expectInternalErrorReason() {
+        val givenMessage = createInAppMessage()
+        controller.setMessageAndRouteForTest(message = givenMessage, route = String.random)
+
         controller.error()
 
         verifyOrder {
             inAppMessagingManager.dispatch(
-                InAppMessagingAction.EngineAction.MessageLoadingFailed(givenMessage)
+                InAppMessagingAction.EngineAction.MessageLoadingFailed(
+                    givenMessage,
+                    InAppMessageError(
+                        reason = InAppMessageErrorReason.INTERNAL_ERROR,
+                        detail = "Engine reported a failure with no reason"
+                    )
+                )
             )
         }
     }

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/ui/controller/InAppMessageViewControllerTest.kt
@@ -1,7 +1,5 @@
 package io.customer.messaginginapp.ui.controller
 
-import io.customer.messaginginapp.type.InAppMessageError
-import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.extensions.assertCalledNever
@@ -22,6 +20,8 @@ import io.customer.messaginginapp.testutils.extension.createInAppMessage
 import io.customer.messaginginapp.testutils.extension.mapToInAppMessage
 import io.customer.messaginginapp.testutils.extension.setMessageAndRouteForTest
 import io.customer.messaginginapp.testutils.fakes.FakeQuerySanitizer
+import io.customer.messaginginapp.type.InAppMessageError
+import io.customer.messaginginapp.type.InAppMessageErrorReason
 import io.customer.messaginginapp.type.InlineMessageActionListener
 import io.customer.messaginginapp.ui.bridge.EngineWebViewDelegate
 import io.customer.messaginginapp.ui.bridge.InAppHostViewDelegate

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/InAppMessageEventListener.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/InAppMessageEventListener.kt
@@ -30,12 +30,13 @@ class InAppMessageEventListener(private val logger: Logger = Logger()) : InAppEv
 
     override fun errorWithMessage(message: InAppMessage, error: InAppMessageError) {
         logInAppEvent("in-app message: errorWithMessage. reason: ${error.reason}, detail: ${error.detail}, message: $message")
+        // `detail` is deliberately logged but not tracked: it is diagnostic text, partly supplied by
+        // the renderer, and not something to forward verbatim to analytics.
         trackInAppEvent(
             "errorWithMessage",
             message,
             hashMapOf(
                 "error-reason" to error.reason.name,
-                "error-detail" to (error.detail ?: "NULL"),
                 "error-code" to (error.code?.toString() ?: "NULL")
             )
         )

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/InAppMessageEventListener.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/data/sdk/InAppMessageEventListener.kt
@@ -3,6 +3,7 @@ package io.customer.android.sample.kotlin_compose.data.sdk
 import io.customer.android.sample.kotlin_compose.util.Logger
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.messaginginapp.type.InAppMessage
+import io.customer.messaginginapp.type.InAppMessageError
 import io.customer.sdk.CustomerIO
 
 /**
@@ -20,9 +21,24 @@ class InAppMessageEventListener(private val logger: Logger = Logger()) : InAppEv
         trackInAppEvent("messageDismissed", message)
     }
 
+    // Still a required member of the interface. The SDK always calls the overload below, so this
+    // only runs if something reports a failure without classifying it.
     override fun errorWithMessage(message: InAppMessage) {
-        logInAppEvent("in-app message: errorWithMessage. message: $message")
+        logInAppEvent("in-app message: errorWithMessage (no reason). message: $message")
         trackInAppEvent("errorWithMessage", message)
+    }
+
+    override fun errorWithMessage(message: InAppMessage, error: InAppMessageError) {
+        logInAppEvent("in-app message: errorWithMessage. reason: ${error.reason}, detail: ${error.detail}, message: $message")
+        trackInAppEvent(
+            "errorWithMessage",
+            message,
+            hashMapOf(
+                "error-reason" to error.reason.name,
+                "error-detail" to (error.detail ?: "NULL"),
+                "error-code" to (error.code?.toString() ?: "NULL")
+            )
+        )
     }
 
     override fun messageActionTaken(


### PR DESCRIPTION
## MBL-2310 · Android stack — step 4 of 4

| Step | PR | |
| --- | --- | --- |
| 1 | #823 — `chore:` emit Java-compatible default methods from messaginginapp interfaces | enables step 4 |
| 2 | #826 — `chore:` report WebView render process termination as an in-app failure |  |
| 3 | #827 — `chore:` classify and log in-app message failures internally |  |
| **4** | **#828 — `fix:` surface the failure reason on `errorWithMessage`** | **← you are here** |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**iOS mirror:** customerio/customerio-ios#1231 → customerio/customerio-ios#1237 → customerio/customerio-ios#1238. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Puts the reason an in-app message failed onto `errorWithMessage`. Closes the MBL-2310 work on Android.

Stacked on #827. Paired with ios#1237's follow-up.

### Why

`errorWithMessage` delivered only `messageId` and `deliveryId`, so an integrator learned that a message failed but never why. The reason existed on device in debug logs only, and nothing is recorded server-side, so diagnosing meant shipping a debug-logging build.

### API

```kotlin
enum class InAppMessageErrorReason { NETWORK, TIMEOUT, RENDER_FAILED, WEB_VIEW_CRASHED, INTERNAL_ERROR }

data class InAppMessageError(
    val reason: InAppMessageErrorReason,
    val detail: String? = null,
    val code: Int? = null
)

fun errorWithMessage(message: InAppMessage, error: InAppMessageError) = errorWithMessage(message)
```

Reasons are coarse on purpose: each maps to a different thing an integrator would actually do — check connectivity, look at a slow renderer, report the message to us, or file an SDK bug. `detail` carries the renderer's own `errorMessage` or the WebView's error description; it is diagnostic text for logs, not for parsing.

### Additive, including for Java

The new overload has a default body, so existing listeners keep compiling **and keep receiving failures** — the default forwards to the reason-less callback.

This is what #823 was for. The API dump shows the payoff:

```
public abstract interface class io/customer/messaginginapp/type/InAppEventListener {
    public abstract fun errorWithMessage (…InAppMessage;)V
    public fun errorWithMessage (…InAppMessage;…InAppMessageError;)V   <- not abstract
}
public final class io/customer/messaginginapp/type/InAppEventListener$DefaultImpls { … }
```

`public fun` rather than `public abstract fun` is the real Java default method, so Java implementers are not forced to override it. `DefaultImpls` is retained, so already-compiled Kotlin still links.

### Verification

**The Java canary is the headline.** `samples/java_layout` implements `InAppEventListener` in Java and is **unchanged in this PR — 0 files touched.** It compiles green against the SDK consumed as a **published artifact**:

```
IS_DEVELOPMENT=true ./gradlew publishToMavenLocal
./gradlew :samples:java_layout:assembleDebug -PcioSDKVersion=local --refresh-dependencies
```

Confirmed with 0 `:messaginginapp:` source tasks, so it really resolved the aar rather than building from source.

- `samples/kotlin_compose` updated to demo the new callback, logging and tracking `reason`, `detail`, and `code`. It keeps the reason-less override too, since that member is still required.
- `:messaginginapp:testDebugUnitTest` and `:messaginginapp:lintDebug` green.
- The temporary `onEngineError` seam added in #827 is removed — the listener carries the error directly now.
- New test asserts the SDK uses the classified overload and **never** the reason-less one, plus a case pinning `INTERNAL_ERROR` for an unclassified failure.
