### PR TITLE
chore(sample): persist SDK logs to an NDJSON file in java_layout

### DIFF
--- a/samples/java_layout/build.gradle
+++ b/samples/java_layout/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation "androidx.datastore:datastore-preferences-rxjava3:$datastore_version"
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-reactivestreams:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.2.0"

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -23,6 +23,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.SampleApp"
         tools:ignore="DataExtractionRules,UnusedAttribute">
+
+        <!-- Emits the SDK's machine-readable geofence diagnostics. Sample app only. -->
+        <meta-data
+            android:name="io.customer.geofence.diagnostics"
+            android:value="true" />
         <!--
           Grants read access to a single diagnostics log file when it is shared. Scoped to the
           diagnostics directory only; see res/xml/diagnostics_paths.xml.

--- a/samples/java_layout/src/main/AndroidManifest.xml
+++ b/samples/java_layout/src/main/AndroidManifest.xml
@@ -23,6 +23,20 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.SampleApp"
         tools:ignore="DataExtractionRules,UnusedAttribute">
+        <!--
+          Grants read access to a single diagnostics log file when it is shared. Scoped to the
+          diagnostics directory only; see res/xml/diagnostics_paths.xml.
+        -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.diagnostics"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/diagnostics_paths" />
+        </provider>
+
         <activity
             android:name=".ui.dashboard.DashboardActivity"
             android:exported="true">

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/SampleApplication.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/SampleApplication.java
@@ -3,6 +3,7 @@ package io.customer.android.sample.java_layout;
 import android.app.Application;
 
 import io.customer.android.sample.java_layout.di.ApplicationGraph;
+import io.customer.android.sample.java_layout.diagnostics.DiagnosticLog;
 
 public class SampleApplication extends Application {
     private final ApplicationGraph appGraph = new ApplicationGraph(this);
@@ -10,6 +11,14 @@ public class SampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        // Field-drive diagnostics sink, installed before anything else runs.
+        //
+        // A cold background wake for a geofence crossing — the case that matters most — runs
+        // Application.onCreate first and reaches SDK code within milliseconds. Anything installed
+        // after SDK initialization misses the wake it was meant to observe.
+        DiagnosticLog.start(SampleApplication.this);
+
         // Initialize Customer.io SDK on app start
         appGraph.getCustomerIORepository().initializeSdk(SampleApplication.this);
     }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
@@ -1,6 +1,5 @@
 package io.customer.android.sample.java_layout.diagnostics
 
-import android.app.Activity
 import android.app.Application
 import android.app.usage.UsageStatsManager
 import android.content.BroadcastReceiver
@@ -11,9 +10,11 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
-import android.os.Bundle
 import android.os.PowerManager
 import android.os.SystemClock
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 
 /**
  * The `dev` block attached to every record.
@@ -33,7 +34,6 @@ internal class DiagnosticDeviceState(private val application: Application) {
     private val lock = Any()
     private var snapshot = Snapshot()
     private var onChange: ((String) -> Unit)? = null
-    private var startedActivities = 0
 
     @Volatile
     private var bucketCache = "unknown"
@@ -139,27 +139,19 @@ internal class DiagnosticDeviceState(private val application: Application) {
     }
 
     /**
-     * Foreground state from activity callbacks rather than `ProcessLifecycleOwner`, so the sink
-     * needs no extra dependency and behaves the same on every supported API level.
+     * Foreground state from `ProcessLifecycleOwner`, which is what the SDK itself observes.
+     *
+     * Counting started activities looks equivalent and is not: the count drops to zero and back
+     * during a configuration change, so a rotation produced a spurious background/foreground pair
+     * in the trace. ProcessLifecycleOwner debounces exactly that.
      */
     private fun registerLifecycleCallbacks() {
-        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityStarted(activity: Activity) {
-                startedActivities += 1
-                update("fg") { it.copy(foreground = startedActivities > 0) }
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) = update("fg") { it.copy(foreground = true) }
+                override fun onStop(owner: LifecycleOwner) = update("fg") { it.copy(foreground = false) }
             }
