### PR TITLE
chore(geofence): add the polygon transition evaluation core

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonAccuracyEvaluator.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonAccuracyEvaluator.kt
@@ -1,0 +1,163 @@
+package io.customer.geofence.polygon
+
+import kotlin.math.PI
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sin
+
+internal data class PolygonLocationSample(
+    val coordinate: PolygonCoordinate,
+    val horizontalAccuracyMeters: Double
+) {
+    init {
+        require(horizontalAccuracyMeters.isFinite() && horizontalAccuracyMeters >= 0.0) {
+            "horizontal accuracy must be finite and non-negative"
+        }
+    }
+}
+
+internal enum class PolygonCommittedState {
+    OUTSIDE,
+    INSIDE
+}
+
+internal enum class PolygonEvidence {
+    ENTER,
+    EXIT,
+    AMBIGUOUS
+}
+
+internal data class PolygonEvaluatorConfig(
+    val perimeterSampleCount: Int = 16,
+    val enterConfidenceThreshold: Double = 0.4,
+    val exitAccuracyInflationMeters: Double = 2.0,
+    val maximumExitAccuracyMeters: Double = 50.0,
+    val maximumAcceptedAccuracyMeters: Double = 200.0,
+    val decisiveMaximumAccuracyMeters: Double = 50.0,
+    val decisiveBoundaryMarginMeters: Double = 10.0
+) {
+    init {
+        require(perimeterSampleCount in 8..64) { "perimeter sample count is outside safe bounds" }
+        require(enterConfidenceThreshold in 0.25..0.75) { "enter confidence is outside safe bounds" }
+        require(exitAccuracyInflationMeters in 0.0..10.0) { "exit accuracy inflation is outside safe bounds" }
+        require(maximumExitAccuracyMeters in 10.0..100.0) { "maximum exit accuracy is outside safe bounds" }
+        require(maximumAcceptedAccuracyMeters in 50.0..500.0) { "accepted accuracy is outside safe bounds" }
+        require(decisiveMaximumAccuracyMeters in 10.0..100.0) {
+            "decisive accuracy is outside safe bounds"
+        }
+        require(decisiveBoundaryMarginMeters in 0.0..50.0) {
+            "decisive boundary margin is outside safe bounds"
+        }
+    }
+}
+
+/** Classifies a location fix without mutating committed polygon state. */
+internal class PolygonAccuracyEvaluator(
+    private val config: PolygonEvaluatorConfig = PolygonEvaluatorConfig()
+) {
+    fun evidenceFor(
+        geometry: PolygonGeometry,
+        sample: PolygonLocationSample,
+        committedState: PolygonCommittedState
+    ): PolygonEvidence {
+        if (sample.horizontalAccuracyMeters > config.maximumAcceptedAccuracyMeters) {
+            return PolygonEvidence.AMBIGUOUS
+        }
+        val centerRelation = geometry.relationTo(sample.coordinate)
+        if (centerRelation == PolygonPointRelation.BOUNDARY) return PolygonEvidence.AMBIGUOUS
+
+        val accuracy = when (committedState) {
+            PolygonCommittedState.OUTSIDE -> sample.horizontalAccuracyMeters
+            PolygonCommittedState.INSIDE -> max(
+                sample.horizontalAccuracyMeters,
+                min(
+                    sample.horizontalAccuracyMeters + config.exitAccuracyInflationMeters,
+                    config.maximumExitAccuracyMeters
+                )
+            )
+        }
+        val perimeterRelations = perimeterSamples(sample.coordinate, accuracy)
+            .map(geometry::relationTo)
+        val insideCount = perimeterRelations.count { it == PolygonPointRelation.INSIDE }
+        val confidence = insideCount.toDouble() / config.perimeterSampleCount
+
+        return when {
+            centerRelation == PolygonPointRelation.INSIDE &&
+                confidence >= config.enterConfidenceThreshold -> PolygonEvidence.ENTER
+            centerRelation == PolygonPointRelation.OUTSIDE &&
+                geometry.boundaryDistanceMeters(sample.coordinate) > accuracy ->
+                PolygonEvidence.EXIT
+            else -> PolygonEvidence.AMBIGUOUS
+        }
+    }
+
+    /**
+     * Classifies a sparse background fix only when its complete accuracy circle, plus an
+     * additional anti-jitter margin, is on the candidate side of the polygon boundary.
+     */
+    fun decisiveEvidenceFor(
+        geometry: PolygonGeometry,
+        sample: PolygonLocationSample,
+        committedState: PolygonCommittedState
+    ): PolygonEvidence {
+        if (sample.horizontalAccuracyMeters > config.decisiveMaximumAccuracyMeters) {
+            return PolygonEvidence.AMBIGUOUS
+        }
+        val relation = geometry.relationTo(sample.coordinate)
+        if (relation == PolygonPointRelation.BOUNDARY) return PolygonEvidence.AMBIGUOUS
+        val requiredDistance = sample.horizontalAccuracyMeters + config.decisiveBoundaryMarginMeters
+        if (geometry.boundaryDistanceMeters(sample.coordinate) <= requiredDistance) {
+            return PolygonEvidence.AMBIGUOUS
+        }
+        return when {
+            committedState == PolygonCommittedState.OUTSIDE && relation == PolygonPointRelation.INSIDE ->
+                PolygonEvidence.ENTER
+            committedState == PolygonCommittedState.INSIDE && relation == PolygonPointRelation.OUTSIDE ->
+                PolygonEvidence.EXIT
+            else -> PolygonEvidence.AMBIGUOUS
+        }
+    }
+
+    private fun perimeterSamples(
+        center: PolygonCoordinate,
+        radiusMeters: Double
+    ): List<PolygonCoordinate> = List(config.perimeterSampleCount) { index ->
+        val bearing = 2.0 * PI * index / config.perimeterSampleCount
+        destination(center, bearing, radiusMeters)
+    }
+
+    private fun destination(
+        origin: PolygonCoordinate,
+        bearingRadians: Double,
+        distanceMeters: Double
+    ): PolygonCoordinate {
+        if (distanceMeters == 0.0) return origin
+
+        val latitude = Math.toRadians(origin.latitude)
+        val longitude = Math.toRadians(origin.longitude)
+        val angularDistance = distanceMeters / EARTH_RADIUS_METERS
+        val destinationLatitude = asin(
+            sin(latitude) * cos(angularDistance) +
+                cos(latitude) * sin(angularDistance) * cos(bearingRadians)
+        )
+        val destinationLongitude = longitude + atan2(
+            sin(bearingRadians) * sin(angularDistance) * cos(latitude),
+            cos(angularDistance) - sin(latitude) * sin(destinationLatitude)
+        )
+
+        return PolygonCoordinate(
+            latitude = Math.toDegrees(destinationLatitude),
+            longitude = normalizeLongitude(Math.toDegrees(destinationLongitude))
+        )
+    }
+
+    private fun normalizeLongitude(longitude: Double): Double =
+        ((longitude + 540.0) % 360.0) - 180.0
+
+    private companion object {
+        const val EARTH_RADIUS_METERS = 6_371_000.0
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonMovementTriggerPolicy.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonMovementTriggerPolicy.kt
@@ -1,0 +1,47 @@
+package io.customer.geofence.polygon
+
+import io.customer.geofence.GeofenceConstants
+import io.customer.geofence.GeofenceRegion
+import kotlin.math.min
+
+/** Computes one conservative movement-trigger radius across the relevant polygon set. */
+internal class PolygonMovementTriggerPolicy {
+    fun safeRadiusMeters(
+        regions: List<GeofenceRegion>,
+        committedInsideIds: Set<String>,
+        sample: PolygonLocationSample,
+        normalRadiusMeters: Float
+    ): Float? {
+        if (sample.horizontalAccuracyMeters > MAXIMUM_ACCEPTED_ACCURACY_METERS) return null
+        val polygons = regions.filter(GeofenceRegion::isPolygon)
+        if (polygons.isEmpty()) return normalRadiusMeters
+
+        var safeRadius = normalRadiusMeters.toDouble()
+        for (region in polygons) {
+            val geometry = region.polygonGeometryOrNull() ?: return null
+            val relation = geometry.relationTo(sample.coordinate)
+            val expectedInside = region.id in committedInsideIds
+            val stateMatches = when (relation) {
+                PolygonPointRelation.INSIDE -> expectedInside
+                PolygonPointRelation.OUTSIDE -> !expectedInside
+                PolygonPointRelation.BOUNDARY -> false
+            }
+            if (!stateMatches) return null
+
+            val clearance = geometry.boundaryDistanceMeters(sample.coordinate) -
+                sample.horizontalAccuracyMeters -
+                PROTOTYPE_WAKE_POLICY_MARGIN_METERS
+            safeRadius = min(safeRadius, clearance)
+        }
+
+        return safeRadius
+            .takeIf { it >= GeofenceConstants.MIN_LOCAL_REFRESH_RADIUS_METERS }
+            ?.toFloat()
+    }
+
+    internal companion object {
+        // Draft policy values only. Field calibration freezes these before polygon rollout.
+        const val MAXIMUM_ACCEPTED_ACCURACY_METERS = 50.0
+        const val PROTOTYPE_WAKE_POLICY_MARGIN_METERS = 100.0
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonRouteProcessor.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonRouteProcessor.kt
@@ -1,0 +1,114 @@
+package io.customer.geofence.polygon
+
+internal data class PolygonFence(
+    val id: String,
+    val geometry: PolygonGeometry,
+    val regionRevision: Int = 0
+) {
+    init {
+        require(id.isNotBlank()) { "polygon id cannot be blank" }
+    }
+}
+
+internal data class PolygonTransitionDetection(
+    val polygonId: String,
+    val transition: PolygonTransition,
+    val regionRevision: Int = 0
+)
+
+internal enum class PolygonEvidencePolicy {
+    CONFIRMED,
+    DECISIVE_SINGLE_FIX
+}
+
+/** Evaluates one ordered location stream against the currently active polygons. */
+internal class PolygonRouteProcessor(
+    private val accuracyEvaluator: PolygonAccuracyEvaluator = PolygonAccuracyEvaluator(),
+    private val stateMachine: PolygonTransitionStateMachine = PolygonTransitionStateMachine(),
+    private val minimumEvidenceIntervalNanos: Long = 0L
+) {
+    private val latestElapsedRealtimeNanos = mutableMapOf<String, Long>()
+
+    fun process(
+        fences: List<PolygonFence>,
+        sample: PolygonLocationSample,
+        elapsedRealtimeNanos: Long,
+        committedStates: Map<String, PolygonCommittedState>,
+        evidencePolicy: PolygonEvidencePolicy = PolygonEvidencePolicy.CONFIRMED
+    ): List<PolygonTransitionDetection> {
+        require(elapsedRealtimeNanos >= 0L) { "elapsed realtime must be non-negative" }
+        require(fences.map(PolygonFence::id).distinct().size == fences.size) {
+            "polygon ids must be unique"
+        }
+
+        val activeIds = fences.mapTo(mutableSetOf(), PolygonFence::id)
+        trackedFenceIds.filterNot(activeIds::contains).forEach(stateMachine::clear)
+        latestElapsedRealtimeNanos.keys.retainAll(activeIds)
+        lastEvidenceElapsedNanos.keys.retainAll(activeIds)
+        trackedFenceIds.clear()
+        trackedFenceIds.addAll(activeIds)
+
+        return fences.mapNotNull { fence ->
+            val latest = latestElapsedRealtimeNanos[fence.id]
+            if (latest != null && elapsedRealtimeNanos <= latest) return@mapNotNull null
+            latestElapsedRealtimeNanos[fence.id] = elapsedRealtimeNanos
+            val committedState = committedStates[fence.id] ?: PolygonCommittedState.OUTSIDE
+            val evidence = when (evidencePolicy) {
+                PolygonEvidencePolicy.CONFIRMED ->
+                    accuracyEvaluator.evidenceFor(fence.geometry, sample, committedState)
+                PolygonEvidencePolicy.DECISIVE_SINGLE_FIX ->
+                    accuracyEvaluator.decisiveEvidenceFor(fence.geometry, sample, committedState)
+            }
+            val isTransitionEvidence =
+                committedState == PolygonCommittedState.OUTSIDE && evidence == PolygonEvidence.ENTER ||
+                    committedState == PolygonCommittedState.INSIDE && evidence == PolygonEvidence.EXIT
+            if (!isTransitionEvidence) {
+                lastEvidenceElapsedNanos.remove(fence.id)
+                stateMachine.evaluate(fence.id, committedState, evidence)
+                return@mapNotNull null
+            }
+            if (evidencePolicy == PolygonEvidencePolicy.DECISIVE_SINGLE_FIX) {
+                lastEvidenceElapsedNanos.remove(fence.id)
+                stateMachine.clear(fence.id)
+                val transition = when (evidence) {
+                    PolygonEvidence.ENTER -> PolygonTransition.ENTER
+                    PolygonEvidence.EXIT -> PolygonTransition.EXIT
+                    PolygonEvidence.AMBIGUOUS -> return@mapNotNull null
+                }
+                return@mapNotNull PolygonTransitionDetection(
+                    fence.id,
+                    transition,
+                    fence.regionRevision
+                )
+            }
+            val previousEvidenceTime = lastEvidenceElapsedNanos[fence.id]
+            if (
+                previousEvidenceTime != null &&
+                elapsedRealtimeNanos - previousEvidenceTime < minimumEvidenceIntervalNanos
+            ) {
+                return@mapNotNull null
+            }
+            lastEvidenceElapsedNanos[fence.id] = elapsedRealtimeNanos
+            stateMachine.evaluate(fence.id, committedState, evidence)?.let { transition ->
+                PolygonTransitionDetection(fence.id, transition, fence.regionRevision)
+            }
+        }
+    }
+
+    fun clear() {
+        latestElapsedRealtimeNanos.clear()
+        trackedFenceIds.clear()
+        lastEvidenceElapsedNanos.clear()
+        stateMachine.clearAll()
+    }
+
+    fun clear(polygonId: String) {
+        trackedFenceIds.remove(polygonId)
+        latestElapsedRealtimeNanos.remove(polygonId)
+        lastEvidenceElapsedNanos.remove(polygonId)
+        stateMachine.clear(polygonId)
+    }
+
+    private val trackedFenceIds = mutableSetOf<String>()
+    private val lastEvidenceElapsedNanos = mutableMapOf<String, Long>()
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonTransitionStateMachine.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonTransitionStateMachine.kt
@@ -1,0 +1,59 @@
+package io.customer.geofence.polygon
+
+internal enum class PolygonTransition {
+    ENTER,
+    EXIT
+}
+
+/** Holds only session-local confirmation evidence. The caller owns durable committed state. */
+internal class PolygonTransitionStateMachine(
+    private val requiredConfirmations: Int = 3
+) {
+    private data class PendingTransition(
+        val transition: PolygonTransition,
+        val confirmations: Int
+    )
+
+    private val pendingByPolygon = mutableMapOf<String, PendingTransition>()
+
+    init {
+        require(requiredConfirmations in 2..5) { "required confirmations are outside safe bounds" }
+    }
+
+    fun evaluate(
+        polygonId: String,
+        committedState: PolygonCommittedState,
+        evidence: PolygonEvidence
+    ): PolygonTransition? {
+        require(polygonId.isNotBlank()) { "polygon id cannot be blank" }
+        val candidate = when {
+            committedState == PolygonCommittedState.OUTSIDE && evidence == PolygonEvidence.ENTER ->
+                PolygonTransition.ENTER
+            committedState == PolygonCommittedState.INSIDE && evidence == PolygonEvidence.EXIT ->
+                PolygonTransition.EXIT
+            else -> null
+        }
+        if (candidate == null) {
+            pendingByPolygon.remove(polygonId)
+            return null
+        }
+
+        val current = pendingByPolygon[polygonId]
+        val confirmations = if (current?.transition == candidate) current.confirmations + 1 else 1
+        if (confirmations < requiredConfirmations) {
+            pendingByPolygon[polygonId] = PendingTransition(candidate, confirmations)
+            return null
+        }
+
+        pendingByPolygon.remove(polygonId)
+        return candidate
+    }
+
+    fun clear(polygonId: String) {
+        pendingByPolygon.remove(polygonId)
+    }
+
+    fun clearAll() {
+        pendingByPolygon.clear()
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonAccuracyEvaluatorTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonAccuracyEvaluatorTest.kt
@@ -1,0 +1,116 @@
+package io.customer.geofence.polygon
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class PolygonAccuracyEvaluatorTest {
+    private val evaluator = PolygonAccuracyEvaluator()
+    private val geometry = PolygonGeometry.from(
+        listOf(
+            point(-0.001, -0.001),
+            point(-0.001, 0.001),
+            point(0.001, 0.001),
+            point(0.001, -0.001)
+        )
+    )
+
+    @Test
+    fun evidenceFor_whenAccuracyDiskIsInside_thenReturnsEnterEvidence() {
+        val sample = sample(latitude = 0.0, longitude = 0.0, accuracyMeters = 10.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.ENTER
+    }
+
+    @Test
+    fun evidenceFor_whenAccuracyDiskStraddlesBoundary_thenReturnsAmbiguousEvidence() {
+        val sample = sample(latitude = 0.00099, longitude = 0.00099, accuracyMeters = 20.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun evidenceFor_whenAccuracyDiskIsOutside_thenReturnsExitEvidence() {
+        val sample = sample(latitude = 0.0, longitude = 0.002, accuracyMeters = 10.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.INSIDE) shouldBeEqualTo
+            PolygonEvidence.EXIT
+    }
+
+    @Test
+    fun evidenceFor_whenCenterIsOnBoundary_thenReturnsAmbiguousEvidence() {
+        val sample = sample(latitude = 0.0, longitude = 0.001, accuracyMeters = 0.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun evidenceFor_whenExitAccuracyInflationTouchesPolygon_thenDefersExit() {
+        val sample = sample(latitude = 0.0, longitude = 0.00101, accuracyMeters = 0.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.INSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun evidenceFor_whenAccuracyIsGrosslyInaccurate_thenReturnsAmbiguousEvidence() {
+        val sample = sample(latitude = 0.0, longitude = 0.002, accuracyMeters = 250.0)
+
+        evaluator.evidenceFor(geometry, sample, PolygonCommittedState.INSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun evidenceFor_whenAccuracyDiskContainsSmallPolygon_thenDefersExit() {
+        val smallGeometry = PolygonGeometry.from(
+            listOf(
+                point(-0.0001, -0.0001),
+                point(-0.0001, 0.0001),
+                point(0.0001, 0.0001),
+                point(0.0001, -0.0001)
+            )
+        )
+        val sample = sample(latitude = 0.0, longitude = 0.0009, accuracyMeters = 150.0)
+
+        evaluator.evidenceFor(smallGeometry, sample, PolygonCommittedState.INSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun decisiveEvidenceFor_whenAccuracyCircleAndMarginAreInside_thenReturnsEnter() {
+        val sample = sample(latitude = 0.0, longitude = 0.0, accuracyMeters = 10.0)
+
+        evaluator.decisiveEvidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.ENTER
+    }
+
+    @Test
+    fun decisiveEvidenceFor_whenFixIsNearBoundary_thenRemainsAmbiguous() {
+        val sample = sample(latitude = 0.0, longitude = 0.0009, accuracyMeters = 5.0)
+
+        evaluator.decisiveEvidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    @Test
+    fun decisiveEvidenceFor_whenAccuracyIsTooLow_thenRemainsAmbiguous() {
+        val sample = sample(latitude = 0.0, longitude = 0.0, accuracyMeters = 60.0)
+
+        evaluator.decisiveEvidenceFor(geometry, sample, PolygonCommittedState.OUTSIDE) shouldBeEqualTo
+            PolygonEvidence.AMBIGUOUS
+    }
+
+    private fun sample(
+        latitude: Double,
+        longitude: Double,
+        accuracyMeters: Double
+    ) = PolygonLocationSample(
+        coordinate = point(latitude, longitude),
+        horizontalAccuracyMeters = accuracyMeters
+    )
+
+    private fun point(latitude: Double, longitude: Double) =
+        PolygonCoordinate(latitude = latitude, longitude = longitude)
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonMovementTriggerPolicyTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonMovementTriggerPolicyTest.kt
@@ -1,0 +1,102 @@
+package io.customer.geofence.polygon
+
+import io.customer.geofence.GeofenceRegion
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInRange
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Test
+
+class PolygonMovementTriggerPolicyTest {
+    private val policy = PolygonMovementTriggerPolicy()
+
+    @Test
+    fun safeRadiusMeters_givenNoPolygons_expectNormalCatalogRadius() {
+        policy.safeRadiusMeters(
+            regions = emptyList(),
+            committedInsideIds = emptySet(),
+            sample = sampleAtOrigin(),
+            normalRadiusMeters = 1_000f
+        ) shouldBeEqualTo 1_000f
+    }
+
+    @Test
+    fun safeRadiusMeters_givenBoundaryNineHundredMetersAway_expectShrinksMovementTrigger() {
+        val radius = policy.safeRadiusMeters(
+            regions = listOf(rectangle(id = "east", westMeters = 900.0, eastMeters = 1_100.0)),
+            committedInsideIds = emptySet(),
+            sample = sampleAtOrigin(accuracyMeters = 10.0),
+            normalRadiusMeters = 1_000f
+        )
+
+        radius.shouldNotBeNull().shouldBeInRange(785f, 795f)
+    }
+
+    @Test
+    fun safeRadiusMeters_givenSeveralPolygons_expectUsesClosestBoundary() {
+        val radius = policy.safeRadiusMeters(
+            regions = listOf(
+                rectangle(id = "east", westMeters = 900.0, eastMeters = 1_100.0),
+                rectangle(id = "north", southMeters = 500.0, northMeters = 700.0)
+            ),
+            committedInsideIds = emptySet(),
+            sample = sampleAtOrigin(accuracyMeters = 10.0),
+            normalRadiusMeters = 1_000f
+        )
+
+        radius.shouldNotBeNull().shouldBeInRange(385f, 395f)
+    }
+
+    @Test
+    fun safeRadiusMeters_givenCommittedStateDisagreesWithFix_expectNoSafeBubble() {
+        policy.safeRadiusMeters(
+            regions = listOf(rectangle(id = "east", westMeters = 900.0, eastMeters = 1_100.0)),
+            committedInsideIds = setOf("east"),
+            sample = sampleAtOrigin(),
+            normalRadiusMeters = 1_000f
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun safeRadiusMeters_givenBoundaryTooClose_expectNoSafeBubble() {
+        policy.safeRadiusMeters(
+            regions = listOf(rectangle(id = "east", westMeters = 150.0, eastMeters = 350.0)),
+            committedInsideIds = emptySet(),
+            sample = sampleAtOrigin(accuracyMeters = 10.0),
+            normalRadiusMeters = 1_000f
+        ).shouldBeNull()
+    }
+
+    private fun sampleAtOrigin(accuracyMeters: Double = 5.0) = PolygonLocationSample(
+        coordinate = meters(),
+        horizontalAccuracyMeters = accuracyMeters
+    )
+
+    private fun rectangle(
+        id: String,
+        westMeters: Double = -100.0,
+        eastMeters: Double = 100.0,
+        southMeters: Double = -100.0,
+        northMeters: Double = 100.0
+    ) = GeofenceRegion(
+        id = id,
+        latitude = 0.0,
+        longitude = 0.0,
+        radius = 2_000f,
+        polygonVertices = listOf(
+            meters(southMeters, westMeters),
+            meters(southMeters, eastMeters),
+            meters(northMeters, eastMeters),
+            meters(northMeters, westMeters)
+        )
+    )
+
+    private fun meters(north: Double = 0.0, east: Double = 0.0) = PolygonCoordinate(
+        latitude = north / METERS_PER_DEGREE,
+        longitude = east / METERS_PER_DEGREE
+    )
+
+    private companion object {
+        const val METERS_PER_DEGREE = 111_320.0
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonRouteIntegrationTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonRouteIntegrationTest.kt
@@ -1,0 +1,261 @@
+package io.customer.geofence.polygon
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+class PolygonRouteIntegrationTest {
+    private val campus = PolygonFence(
+        id = "campus",
+        geometry = PolygonGeometry.from(
+            listOf(
+                point(37.7745, -122.4200),
+                point(37.7745, -122.4188),
+                point(37.7755, -122.4188),
+                point(37.7755, -122.4200)
+            )
+        )
+    )
+
+    @Test
+    fun route_whenUserWalksThroughCampus_thenEmitsOneEnterAndOneExit() {
+        val route = RouteHarness(listOf(campus))
+
+        val events = listOf(
+            route.process(37.7750, -122.4205, accuracy = 5.0),
+            route.process(37.7750, -122.4200, accuracy = 8.0),
+            route.process(37.7750, -122.4197, accuracy = 5.0),
+            route.process(37.7750, -122.4195, accuracy = 5.0),
+            route.process(37.7750, -122.4193, accuracy = 5.0),
+            route.process(37.7750, -122.4189, accuracy = 8.0),
+            route.process(37.7750, -122.4186, accuracy = 5.0),
+            route.process(37.7750, -122.4184, accuracy = 5.0),
+            route.process(37.7750, -122.4182, accuracy = 5.0)
+        ).flatten()
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("campus", PolygonTransition.ENTER),
+            PolygonTransitionDetection("campus", PolygonTransition.EXIT)
+        )
+    }
+
+    @Test
+    fun route_whenBoundaryJitters_thenDoesNotFlicker() {
+        val route = RouteHarness(
+            fences = listOf(campus),
+            initialStates = mapOf("campus" to PolygonCommittedState.INSIDE)
+        )
+
+        val events = listOf(
+            route.process(37.7750, -122.41881, accuracy = 12.0),
+            route.process(37.7750, -122.41879, accuracy = 12.0),
+            route.process(37.7750, -122.41882, accuracy = 15.0),
+            route.process(37.7750, -122.41878, accuracy = 10.0),
+            route.process(37.7750, -122.41883, accuracy = 14.0)
+        ).flatten()
+
+        events shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun route_whenLocationFixIsReplayedOrOutOfOrder_thenDoesNotCountItTwice() {
+        val route = RouteHarness(listOf(campus))
+
+        route.process(37.7750, -122.4194, accuracy = 5.0, elapsedRealtimeNanos = 2L)
+        route.process(37.7750, -122.4194, accuracy = 5.0, elapsedRealtimeNanos = 2L)
+        route.process(37.7750, -122.4194, accuracy = 5.0, elapsedRealtimeNanos = 1L)
+        route.process(37.7750, -122.4194, accuracy = 5.0, elapsedRealtimeNanos = 3L)
+
+        route.process(
+            37.7750,
+            -122.4194,
+            accuracy = 5.0,
+            elapsedRealtimeNanos = 4L
+        ) shouldBeEqualTo listOf(PolygonTransitionDetection("campus", PolygonTransition.ENTER))
+    }
+
+    @Test
+    fun route_whenOlderBatchActivatesAnotherPolygon_thenUsesThatPolygonsOwnTimeline() {
+        val eastCampus = campus.copy(id = "east-campus")
+        val processor = PolygonRouteProcessor()
+        val inside = PolygonLocationSample(point(37.7750, -122.4194), 5.0)
+
+        processor.process(
+            fences = listOf(campus),
+            sample = inside,
+            elapsedRealtimeNanos = 100L,
+            committedStates = emptyMap()
+        )
+        val detections = listOf(10L, 20L, 30L).flatMap { timestamp ->
+            processor.process(
+                fences = listOf(campus, eastCampus),
+                sample = inside,
+                elapsedRealtimeNanos = timestamp,
+                committedStates = emptyMap()
+            )
+        }
+
+        detections shouldBeEqualTo listOf(
+            PolygonTransitionDetection("east-campus", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenAccuracyIsPoorNearBoundary_thenWaitsForClearEvidence() {
+        val route = RouteHarness(listOf(campus))
+
+        val uncertainEvents = listOf(
+            route.process(37.7750, -122.41885, accuracy = 100.0),
+            route.process(37.7750, -122.41885, accuracy = 100.0),
+            route.process(37.7750, -122.41885, accuracy = 100.0)
+        ).flatten()
+        val clearEvents = listOf(
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0)
+        ).flatten()
+
+        uncertainEvents shouldBeEqualTo emptyList()
+        clearEvents shouldBeEqualTo listOf(
+            PolygonTransitionDetection("campus", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenPolygonsOverlap_thenTracksEachPolygonIndependently() {
+        val eastCampus = PolygonFence(
+            id = "east-campus",
+            geometry = PolygonGeometry.from(
+                listOf(
+                    point(37.7745, -122.4196),
+                    point(37.7745, -122.4184),
+                    point(37.7755, -122.4184),
+                    point(37.7755, -122.4196)
+                )
+            )
+        )
+        val route = RouteHarness(listOf(campus, eastCampus))
+
+        val events = listOf(
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0)
+        ).flatten()
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("campus", PolygonTransition.ENTER),
+            PolygonTransitionDetection("east-campus", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenProcessRestarts_thenPendingEvidenceIsDiscardedButCommittedStateSurvives() {
+        val durableStates = mutableMapOf("campus" to PolygonCommittedState.OUTSIDE)
+        var route = RouteHarness(listOf(campus), durableStates)
+        route.process(37.7750, -122.4194, accuracy = 5.0)
+        route.process(37.7750, -122.4194, accuracy = 5.0)
+
+        route = RouteHarness(listOf(campus), durableStates)
+        val eventsAfterRestart = listOf(
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0),
+            route.process(37.7750, -122.4194, accuracy = 5.0)
+        ).flatten()
+
+        eventsAfterRestart shouldBeEqualTo listOf(
+            PolygonTransitionDetection("campus", PolygonTransition.ENTER)
+        )
+        durableStates["campus"] shouldBeEqualTo PolygonCommittedState.INSIDE
+    }
+
+    @Test
+    fun route_whenActiveSessionIsRearmed_thenDoesNotReusePendingEvidence() {
+        val states = mutableMapOf("campus" to PolygonCommittedState.OUTSIDE)
+        val processor = PolygonRouteProcessor()
+
+        processor.process(
+            fences = listOf(campus),
+            sample = PolygonLocationSample(point(37.7750, -122.4194), 5.0),
+            elapsedRealtimeNanos = 1L,
+            committedStates = states
+        )
+        processor.clear()
+        val detections = (1L..3L).flatMap { sequence ->
+            processor.process(
+                fences = listOf(campus),
+                sample = PolygonLocationSample(point(37.7750, -122.4194), 5.0),
+                elapsedRealtimeNanos = sequence,
+                committedStates = states
+            )
+        }
+
+        detections shouldBeEqualTo listOf(
+            PolygonTransitionDetection("campus", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenSparseFixesJumpAcrossPolygon_thenCannotObserveTransit() {
+        val route = RouteHarness(listOf(campus))
+
+        val events = listOf(
+            route.process(37.7750, -122.4205, accuracy = 5.0),
+            route.process(37.7750, -122.4182, accuracy = 5.0)
+        ).flatten()
+
+        events shouldBeEqualTo emptyList()
+    }
+
+    @Test
+    fun route_whenNarrowPolygonHasOnlyTwoInsideFixes_thenDoesNotConfirmEntry() {
+        val route = RouteHarness(listOf(campus))
+
+        val events = listOf(
+            route.process(37.7750, -122.4205, accuracy = 5.0),
+            route.process(37.7750, -122.4197, accuracy = 5.0),
+            route.process(37.7750, -122.4191, accuracy = 5.0),
+            route.process(37.7750, -122.4182, accuracy = 5.0)
+        ).flatten()
+
+        events shouldBeEqualTo emptyList()
+    }
+
+    private class RouteHarness(
+        private val fences: List<PolygonFence>,
+        initialStates: Map<String, PolygonCommittedState> = emptyMap()
+    ) {
+        private val processor = PolygonRouteProcessor()
+        private val committedStates = if (initialStates is MutableMap) {
+            initialStates
+        } else {
+            initialStates.toMutableMap()
+        }
+        private var elapsedRealtimeNanos = 0L
+
+        fun process(
+            latitude: Double,
+            longitude: Double,
+            accuracy: Double,
+            elapsedRealtimeNanos: Long = ++this.elapsedRealtimeNanos
+        ): List<PolygonTransitionDetection> {
+            this.elapsedRealtimeNanos = maxOf(this.elapsedRealtimeNanos, elapsedRealtimeNanos)
+            val detections = processor.process(
+                fences = fences,
+                sample = PolygonLocationSample(point(latitude, longitude), accuracy),
+                elapsedRealtimeNanos = elapsedRealtimeNanos,
+                committedStates = committedStates
+            )
+            detections.forEach { detection ->
+                committedStates[detection.polygonId] = when (detection.transition) {
+                    PolygonTransition.ENTER -> PolygonCommittedState.INSIDE
+                    PolygonTransition.EXIT -> PolygonCommittedState.OUTSIDE
+                }
+            }
+            return detections
+        }
+    }
+
+    private companion object {
+        fun point(latitude: Double, longitude: Double) =
+            PolygonCoordinate(latitude = latitude, longitude = longitude)
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonShapeAdversarialIntegrationTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonShapeAdversarialIntegrationTest.kt
@@ -1,0 +1,241 @@
+package io.customer.geofence.polygon
+
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.junit.Test
+
+class PolygonShapeAdversarialIntegrationTest {
+    @Test
+    fun geometry_givenConcaveLShape_expectRejectedByV1Envelope() {
+        invoking {
+            geometry(
+                point(-0.002, -0.002),
+                point(-0.002, 0.002),
+                point(-0.0005, 0.002),
+                point(-0.0005, -0.0005),
+                point(0.002, -0.0005),
+                point(0.002, -0.002)
+            )
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun route_whenEnteringTriangle_thenEmitsEntry() {
+        val triangle = PolygonFence(
+            id = "triangle",
+            geometry = geometry(
+                point(0.0, -0.002),
+                point(-0.002, 0.002),
+                point(0.002, 0.002)
+            )
+        )
+        val route = RouteHarness(listOf(triangle))
+
+        val events = (1..3).flatMap {
+            route.process(0.0, 0.0005, accuracy = 5.0)
+        }
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("triangle", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenEnteringSixteenVertexCircleLikePolygon_thenEmitsEntry() {
+        val vertices = List(16) { index ->
+            val angle = 2.0 * PI * index / 16.0
+            point(
+                latitude = 0.002 * sin(angle),
+                longitude = 0.002 * cos(angle)
+            )
+        }
+        val route = RouteHarness(
+            listOf(PolygonFence("circle-like", PolygonGeometry.from(vertices)))
+        )
+
+        val events = (1..3).flatMap {
+            route.process(0.0, 0.0, accuracy = 5.0)
+        }
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("circle-like", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenCrossingNarrowCorridorWithClearFixes_thenEmitsEntryAndExit() {
+        val corridor = PolygonFence(
+            id = "corridor",
+            geometry = geometry(
+                point(-0.00006, -0.002),
+                point(-0.00006, 0.002),
+                point(0.00006, 0.002),
+                point(0.00006, -0.002)
+            )
+        )
+        val route = RouteHarness(listOf(corridor))
+
+        val events = buildList {
+            repeat(3) { addAll(route.process(0.0, 0.0, accuracy = 2.0)) }
+            repeat(3) { addAll(route.process(0.0002, 0.0, accuracy = 2.0)) }
+        }
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("corridor", PolygonTransition.ENTER),
+            PolygonTransitionDetection("corridor", PolygonTransition.EXIT)
+        )
+    }
+
+    @Test
+    fun route_whenFixesGrazeEdgeAndVertex_thenWaitsForClearInsideEvidence() {
+        val square = PolygonFence(
+            id = "square",
+            geometry = geometry(
+                point(-0.001, -0.001),
+                point(-0.001, 0.001),
+                point(0.001, 0.001),
+                point(0.001, -0.001)
+            )
+        )
+        val route = RouteHarness(listOf(square))
+
+        val grazingEvents = listOf(
+            route.process(0.001, 0.001, accuracy = 0.0),
+            route.process(0.00099, 0.001, accuracy = 12.0),
+            route.process(0.00101, 0.001, accuracy = 12.0),
+            route.process(0.001, 0.00099, accuracy = 12.0)
+        ).flatten()
+        val confirmedEvents = (1..3).flatMap {
+            route.process(0.0, 0.0, accuracy = 5.0)
+        }
+
+        grazingEvents shouldBeEqualTo emptyList()
+        confirmedEvents shouldBeEqualTo listOf(
+            PolygonTransitionDetection("square", PolygonTransition.ENTER)
+        )
+    }
+
+    @Test
+    fun route_whenQuickEntryAndExitMeetMinimumEvidenceCadence_thenEmitsBothEdges() {
+        val square = PolygonFence(
+            id = "square",
+            geometry = geometry(
+                point(-0.001, -0.001),
+                point(-0.001, 0.001),
+                point(0.001, 0.001),
+                point(0.001, -0.001)
+            )
+        )
+        val interval = 1_500_000_000L
+        val route = RouteHarness(listOf(square), minimumEvidenceIntervalNanos = interval)
+
+        val events = listOf(
+            route.process(0.0, 0.0, accuracy = 2.0, elapsedRealtimeNanos = 1L),
+            route.process(0.0, 0.0, accuracy = 2.0, elapsedRealtimeNanos = interval + 1L),
+            route.process(0.0, 0.0, accuracy = 2.0, elapsedRealtimeNanos = interval * 2 + 1L),
+            route.process(0.0, 0.002, accuracy = 2.0, elapsedRealtimeNanos = interval * 3 + 1L),
+            route.process(0.0, 0.002, accuracy = 2.0, elapsedRealtimeNanos = interval * 4 + 1L),
+            route.process(0.0, 0.002, accuracy = 2.0, elapsedRealtimeNanos = interval * 5 + 1L)
+        ).flatten()
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("square", PolygonTransition.ENTER),
+            PolygonTransitionDetection("square", PolygonTransition.EXIT)
+        )
+    }
+
+    @Test
+    fun route_whenLeavingOnlyOneOfTwoOverlappingPolygons_thenExitsOnlyThatPolygon() {
+        val west = PolygonFence(
+            id = "west",
+            geometry = geometry(
+                point(-0.001, -0.002),
+                point(-0.001, 0.001),
+                point(0.001, 0.001),
+                point(0.001, -0.002)
+            )
+        )
+        val east = PolygonFence(
+            id = "east",
+            geometry = geometry(
+                point(-0.001, -0.001),
+                point(-0.001, 0.002),
+                point(0.001, 0.002),
+                point(0.001, -0.001)
+            )
+        )
+        val route = RouteHarness(listOf(west, east))
+
+        val events = buildList {
+            repeat(3) { addAll(route.process(0.0, 0.0, accuracy = 5.0)) }
+            repeat(3) { addAll(route.process(0.0, 0.0015, accuracy = 5.0)) }
+        }
+
+        events shouldBeEqualTo listOf(
+            PolygonTransitionDetection("west", PolygonTransition.ENTER),
+            PolygonTransitionDetection("east", PolygonTransition.ENTER),
+            PolygonTransitionDetection("west", PolygonTransition.EXIT)
+        )
+    }
+
+    private class RouteHarness(
+        private val fences: List<PolygonFence>,
+        minimumEvidenceIntervalNanos: Long = 0L
+    ) {
+        private val processor = PolygonRouteProcessor(
+            minimumEvidenceIntervalNanos = minimumEvidenceIntervalNanos
+        )
+        private val committedStates = mutableMapOf<String, PolygonCommittedState>()
+        private var elapsedRealtimeNanos = 0L
+
+        fun process(
+            latitude: Double,
+            longitude: Double,
+            accuracy: Double,
+            elapsedRealtimeNanos: Long = ++this.elapsedRealtimeNanos
+        ): List<PolygonTransitionDetection> {
+            this.elapsedRealtimeNanos = maxOf(this.elapsedRealtimeNanos, elapsedRealtimeNanos)
+            return processor.process(
+                fences = fences,
+                sample = PolygonLocationSample(point(latitude, longitude), accuracy),
+                elapsedRealtimeNanos = elapsedRealtimeNanos,
+                committedStates = committedStates
+            ).also { detections ->
+                detections.forEach { detection ->
+                    committedStates[detection.polygonId] = when (detection.transition) {
+                        PolygonTransition.ENTER -> PolygonCommittedState.INSIDE
+                        PolygonTransition.EXIT -> PolygonCommittedState.OUTSIDE
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val EARTH_RADIUS_METERS = 6_371_000.0
+
+        fun geometry(vararg vertices: PolygonCoordinate): PolygonGeometry =
+            PolygonGeometry.from(vertices.toList())
+
+        fun point(latitude: Double, longitude: Double) =
+            PolygonCoordinate(latitude = latitude, longitude = longitude)
+
+        fun distanceMeters(first: PolygonCoordinate, second: PolygonCoordinate): Double {
+            val firstLatitude = Math.toRadians(first.latitude)
+            val secondLatitude = Math.toRadians(second.latitude)
+            val latitudeDelta = secondLatitude - firstLatitude
+            val longitudeDelta = Math.toRadians(second.longitude - first.longitude)
+            val haversine = sin(latitudeDelta / 2.0) * sin(latitudeDelta / 2.0) +
+                cos(firstLatitude) * cos(secondLatitude) *
+                sin(longitudeDelta / 2.0) * sin(longitudeDelta / 2.0)
+            val centralAngle = 2.0 * atan2(sqrt(haversine), sqrt(1.0 - haversine))
+            return EARTH_RADIUS_METERS * centralAngle
+        }
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonTransitionStateMachineTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonTransitionStateMachineTest.kt
@@ -1,0 +1,55 @@
+package io.customer.geofence.polygon
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.Test
+
+class PolygonTransitionStateMachineTest {
+    private val stateMachine = PolygonTransitionStateMachine(requiredConfirmations = 3)
+
+    @Test
+    fun evaluate_whenThreeConsecutiveEnterSamplesArrive_thenCommitsEnter() {
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+
+        evaluate("campus", PolygonEvidence.ENTER) shouldBeEqualTo PolygonTransition.ENTER
+    }
+
+    @Test
+    fun evaluate_whenEvidenceBecomesAmbiguous_thenResetsPendingTransition() {
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus", PolygonEvidence.AMBIGUOUS).shouldBeNull()
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus", PolygonEvidence.ENTER).shouldBeNull()
+
+        evaluate("campus", PolygonEvidence.ENTER) shouldBeEqualTo PolygonTransition.ENTER
+    }
+
+    @Test
+    fun evaluate_whenEvidenceTargetsCurrentState_thenDoesNotCommit() {
+        stateMachine.evaluate(
+            polygonId = "campus",
+            committedState = PolygonCommittedState.OUTSIDE,
+            evidence = PolygonEvidence.EXIT
+        ).shouldBeNull()
+    }
+
+    @Test
+    fun evaluate_whenPolygonsInterleave_thenKeepsConfirmationCountsIndependent() {
+        evaluate("campus-a", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus-b", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus-a", PolygonEvidence.ENTER).shouldBeNull()
+        evaluate("campus-b", PolygonEvidence.ENTER).shouldBeNull()
+
+        evaluate("campus-a", PolygonEvidence.ENTER) shouldBeEqualTo PolygonTransition.ENTER
+        evaluate("campus-b", PolygonEvidence.ENTER) shouldBeEqualTo PolygonTransition.ENTER
+    }
+
+    private fun evaluate(polygonId: String, evidence: PolygonEvidence): PolygonTransition? =
+        stateMachine.evaluate(
+            polygonId = polygonId,
+            committedState = PolygonCommittedState.OUTSIDE,
+            evidence = evidence
+        )
+}


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

- 👉 [#835 polygon transition evaluation core](https://github.com/customerio/customerio-android/pull/835)
- [#836 session ownership and atomic transition staging](https://github.com/customerio/customerio-android/pull/836)
- [#837 stage transitions durably before delivery](https://github.com/customerio/customerio-android/pull/837)
- [#838 polygon location engine](https://github.com/customerio/customerio-android/pull/838)

Three more branches are ready locally and not open yet: the approach monitor + service
controller, the wiring that enables polygon monitoring, and the geofence instrumentation CI
job. Holding them until this half is reviewed.

## What this is

Pure decision logic for polygon monitoring, with no runtime wired to it yet:

- `PolygonAccuracyEvaluator` — judges one fix against one ring, given its accuracy circle
- `PolygonTransitionStateMachine` — turns evidence into a committed ENTER/EXIT
- `PolygonRouteProcessor` — drives both over a stream of fixes
- `PolygonMovementTriggerPolicy` — how far the movement trigger may sit from the device

Nothing calls any of it, so behaviour is unchanged.

## Why it's separate

This is the half of polygon monitoring that has no Android in it, so it can be reviewed against the
geometry rather than against lifecycles. The runtime that calls it lands further up the stack.

Split out of the MBL-2288 monolith (+3592 production lines in one commit), which was rebased onto
the merged `634cd850` first.

## Tests

49 new tests in the polygon package; 898 across geofence, core and messagingpush, 0 failures.
ktlint, `lintDebug` and `apiCheck` clean. No public API change.

Route-replay and adversarial-shape suites move here with the code they exercise.


