### PR TITLE
chore: resolve the published SDK version from the release job

### DIFF
--- a/.github/workflows/build-sample-app-for-sdk-release.yml
+++ b/.github/workflows/build-sample-app-for-sdk-release.yml
@@ -2,10 +2,17 @@ name: Build sample app for SDK release
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      sdk_version:
+        description: "Published SDK version the sample apps should be built against."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   build-sample-apps:
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: true
+      sdk_version: ${{ inputs.sdk_version }}
     secrets: inherit

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -254,7 +254,11 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   publish-sample-apps-public-builds:
-    needs: deploy-sonatype
+    # `deploy-git-tag` is needed for its outputs, not for ordering: the version has to be passed
+    # down because it cannot be discovered from the commit this workflow runs on.
+    needs: [deploy-git-tag, deploy-sonatype]
     uses: ./.github/workflows/build-sample-app-for-sdk-release.yml
+    with:
+      sdk_version: ${{ needs.deploy-git-tag.outputs.new_release_version }}
     secrets: inherit
     

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      sdk_version:
+        description: "Published SDK version the sample apps should be built against. Required when use_latest_sdk_version is true, unless the run was started by hand."
+        type: string
+        required: false
+        default: ""
 
 env:
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -98,13 +103,34 @@ jobs:
       - name: Capture Git Context
         shell: bash
         id: git-context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SDK_VERSION_INPUT: ${{ inputs.sdk_version }}
+          USE_LATEST_SDK_VERSION: ${{ inputs.use_latest_sdk_version }}
         run: |
           echo "BRANCH_NAME=${{ github.head_ref || github.ref_name }}" >> $GITHUB_ENV
           COMMIT_HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "COMMIT_HASH=${COMMIT_HASH:0:7}" >> $GITHUB_ENV
-          # Get the latest tag, making sure we get all tags with --tags flag (in case tag was just created)
+          # Latest tag reachable from HEAD. Only used to count how far this build is ahead of the
+          # last release, which is a question about ancestry, so `git describe` answers it correctly.
           git fetch --tags