-
-            override fun onActivityStopped(activity: Activity) {
-                startedActivities = (startedActivities - 1).coerceAtLeast(0)
-                update("fg") { it.copy(foreground = startedActivities > 0) }
-            }
-
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
-            override fun onActivityResumed(activity: Activity) = Unit
-            override fun onActivityPaused(activity: Activity) = Unit
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
-            override fun onActivityDestroyed(activity: Activity) = Unit
-        })
+        )
     }
 
     private fun registerThermalListener() {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
@@ -13,26 +13,15 @@ import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
+import android.os.SystemClock
 
 /**
  * The `dev` block attached to every record.
- *
- * Two sessions over the same route are only comparable if you know what state the phone was in for
- * each. Doze, standby bucket, power-save mode, thermal pressure and whether Wi-Fi was up all change
- * geofence behaviour materially — geofence monitoring is a *network-location* feature, so "was
- * there Wi-Fi" is frequently the whole explanation for a session that behaved unlike its neighbour.
- *
- * **Everything here is pushed by the OS. Nothing is polled.** No timer, no periodic sampler, and
- * never a Wi-Fi scan. A repeating wakeup is a wakeup the device would not otherwise have taken: it
- * pulls the phone out of Doze and improves the very behaviour we are trying to measure. An observer
- * that changes what it observes is worse than no observer.
- *
- * The one exception is the standby bucket, which has no broadcast and is read on demand — a purely
- * local query against `UsageStatsManager` that schedules nothing.
  */
 internal class DiagnosticDeviceState(private val application: Application) {
     private data class Snapshot(
-        val batteryLevel: Float = -1f,
+        /** `null` until a battery broadcast has been seen; never a sentinel. */
+        val batteryLevel: Float? = null,
         val charging: Boolean = false,
         val powerSave: Boolean = false,
         val idle: Boolean = false,
@@ -45,6 +34,12 @@ internal class DiagnosticDeviceState(private val application: Application) {
     private var snapshot = Snapshot()
     private var onChange: ((String) -> Unit)? = null
     private var startedActivities = 0
+
+    @Volatile
+    private var bucketCache = "unknown"
+
+    @Volatile
+    private var bucketReadAt = 0L
 
     private val powerManager: PowerManager? =
         application.getSystemService(Context.POWER_SERVICE) as? PowerManager
@@ -69,7 +64,9 @@ internal class DiagnosticDeviceState(private val application: Application) {
         val current = synchronized(lock) { snapshot }
         return buildString(160) {
             append('{')
-            append("\"batt\":").append(String.format(java.util.Locale.US, "%.2f", current.batteryLevel))
+            append("\"batt\":").append(
+                current.batteryLevel?.let { String.format(java.util.Locale.US, "%.2f", it) } ?: "null"
+            )
             append(",\"charging\":").append(current.charging)
             append(",\"powerSave\":").append(current.powerSave)
             append(",\"idle\":").append(current.idle)
@@ -92,7 +89,7 @@ internal class DiagnosticDeviceState(private val application: Application) {
                         val scale = intent.getIntExtra("scale", -1)
                         val status = intent.getIntExtra("status", -1)
                         current.copy(
-                            batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else -1f,
+                            batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else null,
                             charging = status == android.os.BatteryManager.BATTERY_STATUS_CHARGING ||
                                 status == android.os.BatteryManager.BATTERY_STATUS_FULL
                         )
@@ -101,8 +98,6 @@ internal class DiagnosticDeviceState(private val application: Application) {
                         update("powerSave") { it.copy(powerSave = powerManager?.isPowerSaveMode == true) }
                     PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED ->
                         update("idle") { it.copy(idle = isDeviceIdle()) }
-                    Intent.ACTION_SCREEN_ON, Intent.ACTION_SCREEN_OFF ->
-                        update("screen") { it }
                 }
             }
         }
@@ -111,8 +106,6 @@ internal class DiagnosticDeviceState(private val application: Application) {
             // Sticky broadcast: registering delivers the current value immediately, without
             // costing a wakeup or a poll.
             addAction(Intent.ACTION_BATTERY_CHANGED)
-            addAction(Intent.ACTION_SCREEN_ON)
-            addAction(Intent.ACTION_SCREEN_OFF)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
             }
@@ -193,7 +186,7 @@ internal class DiagnosticDeviceState(private val application: Application) {
 
         synchronized(lock) {
             snapshot = snapshot.copy(
-                batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else -1f,
+                batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else null,
                 charging = status == android.os.BatteryManager.BATTERY_STATUS_CHARGING ||
                     status == android.os.BatteryManager.BATTERY_STATUS_FULL,
                 powerSave = powerManager?.isPowerSaveMode == true,
@@ -226,13 +219,18 @@ internal class DiagnosticDeviceState(private val application: Application) {
 
     /**
      * Which app-standby bucket the OS has us in.
-     *
-     * No broadcast exists for this, so it is read when a record is written rather than cached from
-     * a change notification. The read is a local binder call that schedules nothing — the rule this
-     * class follows is "cause no wakeups", not "never call a system service".
      */
     private fun standbyBucket(): String {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return "unsupported"
+        val now = SystemClock.elapsedRealtime()
+        if (bucketReadAt != 0L && now - bucketReadAt < BUCKET_TTL_MS) return bucketCache
+        val value = readStandbyBucket()
+        bucketCache = value
+        bucketReadAt = now
+        return value
+    }
+
+    private fun readStandbyBucket(): String {
         return runCatching {
             val manager = application.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
             when (manager?.appStandbyBucket) {
@@ -281,5 +279,9 @@ internal class DiagnosticDeviceState(private val application: Application) {
             callback = onChange
         }
         if (changed) callback?.invoke(reason)
+    }
+
+    private companion object {
+        const val BUCKET_TTL_MS = 60_000L
     }
 }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticDeviceState.kt
@@ -1,0 +1,285 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import android.app.Activity
+import android.app.Application
+import android.app.usage.UsageStatsManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.os.Bundle
+import android.os.PowerManager
+
+/**
+ * The `dev` block attached to every record.
+ *
+ * Two sessions over the same route are only comparable if you know what state the phone was in for
+ * each. Doze, standby bucket, power-save mode, thermal pressure and whether Wi-Fi was up all change
+ * geofence behaviour materially — geofence monitoring is a *network-location* feature, so "was
+ * there Wi-Fi" is frequently the whole explanation for a session that behaved unlike its neighbour.
+ *
+ * **Everything here is pushed by the OS. Nothing is polled.** No timer, no periodic sampler, and
+ * never a Wi-Fi scan. A repeating wakeup is a wakeup the device would not otherwise have taken: it
+ * pulls the phone out of Doze and improves the very behaviour we are trying to measure. An observer
+ * that changes what it observes is worse than no observer.
+ *
+ * The one exception is the standby bucket, which has no broadcast and is read on demand — a purely
+ * local query against `UsageStatsManager` that schedules nothing.
+ */
+internal class DiagnosticDeviceState(private val application: Application) {
+    private data class Snapshot(
+        val batteryLevel: Float = -1f,
+        val charging: Boolean = false,
+        val powerSave: Boolean = false,
+        val idle: Boolean = false,
+        val thermal: String = "unknown",
+        val network: String = "unknown",
+        val foreground: Boolean = false
+    )
+
+    private val lock = Any()
+    private var snapshot = Snapshot()
+    private var onChange: ((String) -> Unit)? = null
+    private var startedActivities = 0
+
+    private val powerManager: PowerManager? =
+        application.getSystemService(Context.POWER_SERVICE) as? PowerManager
+    private val connectivityManager: ConnectivityManager? =
+        application.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    fun start(onChange: (String) -> Unit) {
+        synchronized(lock) { this.onChange = onChange }
+
+        readInitialState()
+        registerSystemReceivers()
+        registerNetworkCallback()
+        registerLifecycleCallbacks()
+        registerThermalListener()
+    }
+
+    /**
+     * Safe to call from any thread: reads only the cached values, never a system service that
+     * might block. SDK log records arrive on whatever thread the SDK happened to be using.
+     */
+    fun snapshotJson(): String {
+        val current = synchronized(lock) { snapshot }
+        return buildString(160) {
+            append('{')
+            append("\"batt\":").append(String.format(java.util.Locale.US, "%.2f", current.batteryLevel))
+            append(",\"charging\":").append(current.charging)
+            append(",\"powerSave\":").append(current.powerSave)
+            append(",\"idle\":").append(current.idle)
+            append(",\"bucket\":").append(DiagnosticEnvelope.json(standbyBucket()))
+            append(",\"thermal\":").append(DiagnosticEnvelope.json(current.thermal))
+            append(",\"net\":").append(DiagnosticEnvelope.json(current.network))
+            append(",\"fg\":").append(current.foreground)
+            append('}')
+        }
+    }
+
+    // MARK: - Registration
+
+    private fun registerSystemReceivers() {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                when (intent?.action) {
+                    Intent.ACTION_BATTERY_CHANGED -> update("batt") { current ->
+                        val level = intent.getIntExtra("level", -1)
+                        val scale = intent.getIntExtra("scale", -1)
+                        val status = intent.getIntExtra("status", -1)
+                        current.copy(
+                            batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else -1f,
+                            charging = status == android.os.BatteryManager.BATTERY_STATUS_CHARGING ||
+                                status == android.os.BatteryManager.BATTERY_STATUS_FULL
+                        )
+                    }
+                    PowerManager.ACTION_POWER_SAVE_MODE_CHANGED ->
+                        update("powerSave") { it.copy(powerSave = powerManager?.isPowerSaveMode == true) }
+                    PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED ->
+                        update("idle") { it.copy(idle = isDeviceIdle()) }
+                    Intent.ACTION_SCREEN_ON, Intent.ACTION_SCREEN_OFF ->
+                        update("screen") { it }
+                }
+            }
+        }
+
+        val filter = IntentFilter().apply {
+            // Sticky broadcast: registering delivers the current value immediately, without
+            // costing a wakeup or a poll.
+            addAction(Intent.ACTION_BATTERY_CHANGED)
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED)
+            }
+        }
+
+        // Screen and Doze broadcasts are protected system actions, so this stays exported=false;
+        // `RECEIVER_NOT_EXPORTED` is required from API 34 and harmless to state earlier.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            application.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            application.registerReceiver(receiver, filter)
+        }
+    }
+
+    private fun registerNetworkCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return
+        runCatching {
+            connectivityManager?.registerDefaultNetworkCallback(
+                object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) = refreshNetwork()
+                    override fun onLost(network: Network) = update("net") { it.copy(network = "none") }
+                    override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+                        update("net") { it.copy(network = describe(capabilities)) }
+                    }
+                }
+            )
+        }
+    }
+
+    /**
+     * Foreground state from activity callbacks rather than `ProcessLifecycleOwner`, so the sink
+     * needs no extra dependency and behaves the same on every supported API level.
+     */
+    private fun registerLifecycleCallbacks() {
+        application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityStarted(activity: Activity) {
+                startedActivities += 1
+                update("fg") { it.copy(foreground = startedActivities > 0) }
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+                startedActivities = (startedActivities - 1).coerceAtLeast(0)
+                update("fg") { it.copy(foreground = startedActivities > 0) }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+            override fun onActivityResumed(activity: Activity) = Unit
+            override fun onActivityPaused(activity: Activity) = Unit
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        })
+    }
+
+    private fun registerThermalListener() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        runCatching {
+            powerManager?.addThermalStatusListener { status ->
+                update("thermal") { it.copy(thermal = describeThermal(status)) }
+            }
+        }
+    }
+
+    // MARK: - Reading
+
+    private fun readInitialState() {
+        // ACTION_BATTERY_CHANGED is sticky, so a null receiver returns the current value straight
+        // away. Without this the first records of every session carry batt=-1 until the first real
+        // 1% step arrives, which on a short background wake may be never.
+        val battery = runCatching {
+            application.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        }.getOrNull()
+        val level = battery?.getIntExtra("level", -1) ?: -1
+        val scale = battery?.getIntExtra("scale", -1) ?: -1
+        val status = battery?.getIntExtra("status", -1) ?: -1
+
+        synchronized(lock) {
+            snapshot = snapshot.copy(
+                batteryLevel = if (level >= 0 && scale > 0) level.toFloat() / scale else -1f,
+                charging = status == android.os.BatteryManager.BATTERY_STATUS_CHARGING ||
+                    status == android.os.BatteryManager.BATTERY_STATUS_FULL,
+                powerSave = powerManager?.isPowerSaveMode == true,
+                idle = isDeviceIdle(),
+                thermal = currentThermal(),
+                network = currentNetwork()
+            )
+        }
+    }
+
+    private fun refreshNetwork() = update("net") { it.copy(network = currentNetwork()) }
+
+    private fun isDeviceIdle(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && powerManager?.isDeviceIdleMode == true
+
+    private fun currentThermal(): String {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return "unsupported"
+        return runCatching { describeThermal(powerManager?.currentThermalStatus ?: -1) }.getOrElse { "unknown" }
+    }
+
+    private fun currentNetwork(): String {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return "unknown"
+        val manager = connectivityManager ?: return "unknown"
+        return runCatching {
+            val active = manager.activeNetwork ?: return "none"
+            val capabilities = manager.getNetworkCapabilities(active) ?: return "none"
+            describe(capabilities)
+        }.getOrElse { "unknown" }
+    }
+
+    /**
+     * Which app-standby bucket the OS has us in.
+     *
+     * No broadcast exists for this, so it is read when a record is written rather than cached from
+     * a change notification. The read is a local binder call that schedules nothing — the rule this
+     * class follows is "cause no wakeups", not "never call a system service".
+     */
+    private fun standbyBucket(): String {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return "unsupported"
+        return runCatching {
+            val manager = application.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
+            when (manager?.appStandbyBucket) {
+                UsageStatsManager.STANDBY_BUCKET_ACTIVE -> "active"
+                UsageStatsManager.STANDBY_BUCKET_WORKING_SET -> "working_set"
+                UsageStatsManager.STANDBY_BUCKET_FREQUENT -> "frequent"
+                UsageStatsManager.STANDBY_BUCKET_RARE -> "rare"
+                45 -> "restricted" // STANDBY_BUCKET_RESTRICTED, API 30 — named literally for API 21 compile
+                else -> "unknown"
+            }
+        }.getOrElse { "unknown" }
+    }
+
+    // MARK: - Descriptions
+
+    private fun describe(capabilities: NetworkCapabilities): String = when {
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "wifi"
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "cellular"
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "wired"
+        else -> "other"
+    }
+
+    private fun describeThermal(status: Int): String = when (status) {
+        PowerManager.THERMAL_STATUS_NONE -> "nominal"
+        PowerManager.THERMAL_STATUS_LIGHT -> "light"
+        PowerManager.THERMAL_STATUS_MODERATE -> "moderate"
+        PowerManager.THERMAL_STATUS_SEVERE -> "severe"
+        PowerManager.THERMAL_STATUS_CRITICAL -> "critical"
+        PowerManager.THERMAL_STATUS_EMERGENCY -> "emergency"
+        PowerManager.THERMAL_STATUS_SHUTDOWN -> "shutdown"
+        else -> "unknown"
+    }
+
+    /**
+     * Writes a `device.state` record only when a value actually moved. Several broadcasts describe
+     * the same transition, and recording each one would fill the file with rows saying nothing
+     * changed — battery in particular fires on every 1% step.
+     */
+    private fun update(reason: String, mutate: (Snapshot) -> Snapshot) {
+        val callback: ((String) -> Unit)?
+        val changed: Boolean
+        synchronized(lock) {
+            val before = snapshot
+            snapshot = mutate(before)
+            changed = snapshot != before
+            callback = onChange
+        }
+        if (changed) callback?.invoke(reason)
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
@@ -1,0 +1,177 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.os.Build
+import android.os.SystemClock
+import android.provider.Settings
+import io.customer.sdk.Version
+import io.customer.sdk.core.util.CioLogLevel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Builds the NDJSON lines.
+ *
+ * Records are assembled by hand rather than through a JSON library so fields land in the
+ * documented envelope order (`v seq ts mono pid up src tag lvl msg dev`). These files are read by
+ * humans scanning for the moment something went wrong at least as often as by a script, and a
+ * serializer's key ordering would scatter the timestamp into the middle of the line.
+ */
+internal object DiagnosticEnvelope {
+    /**
+     * Every record carries both clocks.
+     *
+     * Wall clock is the only thing that correlates one device with another, or with a route file,
+     * but it can step under NTP — mid-drive, by an amount nobody notices. Monotonic cannot step
+     * but resets at boot and means nothing across devices. Carrying both is what lets a step be
+     * *detected* afterwards rather than silently mis-measured as a timing regression.
+     *
+     * `elapsedRealtimeNanos` deliberately, not `nanoTime`: it keeps counting while the device is
+     * in deep sleep, which is precisely the interval a backgrounded phone spends between geofence
+     * wakes. (`CLOCK_MONOTONIC` on the iOS side was chosen for the same property.)
+     */
+    fun record(
+        seq: Long,
+        pid: Int,
+        upMillis: Long,
+        source: DiagnosticLog.Source,
+        tag: String?,
+        level: CioLogLevel,
+        message: String,
+        deviceState: String
+    ): String = buildString(message.length + 256) {
+        append('{')
+        append("\"v\":").append(DiagnosticLog.SCHEMA_VERSION)
+        append(",\"seq\":").append(seq)
+        append(",\"ts\":").append(json(iso8601(System.currentTimeMillis())))
+        append(",\"mono\":").append(SystemClock.elapsedRealtimeNanos())
+        append(",\"pid\":").append(pid)
+        append(",\"up\":").append(upMillis)
+        append(",\"src\":").append(json(source.wire))
+        if (tag != null) append(",\"tag\":").append(json(tag))
+        append(",\"lvl\":").append(json(level.wire()))
+        append(",\"msg\":").append(json(message))
+        append(",\"dev\":").append(deviceState)
+        append('}')
+    }
+
+    /**
+     * First line of every file.
+     *
+     * `boot` matters: `mono` values are only comparable to each other within a single boot, so a
+     * file that does not name its boot cannot be aligned with another.
+     */
+    @SuppressLint("HardwareIds")
+    fun fileHeader(application: Application): String {
+        val packageInfo = runCatching {
+            application.packageManager.getPackageInfo(application.packageName, 0)
+        }.getOrNull()
+
+        return buildString(512) {
+            append('{')
+            append("\"v\":").append(DiagnosticLog.SCHEMA_VERSION)
+            append(",\"ev\":\"file.open\"")
+            append(",\"ts\":").append(json(iso8601(System.currentTimeMillis())))
+            append(",\"boot\":").append(json(bootIdentifier()))
+            bootCount(application)?.let { append(",\"bootCount\":").append(it) }
+            append(",\"device\":{")
+            append("\"model\":").append(json("${Build.MANUFACTURER} ${Build.MODEL}"))
+            append(",\"os\":\"Android\"")
+            append(",\"osVersion\":").append(json("${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})"))
+            append('}')
+            append(",\"app\":{")
+            append("\"id\":").append(json(application.packageName))
+            append(",\"version\":").append(json(packageInfo?.versionName ?: "unknown"))
+            append(",\"build\":").append(json(packageInfo?.let { versionCode(it) } ?: "unknown"))
+            append('}')
+            append(",\"sdk\":{\"version\":").append(json(Version.version)).append('}')
+            append(",\"tz\":").append(json(TimeZone.getDefault().id))
+            append('}')
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun versionCode(info: android.content.pm.PackageInfo): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode.toString()
+        } else {
+            info.versionCode.toString()
+        }
+
+    /**
+     * A monotonically increasing count of device boots. Exact, unlike the derived timestamp below,
+     * so two files from the same boot can be matched with certainty.
+     */
+    private fun bootCount(application: Application): Int? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return null
+        return runCatching {
+            Settings.Global.getInt(application.contentResolver, Settings.Global.BOOT_COUNT)
+        }.getOrNull()
+    }
+
+    /**
+     * Approximate wall-clock instant of boot, derived as now minus uptime.
+     *
+     * Derived rather than read, because Android exposes no `kern.boottime` equivalent. It shifts
+     * slightly if the wall clock is adjusted mid-boot, which is why `bootCount` travels alongside
+     * it — this value exists to be comparable with the iOS side, that one to be exact.
+     */
+    private fun bootIdentifier(): String =
+        iso8601(System.currentTimeMillis() - SystemClock.elapsedRealtime())
+
+    // MARK: - Formatting
+
+    private val formatter = ThreadLocal.withInitial {
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.US)
+    }
+
+    /**
+     * ISO 8601 with milliseconds and a local UTC offset.
+     *
+     * The offset is written by hand rather than with the `XXX` pattern letter, which Android's
+     * `SimpleDateFormat` only understands from API 24 — this app supports 21. The offset itself is
+     * deliberate: a drive log is read next to a route recorded in local time.
+     */
+    fun iso8601(millis: Long): String {
+        val base = formatter.get()!!.format(Date(millis))
+        val offsetMinutes = TimeZone.getDefault().getOffset(millis) / 60000
+        val sign = if (offsetMinutes < 0) '-' else '+'
+        val absolute = kotlin.math.abs(offsetMinutes)
+        return "%s%c%02d:%02d".format(Locale.US, base, sign, absolute / 60, absolute % 60)
+    }
+
+    private fun CioLogLevel.wire(): String = when (this) {
+        CioLogLevel.NONE -> "none"
+        CioLogLevel.ERROR -> "error"
+        CioLogLevel.INFO -> "info"
+        CioLogLevel.DEBUG -> "debug"
+    }
+
+    /** Encodes a string as a complete JSON string literal, quotes included. */
+    fun json(value: String): String = buildString(value.length + 2) {
+        append('"')
+        for (character in value) {
+            when (character) {
+                '"' -> append("\\\"")
+                '\\' -> append("\\\\")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                '\b' -> append("\\b")
+                '\u000C' -> append("\\f")
+                else ->
+                    // Control characters have no literal form and would produce a file no parser
+                    // will read. Everything above U+001F is legal inside a JSON string as-is.
+                    if (character < ' ') {
+                        append("\\u%04x".format(Locale.US, character.code))
+                    } else {
+                        append(character)
+                    }
+            }
+        }
+        append('"')
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
@@ -14,24 +14,10 @@ import java.util.TimeZone
 
 /**
  * Builds the NDJSON lines.
- *
- * Records are assembled by hand rather than through a JSON library so fields land in the
- * documented envelope order (`v seq ts mono pid up src tag lvl msg dev`). These files are read by
- * humans scanning for the moment something went wrong at least as often as by a script, and a
- * serializer's key ordering would scatter the timestamp into the middle of the line.
  */
 internal object DiagnosticEnvelope {
     /**
      * Every record carries both clocks.
-     *
-     * Wall clock is the only thing that correlates one device with another, or with a route file,
-     * but it can step under NTP — mid-drive, by an amount nobody notices. Monotonic cannot step
-     * but resets at boot and means nothing across devices. Carrying both is what lets a step be
-     * *detected* afterwards rather than silently mis-measured as a timing regression.
-     *
-     * `elapsedRealtimeNanos` deliberately, not `nanoTime`: it keeps counting while the device is
-     * in deep sleep, which is precisely the interval a backgrounded phone spends between geofence
-     * wakes. (`CLOCK_MONOTONIC` on the iOS side was chosen for the same property.)
      */
     fun record(
         seq: Long,
@@ -60,9 +46,6 @@ internal object DiagnosticEnvelope {
 
     /**
      * First line of every file.
-     *
-     * `boot` matters: `mono` values are only comparable to each other within a single boot, so a
-     * file that does not name its boot cannot be aligned with another.
      */
     @SuppressLint("HardwareIds")
     fun fileHeader(application: Application): String {
@@ -114,10 +97,6 @@ internal object DiagnosticEnvelope {
 
     /**
      * Approximate wall-clock instant of boot, derived as now minus uptime.
-     *
-     * Derived rather than read, because Android exposes no `kern.boottime` equivalent. It shifts
-     * slightly if the wall clock is adjusted mid-boot, which is why `bootCount` travels alongside
-     * it — this value exists to be comparable with the iOS side, that one to be exact.
      */
     private fun bootIdentifier(): String =
         iso8601(System.currentTimeMillis() - SystemClock.elapsedRealtime())
@@ -130,10 +109,6 @@ internal object DiagnosticEnvelope {
 
     /**
      * ISO 8601 with milliseconds and a local UTC offset.
-     *
-     * The offset is written by hand rather than with the `XXX` pattern letter, which Android's
-     * `SimpleDateFormat` only understands from API 24 — this app supports 21. The offset itself is
-     * deliberate: a drive log is read next to a route recorded in local time.
      */
     fun iso8601(millis: Long): String {
         val base = formatter.get()!!.format(Date(millis))

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
@@ -111,8 +111,16 @@ internal object DiagnosticEnvelope {
      * ISO 8601 with milliseconds and a local UTC offset.
      */
     fun iso8601(millis: Long): String {
-        val base = formatter.get()!!.format(Date(millis))
-        val offsetMinutes = TimeZone.getDefault().getOffset(millis) / 60000
+        // One zone for both halves. SimpleDateFormat captures the zone it was built with, while
+        // the offset below was read live — so after a zone change the text described one instant
+        // and the suffix another. And because the formatter is a ThreadLocal, two threads that
+        // first log either side of the change disagreed with each other without any of this
+        // needing a long-lived process.
+        val zone = TimeZone.getDefault()
+        val format = formatter.get()!!
+        format.timeZone = zone
+        val base = format.format(Date(millis))
+        val offsetMinutes = zone.getOffset(millis) / 60000
         val sign = if (offsetMinutes < 0) '-' else '+'
         val absolute = kotlin.math.abs(offsetMinutes)
         return "%s%c%02d:%02d".format(Locale.US, base, sign, absolute / 60, absolute % 60)

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -4,28 +4,13 @@ import android.app.Application
 import android.os.Process
 import android.os.SystemClock
 import android.util.Log
+import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CioLogLevel
 import java.io.File
 
 /**
  * Field-drive diagnostics sink.
- *
- * Installs a dispatcher on the Customer.io logger and mirrors every record the SDK emits into an
- * NDJSON file on disk, together with a device-state snapshot.
- *
- * Geofence field drives run for hours with the app in the background and no debugger attached.
- * Logcat is a ring buffer that a long drive overruns, so today a completed drive leaves nothing
- * reliable to analyse afterwards. This is the sink that fixes that.
- *
- * **Nothing here parses the SDK's message.** The device writes the raw string, including any
- * ` || key=value` tail, into `msg`. A host-side script splits the tail and fills in `ev` and
- * `data`. One parser, living off-device, means no Kotlin/Swift pair to drift apart, and a parser
- * bug can be fixed and re-run over files already captured instead of having destroyed what it
- * misread.
- *
- * Deliberately schema-identical to the iOS sink in `Apps/APN-UIKit/APN UIKit/Diagnostics`: the
- * same tooling reads both, and a per-platform dialect would double every analysis script.
  */
 object DiagnosticLog {
     /**
@@ -52,13 +37,9 @@ object DiagnosticLog {
 
     /**
      * Install the sink. Call this as the **first** statement of `Application.onCreate`.
-     *
-     * A cold background wake — the geofence case that matters most — reaches SDK code within
-     * milliseconds of process start, and on Android every such wake runs `Application.onCreate`
-     * first. Install this later, from an activity or after SDK initialization, and the wake you
-     * most wanted to observe is already over.
      */
     @JvmStatic
+    @OptIn(InternalCustomerIOApi::class)
     fun start(application: Application) {
         synchronized(lock) {
             if (started) return
@@ -73,6 +54,9 @@ object DiagnosticLog {
                 state.start { reason -> emit(Source.APP, "Diagnostics", CioLogLevel.DEBUG, "device.state changed=$reason") }
             }
         }
+
+        // The SDK's diagnostic tail is enabled by the io.customer.geofence.diagnostics manifest
+        // entry, not from here — there is no API for it.
 
         // Outside the lock: the SDK may log synchronously from inside these calls, and `emit`
         // takes the same lock.
@@ -95,9 +79,6 @@ object DiagnosticLog {
      * Receives every record the SDK emits. Forwards to Logcat **first**: the SDK dispatches as
      * `logDispatcher?.invoke(...) ?: <logcat>`, so a dispatcher that does not forward silently
      * empties Logcat for everyone else using this app.
-     *
-     * Known limitation, recorded rather than solved: the SDK passes only level and message to the
-     * dispatcher, never the `Throwable`, so stack traces on error records cannot reach the file.
      */
     private fun dispatch(level: CioLogLevel, message: String) {
         when (level) {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.os.Process
 import android.os.SystemClock
 import android.util.Log
-import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.util.CioLogLevel
 import java.io.File
@@ -18,6 +17,12 @@ object DiagnosticLog {
      * is not a bump — parsers ignore unknown fields.
      */
     const val SCHEMA_VERSION = 1
+
+    /**
+     * Same delimiter the SDK's geofence tail uses. The app's own records follow the same contract
+     * so one parser reads the whole file — inline `key=value` in the prose would be invisible to it.
+     */
+    private const val DELIMITER = " || "
 
     /** Mirrors the SDK's own Logcat tag, which is `internal` and so cannot be referenced here. */
     private const val LOGCAT_TAG = "[CIO]"
@@ -39,7 +44,6 @@ object DiagnosticLog {
      * Install the sink. Call this as the **first** statement of `Application.onCreate`.
      */
     @JvmStatic
-    @OptIn(InternalCustomerIOApi::class)
     fun start(application: Application) {
         synchronized(lock) {
             if (started) return
@@ -51,7 +55,14 @@ object DiagnosticLog {
             fileWriter.open(DiagnosticEnvelope.fileHeader(application))
 
             deviceState = DiagnosticDeviceState(application).also { state ->
-                state.start { reason -> emit(Source.APP, "Diagnostics", CioLogLevel.DEBUG, "device.state changed=$reason") }
+                state.start { reason ->
+                    emit(
+                        Source.APP,
+                        "Diagnostics",
+                        CioLogLevel.DEBUG,
+                        "Device state changed${DELIMITER}ev=device.state io=obs changed=$reason"
+                    )
+                }
             }
         }
 
@@ -71,7 +82,8 @@ object DiagnosticLog {
             Source.APP,
             "Diagnostics",
             CioLogLevel.INFO,
-            "session.start schema=$SCHEMA_VERSION dir=$DIRECTORY_NAME"
+            "Diagnostic session started$DELIMITER" +
+                "ev=session.start io=obs schema=$SCHEMA_VERSION dir=$DIRECTORY_NAME"
         )
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -165,10 +165,10 @@ object DiagnosticLog {
     }
 
     /** Records produced by the SDK, by the sample app, or by a reference app on this schema. */
+    /** Who produced the record: the SDK's logger, or the sample app itself. */
     enum class Source(val wire: String) {
         SDK("sdk"),
-        APP("app"),
-        REF("ref")
+        APP("app")
     }
 
     internal const val DIRECTORY_NAME = "cio-diagnostics"

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -1,0 +1,182 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import android.app.Application
+import android.os.Process
+import android.os.SystemClock
+import android.util.Log
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.CioLogLevel
+import java.io.File
+
+/**
+ * Field-drive diagnostics sink.
+ *
+ * Installs a dispatcher on the Customer.io logger and mirrors every record the SDK emits into an
+ * NDJSON file on disk, together with a device-state snapshot.
+ *
+ * Geofence field drives run for hours with the app in the background and no debugger attached.
+ * Logcat is a ring buffer that a long drive overruns, so today a completed drive leaves nothing
+ * reliable to analyse afterwards. This is the sink that fixes that.
+ *
+ * **Nothing here parses the SDK's message.** The device writes the raw string, including any
+ * ` || key=value` tail, into `msg`. A host-side script splits the tail and fills in `ev` and
+ * `data`. One parser, living off-device, means no Kotlin/Swift pair to drift apart, and a parser
+ * bug can be fixed and re-run over files already captured instead of having destroyed what it
+ * misread.
+ *
+ * Deliberately schema-identical to the iOS sink in `Apps/APN-UIKit/APN UIKit/Diagnostics`: the
+ * same tooling reads both, and a per-platform dialect would double every analysis script.
+ */
+object DiagnosticLog {
+    /**
+     * Bumped only when a field is removed, renamed, or changes meaning. Adding an optional field
+     * is not a bump — parsers ignore unknown fields.
+     */
+    const val SCHEMA_VERSION = 1
+
+    /** Mirrors the SDK's own Logcat tag, which is `internal` and so cannot be referenced here. */
+    private const val LOGCAT_TAG = "[CIO]"
+
+    private val lock = Any()
+    private var writer: DiagnosticLogWriter? = null
+    private var deviceState: DiagnosticDeviceState? = null
+
+    private var seq = 0L
+    private var started = false
+
+    /** Guards against a record emitted from inside the sink itself recursing forever. */
+    private var isEmitting = false
+
+    private val pid = Process.myPid()
+    private var startElapsedMs = 0L
+
+    /**
+     * Install the sink. Call this as the **first** statement of `Application.onCreate`.
+     *
+     * A cold background wake — the geofence case that matters most — reaches SDK code within
+     * milliseconds of process start, and on Android every such wake runs `Application.onCreate`
+     * first. Install this later, from an activity or after SDK initialization, and the wake you
+     * most wanted to observe is already over.
+     */
+    @JvmStatic
+    fun start(application: Application) {
+        synchronized(lock) {
+            if (started) return
+            started = true
+            startElapsedMs = SystemClock.elapsedRealtime()
+
+            val fileWriter = DiagnosticLogWriter(directory(application))
+            writer = fileWriter
+            fileWriter.open(DiagnosticEnvelope.fileHeader(application))
+
+            deviceState = DiagnosticDeviceState(application).also { state ->
+                state.start { reason -> emit(Source.APP, "Diagnostics", CioLogLevel.DEBUG, "device.state changed=$reason") }
+            }
+        }
+
+        // Outside the lock: the SDK may log synchronously from inside these calls, and `emit`
+        // takes the same lock.
+        val logger = SDKComponent.logger
+        // The SDK filters by level *before* the dispatcher runs, so a sink installed while the
+        // level sits at its default sees nothing. Forced here and again in the config builder,
+        // because `CustomerIO.initialize` re-applies the configured level over this one.
+        logger.logLevel = CioLogLevel.DEBUG
+        logger.setLogDispatcher { level, message -> dispatch(level, message) }
+
+        emit(
+            Source.APP,
+            "Diagnostics",
+            CioLogLevel.INFO,
+            "session.start schema=$SCHEMA_VERSION dir=$DIRECTORY_NAME"
+        )
+    }
+
+    /**
+     * Receives every record the SDK emits. Forwards to Logcat **first**: the SDK dispatches as
+     * `logDispatcher?.invoke(...) ?: <logcat>`, so a dispatcher that does not forward silently
+     * empties Logcat for everyone else using this app.
+     *
+     * Known limitation, recorded rather than solved: the SDK passes only level and message to the
+     * dispatcher, never the `Throwable`, so stack traces on error records cannot reach the file.
+     */
+    private fun dispatch(level: CioLogLevel, message: String) {
+        when (level) {
+            CioLogLevel.NONE -> {}
+            CioLogLevel.ERROR -> Log.e(LOGCAT_TAG, message)
+            CioLogLevel.INFO -> Log.i(LOGCAT_TAG, message)
+            CioLogLevel.DEBUG -> Log.d(LOGCAT_TAG, message)
+        }
+
+        // The SDK has already prefixed `[Tag] `. Lift it into its own field so files can be
+        // filtered by subsystem, and leave the rest of the string untouched.
+        val (tag, body) = splitTag(message)
+        emit(Source.SDK, tag, level, body)
+    }
+
+    /** Write an app-side record, for anything the SDK does not say itself. */
+    @JvmStatic
+    @JvmOverloads
+    fun note(message: String, tag: String = "Diagnostics", level: CioLogLevel = CioLogLevel.DEBUG) {
+        emit(Source.APP, tag, level, message)
+    }
+
+    private fun emit(source: Source, tag: String?, level: CioLogLevel, message: String) {
+        synchronized(lock) {
+            val target = writer ?: return
+            if (!started || isEmitting) return
+            isEmitting = true
+            try {
+                seq += 1
+                target.append(
+                    DiagnosticEnvelope.record(
+                        seq = seq,
+                        pid = pid,
+                        upMillis = SystemClock.elapsedRealtime() - startElapsedMs,
+                        source = source,
+                        tag = tag,
+                        level = level,
+                        message = message,
+                        deviceState = deviceState?.snapshotJson() ?: "{}"
+                    )
+                )
+            } finally {
+                isEmitting = false
+            }
+        }
+    }
+
+    /**
+     * `getExternalFilesDir` rather than internal storage: no permission is required, the directory
+     * survives `adb pull` without `run-as`, and it is visible over MTP — three independent ways to
+     * get a drive off the phone instead of one.
+     */
+    @JvmStatic
+    fun directory(application: Application): File =
+        File(application.getExternalFilesDir(null) ?: application.filesDir, DIRECTORY_NAME)
+
+    /** Files currently on disk, newest first. */
+    @JvmStatic
+    fun sessionFiles(): List<File> = synchronized(lock) { writer?.files() ?: emptyList() }
+
+    /**
+     * Splits `[Geofence] message` into `"Geofence"` and `"message"`. A message with no prefix keeps
+     * its whole text and reports no tag.
+     */
+    internal fun splitTag(message: String): Pair<String?, String> {
+        if (!message.startsWith("[")) return null to message
+        val close = message.indexOf(']')
+        if (close <= 1) return null to message
+        val tag = message.substring(1, close)
+        val rest = message.substring(close + 1).removePrefix(" ")
+        return tag to rest
+    }
+
+    /** Records produced by the SDK, by the sample app, or by a reference app on this schema. */
+    enum class Source(val wire: String) {
+        SDK("sdk"),
+        APP("app"),
+        REF("ref")
+    }
+
+    internal const val DIRECTORY_NAME = "cio-diagnostics"
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogExport.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogExport.kt
@@ -1,0 +1,67 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import java.util.Locale
+
+/**
+ * Getting the files off the phone.
+ *
+ * A drive that produced perfect data and then lost it to a wiped device or a forgotten export is a
+ * drive wasted, and drives are the expensive part. Three independent routes out, because which one
+ * works depends on what is to hand at the end of a drive:
+ *
+ * - **Share sheet** (this type) — Drive, email, Nearby Share; no cable, works standing by the car.
+ * - **`adb pull`** — the directory is under `getExternalFilesDir`, so no `run-as` and no root.
+ * - **MTP over USB** — the same directory is visible in Finder or Explorer.
+ *
+ * Security is deliberately relaxed here. This is a sample app whose entire job is producing
+ * diagnostics; none of it ships in the SDK.
+ */
+object DiagnosticLogExport {
+    /**
+     * Shares the newest log file.
+     *
+     * One file rather than the whole directory: `ACTION_SEND_MULTIPLE` is inconsistently handled by
+     * receiving apps, and the newest file is the drive that just finished. Older ones come off with
+     * `adb pull`.
+     */
+    @JvmStatic
+    fun share(activity: Activity) {
+        val newest = DiagnosticLog.sessionFiles().firstOrNull()
+        if (newest == null) {
+            Toast.makeText(activity, "No diagnostic logs on disk yet.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val uri: Uri = runCatching {
+            FileProvider.getUriForFile(activity, "${activity.packageName}.diagnostics", newest)
+        }.getOrElse {
+            Toast.makeText(activity, "Could not share the diagnostic log.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "application/x-ndjson"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, newest.name)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        activity.startActivity(Intent.createChooser(intent, "Share diagnostic log"))
+    }
+
+    /**
+     * A one-line summary, so it is obvious before setting off whether the sink is capturing
+     * anything at all.
+     */
+    @JvmStatic
+    fun statusSummary(): String {
+        val files = DiagnosticLog.sessionFiles()
+        val newest = files.firstOrNull() ?: return "No log files yet."
+        val kilobytes = newest.length() / 1024.0
+        return String.format(Locale.US, "%d file(s) · newest %s (%.1f KB)", files.size, newest.name, kilobytes)
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogExport.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogExport.kt
@@ -9,25 +9,10 @@ import java.util.Locale
 
 /**
  * Getting the files off the phone.
- *
- * A drive that produced perfect data and then lost it to a wiped device or a forgotten export is a
- * drive wasted, and drives are the expensive part. Three independent routes out, because which one
- * works depends on what is to hand at the end of a drive:
- *
- * - **Share sheet** (this type) — Drive, email, Nearby Share; no cable, works standing by the car.
- * - **`adb pull`** — the directory is under `getExternalFilesDir`, so no `run-as` and no root.
- * - **MTP over USB** — the same directory is visible in Finder or Explorer.
- *
- * Security is deliberately relaxed here. This is a sample app whose entire job is producing
- * diagnostics; none of it ships in the SDK.
  */
 object DiagnosticLogExport {
     /**
      * Shares the newest log file.
-     *
-     * One file rather than the whole directory: `ACTION_SEND_MULTIPLE` is inconsistently handled by
-     * receiving apps, and the newest file is the drive that just finished. Older ones come off with
-     * `adb pull`.
      */
     @JvmStatic
     fun share(activity: Activity) {

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -9,9 +9,6 @@ import java.util.Locale
 
 /**
  * Appends NDJSON records to a file on disk.
- *
- * NDJSON rather than a JSON array specifically because it is append-safe and truncation-tolerant:
- * a process killed mid-write loses one line, not the file. Losing the file is losing the drive.
  */
 internal class DiagnosticLogWriter(private val directory: File) {
     private companion object {
@@ -46,18 +43,12 @@ internal class DiagnosticLogWriter(private val directory: File) {
     fun open(header: String) {
         synchronized(lock) {
             this.header = header
-            prune()
             openCurrentFile(System.currentTimeMillis())
         }
     }
 
     /**
      * Rotation is **per day, not per launch.**
-     *
-     * A phone woken repeatedly in the background relaunches the process many times over a drive,
-     * and per-launch rotation would shatter one drive across a dozen files that then have to be
-     * reassembled in the right order. Process deaths stay perfectly visible as `session.start`
-     * records *inside* the file.
      */
     private fun openCurrentFile(now: Long) {
         closeCurrentFile()
@@ -74,7 +65,15 @@ internal class DiagnosticLogWriter(private val directory: File) {
         rolloverAt = startOfNextDay(now)
         writesSinceExistenceCheck = 0
 
-        if (isNew && header.isNotEmpty()) write(header)
+        // Retention only when a file was actually created. Keeping it off the failure paths
+        // matters: they return before rolloverAt is set, so every later append re-enters this
+        // method.
+        if (isNew) prune()
+
+        // The header repeats on every open, not just on a new file. A same-day relaunch reuses
+        // the file but resets elapsedRealtime and may carry a different bootCount or build, so
+        // without this every record after the first process is correlated to the wrong boot.
+        if (header.isNotEmpty()) write(header)
     }
 
     private fun closeCurrentFile() {
@@ -108,9 +107,6 @@ internal class DiagnosticLogWriter(private val directory: File) {
      * One write and flush per record, so a record that has returned is already in the file and
      * survives the process being killed the instant afterwards — which is the normal way a
      * background wake ends.
-     *
-     * Deliberately no `fd.sync()`: that would only add durability across a kernel panic or power
-     * loss, at the cost of a flash write per log line for hours at a time.
      */
     private fun write(line: String) {
         val target = stream ?: return
@@ -129,23 +125,24 @@ internal class DiagnosticLogWriter(private val directory: File) {
 
     /**
      * Enforces the retention policy by evicting the **oldest** files.
-     *
-     * Never clears the directory on launch. A drive that ended with the phone dying, or an engineer
-     * who forgot to pull the file before the next test, must still find yesterday's data where they
-     * left it.
      */
     private fun prune() {
         var kept = 0
         var total = 0L
+        // Once the budget is spent everything older goes. Without the latch a large file could be
+        // deleted and then a smaller, *older* one still fit and survive it — retention preferring
+        // older data over newer, which is backwards.
+        var budgetSpent = false
         for (file in files()) {
             val withinCount = kept < MAX_FILES
             val withinSize = total + file.length() <= MAX_TOTAL_BYTES
             // The newest file is always kept, however large — it may be the drive nobody has
             // pulled off the device yet.
-            if (kept == 0 || (withinCount && withinSize)) {
+            if (!budgetSpent && (kept == 0 || (withinCount && withinSize))) {
                 kept += 1
                 total += file.length()
             } else {
+                budgetSpent = true
                 file.delete()
             }
         }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -1,0 +1,162 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import java.io.File
+import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Appends NDJSON records to a file on disk.
+ *
+ * NDJSON rather than a JSON array specifically because it is append-safe and truncation-tolerant:
+ * a process killed mid-write loses one line, not the file. Losing the file is losing the drive.
+ */
+internal class DiagnosticLogWriter(private val directory: File) {
+    private companion object {
+        /** Two weeks covers a test cycle; a drive is single-digit megabytes. */
+        const val MAX_FILES = 14
+        const val MAX_TOTAL_BYTES = 100L * 1024 * 1024
+
+        const val FILE_PREFIX = "cio-diag-"
+        const val FILE_SUFFIX = ".ndjson"
+
+        /**
+         * One existence check every this many records — roughly 0.4% overhead, against silently
+         * writing a whole drive into a file somebody deleted from under us.
+         */
+        const val EXISTENCE_CHECK_INTERVAL = 256
+    }
+
+    private val lock = Any()
+    private val dayFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+    private var stream: FileOutputStream? = null
+    private var currentFile: File? = null
+    private var header: String = ""
+
+    /**
+     * Wall-clock instant at which today's file stops being today's file. Compared against on every
+     * record, so rotation costs an inequality rather than a date format.
+     */
+    private var rolloverAt = 0L
+    private var writesSinceExistenceCheck = 0
+
+    fun open(header: String) {
+        synchronized(lock) {
+            this.header = header
+            prune()
+            openCurrentFile(System.currentTimeMillis())
+        }
+    }
+
+    /**
+     * Rotation is **per day, not per launch.**
+     *
+     * A phone woken repeatedly in the background relaunches the process many times over a drive,
+     * and per-launch rotation would shatter one drive across a dozen files that then have to be
+     * reassembled in the right order. Process deaths stay perfectly visible as `session.start`
+     * records *inside* the file.
+     */
+    private fun openCurrentFile(now: Long) {
+        closeCurrentFile()
+
+        if (!directory.exists() && !directory.mkdirs()) return
+
+        val file = File(directory, "$FILE_PREFIX${dayFormat.format(Date(now))}$FILE_SUFFIX")
+        val isNew = !file.exists()
+
+        stream = runCatching { FileOutputStream(file, /* append = */ true) }.getOrNull()
+        if (stream == null) return
+
+        currentFile = file
+        rolloverAt = startOfNextDay(now)
+        writesSinceExistenceCheck = 0
+
+        if (isNew && header.isNotEmpty()) write(header)
+    }
+
+    private fun closeCurrentFile() {
+        runCatching { stream?.close() }
+        stream = null
+    }
+
+    fun append(line: String) {
+        synchronized(lock) {
+            val now = System.currentTimeMillis()
+            if (now >= rolloverAt) {
+                openCurrentFile(now)
+            } else if (needsExistenceCheck() && currentFile?.exists() != true) {
+                // Deleted from under us — someone clearing files over MTP, `adb shell rm`, or the
+                // app's storage being cleared. The stream stays writable and the bytes go nowhere,
+                // so without this the rest of the drive is lost in silence.
+                openCurrentFile(now)
+            }
+            write(line)
+        }
+    }
+
+    private fun needsExistenceCheck(): Boolean {
+        writesSinceExistenceCheck += 1
+        if (writesSinceExistenceCheck < EXISTENCE_CHECK_INTERVAL) return false
+        writesSinceExistenceCheck = 0
+        return true
+    }
+
+    /**
+     * One write and flush per record, so a record that has returned is already in the file and
+     * survives the process being killed the instant afterwards — which is the normal way a
+     * background wake ends.
+     *
+     * Deliberately no `fd.sync()`: that would only add durability across a kernel panic or power
+     * loss, at the cost of a flash write per log line for hours at a time.
+     */
+    private fun write(line: String) {
+        val target = stream ?: return
+        runCatching {
+            target.write((line + "\n").toByteArray(Charsets.UTF_8))
+            target.flush()
+        }
+    }
+
+    /** Files on disk, newest first. */
+    fun files(): List<File> =
+        (directory.listFiles { file -> file.name.startsWith(FILE_PREFIX) } ?: emptyArray())
+            // Names are `cio-diag-YYYY-MM-DD`, so lexical order is chronological order and no
+            // filesystem timestamp has to be trusted.
+            .sortedByDescending { it.name }
+
+    /**
+     * Enforces the retention policy by evicting the **oldest** files.
+     *
+     * Never clears the directory on launch. A drive that ended with the phone dying, or an engineer
+     * who forgot to pull the file before the next test, must still find yesterday's data where they
+     * left it.
+     */
+    private fun prune() {
+        var kept = 0
+        var total = 0L
+        for (file in files()) {
+            val withinCount = kept < MAX_FILES
+            val withinSize = total + file.length() <= MAX_TOTAL_BYTES
+            // The newest file is always kept, however large — it may be the drive nobody has
+            // pulled off the device yet.
+            if (kept == 0 || (withinCount && withinSize)) {
+                kept += 1
+                total += file.length()
+            } else {
+                file.delete()
+            }
+        }
+    }
+
+    private fun startOfNextDay(now: Long): Long = Calendar.getInstance().apply {
+        timeInMillis = now
+        add(Calendar.DAY_OF_YEAR, 1)
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -39,6 +39,16 @@ internal class DiagnosticLogWriter(private val directory: File) {
      * record, so rotation costs an inequality rather than a date format.
      */
     private var rolloverAt = 0L
+
+    /**
+     * Zone the open file was named and its [rolloverAt] computed in. Both are derived from a
+     * single snapshot, so a file can never be named for one zone and roll over on another's
+     * midnight. Compared on every append: reading the zone fresh each time is not enough on its
+     * own, because [rolloverAt] is a precomputed instant and nothing else would notice it had
+     * become the wrong one. Driving east across a zone would otherwise keep appending to the
+     * previous day's file until midnight in the zone the file was opened in.
+     */
+    private var openZoneId: String? = null
     private var writesSinceExistenceCheck = 0
 
     fun open(header: String) {
@@ -58,7 +68,10 @@ internal class DiagnosticLogWriter(private val directory: File) {
 
         // Same stale-zone trap as the envelope: startOfNextDay works off the current zone, so a
         // formatter pinned at construction would name the file for the zone the process started in.
-        dayFormat.timeZone = TimeZone.getDefault()
+        // One snapshot for the name, the boundary, and the recorded id — reading the zone three
+        // times could straddle a change and pair a name with another zone's midnight.
+        val zone = TimeZone.getDefault()
+        dayFormat.timeZone = zone
         val file = File(directory, "$FILE_PREFIX${dayFormat.format(Date(now))}$FILE_SUFFIX")
         val isNew = !file.exists()
 
@@ -66,7 +79,8 @@ internal class DiagnosticLogWriter(private val directory: File) {
         if (stream == null) return
 
         currentFile = file
-        rolloverAt = startOfNextDay(now)
+        rolloverAt = startOfNextDay(now, zone)
+        openZoneId = zone.id
         writesSinceExistenceCheck = 0
 
         // Retention only when a file was actually created. Keeping it off the failure paths
@@ -88,7 +102,7 @@ internal class DiagnosticLogWriter(private val directory: File) {
     fun append(line: String) {
         synchronized(lock) {
             val now = System.currentTimeMillis()
-            if (now >= rolloverAt) {
+            if (now >= rolloverAt || TimeZone.getDefault().id != openZoneId) {
                 openCurrentFile(now)
             } else if (needsExistenceCheck() && currentFile?.exists() != true) {
                 // Deleted from under us — someone clearing files over MTP, `adb shell rm`, or the
@@ -152,7 +166,7 @@ internal class DiagnosticLogWriter(private val directory: File) {
         }
     }
 
-    private fun startOfNextDay(now: Long): Long = Calendar.getInstance().apply {
+    private fun startOfNextDay(now: Long, zone: TimeZone): Long = Calendar.getInstance(zone).apply {
         timeInMillis = now
         add(Calendar.DAY_OF_YEAR, 1)
         set(Calendar.HOUR_OF_DAY, 0)

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -6,6 +6,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 /**
  * Appends NDJSON records to a file on disk.
@@ -55,6 +56,9 @@ internal class DiagnosticLogWriter(private val directory: File) {
 
         if (!directory.exists() && !directory.mkdirs()) return
 
+        // Same stale-zone trap as the envelope: startOfNextDay works off the current zone, so a
+        // formatter pinned at construction would name the file for the zone the process started in.
+        dayFormat.timeZone = TimeZone.getDefault()
         val file = File(directory, "$FILE_PREFIX${dayFormat.format(Date(now))}$FILE_SUFFIX")
         val isNew = !file.exists()
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -161,7 +161,14 @@ internal class DiagnosticLogWriter(private val directory: File) {
                 total += file.length()
             } else {
                 budgetSpent = true
-                file.delete()
+                // Never unlink the file this writer holds open. `prune()` runs from
+                // `openCurrentFile` right after creating today's file, which is normally newest and
+                // so always kept — but a future-dated `cio-diag-` file (clock set forward, a
+                // capture copied back over MTP) takes that slot and can push the open one over
+                // budget. Deleting it would leave writes going to an unlinked inode until the
+                // existence check reopens, losing up to EXISTENCE_CHECK_INTERVAL records in
+                // silence. The latch is still set, so retention cannot prefer older data.
+                if (file != currentFile) file.delete()
             }
         }
     }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -27,6 +27,7 @@ import io.customer.messagingpush.livenotification.LiveNotificationType;
 import io.customer.sdk.CustomerIO;
 import io.customer.sdk.CustomerIOConfig;
 import io.customer.sdk.CustomerIOConfigBuilder;
+import io.customer.sdk.core.util.CioLogLevel;
 
 /**
  * Repository class to hold all Customer.io related operations at single place
@@ -133,7 +134,12 @@ public class CustomerIORepository {
         builder.autoTrackDeviceAttributes(sdkConfig.isDeviceAttributesTrackingEnabled());
         builder.trackApplicationLifecycleEvents(sdkConfig.isApplicationLifecycleTrackingEnabled());
         builder.region(sdkConfig.getRegion());
-        builder.logLevel(sdkConfig.getLogLevel());
+        // Forced to DEBUG rather than taking the stored setting. The SDK filters by level
+        // *before* the dispatcher runs, and CustomerIO.initialize re-applies the configured level
+        // over whatever the sink set at install time — so a stored level of ERROR would produce an
+        // empty file after a three-hour drive. Diagnostics win over the setting; the Location Test
+        // screen says so on screen.
+        builder.logLevel(CioLogLevel.DEBUG);
         builder.screenViewUse(sdkConfig.getScreenViewUse());
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -22,6 +22,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import io.customer.android.sample.java_layout.R;
 import io.customer.android.sample.java_layout.databinding.ActivityLocationTestBinding;
+import io.customer.android.sample.java_layout.diagnostics.DiagnosticLogExport;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.geofence.ModuleGeofence;
 import io.customer.location.ModuleLocation;
@@ -156,6 +157,7 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
 
     private void setupBackgroundPermissionButton() {
         binding.grantBackgroundLocation.setOnClickListener(v -> handleGrantBackgroundLocationTap());
+        binding.shareDiagnosticLogs.setOnClickListener(v -> DiagnosticLogExport.share(LocationTestActivity.this));
         refreshGrantBackgroundLocationUI();
     }
 
@@ -386,6 +388,7 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
     @Override
     protected void onResume() {
         super.onResume();
+        binding.diagnosticLogStatusLabel.setText(DiagnosticLogExport.statusSummary());
         // Permission may have been toggled in Settings while we were in the background.
         // If we previously flagged "permanently denied" but the system now offers rationale,
         // the user lifted don't-ask-again — treat the denial as recoverable.

--- a/samples/java_layout/src/main/res/layout/activity_location_test.xml
+++ b/samples/java_layout/src/main/res/layout/activity_location_test.xml
@@ -37,6 +37,39 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="@string/diagnostics_section_title"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <Button
+                android:id="@+id/share_diagnostic_logs"
+                style="?attr/materialButtonStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/diagnostics_share_button" />
+
+            <TextView
+                android:id="@+id/diagnostic_log_status_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textColor="?android:attr/textColorTertiary"
+                android:textSize="12sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="16dp"
+                android:text="@string/diagnostics_description"
+                android:textColor="?android:attr/textColorTertiary"
+                android:textSize="12sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:text="@string/bg_perm_section_title"
                 android:textColor="?android:attr/textColorSecondary"
                 android:textSize="14sp"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
     <string name="bg_perm_section_title">BACKGROUND LOCATION</string>
     <string name="diagnostics_section_title">DIAGNOSTIC LOGS</string>
     <string name="diagnostics_share_button">Share diagnostic logs</string>
-    <string name="diagnostics_description">Every SDK log line is mirrored to an NDJSON file under the app\'s external files directory, with a device-state snapshot on each record. Rotates daily, keeps 14 files. The SDK log level is forced to DEBUG while this sink is installed, so the Settings log level does not apply. Also reachable with adb pull, no run-as needed.</string>
+    <string name="diagnostics_description">Log level forced to DEBUG while recording, overriding Settings. Rotates daily, keeps 14 files.</string>
     <string name="bg_perm_rationale_title">Allow background location?</string>
     <string name="background_location_description">Geofence background delivery requires the \"Allow all the time\" location authorization. Grant foreground access first; on Android 11+ the system routes the upgrade through Settings instead of showing a dialog.</string>
     <string name="background_location_rationale_message">Geofence transitions only fire while the app is backgrounded if you grant \"Allow all the time\". Tap Continue to open the location permission screen, then select \"Allow all the time\".</string>

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -145,6 +145,9 @@
 
     <!-- Background-location section -->
     <string name="bg_perm_section_title">BACKGROUND LOCATION</string>
+    <string name="diagnostics_section_title">DIAGNOSTIC LOGS</string>
+    <string name="diagnostics_share_button">Share diagnostic logs</string>
+    <string name="diagnostics_description">Every SDK log line is mirrored to an NDJSON file under the app\'s external files directory, with a device-state snapshot on each record. Rotates daily, keeps 14 files. The SDK log level is forced to DEBUG while this sink is installed, so the Settings log level does not apply. Also reachable with adb pull, no run-as needed.</string>
     <string name="bg_perm_rationale_title">Allow background location?</string>
     <string name="background_location_description">Geofence background delivery requires the \"Allow all the time\" location authorization. Grant foreground access first; on Android 11+ the system routes the upgrade through Settings instead of showing a dialog.</string>
     <string name="background_location_rationale_message">Geofence transitions only fire while the app is backgrounded if you grant \"Allow all the time\". Tap Continue to open the location permission screen, then select \"Allow all the time\".</string>

--- a/samples/java_layout/src/main/res/xml/diagnostics_paths.xml
+++ b/samples/java_layout/src/main/res/xml/diagnostics_paths.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Exposes only the diagnostics directory under getExternalFilesDir, so the share sheet can hand a
-  single log file to another app. Nothing else in the app's storage is reachable through it.
+  Exposes only the diagnostics directory, so the share sheet can hand a single log file to another
+  app. Nothing else in the app's storage is reachable through it.
+
+  Both roots are declared because DiagnosticLog.directory() falls back to filesDir when
+  getExternalFilesDir returns null. Without the internal root the share button would fail on that
+  path — logging and adb pull keep working, so it is a quiet failure rather than a loud one.
 -->
 <paths>
     <external-files-path
         name="cio-diagnostics"
+        path="cio-diagnostics/" />
+    <files-path
+        name="cio-diagnostics-internal"
         path="cio-diagnostics/" />
 </paths>

--- a/samples/java_layout/src/main/res/xml/diagnostics_paths.xml
+++ b/samples/java_layout/src/main/res/xml/diagnostics_paths.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Exposes only the diagnostics directory under getExternalFilesDir, so the share sheet can hand a
+  single log file to another app. Nothing else in the app's storage is reachable through it.
+-->
+<paths>
+    <external-files-path
+        name="cio-diagnostics"
+        path="cio-diagnostics/" />
+</paths>


### PR DESCRIPTION
[MBL-2322: Persist SDK logs to an NDJSON file in the sample apps](https://linear.app/customerio/issue/MBL-2322/persist-sdk-logs-to-an-ndjson-file-in-the-sample-apps)

Android half of MBL-2322. iOS is [customerio-ios#1242](https://github.com/customerio/customerio-ios/pull/1242).

Sample app only — no SDK files touched, `make validate-public-api` clean.

Field drives currently leave almost no analysable record: Logcat is a ring buffer that a multi-hour drive overruns. This installs a log dispatcher that mirrors every SDK record into `cio-diagnostics` under the app's external files directory as NDJSON, with a device-state snapshot on each record.

The output is the input for the rest of the geofence testing strategy — see [Testing Trips Without Taking Them](https://claude.ai/code/artifact/9a7cda78-cf55-46fb-b452-ff13b338a56c) for the overview and [Testing Without Driving](https://claude.ai/code/artifact/7394e40e-e61e-4cac-9542-cf5336da76f0) for the engineering detail. Full spec in `geofence-logging-pr-plan.md`.

**Schema-identical to the iOS sink**, deliberately. The same off-device tooling reads both, and a per-platform dialect would double every analysis script.

## What it does

- Installs `setLogDispatcher` as the **first** statement of `Application.onCreate`. Every cold background wake runs `onCreate` first and reaches SDK code within milliseconds.
- **Forwards to Logcat first.** The SDK dispatches as `logDispatcher?.invoke(...) ?: <logcat>`, so a dispatcher that does not forward silently empties Logcat for everyone else using this app.
- Envelope per record: `v seq ts mono pid up src tag lvl msg dev`. `elapsedRealtimeNanos` for `mono` — it keeps counting through deep sleep, which is exactly the interval a backgrounded phone spends between geofence wakes.
- `[Tag]` prefix lifted into its own field; `msg` otherwise holds the complete original string, including the ` || key=value` tail MBL-2323 adds.
- File header carries `boot` (derived, comparable with iOS) **and** `bootCount` from `Settings.Global.BOOT_COUNT`, which is exact.
- Device state from **OS-pushed broadcasts only — no timers, no polling, never a Wi-Fi scan.** A repeating wakeup pulls the phone out of Doze and improves the very behaviour we are measuring. The one read-on-demand value is the standby bucket, which has no broadcast; it is a local binder call that schedules nothing.
- Rotates **daily, not per launch** — background relaunches would otherwise shatter one drive across a dozen files. Retention 14 files / 100 MB, never wiped on launch.
- Three ways off the device: share sheet on the Location Test screen (FileProvider scoped to the diagnostics directory only), `adb pull` with no `run-as`, and MTP over USB.

Parsing is deliberately **not** on-device. One parser, off-device, fixable after the fact and re-runnable over files already captured.

## Two behaviours worth flagging in review

**SDK log level is forced to `DEBUG`.** The SDK filters by level *before* the dispatcher runs, and `CustomerIO.initialize` re-applies the configured level, so a stored level of ERROR would produce an empty file after a three-hour drive. This overrides the Settings screen's log level; the Location Test screen says so on screen.

**`getExternalFilesDir` rather than internal storage.** No permission needed and it survives `adb pull` without `run-as` — deliberately relaxed, because this is a sample app whose whole job is producing diagnostics.

## Verified on an emulator (API 35)

386 records across two launches in one file, every line valid JSON. `Geofence`, `Init`, `SSE`, `Polling`, `Push`, `CIO-Inbox` tags all parsed; 151 debug / 19 info. Append-across-relaunch confirmed by two `session.start` records with distinct `seq=1` in the same file, so process death stays visible inline. `fg` tracks a home-key press correctly.

```json
{"v":1,"ev":"file.open","ts":"2026-08-31T20:07:58.779+04:00","boot":"2026-08-30T15:49:58.244+04:00",
 "bootCount":50,"device":{"model":"Google sdk_gphone64_arm64","os":"Android","osVersion":"15 (API 35)"},
 "app":{"id":"io.customer.android.sample.java_layout","version":"1.0","build":"1"},
 "sdk":{"version":"4.20.2"},"tz":"Asia/Dubai"}
```

One fix came out of running it: the first ~26 records of every session carried `batt=-1` because `ACTION_BATTERY_CHANGED` is sticky and lands just after registration. Now seeded with a null-receiver read at startup, which returns the current value immediately and costs no wakeup.

## Known limitation, recorded not solved

The SDK passes only level and message to the dispatcher, never the `Throwable` (`LoggerImpl.logIfMatchesCriteria`). Stack traces on error records therefore cannot reach the file. Noted in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review fixes folded in

These were raised against this PR but had been committed on the stacked enrichment branch. They now live here, with the code they change.

- **The session header repeats on every open**, not only when the file is new. A same-day reboot or relaunch reuses the file, resets `elapsedRealtime` and changes `bootCount`, so everything appended afterwards was correlated to the wrong boot. Retention still runs only when a file was actually created — the failure paths return before `rolloverAt` is set, so putting it there would re-enter on every append.
- **Retention now runs on the midnight rollover**, not only at process start.
- **Size eviction no longer keeps an older file after deleting a newer one.** With 70 MB / 40 MB / 5 MB newest-first it kept 70, deleted 40, then kept 5. A latch now removes the first file that exceeds the remaining budget and everything older.
- **The no-op screen receiver is gone.** `update("screen") { it }` left the snapshot unchanged, so the callback never fired and `Snapshot` had no screen field either way.
- **`standbyBucket()` is cached with a 60 s TTL.** It was making a `UsageStatsManager` binder call for every record while the sink lock was held, which under Doze could serialize SDK logging behind IPC — perturbing the very path being measured.
- **The battery sentinel** reports `null` rather than a magic value when the level is unknown.
- **The app's own records use the same `||` delimiter as the SDK's tail.** `session.start` and `device.state` carried `key=value` inline in the prose, so the off-device parser — which splits on the last `||` and accepts the remainder only if it is entirely `key=value` — never yielded their fields.
- **Dropped an `@OptIn(InternalCustomerIOApi::class)`** for a marker nothing in the file needs any more.

Known and not addressed here: an open failure is not retried until the next midnight rollover; `application/x-ndjson` filters out some share targets; and the pure `prune` / `splitTag` / `json` helpers have no unit tests, which is how the eviction ordering bug survived.
