### PR TITLE
feat(inbox): replace visual inbox empty-state text with a dimmed bell

### DIFF
--- a/messaginginapp/api/messaginginapp.api
+++ b/messaginginapp/api/messaginginapp.api
@@ -1,8 +1,9 @@
 public final class io/customer/messaginginapp/MessagingInAppModuleConfig : io/customer/sdk/core/module/CustomerIOModuleConfig {
-	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lio/customer/messaginginapp/type/ColorScheme;Lio/customer/messaginginapp/type/InboxEventListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/customer/sdk/data/model/Region;Lio/customer/messaginginapp/type/InAppEventListener;Lio/customer/messaginginapp/type/ColorScheme;Lio/customer/messaginginapp/type/InboxEventListener;Lio/customer/messaginginapp/type/NotificationInboxAccessibilityLabels;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getColorScheme ()Lio/customer/messaginginapp/type/ColorScheme;
 	public final fun getEventListener ()Lio/customer/messaginginapp/type/InAppEventListener;
 	public final fun getInboxEventListener ()Lio/customer/messaginginapp/type/InboxEventListener;
+	public final fun getNotificationInboxAccessibilityLabels ()Lio/customer/messaginginapp/type/NotificationInboxAccessibilityLabels;
 	public final fun getRegion ()Lio/customer/sdk/data/model/Region;
 	public final fun getSiteId ()Ljava/lang/String;
 }