-          echo "LATEST_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+          LATEST_TAG="$(git describe --tags --abbrev=0)"
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          # The published SDK version cannot be derived from this checkout. semantic-release puts the
+          # release tag on a new commit it creates *after* the commit that triggered the release, and
+          # `git describe` only walks ancestors, so it resolves to the previous release every time.
+          # The release workflow passes the version it just published in instead.
+          if [[ -n "$SDK_VERSION_INPUT" ]]; then
+            resolved_sdk_version="$SDK_VERSION_INPUT"
+          elif [[ "$USE_LATEST_SDK_VERSION" != "true" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # Not building against a release, or started by hand once the tag already sits on this branch.
+            resolved_sdk_version="$LATEST_TAG"
+          else
+            echo "::error::A release build needs sdk_version passed in from the job that published the release."
+            exit 1
+          fi
+          echo "Sample apps will be built against SDK version: $resolved_sdk_version"
+          echo "RESOLVED_SDK_VERSION=$resolved_sdk_version" >> $GITHUB_ENV
 
       - name: Setup local.properties file for sample app
         run: |
@@ -119,7 +145,7 @@ jobs:
           COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
           echo "commitsAheadCount=$COMMITS_AHEAD" >> "$LOCAL_PROPS_FILE"
           if [[ "${{ inputs.use_latest_sdk_version }}" == "true" ]]; then
-            echo "sdkVersion=${{ env.LATEST_TAG }}" >> "$LOCAL_PROPS_FILE"
+            echo "sdkVersion=${{ env.RESOLVED_SDK_VERSION }}" >> "$LOCAL_PROPS_FILE"
           fi
 
       - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase.
@@ -128,7 +154,7 @@ jobs:
       - name: Prepare Fastlane Build Arguments
         run: |
           if [ "${{ inputs.use_latest_sdk_version }}" = "true" ]; then
-            sdk_version="\"sdk_version\":\"${{ env.LATEST_TAG }}\""
+            sdk_version="\"sdk_version\":\"${{ env.RESOLVED_SDK_VERSION }}\""
           else
             sdk_version=""
           fi
@@ -162,7 +188,7 @@ jobs:
         id: determine-sdk-version
         run: |
           sdk_version="${{ env.SDK_VERSION }}"
-          sdk_version="${sdk_version:-$LATEST_TAG}"
+          sdk_version="${sdk_version:-$RESOLVED_SDK_VERSION}"
           echo "SDK Version used in app build: $sdk_version"
           echo "APP_SDK_BUILD_VERSION=$sdk_version" >> $GITHUB_ENV
 


### PR DESCRIPTION
Fixes MBL-2324

## Problem

`reusable_build_sample_apps.yml` resolved the SDK version to build the public sample apps against with:

```
LATEST_TAG=$(git describe --tags --abbrev=0)
```

That runs on the commit that *triggered* the release. semantic-release (`@semantic-release/git`) creates a **new child commit** (`chore: prepare for X [skip ci]`) and puts the tag on that, and `git describe` only walks ancestors — so it deterministically resolves to the **previous** release.

Verified against real history on `main`:

```
tag 4.20.2            -> be5acf07
its parent (pushed commit that triggered the deploy) -> 4a9b17c2
git describe --tags --abbrev=0 4a9b17c2 -> 4.20.1   # one behind
```

So every post-release run built and distributed the *previous* SDK, and the Slack release notification reported that same wrong version (the fastlane `SDK_VERSION` env var is only set on the non-release lane, so the release path always hits the `LATEST_TAG` fallback).

The existing comment there — "in case tag was just created" — shows this was noticed once and diagnosed as a *fetch* timing problem. It is not: no amount of fetching makes a child commit's tag reachable from its parent. It is a reachability problem.

## What changed

- **`reusable_build_sample_apps.yml`** — new optional `sdk_version` input. `Capture Git Context` now resolves `RESOLVED_SDK_VERSION`: the input when non-empty, otherwise `git describe` for non-release builds and manual runs, and otherwise a hard failure rather than a silently stale version. The three consumers of the SDK version (`local.properties`, the fastlane args, the Slack notification fallback) read `RESOLVED_SDK_VERSION`.
- `LATEST_TAG` is kept as-is and now only feeds `commitsAheadCount`. That one *is* an ancestry question, so `git describe` is the right answer for it — swapping it too would have regressed PR builds.
- **`build-sample-app-for-sdk-release.yml`** — accepts `sdk_version` on `workflow_call` and forwards it. `workflow_dispatch` deliberately takes no input: by the time you dispatch by hand the tag is already an ancestor, so `git describe` is correct there.
- **`deploy-sdk.yml`** — `publish-sample-apps-public-builds` now also `needs: deploy-git-tag` (for its outputs, not for ordering; `needs` only exposes directly-listed jobs) and passes `needs.deploy-git-tag.outputs.new_release_version`. That output already existed; nothing new had to be exposed.

The reference is `customerio-reactnative`, the one repo without this bug — its release sample-app workflow takes an `sdk_version` input instead of calling `git describe`. This goes one step further than RN, which falls back to `npm show <pkg> version`; here the version is threaded directly from the job that published it.

## Verification / how to review

**This fixes a silent defect — there is no red job to turn green.** Gradle happily resolves the one-behind version, which is exactly why it went unnoticed. Nothing about the bug or the fix is observable in this PR's CI.

- Resolution logic exercised across all six trigger paths: threaded release version → used; missing version on a release build → loud failure; manual dispatch, PR build, push to `main`, and `release: published` → `git describe`, i.e. unchanged from today.
- The PR-build path (`build-sample-apps.yml`, `use_latest_sdk_version: false`) is behaviourally identical to before.
- `actionlint` on the three files adds exactly one new `SC2086:info` for an unquoted `$GITHUB_ENV`, matching the file's existing style throughout. No `actionlint`/`shellcheck` runs in CI.
- **The `workflow_call` path from `deploy-sdk.yml` can only be confirmed on the next real release.** It cannot be exercised from a PR, and it is deliberately not dispatched here.
