### PR TITLE
chore(geofence): add session ownership and atomic transition staging to the store

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRegion.kt
@@ -147,3 +147,13 @@ internal fun GeofenceRegion.equalsForRegistration(other: GeofenceRegion): Boolea
         longitude == other.longitude &&
         radius == other.radius &&
         transitionTypes == other.transitionTypes
+
+/** Stable, process-independent revision for invalidating detections produced by replaced geometry. */
+internal fun GeofenceRegion.transitionRevision(): Int {
+    var result = id.hashCode()
+    result = 31 * result + latitude.hashCode()
+    result = 31 * result + longitude.hashCode()
+    result = 31 * result + radius.hashCode()
+    result = 31 * result + (polygonVertices?.hashCode() ?: 0)
+    return result
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -6,6 +6,8 @@ import io.customer.geofence.GeofenceConfig
 import io.customer.geofence.GeofenceJsonSerializer
 import io.customer.geofence.GeofenceLocation
 import io.customer.geofence.GeofenceRegion
+import io.customer.geofence.transitionRevision
+import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.store.PreferenceCrypto
 import io.customer.sdk.data.store.PreferenceStore
@@ -25,6 +27,8 @@ import kotlinx.serialization.builtins.serializer
  *
  * Cleared on sign-out:
  *   registeredIds               — subset live in OS; drives the stale-cleanup diff.
+ *   retainedRegisteredRegions   — definitions for stale registrations whose OS removal failed;
+ *                                  excluded from nearest-N, but retained for callback routing.
  *   enteredIds                  — fences the device is inside; goes with the registrations it
  *                                  describes.
  *   emittedEnterIds             — fences reported entered, plus the userId they belong to.
@@ -33,6 +37,7 @@ import kotlinx.serialization.builtins.serializer
  *                                  registration; used by boot restore to re-center
  *                                  closer to the user's real position than the anchor.
  *   lastSyncTimestamp           — freshness throttle; cleared so the next login re-fetches.
+ *   pendingPolygonApproachBatches — exact responsive-mode fixes awaiting ordered evaluation.
  *
  * Rationale: the backend geofence fetch is workspace-scoped (no userId on
  * the wire), so cached regions/config stay valid for any user in the workspace
@@ -46,18 +51,89 @@ import kotlinx.serialization.builtins.serializer
  *
  * Storage: SharedPreferences. Workspace configuration (geofence IDs, names,
  * lat/lng, radii, external IDs) is plaintext — UID isolation keeps it
- * app-private. The two user-location snapshots are encrypted at rest via
- * [PreferenceCrypto] (AES-256-GCM, Android Keystore) and cleared on sign-out.
+ * app-private. User-location snapshots and queued polygon approach fixes are encrypted at rest
+ * via [PreferenceCrypto] (AES-256-GCM, Android Keystore) and cleared on sign-out.
  */
 internal interface GeofenceRegionStore {
+    /** Ordered exact-location batches used by responsive polygon evaluation. */
+    fun appendPendingPolygonApproachBatches(entries: List<PendingPolygonApproachBatch>): Boolean
+    fun getPendingPolygonApproachBatches(): List<PendingPolygonApproachBatch>
+    fun removePendingPolygonApproachBatch(id: String): Boolean
+    fun clearPendingPolygonApproachBatches()
+
     fun saveCachedRegions(regions: List<GeofenceRegion>)
     fun getCachedRegions(): List<GeofenceRegion>
 
-    /** The cached region with [id], or null if it isn't cached. */
+    /** Current server-catalog region. Retained cleanup-only definitions are deliberately excluded. */
     fun getCachedRegion(id: String): GeofenceRegion? = getCachedRegions().find { it.id == id }
+
+    /** Shape discriminator for an OS registration, including a failed-removal tombstone. */
+    fun getRegisteredRegion(id: String): GeofenceRegion? =
+        getCachedRegion(id) ?: getRetainedRegisteredRegions().find { it.id == id }
+
+    fun saveRetainedRegisteredRegions(regions: List<GeofenceRegion>)
+    fun getRetainedRegisteredRegions(): List<GeofenceRegion>
+
+    /** Durable staging rows used to recover the crash window before the delivery outbox append. */
+    fun getPendingTransitionEntries(
+        userId: String,
+        geofenceId: String,
+        transition: Event.GeofenceTransition
+    ): List<PendingGeofenceDelivery>
+
+    fun getAllPendingTransitionEntries(): List<PendingGeofenceDelivery>
+
+    /**
+     * Synchronously stages one attempt and commits its physical containment if
+     * [expectedUserStateGeneration] is still current.
+     */
+    fun savePendingTransitionEntries(
+        entries: List<PendingGeofenceDelivery>,
+        expectedUserStateGeneration: Long
+    ): Boolean
+    fun clearPendingTransitionEntries(transitionId: String)
+
+    /** Synchronously clears a staged attempt after its file-outbox rows are durable. */
+    fun completePendingTransition(transitionId: String): Boolean
+
+    /** Changes whenever sign-out clears user-scoped state. */
+    fun userStateGeneration(): Long
+
+    /** Whether polygon fine monitoring belongs to a currently identified user session. */
+    fun hasActiveUserSession(): Boolean
+
+    fun activeUserSessionId(): String?
+
+    /** Invalidates in-flight transition work when the identified profile changes. */
+    fun beginUserSession(userId: String)
+
+    /** Atomically commits containment and clears its staged transition for this user generation. */
+    fun commitBusinessTransition(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        transitionId: String?,
+        expectedUserStateGeneration: Long,
+        expectedRegionRevision: Int? = null
+    ): Boolean
 
     fun saveRegisteredIds(ids: Set<String>)
     fun getRegisteredIds(): Set<String>
+
+    /** OS registrations allowed to generate business events for the current user session. */
+    fun saveRoutableRegisteredIds(ids: Set<String>)
+    fun getRoutableRegisteredIds(): Set<String>
+
+    /** Polygon enclosing circles currently known to contain the device. */
+    fun getActivePolygonIds(): Set<String>
+    fun activatePolygon(id: String)
+    fun deactivatePolygon(id: String)
+    fun deactivatePolygonIfCurrent(id: String, expectedUserStateGeneration: Long): Boolean
+    fun retainActivePolygonIds(ids: Set<String>)
+    fun clearActivePolygonIds()
+    fun getCoarseInsidePolygonIds(): Set<String>
+    fun recordPolygonCoarseInside(id: String)
+    fun recordPolygonCoarseOutside(id: String)
+    fun retainCoarseInsidePolygonIds(ids: Set<String>)
 
     /** Fences the device is known to be inside. Drives the EXIT guard — see [claimExit]. */
     fun getEnteredIds(): Set<String>
@@ -159,6 +235,16 @@ internal interface GeofenceRegionStore {
      */
     fun clearUserScopedState()
 
+    /** Stops user-scoped work after OS cleanup fails while retaining IDs needed to retry removal. */
+    fun clearUserSessionRetainingOsRegistrations()
+
+    /**
+     * Completes a sign-out that started at [expectedUserStateGeneration]. If a newer identify has
+     * already advanced the generation, its owner is preserved while the departing user's state is
+     * still cleared.
+     */
+    fun completeUserReset(expectedUserStateGeneration: Long, osRegistrationsCleared: Boolean)
+
     fun clearAll()
 }
 
@@ -166,29 +252,384 @@ internal interface GeofenceRegionStore {
 internal fun GeofenceRegionStore.getCachedConfigOrFallback(): GeofenceConfig =
     getCachedConfig() ?: GeofenceConfig.fallback()
 
+internal interface GeofenceLocationCrypto {
+    fun encrypt(plaintext: String): String
+    fun decrypt(encoded: String): String
+}
+
+private class PreferenceGeofenceLocationCrypto(logger: Logger) : GeofenceLocationCrypto {
+    private val delegate = PreferenceCrypto("cio_geofence_location_key", logger)
+
+    override fun encrypt(plaintext: String): String = delegate.encrypt(plaintext)
+    override fun decrypt(encoded: String): String = delegate.decrypt(encoded)
+}
+
 internal class GeofenceRegionStoreImpl(
     context: Context,
     private val jsonSerializer: GeofenceJsonSerializer,
-    logger: Logger
+    logger: Logger,
+    private val locationCrypto: GeofenceLocationCrypto = PreferenceGeofenceLocationCrypto(logger)
 ) : PreferenceStore(context), GeofenceRegionStore {
 
     override val prefsName: String by lazy {
         "io.customer.sdk.geofence_regions.${context.packageName}"
     }
 
-    private val crypto = PreferenceCrypto(CRYPTO_KEY_ALIAS, logger)
+    override fun appendPendingPolygonApproachBatches(
+        entries: List<PendingPolygonApproachBatch>
+    ): Boolean = synchronized(enteredLock) {
+        if (entries.isEmpty()) return@synchronized true
+        val expectedGeneration = entries.first().userStateGeneration
+        if (
+            entries.any { it.userStateGeneration != expectedGeneration } ||
+            expectedGeneration != currentUserStateGenerationLocked() ||
+            !hasActiveUserSession()
+        ) {
+            return@synchronized false
+        }
+        val incomingIds = entries.mapTo(mutableSetOf(), PendingPolygonApproachBatch::id)
+        val retained = readPendingPolygonApproachBatches().filterNot { it.id in incomingIds }
+        // Preserve the oldest evidence when storage is under sustained pressure: a newer fix must
+        // never overtake an already-persisted route segment. But a batch that doesn't fit is a batch
+        // nothing will ever replay, and reporting success for it would tell the scheduler to enqueue
+        // work for locations that are not on disk — silently losing them. Report failure instead, so
+        // PolygonApproachReceiver evaluates these locations in-process while it still holds them.
+        if (retained.size + entries.size > MAXIMUM_PENDING_APPROACH_BATCHES) {
+            return@synchronized false
+        }
+        writeEncryptedJsonCommitted(
+            KEY_PENDING_POLYGON_APPROACH_BATCHES,
+            PENDING_APPROACH_BATCHES_SERIALIZER,
+            retained + entries
+        )
+    }
 
-    override fun saveCachedRegions(regions: List<GeofenceRegion>) =
+    override fun getPendingPolygonApproachBatches(): List<PendingPolygonApproachBatch> =
+        synchronized(enteredLock) { readPendingPolygonApproachBatches() }
+
+    override fun removePendingPolygonApproachBatch(id: String): Boolean = synchronized(enteredLock) {
+        val entries = readPendingPolygonApproachBatches()
+        val retained = entries.filterNot { it.id == id }
+        if (retained.size == entries.size) return@synchronized true
+        if (retained.isEmpty()) {
+            prefs.edit().remove(KEY_PENDING_POLYGON_APPROACH_BATCHES).commit()
+        } else {
+            writeEncryptedJsonCommitted(
+                KEY_PENDING_POLYGON_APPROACH_BATCHES,
+                PENDING_APPROACH_BATCHES_SERIALIZER,
+                retained
+            )
+        }
+    }
+
+    override fun clearPendingPolygonApproachBatches() = synchronized(enteredLock) {
+        prefs.edit().remove(KEY_PENDING_POLYGON_APPROACH_BATCHES).commit()
+        Unit
+    }
+
+    override fun saveCachedRegions(regions: List<GeofenceRegion>) = synchronized(enteredLock) {
         writeJson(KEY_CACHED_REGIONS, REGIONS_SERIALIZER, regions)
+    }
 
     override fun getCachedRegions(): List<GeofenceRegion> =
         readJson(KEY_CACHED_REGIONS, REGIONS_SERIALIZER) ?: emptyList()
+
+    override fun saveRetainedRegisteredRegions(regions: List<GeofenceRegion>) = synchronized(enteredLock) {
+        if (regions.isEmpty()) {
+            prefs.edit { remove(KEY_RETAINED_REGISTERED_REGIONS) }
+        } else {
+            writeJson(KEY_RETAINED_REGISTERED_REGIONS, REGIONS_SERIALIZER, regions)
+        }
+    }
+
+    override fun getRetainedRegisteredRegions(): List<GeofenceRegion> =
+        readJson(KEY_RETAINED_REGISTERED_REGIONS, REGIONS_SERIALIZER) ?: emptyList()
+
+    override fun getPendingTransitionEntries(
+        userId: String,
+        geofenceId: String,
+        transition: Event.GeofenceTransition
+    ): List<PendingGeofenceDelivery> = synchronized(enteredLock) {
+        readPendingTransitionEntries().filter {
+            it.userId == userId && it.geofenceId == geofenceId && it.transition == transition
+        }
+    }
+
+    override fun getAllPendingTransitionEntries(): List<PendingGeofenceDelivery> = synchronized(enteredLock) {
+        readPendingTransitionEntries()
+    }
+
+    override fun savePendingTransitionEntries(
+        entries: List<PendingGeofenceDelivery>,
+        expectedUserStateGeneration: Long
+    ): Boolean = synchronized(enteredLock) {
+        require(entries.isNotEmpty()) { "pending transition entries cannot be empty" }
+        require(entries.map(PendingGeofenceDelivery::transitionId).distinct().size == 1) {
+            "pending transition entries must share a transition id"
+        }
+        if (expectedUserStateGeneration != currentUserStateGenerationLocked()) {
+            return@synchronized false
+        }
+        val first = entries.first()
+        if (
+            first.regionRevision != null &&
+            getCachedRegion(first.geofenceId)?.transitionRevision() != first.regionRevision
+        ) {
+            return@synchronized false
+        }
+        // Distinct physical crossings can repeat a direction while an older attempt is still staged
+        // (ENTER → EXIT → ENTER). Replace only an idempotent replay of this exact attempt.
+        val retained = readPendingTransitionEntries().filterNot {
+            it.transitionId == first.transitionId
+        }
+        val updatedEntered = when (first.transition) {
+            Event.GeofenceTransition.ENTER -> getEnteredIds() + first.geofenceId
+            Event.GeofenceTransition.EXIT -> getEnteredIds() - first.geofenceId
+        }
+        val emittedOwner = readEmittedEnterOwner()
+        val updatedEmitted = when {
+            first.transition == Event.GeofenceTransition.EXIT -> readEmittedEnterIds() - first.geofenceId
+            first.marksEnterReported -> {
+                val sameOwner = emittedOwner == first.userId
+                (if (sameOwner) readEmittedEnterIds() else emptySet()) + first.geofenceId
+            }
+            else -> null
+        }
+        val editor = prefs.edit()
+            .putString(
+                KEY_PENDING_TRANSITION_ENTRIES,
+                jsonSerializer.encode(PENDING_TRANSITIONS_SERIALIZER, retained + entries)
+            )
+            .putString(KEY_ENTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, updatedEntered))
+        updatedEmitted?.let {
+            editor.putString(KEY_EMITTED_ENTER_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, it))
+        }
+        if (first.marksEnterReported && first.userId != null) {
+            editor.putString(KEY_EMITTED_ENTER_OWNER, first.userId)
+        }
+        if (!editor.commit()) return@synchronized false
+
+        epoch += 1
+        when (first.transition) {
+            Event.GeofenceTransition.ENTER -> enterEpochByGeofenceId[first.geofenceId] = epoch
+            Event.GeofenceTransition.EXIT -> exitEpochByGeofenceId[first.geofenceId] = epoch
+        }
+        true
+    }
+
+    override fun clearPendingTransitionEntries(transitionId: String) = synchronized(enteredLock) {
+        val retained = readPendingTransitionEntries().filterNot { it.transitionId == transitionId }
+        if (retained.isEmpty()) {
+            prefs.edit { remove(KEY_PENDING_TRANSITION_ENTRIES) }
+        } else {
+            writeJson(KEY_PENDING_TRANSITION_ENTRIES, PENDING_TRANSITIONS_SERIALIZER, retained)
+        }
+    }
+
+    override fun completePendingTransition(transitionId: String): Boolean = synchronized(enteredLock) {
+        val allPending = readPendingTransitionEntries()
+        val pending = allPending.filterNot { it.transitionId == transitionId }
+        if (pending.size == allPending.size) return@synchronized true
+        val editor = prefs.edit()
+        if (pending.isEmpty()) {
+            editor.remove(KEY_PENDING_TRANSITION_ENTRIES)
+        } else {
+            editor.putString(
+                KEY_PENDING_TRANSITION_ENTRIES,
+                jsonSerializer.encode(PENDING_TRANSITIONS_SERIALIZER, pending)
+            )
+        }
+        editor.commit()
+    }
+
+    override fun userStateGeneration(): Long = synchronized(enteredLock) {
+        currentUserStateGenerationLocked()
+    }
+
+    override fun hasActiveUserSession(): Boolean = synchronized(enteredLock) {
+        !prefs.read { getString(KEY_USER_STATE_OWNER, null) }.isNullOrEmpty()
+    }
+
+    override fun activeUserSessionId(): String? = synchronized(enteredLock) {
+        prefs.read { getString(KEY_USER_STATE_OWNER, null) }?.takeIf { it.isNotEmpty() }
+    }
+
+    override fun beginUserSession(userId: String) = synchronized(enteredLock) {
+        val currentOwner = prefs.read { getString(KEY_USER_STATE_OWNER, null) }
+        if (currentOwner == userId) return@synchronized
+        val nextGeneration = currentUserStateGenerationLocked() + 1L
+        val hasRoutingState = prefs.read { contains(KEY_ROUTABLE_REGISTERED_IDS) } == true
+        if (currentOwner == null && !hasRoutingState) {
+            // Upgrade migration: older SDKs persisted a secure user and registrations but no
+            // geofence-session owner/routing key. Adopt that same persisted session without
+            // discarding valid OS registrations or containment before the first callback.
+            prefs.edit()
+                .putString(KEY_USER_STATE_OWNER, userId)
+                .putLong(KEY_USER_STATE_GENERATION, nextGeneration)
+                .commit()
+            return@synchronized
+        }
+        prefs.edit()
+            .putString(KEY_USER_STATE_OWNER, userId)
+            .putLong(KEY_USER_STATE_GENERATION, nextGeneration)
+            .putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
+            .remove(KEY_LAST_API_FETCH_LOCATION)
+            .remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
+            .remove(KEY_PENDING_TRANSITION_ENTRIES)
+            .remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
+            .remove(KEY_ACTIVE_POLYGON_IDS)
+            .remove(KEY_COARSE_INSIDE_POLYGON_IDS)
+            .remove(KEY_ENTERED_IDS)
+            .remove(KEY_EMITTED_ENTER_IDS)
+            .remove(KEY_EMITTED_ENTER_OWNER)
+            .remove(KEY_LAST_SYNC)
+            .commit()
+    }
+
+    override fun commitBusinessTransition(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        transitionId: String?,
+        expectedUserStateGeneration: Long,
+        expectedRegionRevision: Int?
+    ): Boolean = synchronized(enteredLock) {
+        if (expectedUserStateGeneration != currentUserStateGenerationLocked()) return@synchronized false
+        if (
+            expectedRegionRevision != null &&
+            getCachedRegion(geofenceId)?.transitionRevision() != expectedRegionRevision
+        ) {
+            return@synchronized false
+        }
+
+        val currentEntered = getEnteredIds()
+        val updatedEntered = when (transition) {
+            Event.GeofenceTransition.ENTER -> currentEntered + geofenceId
+            Event.GeofenceTransition.EXIT -> currentEntered - geofenceId
+        }
+        val allPending = readPendingTransitionEntries()
+        val committedAttempt = transitionId?.let { id -> allPending.firstOrNull { it.transitionId == id } }
+        val pending = transitionId?.let { id ->
+            allPending.filterNot { it.transitionId == id }
+        } ?: allPending
+        val emittedOwner = readEmittedEnterOwner()
+        val emitted = when {
+            transition == Event.GeofenceTransition.EXIT -> readEmittedEnterIds() - geofenceId
+            committedAttempt?.marksEnterReported == true -> {
+                val sameOwner = emittedOwner == committedAttempt.userId
+                (if (sameOwner) readEmittedEnterIds() else emptySet()) + geofenceId
+            }
+            else -> null
+        }
+        val editor = prefs.edit()
+            .putString(KEY_ENTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, updatedEntered))
+        if (pending.isEmpty()) {
+            editor.remove(KEY_PENDING_TRANSITION_ENTRIES)
+        } else {
+            editor.putString(
+                KEY_PENDING_TRANSITION_ENTRIES,
+                jsonSerializer.encode(PENDING_TRANSITIONS_SERIALIZER, pending)
+            )
+        }
+        emitted?.let {
+            editor.putString(KEY_EMITTED_ENTER_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, it))
+        }
+        if (committedAttempt?.marksEnterReported == true && committedAttempt.userId != null) {
+            editor.putString(KEY_EMITTED_ENTER_OWNER, committedAttempt.userId)
+        }
+        if (!editor.commit()) return@synchronized false
+
+        epoch += 1
+        when (transition) {
+            Event.GeofenceTransition.ENTER -> enterEpochByGeofenceId[geofenceId] = epoch
+            Event.GeofenceTransition.EXIT -> exitEpochByGeofenceId[geofenceId] = epoch
+        }
+        true
+    }
+
+    private fun readPendingTransitionEntries(): List<PendingGeofenceDelivery> =
+        readJson(KEY_PENDING_TRANSITION_ENTRIES, PENDING_TRANSITIONS_SERIALIZER) ?: emptyList()
+
+    private fun currentUserStateGenerationLocked(): Long =
+        prefs.read { getLong(KEY_USER_STATE_GENERATION, 0L) } ?: 0L
 
     override fun saveRegisteredIds(ids: Set<String>) =
         writeJson(KEY_REGISTERED_IDS, ID_SET_SERIALIZER, ids)
 
     override fun getRegisteredIds(): Set<String> =
         readJson(KEY_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
+
+    override fun saveRoutableRegisteredIds(ids: Set<String>) =
+        writeJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER, ids)
+
+    override fun getRoutableRegisteredIds(): Set<String> {
+        val hasExplicitRoutingState = prefs.read { contains(KEY_ROUTABLE_REGISTERED_IDS) } == true
+        if (!hasExplicitRoutingState) return getRegisteredIds()
+        return readJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
+    }
+
+    override fun getActivePolygonIds(): Set<String> = synchronized(activePolygonLock) {
+        readJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER) ?: emptySet()
+    }
+
+    override fun activatePolygon(id: String) = synchronized(activePolygonLock) {
+        val current = getActivePolygonIds()
+        if (id !in current) writeJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER, current + id)
+    }
+
+    override fun deactivatePolygon(id: String) = synchronized(activePolygonLock) {
+        val current = getActivePolygonIds()
+        if (id in current) writeJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER, current - id)
+    }
+
+    override fun deactivatePolygonIfCurrent(
+        id: String,
+        expectedUserStateGeneration: Long
+    ): Boolean = synchronized(enteredLock) {
+        if (currentUserStateGenerationLocked() != expectedUserStateGeneration) {
+            return@synchronized false
+        }
+        synchronized(activePolygonLock) {
+            val current = getActivePolygonIds()
+            if (id in current) writeJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER, current - id)
+        }
+        true
+    }
+
+    override fun retainActivePolygonIds(ids: Set<String>) = synchronized(activePolygonLock) {
+        val retained = getActivePolygonIds() intersect ids
+        if (retained.isEmpty()) {
+            prefs.edit { remove(KEY_ACTIVE_POLYGON_IDS) }
+        } else {
+            writeJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER, retained)
+        }
+    }
+
+    override fun clearActivePolygonIds() = synchronized(activePolygonLock) {
+        prefs.edit { remove(KEY_ACTIVE_POLYGON_IDS) }
+    }
+
+    override fun getCoarseInsidePolygonIds(): Set<String> = synchronized(activePolygonLock) {
+        readJson(KEY_COARSE_INSIDE_POLYGON_IDS, ID_SET_SERIALIZER) ?: emptySet()
+    }
+
+    override fun recordPolygonCoarseInside(id: String) = synchronized(activePolygonLock) {
+        val current = getCoarseInsidePolygonIds()
+        if (id !in current) writeJson(KEY_COARSE_INSIDE_POLYGON_IDS, ID_SET_SERIALIZER, current + id)
+    }
+
+    override fun recordPolygonCoarseOutside(id: String) = synchronized(activePolygonLock) {
+        val current = getCoarseInsidePolygonIds()
+        if (id in current) writeJson(KEY_COARSE_INSIDE_POLYGON_IDS, ID_SET_SERIALIZER, current - id)
+    }
+
+    override fun retainCoarseInsidePolygonIds(ids: Set<String>) = synchronized(activePolygonLock) {
+        val retained = getCoarseInsidePolygonIds() intersect ids
+        if (retained.isEmpty()) {
+            prefs.edit { remove(KEY_COARSE_INSIDE_POLYGON_IDS) }
+        } else {
+            writeJson(KEY_COARSE_INSIDE_POLYGON_IDS, ID_SET_SERIALIZER, retained)
+        }
+    }
 
     override fun getEnteredIds(): Set<String> =
         readJson(KEY_ENTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
@@ -330,17 +771,49 @@ internal class GeofenceRegionStoreImpl(
     }
 
     override fun clearUserScopedState() {
-        prefs.edit {
-            remove(KEY_LAST_API_FETCH_LOCATION)
-            remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
-            remove(KEY_REGISTERED_IDS)
-            remove(KEY_ENTERED_IDS)
-            remove(KEY_EMITTED_ENTER_IDS)
-            remove(KEY_EMITTED_ENTER_OWNER)
-            remove(KEY_LAST_REGISTRATION_UPTIME)
-            remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
-            remove(KEY_LAST_SYNC)
+        completeUserReset(userStateGeneration(), osRegistrationsCleared = true)
+    }
+
+    override fun clearUserSessionRetainingOsRegistrations() {
+        completeUserReset(userStateGeneration(), osRegistrationsCleared = false)
+    }
+
+    override fun completeUserReset(
+        expectedUserStateGeneration: Long,
+        osRegistrationsCleared: Boolean
+    ): Unit = synchronized(enteredLock) {
+        val currentGeneration = currentUserStateGenerationLocked()
+        val resetWasSuperseded = currentGeneration != expectedUserStateGeneration
+        val editor = prefs.edit()
+            .remove(KEY_LAST_API_FETCH_LOCATION)
+            .remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
+            .remove(KEY_PENDING_TRANSITION_ENTRIES)
+            .remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
+            .remove(KEY_ACTIVE_POLYGON_IDS)
+            .remove(KEY_COARSE_INSIDE_POLYGON_IDS)
+            .remove(KEY_ENTERED_IDS)
+            .remove(KEY_EMITTED_ENTER_IDS)
+            .remove(KEY_EMITTED_ENTER_OWNER)
+            .remove(KEY_LAST_SYNC)
+        if (osRegistrationsCleared) {
+            editor
+                .remove(KEY_REGISTERED_IDS)
+                .remove(KEY_ROUTABLE_REGISTERED_IDS)
+                .remove(KEY_RETAINED_REGISTERED_REGIONS)
+                .remove(KEY_LAST_REGISTRATION_UPTIME)
+                .remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
+        } else {
+            // Explicit empty is distinct from key absence. Absence is the upgrade path for SDK
+            // versions that only stored registered_ids and must remain routable until refreshed.
+            editor.putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
         }
+        if (!resetWasSuperseded) {
+            editor
+                .remove(KEY_USER_STATE_OWNER)
+                .putLong(KEY_USER_STATE_GENERATION, currentGeneration + 1L)
+        }
+        editor.commit()
+        Unit
     }
 
     override fun clearAll() {
@@ -366,7 +839,20 @@ internal class GeofenceRegionStoreImpl(
     }
 
     private fun <T> writeEncryptedJson(key: String, serializer: KSerializer<T>, value: T) {
-        prefs.edit { putString(key, crypto.encrypt(jsonSerializer.encode(serializer, value))) }
+        prefs.edit { putString(key, locationCrypto.encrypt(jsonSerializer.encode(serializer, value))) }
+    }
+
+    private fun <T> writeEncryptedJsonCommitted(
+        key: String,
+        serializer: KSerializer<T>,
+        value: T
+    ): Boolean {
+        val plaintext = jsonSerializer.encode(serializer, value)
+        val encrypted = locationCrypto.encrypt(plaintext)
+        // Exact route history must never take PreferenceCrypto's API 21/OEM plaintext fallback.
+        // The receiver can evaluate the batch immediately when durable encryption is unavailable.
+        if (encrypted == plaintext) return false
+        return prefs.edit().putString(key, encrypted).commit()
     }
 
     /**
@@ -377,13 +863,20 @@ internal class GeofenceRegionStoreImpl(
      */
     private fun <T> readEncryptedJson(key: String, serializer: KSerializer<T>): T? {
         val raw = prefs.read { getString(key, null) } ?: return null
-        return jsonSerializer.decodeOrNull(serializer, crypto.decrypt(raw)) ?: run {
+        return jsonSerializer.decodeOrNull(serializer, locationCrypto.decrypt(raw)) ?: run {
             prefs.edit { remove(key) }
             null
         }
     }
 
     private val enteredLock = Any()
+    private val activePolygonLock = Any()
+
+    private fun readPendingPolygonApproachBatches(): List<PendingPolygonApproachBatch> =
+        readEncryptedJson(
+            KEY_PENDING_POLYGON_APPROACH_BATCHES,
+            PENDING_APPROACH_BATCHES_SERIALIZER
+        ) ?: emptyList()
 
     // Guarded by [enteredLock]. Bumped per reported transition, so a sync can tell which of the two
     // directions a fence reported most recently against the fix the sync is holding. Per-fence
@@ -392,9 +885,17 @@ internal class GeofenceRegionStoreImpl(
     private val exitEpochByGeofenceId = mutableMapOf<String, Long>()
     private val enterEpochByGeofenceId = mutableMapOf<String, Long>()
 
-    private companion object {
+    internal companion object {
         const val KEY_CACHED_REGIONS = "cached_regions"
         const val KEY_REGISTERED_IDS = "registered_ids"
+        const val KEY_ROUTABLE_REGISTERED_IDS = "routable_registered_ids"
+        const val KEY_RETAINED_REGISTERED_REGIONS = "retained_registered_regions"
+        const val KEY_PENDING_TRANSITION_ENTRIES = "pending_transition_entries"
+        const val KEY_PENDING_POLYGON_APPROACH_BATCHES = "pending_polygon_approach_batches"
+        const val KEY_USER_STATE_GENERATION = "user_state_generation"
+        const val KEY_USER_STATE_OWNER = "user_state_owner"
+        const val KEY_ACTIVE_POLYGON_IDS = "active_polygon_ids"
+        const val KEY_COARSE_INSIDE_POLYGON_IDS = "coarse_inside_polygon_ids"
         const val KEY_ENTERED_IDS = "entered_ids"
         const val KEY_EMITTED_ENTER_IDS = "emitted_enter_ids"
         const val KEY_EMITTED_ENTER_OWNER = "emitted_enter_owner"
@@ -404,8 +905,11 @@ internal class GeofenceRegionStoreImpl(
         const val KEY_LAST_SYNC = "last_sync_timestamp"
         const val KEY_LAST_REGISTRATION_UPTIME = "last_registration_uptime"
         const val KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME = "last_registration_package_update_time"
-        const val CRYPTO_KEY_ALIAS = "cio_geofence_location_key"
+        const val MAXIMUM_PENDING_APPROACH_BATCHES = 128
         val REGIONS_SERIALIZER = ListSerializer(GeofenceRegion.serializer())
+        val PENDING_TRANSITIONS_SERIALIZER = ListSerializer(PendingGeofenceDelivery.serializer())
+        val PENDING_APPROACH_BATCHES_SERIALIZER =
+            ListSerializer(PendingPolygonApproachBatch.serializer())
         val ID_SET_SERIALIZER = SetSerializer(String.serializer())
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -39,7 +39,13 @@ internal data class PendingGeofenceDelivery(
     /** Part of [key] so per-geoset entries for one crossing don't collide; null when the fence has no geosets. */
     val geosetId: String? = null,
     /** Snapshot of the fence's `metadata` at crossing time; the send-time fallback when it's left the cache. */
-    val metadata: Map<String, JsonElement> = emptyMap()
+    val metadata: Map<String, JsonElement> = emptyMap(),
+    /** User-state generation that observed this crossing. Internal only, never sent as event data. */
+    val stateGeneration: Long = 0L,
+    /** Geometry revision used to reject a transition computed from a replaced polygon. */
+    val regionRevision: Int? = null,
+    /** Whether committing this staged ENTER must atomically set the reboot dedupe marker. */
+    val marksEnterReported: Boolean = false
 ) : PendingDeliveryStore.PendingDeliveryEntry {
     override val key: String get() = "${geofenceId}_${transition.name}_${timestamp}_${geosetId ?: "none"}"
 

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingPolygonApproachBatch.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingPolygonApproachBatch.kt
@@ -1,0 +1,23 @@
+package io.customer.geofence.store
+
+import kotlinx.serialization.Serializable
+
+/** Exact location samples awaiting ordered, encrypted polygon evaluation. */
+@Serializable
+internal data class PendingPolygonApproachBatch(
+    val id: String,
+    val userStateGeneration: Long,
+    val bootSessionId: String,
+    val sessionDeadlineElapsedRealtimeMs: Long = Long.MIN_VALUE,
+    val locations: List<PendingPolygonApproachLocation>
+)
+
+@Serializable
+internal data class PendingPolygonApproachLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracy: Float?,
+    val speed: Float?,
+    val timestampMillis: Long,
+    val elapsedRealtimeNanos: Long
+)

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -11,6 +11,8 @@ import io.customer.geofence.GeofenceLocation
 import io.customer.geofence.GeofenceRegion
 import io.customer.geofence.GeofenceTransitionType
 import io.customer.geofence.polygon.PolygonCoordinate
+import io.customer.geofence.transitionRevision
+import io.customer.sdk.communication.Event
 import io.mockk.mockk
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
@@ -45,6 +47,107 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     // --- Cached regions (full backend response) ---
 
     @Test
+    fun polygonApproachBatches_givenMultipleAppends_expectOrderedRoundTrip() {
+        val encryptedStore = encryptedStore().also { it.beginUserSession(USER) }
+        val generation = encryptedStore.userStateGeneration()
+        val first = approachBatch("first", 37.0, generation)
+        val second = approachBatch("second", 38.0, generation)
+
+        encryptedStore.appendPendingPolygonApproachBatches(listOf(first)).shouldBeTrue()
+        encryptedStore.appendPendingPolygonApproachBatches(listOf(second)).shouldBeTrue()
+
+        encryptedStore.getPendingPolygonApproachBatches() shouldBeEqualTo listOf(first, second)
+        val raw = readRaw("pending_polygon_approach_batches")
+        raw.isNotEmpty().shouldBeTrue()
+        raw.contains("\"latitude\"").shouldBeFalse()
+        raw.contains("37.0").shouldBeFalse()
+        encryptedStore.removePendingPolygonApproachBatch(first.id).shouldBeTrue()
+        encryptedStore.getPendingPolygonApproachBatches() shouldBeEqualTo listOf(second)
+    }
+
+    @Test
+    fun polygonApproachBatches_givenSignOut_expectExactLocationsCleared() {
+        val encryptedStore = encryptedStore().also { it.beginUserSession(USER) }
+        encryptedStore.appendPendingPolygonApproachBatches(
+            listOf(approachBatch("pending", 37.0, encryptedStore.userStateGeneration()))
+        ).shouldBeTrue()
+
+        encryptedStore.clearUserSessionRetainingOsRegistrations()
+
+        encryptedStore.getPendingPolygonApproachBatches().shouldBeEmpty()
+    }
+
+    @Test
+    fun polygonApproachBatches_givenOldGenerationAfterSignOut_expectRejected() {
+        val encryptedStore = encryptedStore().also { it.beginUserSession(USER) }
+        val stale = approachBatch("stale", 37.0, encryptedStore.userStateGeneration())
+        encryptedStore.clearUserSessionRetainingOsRegistrations()
+
+        encryptedStore.appendPendingPolygonApproachBatches(listOf(stale)).shouldBeFalse()
+
+        encryptedStore.getPendingPolygonApproachBatches().shouldBeEmpty()
+    }
+
+    @Test
+    fun polygonApproachBatches_givenCapReached_expectRejectedInsteadOfSilentlyDropped() {
+        // Reporting success here would tell the scheduler to enqueue a worker for locations that never
+        // reached disk; the worker finds nothing and the fixes are lost. Failing lets the receiver
+        // evaluate them in-process while it still holds them.
+        val encryptedStore = encryptedStore().also { it.beginUserSession(USER) }
+        val generation = encryptedStore.userStateGeneration()
+        val atCapacity = List(GeofenceRegionStoreImpl.MAXIMUM_PENDING_APPROACH_BATCHES) { index ->
+            approachBatch("existing-$index", 37.0 + index, generation)
+        }
+        encryptedStore.appendPendingPolygonApproachBatches(atCapacity).shouldBeTrue()
+
+        encryptedStore.appendPendingPolygonApproachBatches(
+            listOf(approachBatch("overflow", 12.0, generation))
+        ).shouldBeFalse()
+
+        // The oldest evidence is still intact, and the rejected batch was not partially written.
+        val stored = encryptedStore.getPendingPolygonApproachBatches()
+        stored.size shouldBeEqualTo GeofenceRegionStoreImpl.MAXIMUM_PENDING_APPROACH_BATCHES
+        stored.none { it.id == "overflow" }.shouldBeTrue()
+        stored.first().id shouldBeEqualTo "existing-0"
+    }
+
+    @Test
+    fun polygonApproachBatches_givenReplayOfAlreadyStoredBatchAtCapacity_expectStillAccepted() {
+        // An idempotent re-append of a batch already on disk doesn't grow the queue, so the cap must
+        // not reject it and push a batch that *is* durable onto the in-process fallback.
+        val encryptedStore = encryptedStore().also { it.beginUserSession(USER) }
+        val generation = encryptedStore.userStateGeneration()
+        val atCapacity = List(GeofenceRegionStoreImpl.MAXIMUM_PENDING_APPROACH_BATCHES) { index ->
+            approachBatch("existing-$index", 37.0 + index, generation)
+        }
+        encryptedStore.appendPendingPolygonApproachBatches(atCapacity).shouldBeTrue()
+
+        encryptedStore.appendPendingPolygonApproachBatches(listOf(atCapacity.first())).shouldBeTrue()
+
+        encryptedStore.getPendingPolygonApproachBatches().size shouldBeEqualTo
+            GeofenceRegionStoreImpl.MAXIMUM_PENDING_APPROACH_BATCHES
+    }
+
+    @Test
+    fun polygonApproachBatches_givenEncryptionFallbackToPlaintext_expectNotPersisted() {
+        val plaintextStore = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true),
+            locationCrypto = object : GeofenceLocationCrypto {
+                override fun encrypt(plaintext: String): String = plaintext
+                override fun decrypt(encoded: String): String = encoded
+            }
+        ).also { it.beginUserSession(USER) }
+
+        plaintextStore.appendPendingPolygonApproachBatches(
+            listOf(approachBatch("unsafe", 37.0, plaintextStore.userStateGeneration()))
+        ).shouldBeFalse()
+
+        readRaw("pending_polygon_approach_batches") shouldBeEqualTo ""
+    }
+
+    @Test
     fun getCachedRegions_givenNothingStored_expectEmpty() {
         store.getCachedRegions().shouldBeEmpty()
     }
@@ -73,14 +176,14 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     fun saveCachedRegions_givenPolygon_expectGeometryRoundTrip() {
         val polygon = GeofenceRegion(
             id = "campus",
-            latitude = 37.775,
-            longitude = -122.419,
-            radius = 1_000f,
+            latitude = 37.0,
+            longitude = -122.0,
+            radius = 500f,
             polygonVertices = listOf(
-                PolygonCoordinate(37.7745, -122.4200),
-                PolygonCoordinate(37.7745, -122.4188),
-                PolygonCoordinate(37.7755, -122.4188),
-                PolygonCoordinate(37.7755, -122.4200)
+                PolygonCoordinate(37.0, -122.0),
+                PolygonCoordinate(37.0, -121.99),
+                PolygonCoordinate(37.01, -121.99),
+                PolygonCoordinate(37.01, -122.0)
             )
         )
 
@@ -102,6 +205,282 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 37.7749, -122.4194, 100f, name = "Coffee")))
 
         store.getCachedRegion("biz-missing") shouldBeEqualTo null
+    }
+
+    @Test
+    fun getRegisteredRegion_givenRetainedRegistration_expectRoutingFallbackWithoutAddingToCatalog() {
+        val stale = GeofenceRegion("biz-stale", 37.7749, -122.4194, 100f, name = "Old")
+
+        store.saveRetainedRegisteredRegions(listOf(stale))
+
+        store.getCachedRegion("biz-stale") shouldBeEqualTo null
+        store.getRegisteredRegion("biz-stale") shouldBeEqualTo stale
+        store.getCachedRegions().shouldBeEmpty()
+    }
+
+    @Test
+    fun pendingTransition_givenCommittedEnter_expectContainmentAndStageUpdatedAtomically() {
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-1",
+            marksEnterReported = true
+        )
+        val generation = store.userStateGeneration()
+        store.savePendingTransitionEntries(listOf(staged), generation).shouldBeTrue()
+
+        store.getEnteredIds() shouldContain "biz-1"
+        store.hasEmittedEnter("user-1", "biz-1").shouldBeTrue()
+        store.getAllPendingTransitionEntries() shouldBeEqualTo listOf(staged)
+
+        store.completePendingTransition("transition-1").shouldBeTrue()
+
+        store.getAllPendingTransitionEntries().shouldBeEmpty()
+    }
+
+    @Test
+    fun pendingTransition_givenOppositeStageBeforeOlderDeliveryCompletes_expectOlderCompletionCannotResurrectState() {
+        val generation = store.userStateGeneration()
+        val enter = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-enter"
+        )
+        val exit = enter.copy(
+            transition = Event.GeofenceTransition.EXIT,
+            timestamp = 101L,
+            transitionId = "transition-exit"
+        )
+
+        store.savePendingTransitionEntries(listOf(enter), generation).shouldBeTrue()
+        store.savePendingTransitionEntries(listOf(exit), generation).shouldBeTrue()
+        store.getEnteredIds().shouldBeEmpty()
+
+        store.completePendingTransition("transition-enter").shouldBeTrue()
+
+        store.getEnteredIds().shouldBeEmpty()
+        store.getAllPendingTransitionEntries() shouldBeEqualTo listOf(exit)
+    }
+
+    @Test
+    fun pendingTransition_givenAlternatingEdgesWhileDeliveryBlocked_expectEveryAttemptAndLatestContainmentPreserved() {
+        val generation = store.userStateGeneration()
+        val enterOne = PendingGeofenceDelivery(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "enter-1"
+        )
+        val exit = enterOne.copy(
+            transition = Event.GeofenceTransition.EXIT,
+            timestamp = 101L,
+            transitionId = "exit-1"
+        )
+        val enterTwo = enterOne.copy(timestamp = 102L, transitionId = "enter-2")
+
+        store.savePendingTransitionEntries(listOf(enterOne), generation).shouldBeTrue()
+        store.savePendingTransitionEntries(listOf(exit), generation).shouldBeTrue()
+        store.savePendingTransitionEntries(listOf(enterTwo), generation).shouldBeTrue()
+
+        store.getAllPendingTransitionEntries() shouldBeEqualTo listOf(enterOne, exit, enterTwo)
+        store.getEnteredIds() shouldBeEqualTo setOf("polygon")
+    }
+
+    @Test
+    fun commitBusinessTransition_givenGeometryReplacedSinceTheDetection_expectRejected() {
+        val region = GeofenceRegion("biz-1", 1.0, 2.0, 100f)
+        store.saveCachedRegions(listOf(region))
+        val revisionAtDetection = region.transitionRevision()
+        store.saveCachedRegions(listOf(region.copy(radius = 250f)))
+
+        store.commitBusinessTransition(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            transitionId = null,
+            expectedUserStateGeneration = store.userStateGeneration(),
+            expectedRegionRevision = revisionAtDetection
+        ).shouldBeFalse()
+
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun commitBusinessTransition_givenStagedEnterThatMarksReported_expectContainmentAndMarkCommittedTogether() {
+        val generation = store.userStateGeneration()
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-1",
+            marksEnterReported = true
+        )
+        store.savePendingTransitionEntries(listOf(staged), generation).shouldBeTrue()
+
+        store.commitBusinessTransition(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            transitionId = "transition-1",
+            expectedUserStateGeneration = generation
+        ).shouldBeTrue()
+
+        store.getEnteredIds() shouldContain "biz-1"
+        store.hasEmittedEnter("user-1", "biz-1").shouldBeTrue()
+        store.getAllPendingTransitionEntries().shouldBeEmpty()
+    }
+
+    @Test
+    fun commitBusinessTransition_givenExit_expectContainmentAndMarkCleared() {
+        val generation = store.userStateGeneration()
+        val enter = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-1",
+            marksEnterReported = true
+        )
+        store.savePendingTransitionEntries(listOf(enter), generation).shouldBeTrue()
+        store.commitBusinessTransition(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            transitionId = "transition-1",
+            expectedUserStateGeneration = generation
+        ).shouldBeTrue()
+
+        store.commitBusinessTransition(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.EXIT,
+            transitionId = null,
+            expectedUserStateGeneration = generation
+        ).shouldBeTrue()
+
+        store.getEnteredIds().shouldBeEmpty()
+        store.hasEmittedEnter("user-1", "biz-1").shouldBeFalse()
+    }
+
+    @Test
+    fun pendingTransition_givenSignOutBeforeDelayedCommit_expectGenerationRejectsStateResurrection() {
+        val generation = store.userStateGeneration()
+        store.clearUserScopedState()
+
+        store.commitBusinessTransition(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            transitionId = null,
+            expectedUserStateGeneration = generation
+        ).shouldBeFalse()
+
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun pendingTransition_givenSignOutBeforeDelayedStage_expectDurableGenerationRejectsWrite() {
+        val oldGeneration = store.userStateGeneration()
+        store.clearUserScopedState()
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "old-user",
+            transitionId = "transition-1",
+            stateGeneration = oldGeneration
+        )
+
+        store.savePendingTransitionEntries(listOf(staged), oldGeneration).shouldBeFalse()
+        store.getAllPendingTransitionEntries().shouldBeEmpty()
+    }
+
+    @Test
+    fun beginUserSession_givenProcessRecreation_expectGenerationRemainsDurable() {
+        store.beginUserSession("user-1")
+        val generation = store.userStateGeneration()
+        store.saveRegisteredIds(setOf("biz-1"))
+        store.saveRoutableRegisteredIds(setOf("biz-1"))
+        store.activatePolygon("biz-1")
+        val recreated = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+
+        recreated.userStateGeneration() shouldBeEqualTo generation
+        recreated.beginUserSession("user-1")
+        recreated.userStateGeneration() shouldBeEqualTo generation
+        recreated.beginUserSession("user-2")
+        recreated.userStateGeneration() shouldBeEqualTo generation + 1L
+        recreated.activeUserSessionId() shouldBeEqualTo "user-2"
+        recreated.getRegisteredIds() shouldBeEqualTo setOf("biz-1")
+        recreated.getRoutableRegisteredIds().shouldBeEmpty()
+        recreated.getActivePolygonIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun beginUserSession_givenLegacyRegistrationsWithoutOwnerOrRoutingKey_expectAdoptsWithoutCoverageLoss() {
+        store.saveRegisteredIds(setOf("biz-1"))
+        store.recordEntered("biz-1")
+        val recreated = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+
+        recreated.beginUserSession("user-1")
+
+        recreated.activeUserSessionId() shouldBeEqualTo "user-1"
+        recreated.getRegisteredIds() shouldBeEqualTo setOf("biz-1")
+        recreated.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1")
+        recreated.getEnteredIds() shouldBeEqualTo setOf("biz-1")
+    }
+
+    @Test
+    fun completeUserReset_givenNewUserBeganWhileOsClearWasInFlight_expectPreservesNewOwner() {
+        store.beginUserSession("user-A")
+        val resetGeneration = store.userStateGeneration()
+        store.saveRegisteredIds(setOf("biz-1"))
+        store.saveRoutableRegisteredIds(setOf("biz-1"))
+        store.activatePolygon("biz-1")
+        store.recordPolygonCoarseInside("biz-1")
+        store.recordEntered("biz-1")
+        store.setLastSyncTimestamp(100L)
+
+        store.beginUserSession("user-B")
+        val userBGeneration = store.userStateGeneration()
+        store.completeUserReset(resetGeneration, osRegistrationsCleared = true)
+
+        store.activeUserSessionId() shouldBeEqualTo "user-B"
+        store.userStateGeneration() shouldBeEqualTo userBGeneration
+        store.getRegisteredIds().shouldBeEmpty()
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+        store.getActivePolygonIds().shouldBeEmpty()
+        store.getCoarseInsidePolygonIds().shouldBeEmpty()
+        store.getEnteredIds().shouldBeEmpty()
+        store.getLastSyncTimestamp().shouldBeNull()
+    }
+
+    @Test
+    fun completeUserReset_givenNewUserBeganAndOsClearFailed_expectPreservesOwnerAndCleanupIds() {
+        val retained = GeofenceRegion("biz-old", 1.0, 2.0, 50f)
+        store.beginUserSession("user-A")
+        val resetGeneration = store.userStateGeneration()
+        store.saveRegisteredIds(setOf(retained.id))
+        store.saveRoutableRegisteredIds(setOf(retained.id))
+        store.saveRetainedRegisteredRegions(listOf(retained))
+
+        store.beginUserSession("user-B")
+        val userBGeneration = store.userStateGeneration()
+        store.completeUserReset(resetGeneration, osRegistrationsCleared = false)
+
+        store.activeUserSessionId() shouldBeEqualTo "user-B"
+        store.userStateGeneration() shouldBeEqualTo userBGeneration
+        store.getRegisteredIds() shouldBeEqualTo setOf(retained.id)
+        store.getRetainedRegisteredRegions() shouldBeEqualTo listOf(retained)
+        store.getRoutableRegisteredIds().shouldBeEmpty()
     }
 
     @Test
@@ -136,6 +515,54 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRegisteredIds(emptySet())
 
         store.getRegisteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun getRoutableRegisteredIds_givenPreFeatureStore_expectFallsBackToRegisteredIds() {
+        store.saveRegisteredIds(setOf("biz-legacy"))
+
+        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-legacy")
+    }
+
+    @Test
+    fun polygonSessionState_givenProcessStyleStoreRecreation_expectPersistsActiveAndCoarseState() {
+        store.activatePolygon("campus")
+        store.recordPolygonCoarseInside("campus")
+
+        val recreated = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+
+        recreated.getActivePolygonIds() shouldContainSame setOf("campus")
+        recreated.getCoarseInsidePolygonIds() shouldContainSame setOf("campus")
+    }
+
+    @Test
+    fun retainPolygonSessionState_givenRegionRemoved_expectBothSetsPruned() {
+        store.activatePolygon("kept")
+        store.activatePolygon("removed")
+        store.recordPolygonCoarseInside("kept")
+        store.recordPolygonCoarseInside("removed")
+
+        store.retainActivePolygonIds(setOf("kept"))
+        store.retainCoarseInsidePolygonIds(setOf("kept"))
+
+        store.getActivePolygonIds() shouldContainSame setOf("kept")
+        store.getCoarseInsidePolygonIds() shouldContainSame setOf("kept")
+    }
+
+    @Test
+    fun deactivatePolygonIfCurrent_givenPreviousUserGeneration_expectKeepsNewSessionActive() {
+        store.beginUserSession("user-1")
+        val previousGeneration = store.userStateGeneration()
+        store.beginUserSession("user-2")
+        store.activatePolygon("campus")
+
+        store.deactivatePolygonIfCurrent("campus", previousGeneration) shouldBeEqualTo false
+
+        store.getActivePolygonIds() shouldContainSame setOf("campus")
     }
 
     @Test
@@ -617,6 +1044,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     fun clearAll_expectEverythingRemoved() {
         store.saveCachedRegions(listOf(GeofenceRegion("biz-1", 0.0, 0.0, 50f)))
         store.saveRegisteredIds(setOf("biz-1"))
+        store.saveRoutableRegisteredIds(setOf("biz-1"))
+        store.saveRetainedRegisteredRegions(listOf(GeofenceRegion("biz-stale", 1.0, 1.0, 50f)))
         store.saveCachedConfig(
             GeofenceConfig(
                 localRefreshTriggerRadius = 1_000f,
@@ -636,6 +1065,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         store.getCachedRegions().shouldBeEmpty()
         store.getRegisteredIds().shouldBeEmpty()
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+        store.getRetainedRegisteredRegions().shouldBeEmpty()
         store.getEnteredIds().shouldBeEmpty()
         store.getCachedConfig().shouldBeNull()
         store.getLastApiFetchLocation().shouldBeNull()
@@ -659,6 +1090,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveCachedRegions(regions)
         store.saveCachedConfig(config)
         store.saveRegisteredIds(setOf("biz-1"))
+        store.saveRoutableRegisteredIds(setOf("biz-1"))
+        store.saveRetainedRegisteredRegions(listOf(GeofenceRegion("biz-stale", 1.0, 1.0, 50f)))
         store.recordEntered("biz-1")
         store.markEnterEmitted(USER, "biz-1")
         store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
@@ -671,6 +1104,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
 
         // User-specific: wiped.
         store.getRegisteredIds().shouldBeEmpty()
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+        store.getRetainedRegisteredRegions().shouldBeEmpty()
         // Goes with the registrations it describes — sign-out drops those from the OS.
         store.getEnteredIds().shouldBeEmpty()
         // The next user must not inherit a suppressed ENTER for a fence they were never told about.
@@ -684,6 +1119,46 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         // Cached regions/config: preserved.
         store.getCachedRegions() shouldBeEqualTo regions
         store.getCachedConfig() shouldBeEqualTo config
+    }
+
+    @Test
+    fun clearUserSessionRetainingOsRegistrations_expectSamplingStopsButCleanupStateSurvives() {
+        val registered = GeofenceRegion("biz-1", 0.0, 0.0, 50f)
+        val retained = GeofenceRegion("biz-stale", 1.0, 1.0, 50f)
+        store.beginUserSession(USER)
+        val generation = store.userStateGeneration()
+        store.saveCachedRegions(listOf(registered))
+        store.saveRegisteredIds(setOf(registered.id))
+        store.saveRoutableRegisteredIds(setOf(registered.id))
+        store.saveRetainedRegisteredRegions(listOf(retained))
+        store.activatePolygon(registered.id)
+        store.recordPolygonCoarseInside(registered.id)
+        store.recordEntered(registered.id)
+        store.markEnterEmitted(USER, registered.id)
+        store.setLastSyncTimestamp(12_345L)
+
+        store.clearUserSessionRetainingOsRegistrations()
+
+        store.getRegisteredIds() shouldBeEqualTo setOf(registered.id)
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+        store.getRetainedRegisteredRegions() shouldBeEqualTo listOf(retained)
+        store.getCachedRegions() shouldBeEqualTo listOf(registered)
+        store.getActivePolygonIds().shouldBeEmpty()
+        store.getCoarseInsidePolygonIds().shouldBeEmpty()
+        store.getEnteredIds().shouldBeEmpty()
+        store.hasEmittedEnter(USER, registered.id).shouldBeFalse()
+        store.hasActiveUserSession().shouldBeFalse()
+        store.userStateGeneration() shouldBeEqualTo generation + 1L
+        store.getLastSyncTimestamp().shouldBeNull()
+
+        val recreated = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+        recreated.beginUserSession("user-B")
+        recreated.getRegisteredIds() shouldBeEqualTo setOf(registered.id)
+        recreated.getRoutableRegisteredIds().shouldBeEmpty()
     }
 
     // --- Schema-drift / corruption safety ---
@@ -842,6 +1317,37 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         private const val USER = "user-1"
         private const val OTHER_USER = "user-2"
     }
+
+    private fun approachBatch(
+        id: String,
+        latitude: Double,
+        generation: Long = store.userStateGeneration()
+    ) = PendingPolygonApproachBatch(
+        id = id,
+        userStateGeneration = generation,
+        bootSessionId = "boot-1",
+        locations = listOf(
+            PendingPolygonApproachLocation(
+                latitude = latitude,
+                longitude = -122.0,
+                accuracy = 5f,
+                speed = null,
+                timestampMillis = 1_000L,
+                elapsedRealtimeNanos = 2_000L
+            )
+        )
+    )
+
+    private fun encryptedStore() = GeofenceRegionStoreImpl(
+        context = applicationMock,
+        jsonSerializer = GeofenceJsonSerializer(),
+        logger = mockk(relaxed = true),
+        locationCrypto = object : GeofenceLocationCrypto {
+            override fun encrypt(plaintext: String): String = "encrypted:${plaintext.reversed()}"
+            override fun decrypt(encoded: String): String =
+                encoded.removePrefix("encrypted:").reversed()
+        }
+    )
 
     private fun writeRaw(key: String, value: String) {
         applicationMock.getSharedPreferences(


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

- [#835 polygon transition evaluation core](https://github.com/customerio/customerio-android/pull/835)
- 👉 [#836 session ownership and atomic transition staging](https://github.com/customerio/customerio-android/pull/836)
- [#837 stage transitions durably before delivery](https://github.com/customerio/customerio-android/pull/837)
- [#838 polygon location engine](https://github.com/customerio/customerio-android/pull/838)

Three more branches are ready locally and not open yet: the approach monitor + service
controller, the wiring that enables polygon monitoring, and the geofence instrumentation CI
job. Holding them until this half is reviewed.

## What this is

The persisted state responsive polygon monitoring needs, ahead of the runtime that uses it:

- **user-state generation + session owner** — work started under one user can never commit against
  the next one, and a legacy install with registrations but no owner is adopted rather than wiped
- **routable registration ids + retained region tombstones** — separates what may generate events
  from what is only kept to retry a failed OS removal
- **staged transition entries + `commitBusinessTransition`** — containment and the reboot dedupe
  mark move in one atomic write alongside the durable outbox row
- **polygon activation, coarse membership, pending approach batches** — read by the runtime later

No caller reads any of the new state yet. `GeofenceRegion.transitionRevision()` comes along because
the store rejects a commit computed from geometry that has since been replaced.

## Tests

922 tests across geofence, core and messagingpush, 0 failures. ktlint, `lintDebug` and `apiCheck`
clean. No public API change.

I added three `commitBusinessTransition` tests — the revision guard, the staged-ENTER commit and the
EXIT clear — because the method arrived with only its generation guard covered. Each was
mutation-tested; reverting the guard in isolation fails a named test.

One arm is deliberately not covered and I'd rather flag it than pretend: the `marksEnterReported`
branch inside `commitBusinessTransition` is unreachable, since staging already wrote the mark and
`beginUserSession` bumps the generation on any user change. Left as written for symmetry with
staging; its mutation survives.