@@ -14,6 +15,7 @@ public final class io/customer/messaginginapp/MessagingInAppModuleConfig$Builder
 	public final fun setColorScheme (Lio/customer/messaginginapp/type/ColorScheme;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 	public final fun setEventListener (Lio/customer/messaginginapp/type/InAppEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 	public final fun setInboxEventListener (Lio/customer/messaginginapp/type/InboxEventListener;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
+	public final fun setNotificationInboxAccessibilityLabels (Lio/customer/messaginginapp/type/NotificationInboxAccessibilityLabels;)Lio/customer/messaginginapp/MessagingInAppModuleConfig$Builder;
 }
 
 public final class io/customer/messaginginapp/ModuleMessagingInApp : io/customer/messaginginapp/gist/presentation/GistListener, io/customer/sdk/core/module/CustomerIOModule {
@@ -293,6 +295,19 @@ public final class io/customer/messaginginapp/type/InboxEventListener$DefaultImp
 
 public abstract interface class io/customer/messaginginapp/type/InlineMessageActionListener {
 	public abstract fun onActionClick (Lio/customer/messaginginapp/type/InAppMessage;Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class io/customer/messaginginapp/type/NotificationInboxAccessibilityLabels {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBell ()Ljava/lang/String;
+	public final fun getBellWithUnreadCount ()Lkotlin/jvm/functions/Function1;
+	public final fun getEmptyState ()Ljava/lang/String;
+	public final fun getLoadingIndicator ()Ljava/lang/String;
 }
 
 public final class io/customer/messaginginapp/ui/InlineInAppMessageView : io/customer/messaginginapp/ui/core/BaseInlineInAppMessageView, io/customer/messaginginapp/ui/bridge/InlineInAppMessageViewCallback {

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/MessagingInAppModuleConfig.kt
@@ -3,6 +3,7 @@ package io.customer.messaginginapp
 import io.customer.messaginginapp.type.ColorScheme
 import io.customer.messaginginapp.type.InAppEventListener
 import io.customer.messaginginapp.type.InboxEventListener
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
 import io.customer.sdk.core.module.CustomerIOModuleConfig
 import io.customer.sdk.data.model.Region
 
@@ -15,7 +16,12 @@ class MessagingInAppModuleConfig private constructor(
     val region: Region,
     val eventListener: InAppEventListener?,
     val colorScheme: ColorScheme,
-    val inboxEventListener: InboxEventListener?
+    val inboxEventListener: InboxEventListener?,
+    /**
+     * Host-provided TalkBack labels for the Visual Notification Inbox UI. All null by default (the SDK
+     * emits no strings of its own). See [NotificationInboxAccessibilityLabels].
+     */
+    val notificationInboxAccessibilityLabels: NotificationInboxAccessibilityLabels
 ) : CustomerIOModuleConfig {
     class Builder(
         private val siteId: String,
@@ -24,6 +30,7 @@ class MessagingInAppModuleConfig private constructor(
         private var eventListener: InAppEventListener? = null
         private var colorScheme: ColorScheme = ColorScheme.AUTO
         private var inboxEventListener: InboxEventListener? = null
+        private var notificationInboxAccessibilityLabels: NotificationInboxAccessibilityLabels = NotificationInboxAccessibilityLabels()
 
         fun setEventListener(eventListener: InAppEventListener): Builder {
             this.eventListener = eventListener
@@ -45,13 +52,25 @@ class MessagingInAppModuleConfig private constructor(
             return this
         }
 
+        /**
+         * Sets the TalkBack labels for the Visual Notification Inbox UI (bell, unread badge, loading
+         * and empty states). The SDK ships no default labels, so provide these in your app's language
+         * if you want the inbox to be announced by assistive technologies. See
+         * [NotificationInboxAccessibilityLabels].
+         */
+        fun setNotificationInboxAccessibilityLabels(labels: NotificationInboxAccessibilityLabels): Builder {
+            this.notificationInboxAccessibilityLabels = labels
+            return this
+        }
+
         override fun build(): MessagingInAppModuleConfig {
             return MessagingInAppModuleConfig(
                 siteId = siteId,
                 region = region,
                 eventListener = eventListener,
                 colorScheme = colorScheme,
-                inboxEventListener = inboxEventListener
+                inboxEventListener = inboxEventListener,
+                notificationInboxAccessibilityLabels = notificationInboxAccessibilityLabels
             )
         }
     }

--- a/messaginginapp/src/main/java/io/customer/messaginginapp/type/NotificationInboxAccessibilityLabels.kt
+++ b/messaginginapp/src/main/java/io/customer/messaginginapp/type/NotificationInboxAccessibilityLabels.kt
@@ -1,0 +1,49 @@
+package io.customer.messaginginapp.type
+
+/**
+ * Host-provided accessibility (TalkBack) labels for the Visual Notification Inbox UI —
+ * `NotificationInboxView`, `NotificationInboxBell` and `NotificationInboxOverlay`.
+ *
+ * The SDK ships **no** text of its own in the visual inbox: the empty state is an icon and the loading
+ * state is a spinner, so nothing on screen needs translating. Accessibility labels are the one place a
+ * string is still needed, and because the SDK cannot know the host app's language, every label is
+ * optional and **null by default**. A null label emits no content description for that element: the
+ * empty-state icon is decorative, the spinner is announced only as indeterminate progress, and the
+ * bell stays focusable and tappable but unnamed (hiding it would leave TalkBack users no way into the
+ * inbox). Provide values in whatever language your app ships in — typically from your own
+ * `strings.xml`.
+ *
+ * ```kotlin
+ * MessagingInAppModuleConfig.Builder(siteId, Region.US)
+ *     .setNotificationInboxAccessibilityLabels(
+ *         NotificationInboxAccessibilityLabels(
+ *             bell = context.getString(R.string.inbox_bell),
+ *             bellWithUnreadCount = { count ->
+ *                 context.resources.getQuantityString(R.plurals.inbox_unread, count, count)
+ *             },
+ *             loadingIndicator = context.getString(R.string.inbox_loading),
+ *             emptyState = context.getString(R.string.inbox_empty)
+ *         )
+ *     )
+ *     .build()
+ * ```
+ *
+ * Threading: [bellWithUnreadCount] is invoked on the main thread while the bell composes, each time
+ * the unread count changes. Keep it cheap and side-effect free.
+ *
+ * @property bell label for the inbox bell button. Also used when the bell shows an unread badge but
+ *   [bellWithUnreadCount] is not provided. null → the bell is announced as an unnamed button.
+ * @property bellWithUnreadCount builds the bell's label while it shows an unread badge, given the
+ *   unread count. A function (not a template) so hosts can apply their language's plural rules. null →
+ *   falls back to [bell]. The badge itself is always hidden from TalkBack, so the count is announced
+ *   only through this label, never as bare digits appended to the button.
+ * @property loadingIndicator label announced for the loading spinner. null → none, leaving only the
+ *   indeterminate-progress role that TalkBack describes in the device's own language.
+ * @property emptyState label announced for the empty-state icon. null → the icon is decorative.
+ */
+class NotificationInboxAccessibilityLabels @JvmOverloads constructor(
+    val bell: String? = null,
+    val bellWithUnreadCount: ((Int) -> String)? = null,
+    val loadingIndicator: String? = null,
+    val emptyState: String? = null
+)

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/MessagingInAppModuleConfigTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/MessagingInAppModuleConfigTest.kt
@@ -1,0 +1,40 @@
+package io.customer.messaginginapp
+
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
+import io.customer.sdk.data.model.Region
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+
+class MessagingInAppModuleConfigTest {
+
+    @Test
+    fun build_givenNoNotificationInboxAccessibilityLabels_expectAllNull() {
+        val config = MessagingInAppModuleConfig.Builder(siteId = "site", region = Region.US).build()
+
+        config.notificationInboxAccessibilityLabels.bell.shouldBeNull()
+        config.notificationInboxAccessibilityLabels.bellWithUnreadCount.shouldBeNull()
+        config.notificationInboxAccessibilityLabels.loadingIndicator.shouldBeNull()
+        config.notificationInboxAccessibilityLabels.emptyState.shouldBeNull()
+    }
+
+    @Test
+    fun setNotificationInboxAccessibilityLabels_expectLabelsOnConfig() {
+        val config = MessagingInAppModuleConfig.Builder(siteId = "site", region = Region.US)
+            .setNotificationInboxAccessibilityLabels(
+                NotificationInboxAccessibilityLabels(
+                    bell = "Aviseringar",
+                    bellWithUnreadCount = { count -> if (count == 1) "1 oläst avisering" else "$count olästa aviseringar" },
+                    loadingIndicator = "Laddar",
+                    emptyState = "Inga aviseringar"
+                )
+            )
+            .build()
+
+        config.notificationInboxAccessibilityLabels.bell shouldBeEqualTo "Aviseringar"
+        config.notificationInboxAccessibilityLabels.bellWithUnreadCount?.invoke(1) shouldBeEqualTo "1 oläst avisering"
+        config.notificationInboxAccessibilityLabels.bellWithUnreadCount?.invoke(4) shouldBeEqualTo "4 olästa aviseringar"
+        config.notificationInboxAccessibilityLabels.loadingIndicator shouldBeEqualTo "Laddar"
+        config.notificationInboxAccessibilityLabels.emptyState shouldBeEqualTo "Inga aviseringar"
+    }
+}

--- a/messaginginapp/src/test/java/io/customer/messaginginapp/type/NotificationInboxAccessibilityLabelsTest.kt
+++ b/messaginginapp/src/test/java/io/customer/messaginginapp/type/NotificationInboxAccessibilityLabelsTest.kt
@@ -1,0 +1,17 @@
+package io.customer.messaginginapp.type
+
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+
+class NotificationInboxAccessibilityLabelsTest {
+
+    @Test
+    fun init_givenNoArguments_expectAllLabelsNull() {
+        val labels = NotificationInboxAccessibilityLabels()
+
+        labels.bell.shouldBeNull()
+        labels.bellWithUnreadCount.shouldBeNull()
+        labels.loadingIndicator.shouldBeNull()
+        labels.emptyState.shouldBeNull()
+    }
+}

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/InboxAccessibility.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/InboxAccessibility.kt
@@ -1,0 +1,83 @@
+package io.customer.messaginginbox
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import io.customer.messaginginapp.di.inAppModuleConfig
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
+import io.customer.sdk.core.di.SDKComponent
+
+/**
+ * Accessibility plumbing for the visual inbox: the SDK emits no strings of its own — every TalkBack
+ * label comes from the host's [NotificationInboxAccessibilityLabels] on the in-app module config, and
+ * an unconfigured label leaves the element unlabeled rather than falling back to English.
+ */
+
+/**
+ * The host's labels from the in-app module config.
+ *
+ * Read on each composition rather than `remember`ed: an inbox composable can enter composition before
+ * `CustomerIO` finishes initializing, and a remembered value would pin the empty defaults for as long
+ * as that composable stays on screen. Reading module config is a property lookup, cheap enough to
+ * repeat.
+ */
+@Composable
+internal fun inboxAccessibilityLabels(): NotificationInboxAccessibilityLabels =
+    SDKComponent.inAppModuleConfig.notificationInboxAccessibilityLabels
+
+/**
+ * The bell button's label: the count-aware [NotificationInboxAccessibilityLabels.bellWithUnreadCount]
+ * while the badge shows (falling back to the plain [NotificationInboxAccessibilityLabels.bell]), the
+ * plain bell label otherwise, or null when the host configured neither — leaving a button that is
+ * still focusable and tappable, just unnamed. [showsUnreadCount] gates the count so TalkBack never
+ * announces a count the workspace chose to hide (branding `unreadIndicator.showAlert`).
+ *
+ * Pure (non-Compose) so it is unit-testable on the JVM.
+ */
+internal fun resolveBellAccessibilityLabel(
+    labels: NotificationInboxAccessibilityLabels,
+    unopenedCount: Int,
+    showsUnreadCount: Boolean
+): String? = if (showsUnreadCount) {
+    labels.bellWithUnreadCount?.invoke(unopenedCount) ?: labels.bell
+} else {
+    labels.bell
+}
+
+/** Applies [label] as the node's content description, or leaves the node unlabeled when null. */
+internal fun Modifier.inboxContentDescription(label: String?): Modifier =
+    if (label == null) this else semantics { contentDescription = label }
+
+/**
+ * The inbox bell glyph, shared by the bell button and the empty state so both draw identical art:
+ * the workspace's branding SVG (`patterns.inbox.floatingIcon.svg`) when present and parseable,
+ * otherwise the bundled default bell drawable. Both are tinted with [tint]. Decorative — callers
+ * attach any content description to their own node.
+ *
+ * The SVG art is built (and validated) once per [bellSvg] via `remember` — malformed path data yields
+ * null (not a crash) and falls back to the drawable — rather than parsed per frame.
+ */
+@Composable
+internal fun InboxBellGlyph(
+    bellSvg: String?,
+    tint: Color,
+    modifier: Modifier = Modifier
+) {
+    val bellArt = remember(bellSvg) { bellSvg?.let(InboxBellSvg::buildArt) }
+    if (bellArt != null) {
+        InboxBellIcon(art = bellArt, tint = tint, modifier = modifier)
+    } else {
+        Image(
+            painter = painterResource(id = R.drawable.cio_inbox_notifications),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(tint),
+            modifier = modifier
+        )
+    }
+}

--- a/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
+++ b/messaginginbox/src/main/java/io/customer/messaginginbox/NotificationInboxOverlay.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -44,15 +43,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -146,10 +143,12 @@ fun NotificationInboxView(
     // collects its own state for the message list.
     val state by remember(controller) { controller.uiStateFlow() }
         .collectAsStateWithLifecycle(initialValue = VisualInboxUiState(loading = true))
+    val branding = (state.visibility as? InboxVisibility.Visible)?.branding
     InboxListContent(
         controller = controller,
         state = state,
-        colors = rememberInboxColors((state.visibility as? InboxVisibility.Visible)?.branding),
+        colors = rememberInboxColors(branding),
+        bellSvg = rememberInboxChrome(branding).bellSvg,
         fonts = fonts,
         onNavigatedAway = onDismissRequest,
         modifier = modifier.fillMaxSize()
@@ -279,6 +278,7 @@ internal fun NotificationInboxOverlay(
                 controller = controller,
                 state = state,
                 colors = colors,
+                bellSvg = chrome.bellSvg,
                 fonts = fonts,
                 // Close the sheet when a tapped message navigates via a deep link, so the deep-linked
                 // screen isn't left behind the sheet (openUrl external does not close).
@@ -307,6 +307,12 @@ private fun InboxBellContent(
     // MBL-2126/2127: branding-driven unread-badge text size (`unreadIndicator.text.size`).
     badgeTextSize: TextUnit = BADGE_TEXT_SIZE
 ) {
+    // The SDK ships no strings of its own: the bell's label comes from the host's
+    // NotificationInboxAccessibilityLabels (count-aware while the badge shows), or none when
+    // unconfigured, leaving an unnamed-but-reachable button.
+    val showsUnreadCount = unopenedCount > 0 && showAlert
+    val labels = inboxAccessibilityLabels()
+    val bellLabel = resolveBellAccessibilityLabel(labels, unopenedCount, showsUnreadCount)
     Box(modifier = modifier) {
         Box(
             contentAlignment = Alignment.Center,
@@ -315,40 +321,31 @@ private fun InboxBellContent(
                 .shadow(6.dp, CircleShape)
                 .clip(CircleShape)
                 .background(colors.bellColor)
-                .semantics { contentDescription = "Notifications inbox" }
+                .inboxContentDescription(bellLabel)
                 .clickable(role = Role.Button, onClick = onClick)
         ) {
             // Prefer the workspace's configured bell SVG; fall back to the bundled glyph when it is
-            // absent or unparseable. The art is built (and validated) once per svg here — malformed
-            // path data yields null (not a crash), and the parse is cached rather than run per frame.
-            val bellArt = remember(bellSvg) { bellSvg?.let(InboxBellSvg::buildArt) }
-            if (bellArt != null) {
-                InboxBellIcon(
-                    art = bellArt,
-                    tint = colors.bellIconColor,
-                    modifier = Modifier.size(BELL_GLYPH_SIZE)
-                )
-            } else {
-                Image(
-                    painter = painterResource(id = R.drawable.cio_inbox_notifications),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(colors.bellIconColor),
-                    // MBL-2123: pin the default bell to the same size as the branded glyph. Without an
-                    // explicit size it rendered at the drawable's intrinsic size (parity mismatch).
-                    modifier = Modifier.size(BELL_GLYPH_SIZE)
-                )
-            }
+            // absent or unparseable (InboxBellGlyph builds + caches the art once per svg). MBL-2123:
+            // pinned to BELL_GLYPH_SIZE so the default bell matches the branded glyph's size.
+            InboxBellGlyph(
+                bellSvg = bellSvg,
+                tint = colors.bellIconColor,
+                modifier = Modifier.size(BELL_GLYPH_SIZE)
+            )
         }
 
         // Badge shows only when there are unread messages AND branding has not disabled the alert
         // (default show when unset), matching web renderBadge (hidden when count===0 || !showAlert).
-        if (unopenedCount > 0 && showAlert) {
+        // The badge is decorative for TalkBack: `clickable` merges descendants into the bell's own
+        // node, so leaving the digits visible would append a bare number to an otherwise unnamed bell.
+        // The count reaches TalkBack only through the host's `bellWithUnreadCount` label.
+        if (showsUnreadCount) {
             Box(
                 contentAlignment = Alignment.Center,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .offset(x = 4.dp, y = (-4).dp)
-                    .semantics { contentDescription = "$unopenedCount unread notifications" }
+                    .clearAndSetSemantics { }
                     // Geometry mirrors web (#gist-inbox-badge): a 20dp-tall stadium (radius =
                     // height/2) with min-width 20 + 6dp horizontal padding, so a single digit is a
                     // circle and multi-digit counts grow horizontally instead of forcing a full
@@ -388,6 +385,8 @@ private fun InboxListContent(
     controller: VisualInboxController,
     state: VisualInboxUiState,
     colors: InboxColors,
+    // Branding bell SVG (`floatingIcon.svg`), drawn dimmed as the empty state; null = bundled bell.
+    bellSvg: String?,
     modifier: Modifier = Modifier,
     // Custom-font registry forwarded to the Jist renderer (see NotificationInboxOverlay); empty = none.
     fonts: Map<String, FontFamily> = emptyMap(),
@@ -411,16 +410,24 @@ private fun InboxListContent(
         InboxJistDecoder.toJsonObject(visible?.branding?.theme)
     }
 
+    val labels = inboxAccessibilityLabels()
     Column(modifier = modifier) {
         when {
-            state.loading -> LoadingState(color = colors.bellColor)
+            state.loading -> LoadingState(
+                color = colors.bellColor,
+                accessibilityLabel = labels.loadingIndicator
+            )
             // Inbox is not renderable (disabled workspace, missing templates/branding). Render
             // nothing — matching the overlay, which hides its chrome entirely in this state, and the
             // iOS NotificationInboxView — rather than a stale list or a misleading "empty" placeholder.
             visible == null -> Unit
             // Visible but genuinely caught up (no messages). The list is only rendered in `else`
             // (Visible + has messages), so it is never fed null templates/theme.
-            state.messages.isEmpty() -> EmptyState(textColor = colors.textColorPrimary)
+            state.messages.isEmpty() -> EmptyState(
+                bellSvg = bellSvg,
+                tint = colors.textColorPrimary,
+                accessibilityLabel = labels.emptyState
+            )
             else -> InboxMessageList(
                 messages = state.messages,
                 templates = templates,
@@ -631,9 +638,15 @@ private fun startDeepLinkActivity(context: android.content.Context, intent: andr
     }
 }
 
+/**
+ * Loading state: the spinner, announced as indeterminate progress. Its content description is the
+ * host-configured `loadingIndicator` label, or none when unconfigured — never SDK English. The
+ * progress role remains either way; TalkBack describes it in the device's own language.
+ */
 @Composable
 private fun LoadingState(
     color: Color,
+    accessibilityLabel: String?,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -644,17 +657,24 @@ private fun LoadingState(
     ) {
         CustomCircularProgressIndicator(
             color = color,
-            modifier = Modifier.semantics {
-                contentDescription = "Loading inbox"
-                progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
-            }
+            modifier = Modifier
+                .semantics { progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate }
+                .inboxContentDescription(accessibilityLabel)
         )
     }
 }
 
+/**
+ * Empty state (visible + no messages): the workspace's own bell, dimmed — no text. The SDK cannot know
+ * the host's language, and a faint glyph reads as "nothing here" without words.
+ * [EMPTY_STATE_GLYPH_ALPHA] is deliberate: fainter reads as a rendering failure, stronger reads as a
+ * tappable control. Decorative for TalkBack unless the host supplied an `emptyState` label.
+ */
 @Composable
 private fun EmptyState(
-    textColor: Color,
+    bellSvg: String?,
+    tint: Color,
+    accessibilityLabel: String?,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -663,10 +683,12 @@ private fun EmptyState(
             .padding(32.dp),
         contentAlignment = Alignment.Center
     ) {
-        BasicText(
-            text = "No notifications yet",
-            style = TextStyle(color = textColor, fontSize = 16.sp, fontWeight = FontWeight.Normal),
-            modifier = Modifier.semantics { contentDescription = "Inbox empty" }
+        InboxBellGlyph(
+            bellSvg = bellSvg,
+            tint = tint.copy(alpha = EMPTY_STATE_GLYPH_ALPHA),
+            modifier = Modifier
+                .size(EMPTY_STATE_GLYPH_SIZE)
+                .inboxContentDescription(accessibilityLabel)
         )
     }
 }
@@ -952,6 +974,10 @@ private val ITEM_VERTICAL_PADDING = 12.dp
 
 /** Bell glyph size, shared by the branded SVG and the bundled default so they render identically. */
 private val BELL_GLYPH_SIZE = 26.dp
+
+// Empty-state bell size and dimming. Kept in sync with the iOS inbox (50pt, 0.22 opacity).
+private val EMPTY_STATE_GLYPH_SIZE = 50.dp
+private const val EMPTY_STATE_GLYPH_ALPHA = 0.22f
 
 /** MBL-2127: default unread-badge text size when branding does not configure `unreadIndicator.text.size`. */
 private val BADGE_TEXT_SIZE = 10.sp

--- a/messaginginbox/src/test/java/io/customer/messaginginbox/InboxAccessibilityTest.kt
+++ b/messaginginbox/src/test/java/io/customer/messaginginbox/InboxAccessibilityTest.kt
@@ -1,0 +1,57 @@
+package io.customer.messaginginbox
+
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+
+/**
+ * Unit tests for [resolveBellAccessibilityLabel]: the bell's TalkBack label is derived only
+ * from the host's [NotificationInboxAccessibilityLabels] — never from SDK-owned English — and the unread count is
+ * announced only while the badge is shown.
+ */
+class InboxAccessibilityTest {
+
+    @Test
+    fun resolveBellLabel_givenNoLabels_expectNullRegardlessOfCount() {
+        val labels = NotificationInboxAccessibilityLabels()
+
+        resolveBellAccessibilityLabel(labels, unopenedCount = 0, showsUnreadCount = false).shouldBeNull()
+        resolveBellAccessibilityLabel(labels, unopenedCount = 3, showsUnreadCount = true).shouldBeNull()
+    }
+
+    @Test
+    fun resolveBellLabel_givenBadgeShown_expectUnreadCountLabelWithCount() {
+        val labels = NotificationInboxAccessibilityLabels(
+            bell = "Aviseringar",
+            bellWithUnreadCount = { count -> "$count olästa" }
+        )
+
+        resolveBellAccessibilityLabel(labels, unopenedCount = 3, showsUnreadCount = true) shouldBeEqualTo "3 olästa"
+    }
+
+    @Test
+    fun resolveBellLabel_givenBadgeHidden_expectPlainBellLabelEvenWithUnread() {
+        // Branding `unreadIndicator.showAlert = false` hides the badge; the count must not be announced.
+        val labels = NotificationInboxAccessibilityLabels(
+            bell = "Aviseringar",
+            bellWithUnreadCount = { count -> "$count olästa" }
+        )
+
+        resolveBellAccessibilityLabel(labels, unopenedCount = 3, showsUnreadCount = false) shouldBeEqualTo "Aviseringar"
+    }
+
+    @Test
+    fun resolveBellLabel_givenBadgeShownButNoUnreadCountLabel_expectFallbackToBellLabel() {
+        val labels = NotificationInboxAccessibilityLabels(bell = "Aviseringar")
+
+        resolveBellAccessibilityLabel(labels, unopenedCount = 3, showsUnreadCount = true) shouldBeEqualTo "Aviseringar"
+    }
+
+    @Test
+    fun resolveBellLabel_givenOnlyUnreadCountLabelAndBadgeHidden_expectNull() {
+        val labels = NotificationInboxAccessibilityLabels(bellWithUnreadCount = { count -> "$count olästa" })
+
+        resolveBellAccessibilityLabel(labels, unopenedCount = 0, showsUnreadCount = false).shouldBeNull()
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/sdk/CustomerIORepository.java
@@ -13,6 +13,7 @@ import io.customer.android.sample.java_layout.di.ApplicationGraph;
 import io.customer.android.sample.java_layout.support.Optional;
 import io.customer.geofence.ModuleGeofence;
 import io.customer.messaginginapp.MessagingInAppModuleConfig;
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels;
 import io.customer.messaginginapp.ModuleMessagingInApp;
 import io.customer.location.LocationModuleConfig;
 import io.customer.location.ModuleLocation;
@@ -102,6 +103,16 @@ public class CustomerIORepository {
                     new MessagingInAppModuleConfig.Builder(sdkConfig.getSiteId(), sdkConfig.getRegion())
                             .setEventListener(new InAppMessageEventListener(appGraph.getLogger()))
                             .setInboxEventListener(new SampleInboxEventListener(appGraph.getLogger()))
+                            // Visual Notification Inbox TalkBack labels. The SDK ships none of its own (so
+                            // no English leaks into a localized app); the host supplies them in its
+                            // language. `bellWithUnreadCount` is a function so the app applies its own
+                            // plural rules.
+                            .setNotificationInboxAccessibilityLabels(new NotificationInboxAccessibilityLabels(
+                                    "Notifications",
+                                    count -> count == 1 ? "Notifications, 1 unread" : "Notifications, " + count + " unread",
+                                    "Loading inbox",
+                                    "No notifications"
+                            ))
                             .build()
             ));
         }

--- a/samples/kotlin_compose/src/main/AndroidManifest.xml
+++ b/samples/kotlin_compose/src/main/AndroidManifest.xml
@@ -63,6 +63,10 @@
             android:exported="false"
             android:label="Inline Examples (Tabs)"
             android:theme="@style/Theme.CustomerioSDK.NoActionBar" />
+        <activity
+            android:name=".ui.inbox.VisualInboxActivity"
+            android:exported="false"
+            android:label="Visual Inbox" />
     </application>
 
 </manifest>

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/MainApplication.kt
@@ -9,6 +9,7 @@ import io.customer.geofence.ModuleGeofence
 import io.customer.location.ModuleLocation
 import io.customer.messaginginapp.MessagingInAppModuleConfig
 import io.customer.messaginginapp.ModuleMessagingInApp
+import io.customer.messaginginapp.type.NotificationInboxAccessibilityLabels
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOConfigBuilder
@@ -38,6 +39,17 @@ class MainApplication : Application() {
                         region = Region.US
                     ).setEventListener(InAppMessageEventListener())
                         .setInboxEventListener(SampleInboxEventListener())
+                        // Visual Notification Inbox TalkBack labels. The SDK ships none of its own (so no
+                        // English leaks into a localized app); the host supplies them in its language.
+                        // `bellWithUnreadCount` is a lambda so the app applies its own plural rules.
+                        .setNotificationInboxAccessibilityLabels(
+                            NotificationInboxAccessibilityLabels(
+                                bell = "Notifications",
+                                bellWithUnreadCount = { count -> if (count == 1) "Notifications, 1 unread" else "Notifications, $count unread" },
+                                loadingIndicator = "Loading inbox",
+                                emptyState = "No notifications"
+                            )
+                        )
                         .build()
                 )
             )

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/dashboard/Dashboard.kt
@@ -34,6 +34,7 @@ import io.customer.android.sample.kotlin_compose.ui.components.HeaderText
 import io.customer.android.sample.kotlin_compose.ui.components.SettingsIcon
 import io.customer.android.sample.kotlin_compose.ui.components.TrackScreenLifecycle
 import io.customer.android.sample.kotlin_compose.ui.components.VersionText
+import io.customer.android.sample.kotlin_compose.ui.inbox.VisualInboxActivity
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesNavigationActivity
 import io.customer.android.sample.kotlin_compose.ui.inline.InlineMessagesTabbedActivity
 import io.customer.messaginginbox.NotificationInboxOverlay
@@ -42,7 +43,7 @@ import kotlinx.coroutines.launch
 
 // Host-supplied custom fonts for the Visual Inbox. Keys must match the workspace theme's `fontFamily`
 // tokens; Jist resolves a theme font ONLY from this map (falls back to the system font otherwise).
-private val jistCustomFonts: Map<String, FontFamily> = mapOf(
+internal val jistCustomFonts: Map<String, FontFamily> = mapOf(
     "Abril Fatface" to FontFamily(Font(R.font.abril_fatface, FontWeight.Normal)),
     "DM Sans" to FontFamily(
         Font(R.font.dm_sans_regular, FontWeight.Normal),
@@ -187,6 +188,14 @@ fun SendEventsView(
             text = "Inline Examples (Tabs)",
             onClick = {
                 context.startActivity(Intent(context, InlineMessagesTabbedActivity::class.java))
+            }
+        )
+        // Standalone Visual Notification Inbox screen (the embeddable list, no bell/sheet) — shown
+        // alongside the drop-in overlay mounted on this dashboard so both integrations are exercised.
+        ActionButton(
+            text = "Visual Inbox (Screen)",
+            onClick = {
+                context.startActivity(Intent(context, VisualInboxActivity::class.java))
             }
         )
         ActionButton(

--- a/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/inbox/VisualInboxActivity.kt
+++ b/samples/kotlin_compose/src/main/java/io/customer/android/sample/kotlin_compose/ui/inbox/VisualInboxActivity.kt
@@ -1,0 +1,42 @@
+package io.customer.android.sample.kotlin_compose.ui.inbox
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import io.customer.android.sample.kotlin_compose.ui.dashboard.jistCustomFonts
+import io.customer.android.sample.kotlin_compose.ui.theme.CustomerIoSDKTheme
+import io.customer.messaginginbox.NotificationInboxView
+
+/**
+ * Dedicated full-screen host for Customer.io's visual notification inbox list.
+ *
+ * Demonstrates the screen-style integration ([NotificationInboxView], embedded in the host's own
+ * screen) as opposed to the drop-in floating bell + bottom sheet ([NotificationInboxOverlay]) mounted
+ * on the dashboard. Because the host can show this screen even when the inbox has no messages, it is
+ * where the SDK's empty state (a dimmed bell — no text) is visible.
+ */
+class VisualInboxActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CustomerIoSDKTheme {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .systemBarsPadding(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    NotificationInboxView(
+                        modifier = Modifier.fillMaxSize(),
+                        fonts = jistCustomFonts
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Removes the Visual Notification Inbox's hardcoded English copy and accessibility labels: the empty state becomes the workspace's own bell glyph (dimmed, no text), and host apps supply any accessibility labels themselves via `InboxAccessibilityLabels` on the in-app module config.

Pairs with customerio/customerio-ios#1251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)