### PR TITLE
chore(geofence): stage transitions durably before they are delivered

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
@@ -1,7 +1,7 @@
 package io.customer.sdk.core.network
 
-import android.net.Uri
 import android.util.Base64
+import androidx.core.net.toUri
 import io.customer.base.internal.InternalCustomerIOApi
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.data.store.Client
@@ -56,7 +56,7 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
         // here — it would percent-encode the embedded `/`. Compose the base URL
         // first, then layer query params on top via `buildUpon`.
         val cleanedPath = if (params.path.startsWith("/")) params.path else "/${params.path}"
-        val urlString = Uri.parse("https://$apiHost$cleanedPath")
+        val urlString = "https://$apiHost$cleanedPath".toUri()
             .buildUpon()
             .apply {
                 params.queryParams.forEach { (k, v) -> appendQueryParameter(k, v) }

--- a/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/CustomerIOHttpClient.kt
@@ -112,7 +112,7 @@ internal class CustomerIOHttpClientImpl : CustomerIOHttpClient {
             if (responseCode in 200..299) {
                 Result.success(responseBody)
             } else {
-                Result.failure(IOException("HTTP $responseCode: $responseBody"))
+                Result.failure(HttpRequestFailure(responseCode, responseBody))
             }
         } catch (e: IOException) {
             Result.failure(e)

--- a/core/src/main/kotlin/io/customer/sdk/core/network/HttpRequestFailure.kt
+++ b/core/src/main/kotlin/io/customer/sdk/core/network/HttpRequestFailure.kt
@@ -1,0 +1,27 @@
+package io.customer.sdk.core.network
+
+import io.customer.base.internal.InternalCustomerIOApi
+import java.io.IOException
+
+/**
+ * A non-2xx HTTP response, carrying the status a caller needs to tell "try again later" apart from
+ * "this will never be accepted".
+ *
+ * Extends [IOException] so the existing `it is IOException` retry predicates keep classifying it the
+ * way they always have; only callers that opt in to reading [statusCode] behave differently.
+ */
+@InternalCustomerIOApi
+class HttpRequestFailure(
+    val statusCode: Int,
+    val responseBody: String
+) : IOException("HTTP $statusCode: $responseBody") {
+    /**
+     * Whether retrying the identical request could plausibly succeed.
+     *
+     * 408 and 429 are explicit invitations to retry, and 5xx is the server failing rather than
+     * refusing. Every other 4xx is a rejection of this payload: retrying it forever only blocks
+     * whatever is queued behind it.
+     */
+    val isRetryable: Boolean
+        get() = statusCode == 408 || statusCode == 429 || statusCode >= 500
+}

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
@@ -19,6 +19,17 @@ sealed interface PendingDeliveryResult {
      */
     object AlreadyClaimed : PendingDeliveryResult
 
+    /**
+     * [send] reported success but the removing write did not land, so the entry is still queued.
+     *
+     * Distinct from [Delivered] because the work is done while the bookkeeping is not: a caller that
+     * drains "the oldest entry" in a loop would otherwise read the same entry again and resend it
+     * immediately, without bound. Hand this to a backoff-capable channel (a WorkManager retry) so the
+     * duplicate — deduped backend-side on the stable payload id — costs one delayed attempt rather
+     * than a tight loop.
+     */
+    object DeliveredNotRemoved : PendingDeliveryResult
+
     /** [send] failed transiently; the entry was restored so a retry can deliver it later. */
     data class Retryable(val cause: Throwable?) : PendingDeliveryResult
 
@@ -87,6 +98,10 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
  * The presence check is best-effort — not atomic with [send] — so it only trims a duplicate when
  * another channel already removed the entry. On failure the row is left in place (never removed)
  * so the next attempt can deliver it.
+ *
+ * A send that succeeds but whose removal doesn't persist reports
+ * [PendingDeliveryResult.DeliveredNotRemoved], never [PendingDeliveryResult.Delivered]: the entry is
+ * still queued, and a caller that assumed otherwise would resend it on its very next pass.
  */
 @InternalCustomerIOApi
 suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore<T>.sendRemoveOnSuccess(
@@ -98,9 +113,10 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
 
     val result = send()
     return when {
-        result.isSuccess -> {
-            remove(entry.key)
+        result.isSuccess -> if (remove(entry.key)) {
             PendingDeliveryResult.Delivered
+        } else {
+            PendingDeliveryResult.DeliveredNotRemoved
         }
         isRetryable(result.exceptionOrNull()) -> PendingDeliveryResult.Retryable(result.exceptionOrNull())
         else -> PendingDeliveryResult.Failed(result.exceptionOrNull())

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.launch
  *
  * Entries are processed in isolation: one failed cancel/publish does not abort
  * the batch, and an unclaimed or failed entry survives for the next flush. The
- * worker's unique-work name must equal [PendingDeliveryStore.PendingDeliveryEntry.key].
+ * [uniqueWorkName] maps an entry to its independently cancellable worker name. Return null when a
+ * feature uses a shared ordered work chain; removing the outbox row then makes that worker a no-op.
  *
  * Both push (`handoffPendingPushDeliveryToAnalyticsPipeline`) and geofence
  * share this so the drain logic lives in one place — only the [publish]
@@ -32,7 +33,9 @@ import kotlinx.coroutines.launch
 class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
     private val store: PendingDeliveryStore<T>,
     private val workManagerProvider: CustomerIOWorkManagerProvider,
-    private val dispatchersProvider: DispatchersProvider
+    private val dispatchersProvider: DispatchersProvider,
+    private val uniqueWorkName: (T) -> String? = { it.key },
+    private val stopOnFailure: Boolean = false
 ) {
 
     /**
@@ -98,11 +101,12 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
 
                 val workManager = workManagerProvider.getWorkManager()
                 var publishedCount = 0
-                pending.forEach { entry ->
+                for (entry in pending) {
                     try {
                         suspend fun cancelWorker() {
-                            if (workManager != null) {
-                                workManager.cancelUniqueWork(entry.key).await()
+                            val workName = uniqueWorkName(entry)
+                            if (workManager != null && workName != null) {
+                                workManager.cancelUniqueWork(workName).await()
                                 callbacks.onWorkCancelled(entry)
                             }
                         }
@@ -111,7 +115,7 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                                 // A false claim (already gone, or the removing write failed) means we don't own
                                 // the send — back off; the row is retried on the next flush.
                                 cancelWorker()
-                                if (!store.claim(entry.key)) return@forEach
+                                if (!store.claim(entry.key)) continue
                                 publish(entry)
                             }
                             DeliveryGuarantee.AT_LEAST_ONCE -> {
@@ -134,6 +138,7 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
                         throw ce
                     } catch (ex: Exception) {
                         callbacks.onEntryFailed(entry, ex)
+                        if (stopOnFailure) break
                     }
                 }
                 callbacks.onComplete(publishedCount)

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -74,7 +74,10 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     fun appendAll(entries: List<T>): Boolean {
         if (entries.isEmpty()) return true
         return lock.withLock {
-            val all = readAll().toMutableList()
+            // A caller recovering a staged outbox attempt may append the same stable keys again.
+            // Replace those rows atomically instead of duplicating one physical delivery.
+            val incomingKeys = entries.mapTo(mutableSetOf(), PendingDeliveryEntry::key)
+            val all = readAll().filterNot { it.key in incomingKeys }.toMutableList()
             all.addAll(entries)
             while (all.size > maxEntries) {
                 all.removeAt(0)
@@ -93,12 +96,17 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * Remove the entry whose [PendingDeliveryEntry.key] equals [key]. No-op
      * if no such entry exists. Skips the write when no entry was actually
      * removed so a transient read failure cannot wipe the file.
+     *
+     * @return `true` when the store no longer holds [key] — it was removed, or was already absent.
+     * `false` only when the entry is present and the removing write failed, so it is still queued.
+     * A caller that removes to mark work *done* must check this: treating a failed removal as done
+     * lets it re-read the same head entry and repeat the work without bound.
      */
-    fun remove(key: String) {
-        lock.withLock {
+    fun remove(key: String): Boolean {
+        return lock.withLock {
             val entries = readAll()
             val filtered = entries.filterNot { it.key == key }
-            if (filtered.size == entries.size) return@withLock
+            if (filtered.size == entries.size) return@withLock true
             writeAll(filtered)
         }
     }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -153,6 +153,32 @@ class PendingDeliveryClaimTest : RobolectricTest() {
     }
 
     @Test
+    fun sendRemoveOnSuccess_givenSendSucceedsButRemovalCannotPersist_expectDeliveredNotRemoved() = runBlocking<Unit> {
+        // The send happened; the record of it did not. Reporting Delivered here would tell a caller
+        // that drains the oldest row in a loop that the row is gone, and it would read the same row
+        // again and resend it immediately, over and over.
+        val store = newStore()
+        val entry = TestEntry("delivered-but-stuck")
+        store.append(entry)
+        var sendCount = 0
+
+        val dir = contextMock.applicationContext.filesDir
+        dir.setReadOnly()
+        val result = try {
+            store.sendRemoveOnSuccess(entry) {
+                sendCount++
+                Result.success(Unit)
+            }
+        } finally {
+            dir.setWritable(true)
+        }
+
+        result shouldBeEqualTo PendingDeliveryResult.DeliveredNotRemoved
+        sendCount shouldBeEqualTo 1
+        store.loadAll() shouldBeEqualTo listOf(entry)
+    }
+
+    @Test
     fun sendRemoveOnSuccess_whileSending_expectEntryStillPresentUntilSuccess() = runBlocking<Unit> {
         // The core difference from claimSendRestore: the row is NOT removed before the send, so a
         // process death mid-send leaves it for a retry/flush instead of dropping it.

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -43,8 +43,15 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         logger = mockLogger
     ).also { it.removeAll() }
 
-    private fun newFlusher(store: PendingDeliveryStore<TestEntry>) =
-        PendingDeliveryFlusher(store, workManagerProvider, dispatchers)
+    private fun newFlusher(
+        store: PendingDeliveryStore<TestEntry>,
+        stopOnFailure: Boolean = false
+    ) = PendingDeliveryFlusher(
+        store,
+        workManagerProvider,
+        dispatchers,
+        stopOnFailure = stopOnFailure
+    )
 
     private class RecordingCallbacks : PendingDeliveryFlusher.Callbacks<TestEntry>() {
         var snapshotCount: Int? = null
@@ -204,6 +211,26 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.failed shouldBeEqualTo listOf("bad")
         callbacks.completeCount shouldBeEqualTo 2
         store.loadAll().map { it.key } shouldBeEqualTo listOf("bad")
+    }
+
+    @Test
+    fun flush_givenOrderedAtLeastOnceAndPublishThrows_expectLaterEntriesRemainQueued() {
+        val store = newStore()
+        listOf("a", "bad", "c").forEach { store.append(TestEntry(it)) }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(store, stopOnFailure = true).flush(
+            callbacks,
+            PendingDeliveryFlusher.DeliveryGuarantee.AT_LEAST_ONCE
+        ) { entry ->
+            if (entry.key == "bad") throw IllegalStateException("publish failed")
+            publishedKeys += entry.key
+        }
+
+        publishedKeys shouldBeEqualTo listOf("a")
+        callbacks.failed shouldBeEqualTo listOf("bad")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("bad", "c")
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -92,6 +92,16 @@ class PendingDeliveryStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun appendAll_givenExistingStableKeys_expectAtomicReplacementWithoutDuplicates() {
+        val store = newStore()
+        store.appendAll(listOf(entry("a", "old"), entry("b", "keep")))
+
+        store.appendAll(listOf(entry("a", "recovered")))
+
+        store.loadAll() shouldBeEqualTo listOf(entry("b", "keep"), entry("a", "recovered"))
+    }
+
+    @Test
     fun appendAll_givenWriteSucceeds_expectTrue() {
         val store = newStore()
 
@@ -135,7 +145,7 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         store.append(keep)
         store.append(drop)
 
-        store.remove(drop.key)
+        store.remove(drop.key) shouldBeEqualTo true
 
         val remaining = store.loadAll()
         remaining.size shouldBeEqualTo 1
@@ -200,9 +210,30 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         val keep = entry("keep")
         store.append(keep)
 
-        store.remove("not-a-real-id")
+        // Already absent counts as removed: the caller's postcondition — "this key is not queued" — holds.
+        store.remove("not-a-real-id") shouldBeEqualTo true
 
         store.loadAll() shouldBeEqualTo listOf(keep)
+    }
+
+    @Test
+    fun remove_givenWriteFailure_expectFalseAndEntryStillQueued() {
+        // A caller that removes to mark work done must be able to tell this apart from success, or it
+        // will treat the still-queued entry as gone and repeat that work on its next pass.
+        val store = newStore()
+        val stuck = entry("stuck")
+        store.append(stuck)
+
+        val dir = contextMock.applicationContext.filesDir
+        dir.setReadOnly()
+        val removed = try {
+            store.remove(stuck.key)
+        } finally {
+            dir.setWritable(true)
+        }
+
+        removed shouldBeEqualTo false
+        store.loadAll() shouldBeEqualTo listOf(stuck)
     }
 
     @Test

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -6,13 +6,12 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingEvent
+import io.customer.geofence.di.geofenceBusinessTransitionProcessor
 import io.customer.geofence.di.geofenceLogger
 import io.customer.geofence.di.geofenceManager
 import io.customer.geofence.di.geofenceRegionStore
 import io.customer.geofence.di.geofenceServices
-import io.customer.geofence.di.geofenceTransitionEmitter
 import io.customer.sdk.communication.Event
-import io.customer.sdk.core.di.AndroidSDKComponent
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.clock
 import io.customer.sdk.core.di.setupAndroidComponent
@@ -21,8 +20,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 
 /** Receives OS geofence transition callbacks and dispatches them to the SDK. */
@@ -97,10 +94,20 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         val timestamp = SDKComponent.clock.currentTimeSeconds()
         val dispatchStartUptimeMs = SDKComponent.clock.elapsedRealtime()
         val androidComponent = SDKComponent.android()
+        // Cold-start callbacks can beat the posted launch initialization. Establish the persisted
+        // secure user's session synchronously; legacy installs without an owner are migrated by the
+        // store without discarding their already-live OS registrations.
+        androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }?.let {
+            androidComponent.geofenceRegionStore.beginUserSession(it)
+        }
+        // A previous callback can have staged a transition before the file outbox was writable.
+        // Recover it before interpreting this edge so an ENTER followed by EXIT stays ordered.
+        androidComponent.geofenceBusinessTransitionProcessor.recoverPendingTransitions()
         // Defense-in-depth against orphans (failed clearAll, app-data wipe, SDK
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
-        val registeredIds = androidComponent.geofenceRegionStore.getRegisteredIds()
+        val userStateGeneration = androidComponent.geofenceRegionStore.userStateGeneration()
+        val registeredIds = androidComponent.geofenceRegionStore.getRoutableRegisteredIds()
         val (knownIds, unknownIds) = triggeringGeofenceIds.partition { it in registeredIds }
         if (unknownIds.isNotEmpty()) {
             unknownIds.forEach { logger.logTransitionDroppedUnknownId(it) }
@@ -121,6 +128,15 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 return@forEach
             }
 
+            val region = androidComponent.geofenceRegionStore.getCachedRegion(geofenceId)
+            if (region == null && androidComponent.geofenceRegionStore.getRegisteredRegion(geofenceId) != null) {
+                // The server removed this region, but an earlier GMS removal failed. Its retained
+                // definition is a routing tombstone only; never manufacture business activity for
+                // a fence that no longer exists. Every orphan callback also retries OS cleanup.
+                logger.logTransitionDroppedRetiredId(geofenceId)
+                androidComponent.geofenceManager.removeGeofencesByIds(listOf(geofenceId))
+                return@forEach
+            }
             val transition = when (gmsTransitionType) {
                 Geofence.GEOFENCE_TRANSITION_ENTER -> Event.GeofenceTransition.ENTER
                 Geofence.GEOFENCE_TRANSITION_EXIT -> Event.GeofenceTransition.EXIT
@@ -130,17 +146,15 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 }
             }
 
-            // Each broadcast runs on its own scope, so two transitions for one fence would
-            // otherwise interleave read-decide-persist and lose a containment record.
-            transitionMutex.withLock {
-                handleBusinessTransition(
-                    geofenceId = geofenceId,
-                    transition = transition,
-                    timestamp = timestamp,
-                    androidComponent = androidComponent,
-                    logger = logger
-                )
-            }
+            androidComponent.geofenceBusinessTransitionProcessor.process(
+                geofenceId = geofenceId,
+                transition = transition,
+                timestampSeconds = timestamp,
+                enforceConfiguredTransition = region != null,
+                expectedRegionRevision = region?.transitionRevision(),
+                expectedUserStateGeneration = userStateGeneration,
+                requireRegistered = true
+            )
         }
 
         // Hold the goAsync window open until the refresh lands so the OS doesn't kill a
@@ -155,55 +169,6 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         }
     }
 
-    private suspend fun handleBusinessTransition(
-        geofenceId: String,
-        transition: Event.GeofenceTransition,
-        timestamp: Long,
-        androidComponent: AndroidSDKComponent,
-        logger: GeofenceLogger
-    ) {
-        // Ahead of the identity checks below: being inside a fence is a physical fact, independent of
-        // whether the transition is deliverable.
-        val store = androidComponent.geofenceRegionStore
-        val cachedRegion = store.getCachedRegion(geofenceId)
-        when (transition) {
-            Event.GeofenceTransition.ENTER -> store.recordEntered(geofenceId)
-            // An unmatched EXIT is a GMS reconciliation artifact, not a crossing — delivering it
-            // fires EXIT campaigns at people who were never there. The two guards after claimExit
-            // cover the cases where an absent record proves nothing: an upgraded install with no set
-            // yet, and a region that never monitored ENTER (a missing cache row counts as unknown).
-            Event.GeofenceTransition.EXIT -> if (
-                !store.claimExit(geofenceId) &&
-                store.hasContainmentRecord() &&
-                cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
-            ) {
-                logger.logExitDroppedNeverEntered(geofenceId)
-                return
-            }
-        }
-
-        // Snapshot userId so a sign-out + sign-in before delivery can't reattribute this
-        // transition. Empty userId is treated as "not identified" per `isUserIdentified`.
-        val userId = androidComponent.secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
-        // Identified-only: the backend rejects anonymous geofence tracks, so drop before spending a
-        // cooldown slot or persisting a row neither channel could send.
-        if (userId == null) {
-            logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
-            return
-        }
-
-        androidComponent.geofenceTransitionEmitter.emit(
-            geofenceId = geofenceId,
-            transition = transition,
-            userId = userId,
-            timestampSeconds = timestamp,
-            geofenceName = cachedRegion?.name,
-            metadata = cachedRegion?.metadata ?: emptyMap(),
-            geosetIds = cachedRegion?.geosetIds ?: emptyList(),
-            monitorsExit = cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.EXIT) == true
-        )
-    }
-
     private fun transitionName(gmsTransitionType: Int): String = when (gmsTransitionType) {
         Geofence.GEOFENCE_TRANSITION_ENTER -> "ENTER"
         Geofence.GEOFENCE_TRANSITION_EXIT -> "EXIT"
@@ -215,8 +180,5 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         // goAsync grants ~10s before the OS considers the receiver blocked; total budget for
         // one dispatch (persistence + GMS awaits + movement-refresh wait), with headroom.
         private const val DISPATCH_WAIT_BUDGET_MS = 8_000L
-
-        // Process-wide: a receiver instance lives for one broadcast, so the lock has to outlive it.
-        private val transitionMutex = Mutex()
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -107,13 +107,32 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
         // ID-format changes): events for unregistered IDs are dropped and the OS-side
         // registration is removed so it stops firing.
         val userStateGeneration = androidComponent.geofenceRegionStore.userStateGeneration()
-        val registeredIds = androidComponent.geofenceRegionStore.getRoutableRegisteredIds()
-        val (knownIds, unknownIds) = triggeringGeofenceIds.partition { it in registeredIds }
-        if (unknownIds.isNotEmpty()) {
-            unknownIds.forEach { logger.logTransitionDroppedUnknownId(it) }
-            // Result ignored — a failed removal self-heals on the next orphan event.
-            androidComponent.geofenceManager.removeGeofencesByIds(unknownIds)
+        val routableIds = androidComponent.geofenceRegionStore.getRoutableRegisteredIds()
+        val (routableTriggeringIds, unroutableIds) = triggeringGeofenceIds.partition { it in routableIds }
+        // An identify clears routing and only the completing refresh re-arms it, so between the two
+        // a live registration is unroutable without being an orphan. Removing it there strands it:
+        // the refresh that follows still sees the id in registeredIds with matching params, skips it
+        // as unchanged, and never re-adds it to the OS. Only evict what the bookkeeping no longer
+        // claims, and drop the rest — routing is what authorizes a business event.
+        val unarmedTriggerIds = if (unroutableIds.isEmpty()) {
+            emptyList()
+        } else {
+            val registeredIds = androidComponent.geofenceRegionStore.getRegisteredIds()
+            val (unarmedIds, orphanIds) = unroutableIds.partition { it in registeredIds }
+            orphanIds.forEach { logger.logTransitionDroppedUnknownId(it) }
+            if (orphanIds.isNotEmpty()) {
+                // Result ignored — a failed removal self-heals on the next orphan event.
+                androidComponent.geofenceManager.removeGeofencesByIds(orphanIds)
+            }
+            // The movement trigger is SDK-owned and carries no business meaning — routing it only
+            // re-fetches. It is also the only refresh path that runs without the app being opened,
+            // so dropping its EXIT here would leave an unarmed session with nothing to re-arm it
+            // until the next launch. handleMovement waits for the slot and runs as the current user.
+            val (triggerIds, businessIds) = unarmedIds.partition { it == GeofenceConstants.MOVEMENT_TRIGGER_ID }
+            businessIds.forEach { logger.logTransitionDroppedUnarmedId(it) }
+            triggerIds
         }
+        val knownIds = routableTriggeringIds + unarmedTriggerIds
 
         var movementRefreshJob: Job? = null
         knownIds.forEach { geofenceId ->

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBusinessTransitionProcessor.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBusinessTransitionProcessor.kt
@@ -1,0 +1,121 @@
+package io.customer.geofence
+
+import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.SecureUserStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Single authority for durable containment and transition delivery for every geofence shape. */
+internal class GeofenceBusinessTransitionProcessor(
+    private val store: GeofenceRegionStore,
+    private val secureUserStore: SecureUserStore,
+    private val transitionEmitter: GeofenceTransitionEmitter,
+    private val logger: GeofenceLogger
+) {
+    suspend fun recoverPendingTransitions(): Boolean = transitionMutex.withLock {
+        transitionEmitter.recoverPendingTransitions()
+    }
+
+    suspend fun process(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        timestampSeconds: Long,
+        enforceConfiguredTransition: Boolean = false,
+        expectedRegionRevision: Int? = null,
+        expectedUserStateGeneration: Long? = null,
+        requireRegistered: Boolean = false
+    ) = transitionMutex.withLock {
+        // Capture admission before consulting routability. A user switch clears routability and
+        // increments this generation; whichever side of that boundary this callback observes, it
+        // cannot be attributed to the next identified user.
+        val userStateGeneration = expectedUserStateGeneration ?: store.userStateGeneration()
+        if (store.userStateGeneration() != userStateGeneration) return@withLock
+        if (requireRegistered && geofenceId !in store.getRoutableRegisteredIds()) return@withLock
+        val cachedRegion = store.getCachedRegion(geofenceId)
+        val currentRegionRevision = cachedRegion?.transitionRevision()
+        if (expectedRegionRevision != null && currentRegionRevision != expectedRegionRevision) {
+            return@withLock
+        }
+        val isUnmatchedExit = transition == Event.GeofenceTransition.EXIT &&
+            geofenceId !in store.getEnteredIds() &&
+            store.hasContainmentRecord() &&
+            cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.ENTER) == true
+        if (isUnmatchedExit) {
+            logger.logExitDroppedNeverEntered(geofenceId)
+            return@withLock
+        }
+
+        val configuredTransition = when (transition) {
+            Event.GeofenceTransition.ENTER -> GeofenceTransitionType.ENTER
+            Event.GeofenceTransition.EXIT -> GeofenceTransitionType.EXIT
+        }
+        val shouldEmit = !enforceConfiguredTransition ||
+            cachedRegion?.transitionTypes?.contains(configuredTransition) == true
+        var emissionResult: GeofenceTransitionEmitter.Result? = null
+        var emittingUserId: String? = null
+        if (shouldEmit) {
+            val userId = secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+            if (userId == null) {
+                logger.logTransitionDroppedAnonymous(geofenceId, transition.name)
+            } else if (
+                store.userStateGeneration() != userStateGeneration ||
+                store.activeUserSessionId() != userId
+            ) {
+                return@withLock
+            } else {
+                // Synchronously stage the attempt, then append the file outbox before committing
+                // containment. Recovery reuses the staged transition ID across every crash window.
+                emittingUserId = userId
+                emissionResult = transitionEmitter.emitWithRetainedAttempt(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    userId = userId,
+                    timestampSeconds = timestampSeconds,
+                    geofenceName = cachedRegion?.name,
+                    metadata = cachedRegion?.metadata ?: emptyMap(),
+                    geosetIds = cachedRegion?.geosetIds ?: emptyList(),
+                    monitorsExit = cachedRegion?.transitionTypes?.contains(GeofenceTransitionType.EXIT) == true,
+                    expectedUserStateGeneration = userStateGeneration,
+                    expectedRegionRevision = expectedRegionRevision ?: currentRegionRevision
+                )
+            }
+        }
+
+        val transitionId = emittingUserId?.let { userId ->
+            store.getPendingTransitionEntries(userId, geofenceId, transition)
+                .lastOrNull()
+                ?.transitionId
+        }
+        when (emissionResult) {
+            GeofenceTransitionEmitter.Result.PERSISTED -> {
+                store.commitBusinessTransition(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    transitionId = transitionId,
+                    expectedUserStateGeneration = userStateGeneration,
+                    expectedRegionRevision = expectedRegionRevision ?: currentRegionRevision
+                )
+                return@withLock
+            }
+            GeofenceTransitionEmitter.Result.PERSIST_FAILED -> {
+                // A successful stage already committed physical containment atomically. If staging
+                // itself failed, neither state nor event is durable and a later fine fix can retry.
+                return@withLock
+            }
+            GeofenceTransitionEmitter.Result.SUPPRESSED,
+            null -> Unit
+        }
+        store.commitBusinessTransition(
+            geofenceId = geofenceId,
+            transition = transition,
+            transitionId = null,
+            expectedUserStateGeneration = userStateGeneration,
+            expectedRegionRevision = expectedRegionRevision ?: currentRegionRevision
+        )
+    }
+
+    private companion object {
+        val transitionMutex = Mutex()
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceCooldownFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceCooldownFilter.kt
@@ -20,7 +20,7 @@ internal class GeofenceCooldownFilter(
      * caller should proceed to emit, false if the transition is within the cooldown window.
      */
     @Synchronized
-    fun tryAcquire(
+    fun isAllowed(
         userId: String,
         geofenceId: String,
         transition: Event.GeofenceTransition
@@ -29,21 +29,21 @@ internal class GeofenceCooldownFilter(
             ?: GeofenceConstants.DEDUPE_COOLDOWN_MS
         val last = store.getLastEmitTimestamp(userId, geofenceId, transition)
         val now = clock.currentTimeMillis()
-        if (last != null && (now - last) < cooldownMs) return false
+        return last == null || (now - last) >= cooldownMs
+    }
+
+    @Synchronized
+    fun record(
+        userId: String,
+        geofenceId: String,
+        transition: Event.GeofenceTransition
+    ) {
+        val now = clock.currentTimeMillis()
         store.recordEmit(userId, geofenceId, transition, now)
         // Sweep entries past the max possible cooldown — they can't suppress under any config —
         // to bound the store as fences churn, without the double-fire risk of pruning by cached set.
         store.pruneOlderThan(now - GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS)
-        return true
     }
-
-    /**
-     * Rolls back a prior [tryAcquire] for this key so a later transition isn't suppressed. Used when
-     * the work that followed the acquire couldn't be durably queued, so the crossing can be retried.
-     */
-    @Synchronized
-    fun release(userId: String, geofenceId: String, transition: Event.GeofenceTransition) =
-        store.remove(userId, geofenceId, transition)
 
     @Synchronized
     fun clearAll() = store.clearAll()

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -89,6 +89,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logTransitionDroppedRetiredId(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' transition dropped — backend removed it and OS cleanup is pending", tag = TAG)
+    }
+
     fun logEnterDroppedAlreadyReported(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' ENTER: dropped — already reported as entered and no exit since, so the OS is re-reporting a state we already sent", tag = TAG)
     }
@@ -183,7 +187,10 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     fun logEventDeliveryFailed(geofenceId: String, transitionName: String, message: String?) {
-        logger.error("Geofence '$geofenceId' $transitionName: HTTP delivery failed and will not retry — $message", tag = TAG)
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: HTTP delivery failed; retained at the head of the ordered outbox — $message",
+            tag = TAG
+        )
     }
 
     fun logEventInvalidInput(geofenceId: String?, transitionName: String?) {
@@ -198,12 +205,19 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' $transitionName: delivered via WorkManager (direct HTTP); removed from pending store", tag = TAG)
     }
 
+    fun logEventDeliveredButNotRemoved(geofenceId: String, transitionName: String) {
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: delivered, but removing it from the pending store failed, so it is still queued. Retrying on a backoff; the backend deduplicates the repeat send on transitionId.",
+            tag = TAG
+        )
+    }
+
     fun logEventDeliverySkippedAlreadyDelivered(geofenceId: String, transitionName: String) {
         logger.debug("Geofence '$geofenceId' $transitionName: worker skipped — entry no longer in store (already delivered via the analytics pipeline)", tag = TAG)
     }
 
     fun logPersistFailed(geofenceId: String, transitionName: String) {
-        logger.error("Geofence '$geofenceId' $transitionName: failed to persist pending transition — skipped delivery and rolled back cooldown so a later crossing can retry", tag = TAG)
+        logger.error("Geofence '$geofenceId' $transitionName: file outbox unavailable — kept durable staging for recovery", tag = TAG)
     }
 
     fun logEventWorkerEntryMissing(key: String) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -89,6 +89,10 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
     }
 
+    fun logTransitionDroppedUnarmedId(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' transition dropped — registered but routing is not armed for this session; OS registration kept", tag = TAG)
+    }
+
     fun logTransitionDroppedRetiredId(geofenceId: String) {
         logger.debug("Geofence '$geofenceId' transition dropped — backend removed it and OS cleanup is pending", tag = TAG)
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -610,9 +610,6 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
-            // Snapshot for the routing arm below. beginUserSession bumps this under its own lock, so
-            // an identify landing after this point invalidates the write rather than racing it.
-            val userStateGeneration = store.userStateGeneration()
             val registeredIds = store.getRegisteredIds()
             val monitored = store.getCachedRegions().filter { it.id in registeredIds }
             val insideNow = monitored

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -516,9 +516,7 @@ internal class GeofenceRepositoryImpl(
                     // set, and getRoutableRegisteredIds stops falling back to the registered set once
                     // that key exists. Without this write the first callback after an identify
                     // classifies every live ID as unknown and removes it from the OS.
-                    if (!store.saveRoutableRegisteredIdsIfCurrent(idsToSave, userStateGeneration)) {
-                        logger.logSyncSkipped("user changed before routing could be armed")
-                    }
+                    val routingArmed = store.saveRoutableRegisteredIdsIfCurrent(idsToSave, userStateGeneration)
                     // An exact point check, with no accuracy margin in either direction. Widening
                     // the inside test would make a fence smaller than the fix unjudgable, so the
                     // initial-ENTER backstop would never fire; narrowing the outside test would keep
@@ -557,7 +555,16 @@ internal class GeofenceRepositoryImpl(
                     } else {
                         store.clearLastMovementTriggerLocation()
                     }
-                    onRegistered()
+                    if (routingArmed) {
+                        onRegistered()
+                    } else {
+                        // An identify landed mid-pass, so these registrations belong to the departing
+                        // user and routing was left cleared for the new one. Stamping the sync fresh
+                        // anyway would make the new user's own refresh SKIP on our timestamp and
+                        // never arm routing, and its first callback would then remove every fence.
+                        // Leaving the stamp stale sends that refresh down the remote path instead.
+                        logger.logSyncSkipped("user changed before routing could be armed")
+                    }
                     logger.logSyncSucceeded(nearest.size, movementTriggerRegistered = monitoringEnabled)
                 }
             }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -478,6 +478,9 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
+            // Snapshot for the routing arm below. beginUserSession bumps this under its own lock, so
+            // an identify landing after this point invalidates the write rather than racing it.
+            val userStateGeneration = store.userStateGeneration()
             // Synthesis baseline, snapshotted before register/persist mutate the store. No reboot
             // override here (unlike the registration diff): a reboot re-registers with
             // INITIAL_TRIGGER_ENTER, so the OS re-reports these itself.
@@ -509,6 +512,13 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // Routing is armed separately: beginUserSession writes an explicit empty routable
+                    // set, and getRoutableRegisteredIds stops falling back to the registered set once
+                    // that key exists. Without this write the first callback after an identify
+                    // classifies every live ID as unknown and removes it from the OS.
+                    if (!store.saveRoutableRegisteredIdsIfCurrent(idsToSave, userStateGeneration)) {
+                        logger.logSyncSkipped("user changed before routing could be armed")
+                    }
                     // An exact point check, with no accuracy margin in either direction. Widening
                     // the inside test would make a fence smaller than the fix unjudgable, so the
                     // initial-ENTER backstop would never fire; narrowing the outside test would keep
@@ -600,6 +610,9 @@ internal class GeofenceRepositoryImpl(
                 logger.logSyncSkipped("user changed during refresh")
                 return@withLock Result.success(Unit)
             }
+            // Snapshot for the routing arm below. beginUserSession bumps this under its own lock, so
+            // an identify landing after this point invalidates the write rather than racing it.
+            val userStateGeneration = store.userStateGeneration()
             val registeredIds = store.getRegisteredIds()
             val monitored = store.getCachedRegions().filter { it.id in registeredIds }
             val insideNow = monitored

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -536,6 +536,25 @@ internal class GeofenceRepositoryImpl(
                         newIds + staleIds
                     }
                     store.saveRegisteredIds(idsToSave)
+                    // A stale id whose removal failed stays registered and routable, so it keeps
+                    // firing after the backend deleted it. Retain its last known definition: the
+                    // receiver reads that to tell a retired fence from one it simply has no cache
+                    // row for, and only the former may be dropped and cleaned up. Without this the
+                    // retained set is never written, so that branch can never be taken. The catalog
+                    // here is still the pre-sync one — saveCachedRegions runs later, in onRegistered.
+                    store.saveRetainedRegisteredRegions(
+                        if (staleRemovalSucceeded) {
+                            emptyList()
+                        } else {
+                            // Merged with what is already retained: the first failure is the last
+                            // pass that still sees the deleted fence in the catalog, so rebuilding
+                            // from the catalog alone would drop the tombstone on the very next
+                            // retry and leave the id registered with nothing to identify it.
+                            val cachedById = store.getCachedRegions().associateBy { it.id }
+                            val retainedById = store.getRetainedRegisteredRegions().associateBy { it.id }
+                            staleIds.mapNotNull { cachedById[it] ?: retainedById[it] }
+                        }
+                    )
                     // Routing is armed separately: beginUserSession writes an explicit empty routable
                     // set, and getRoutableRegisteredIds stops falling back to the registered set once
                     // that key exists. Without this write the first callback after an identify

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -156,7 +156,19 @@ internal class GeofenceRepositoryImpl(
             // a just-identified user unmonitored. Pref reads only; network stays outside the lock.
             val action = stateMutex.withLock { refreshAction(LocationCoordinates(latitude, longitude), config) }
             return when (action) {
-                RefreshAction.REMOTE -> performRemoteRefresh(userId, latitude, longitude, containmentEpoch, fixSource)
+                RefreshAction.REMOTE -> {
+                    val remote = performRemoteRefresh(userId, latitude, longitude, containmentEpoch, fixSource)
+                    // A session with nothing armed cannot recover on its own: its fences are still
+                    // registered but unroutable, and only a completing pass arms them. Re-rank from
+                    // the cache so an offline start still routes, as a failed movement pass does.
+                    if (remote.isFailure &&
+                        store.getRoutableRegisteredIds().isEmpty() &&
+                        store.getCachedRegions().isNotEmpty()
+                    ) {
+                        performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, fixSource)
+                    }
+                    remote
+                }
                 RefreshAction.LOCAL -> performLocalRefresh(userId, latitude, longitude, config, containmentEpoch, fixSource)
                 RefreshAction.SKIP -> {
                     logger.logSyncSkippedFresh()

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -288,6 +288,9 @@ internal class GeofenceRepositoryImpl(
             return Result.success(Unit)
         }
         try {
+            // Same as the other two slot holders: a caller serving this session can then recognise
+            // the holder as its own and drop immediately instead of polling out the whole wait.
+            inFlightUserStateGeneration.set(store.userStateGeneration())
             val userId = secureUserStore.getUserId()
             if (userId.isNullOrBlank()) {
                 logger.logSyncSkipped("no identified user")

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -12,6 +12,7 @@ import io.customer.sdk.communication.Event
 import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -83,6 +84,10 @@ internal class GeofenceRepositoryImpl(
     // or cancellation can't latch the gate.
     private val refreshInProgress = AtomicBoolean(false)
 
+    // Which user session the pass holding the slot is running for. A pass can only arm routing for
+    // its own generation, so a caller from a newer session must not treat it as covering theirs.
+    private val inFlightUserStateGeneration = AtomicLong(NO_SESSION)
+
     // Serializes state-mutation against reset() (sign-out). Held only around the
     // write block — the long-running API call happens outside the lock.
     private val stateMutex = Mutex()
@@ -90,16 +95,31 @@ internal class GeofenceRepositoryImpl(
     private fun tryTakeRefreshSlot(): Boolean = refreshInProgress.compareAndSet(false, true)
 
     private fun releaseRefreshSlot() {
+        inFlightUserStateGeneration.set(NO_SESSION)
         refreshInProgress.set(false)
     }
 
     @RequiresPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     override suspend fun refresh(latitude: Double, longitude: Double): Result<Unit> {
         val containmentEpoch = store.containmentEpoch()
+        val userStateGeneration = store.userStateGeneration()
         if (!tryTakeRefreshSlot()) {
-            logger.logSyncSkipped("refresh already in progress")
-            return Result.success(Unit)
+            // Identify and app-launch fire together on the same anchor, so a duplicate still drops.
+            // A pass from an older session is different: beginUserSession has already cleared
+            // routing, and that pass can only refuse to arm the generation it no longer serves.
+            // Dropping here would leave routing empty with nothing pending, and the next callback
+            // would treat every live fence as unknown and remove it. So wait for the slot instead,
+            // keeping anchor semantics — this is still not a live fix.
+            if (userStateGeneration == inFlightUserStateGeneration.get()) {
+                logger.logSyncSkipped("refresh already in progress")
+                return Result.success(Unit)
+            }
+            if (!awaitRefreshSlot()) {
+                logger.logSyncSkipped("refresh already in progress after waiting")
+                return Result.success(Unit)
+            }
         }
+        inFlightUserStateGeneration.set(userStateGeneration)
         return runRefresh(latitude, longitude, FixSource.ANCHOR, containmentEpoch)
     }
 
@@ -112,6 +132,7 @@ internal class GeofenceRepositoryImpl(
             logger.logSyncSkipped("refresh already in progress after waiting")
             return Result.success(Unit)
         }
+        inFlightUserStateGeneration.set(store.userStateGeneration())
         return runRefresh(latitude, longitude, FixSource.LIVE, containmentEpoch)
     }
 
@@ -707,6 +728,10 @@ internal class GeofenceRepositoryImpl(
     )
 
     private companion object {
+        // No pass holds the slot. Distinct from any real generation, which starts at zero and only
+        // ever increases.
+        const val NO_SESSION = -1L
+
         // Long enough to outlast the slowest holder: a remote pass can spend the HTTP client's
         // connect plus read timeout (10s each) before it releases, and giving up on one that then
         // fails to register is the case that strands the trigger. Deliberately past the receiver's

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -117,6 +117,12 @@ internal class GeofenceServicesImpl(
         )
 
     override fun onUserIdentified(latitude: Double?, longitude: Double?) {
+        // Establish the session boundary here, not on the first OS callback. beginUserSession clears
+        // routing and the last-sync stamp, so opening it now sends the refresh below down the REMOTE
+        // path and arms routing for the new user before any transition can arrive. Left to the
+        // receiver, the identify would SKIP as fresh, and the first callback would then open the
+        // session, read the empty routable set it had just written, and remove every live fence.
+        secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }?.let(regionStore::beginUserSession)
         triggerSync(
             reason = REASON_USER_IDENTIFIED,
             latitude = latitude,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -132,10 +132,11 @@ internal class GeofenceServicesImpl(
     }
 
     override fun onAppLaunch(latitude: Double?, longitude: Double?) {
-        // On an install upgraded from a version without the session keys, the first beginUserSession
-        // adopts whoever is identified rather than switching. Opening it here makes that adoption
-        // name the launching user, so a later identify is seen as the switch it is, not absorbed.
-        secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }?.let(regionStore::beginUserSession)
+        // Launch establishes a session where none exists; it must never redefine one. This runs
+        // asynchronously, so an identify can land between reading the user and reaching the store,
+        // and reopening the older user would clear the routing that identify's refresh just armed.
+        secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }
+            ?.let(regionStore::beginUserSessionIfAbsent)
         triggerSync(
             reason = REASON_APP_LAUNCH,
             latitude = latitude,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceServices.kt
@@ -132,6 +132,10 @@ internal class GeofenceServicesImpl(
     }
 
     override fun onAppLaunch(latitude: Double?, longitude: Double?) {
+        // On an install upgraded from a version without the session keys, the first beginUserSession
+        // adopts whoever is identified rather than switching. Opening it here makes that adoption
+        // name the launching user, so a later identify is seen as the switch it is, not absorbed.
+        secureUserStore.getUserId()?.takeIf { it.isNotEmpty() }?.let(regionStore::beginUserSession)
         triggerSync(
             reason = REASON_APP_LAUNCH,
             latitude = latitude,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -7,6 +7,8 @@ import io.customer.sdk.communication.Event
 import io.customer.sdk.data.store.PendingDeliveryStore
 import java.util.UUID
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -24,9 +26,15 @@ internal class GeofenceTransitionEmitter(
     private val regionStore: GeofenceRegionStore,
     private val logger: GeofenceLogger
 ) {
+    internal enum class Result {
+        PERSISTED,
+        SUPPRESSED,
+        PERSIST_FAILED
+    }
+
     /**
-     * @return false when the ENTER was already reported, the cooldown suppressed it, or the persist
-     * failed (cooldown rolled back).
+     * @return false when the ENTER was already reported, the cooldown suppressed it, or the durable
+     * outbox append failed. A failed append keeps its synchronous staging row for recovery.
      */
     suspend fun emit(
         geofenceId: String,
@@ -37,7 +45,145 @@ internal class GeofenceTransitionEmitter(
         metadata: Map<String, JsonElement>,
         geosetIds: List<String>,
         monitorsExit: Boolean
-    ): Boolean {
+    ): Boolean = emitWithResult(
+        geofenceId = geofenceId,
+        transition = transition,
+        userId = userId,
+        timestampSeconds = timestampSeconds,
+        geofenceName = geofenceName,
+        metadata = metadata,
+        geosetIds = geosetIds,
+        monitorsExit = monitorsExit
+    ) == Result.PERSISTED
+
+    suspend fun emitWithExpectedState(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        userId: String,
+        timestampSeconds: Long,
+        geofenceName: String?,
+        metadata: Map<String, JsonElement>,
+        geosetIds: List<String>,
+        monitorsExit: Boolean,
+        expectedUserStateGeneration: Long,
+        expectedRegionRevision: Int?
+    ): Boolean = emitInternal(
+        geofenceId,
+        transition,
+        userId,
+        timestampSeconds,
+        geofenceName,
+        metadata,
+        geosetIds,
+        monitorsExit,
+        retainAttempt = false,
+        expectedUserStateGeneration = expectedUserStateGeneration,
+        expectedRegionRevision = expectedRegionRevision
+    ) == Result.PERSISTED
+
+    suspend fun emitWithResult(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        userId: String,
+        timestampSeconds: Long,
+        geofenceName: String?,
+        metadata: Map<String, JsonElement>,
+        geosetIds: List<String>,
+        monitorsExit: Boolean
+    ): Result = emitInternal(
+        geofenceId,
+        transition,
+        userId,
+        timestampSeconds,
+        geofenceName,
+        metadata,
+        geosetIds,
+        monitorsExit,
+        retainAttempt = false
+    )
+
+    suspend fun emitWithRetainedAttempt(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        userId: String,
+        timestampSeconds: Long,
+        geofenceName: String?,
+        metadata: Map<String, JsonElement>,
+        geosetIds: List<String>,
+        monitorsExit: Boolean,
+        expectedUserStateGeneration: Long,
+        expectedRegionRevision: Int?
+    ): Result = emitInternal(
+        geofenceId,
+        transition,
+        userId,
+        timestampSeconds,
+        geofenceName,
+        metadata,
+        geosetIds,
+        monitorsExit,
+        retainAttempt = true,
+        expectedUserStateGeneration = expectedUserStateGeneration,
+        expectedRegionRevision = expectedRegionRevision
+    )
+
+    suspend fun recoverPendingTransitions(): Boolean = emissionMutex.withLock {
+        recoverPendingTransitionsLocked()
+    }
+
+    private suspend fun recoverPendingTransitionsLocked(): Boolean {
+        val attempts = regionStore.getAllPendingTransitionEntries()
+            .groupBy(PendingGeofenceDelivery::transitionId)
+            .values
+        for (entries in attempts) {
+            // Stop at the first unavailable append. Later transitions must not overtake it.
+            if (!pendingStore.appendAll(entries)) return false
+            val first = entries.first()
+            first.userId?.let { userId ->
+                cooldownFilter.record(userId, first.geofenceId, first.transition)
+            }
+            entries.forEach { entry ->
+                try {
+                    scheduler.schedule(entry)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.logSchedulerFailed(entry.geofenceId, entry.transition.name, e.message)
+                }
+            }
+            // Physical containment was committed atomically with the stage. Recovery only
+            // completes the durable delivery handoff; replaying old containment here could
+            // overwrite a newer opposite transition.
+            if (!regionStore.completePendingTransition(first.transitionId)) return false
+        }
+        return true
+    }
+
+    private suspend fun emitInternal(
+        geofenceId: String,
+        transition: Event.GeofenceTransition,
+        userId: String,
+        timestampSeconds: Long,
+        geofenceName: String?,
+        metadata: Map<String, JsonElement>,
+        geosetIds: List<String>,
+        monitorsExit: Boolean,
+        retainAttempt: Boolean,
+        expectedUserStateGeneration: Long = regionStore.userStateGeneration(),
+        expectedRegionRevision: Int? = regionStore.getCachedRegion(geofenceId)?.transitionRevision()
+    ): Result = emissionMutex.withLock {
+        // Drain older attempts first. If storage is still unavailable, the new physical edge is
+        // staged below but deliberately not appended, preserving delivery order for recovery.
+        val olderAttemptsDrained = recoverPendingTransitionsLocked()
+        // A business transition is a newly-confirmed physical edge, even when an older edge in the
+        // same direction is still staged behind a failed outbox append (ENTER → EXIT → ENTER). Only
+        // the direct synthetic path may reuse an existing stage for the same visit.
+        val stagedEntries = if (retainAttempt) {
+            emptyList()
+        } else {
+            regionStore.getPendingTransitionEntries(userId, geofenceId, transition)
+        }
+        val isRecovery = stagedEntries.isNotEmpty()
         // Reboot and app update both re-register with INITIAL_TRIGGER_ENTER, so the OS re-reports
         // ENTER for a fence the device never left. Ahead of the cooldown so the drop doesn't spend
         // the fence's slot, and only where an EXIT can clear the mark — an enter-only fence never
@@ -45,46 +191,55 @@ internal class GeofenceTransitionEmitter(
         val isRedundantEnter = transition == Event.GeofenceTransition.ENTER &&
             monitorsExit &&
             regionStore.hasEmittedEnter(userId, geofenceId)
-        if (isRedundantEnter) {
+        if (!isRecovery && isRedundantEnter) {
             logger.logEnterDroppedAlreadyReported(geofenceId)
-            return false
+            return@withLock Result.SUPPRESSED
         }
-        if (!cooldownFilter.tryAcquire(userId, geofenceId, transition)) {
+        if (!isRecovery && !cooldownFilter.isAllowed(userId, geofenceId, transition)) {
             logger.logTransitionSuppressed(geofenceId, transition.name)
-            return false
+            return@withLock Result.SUPPRESSED
         }
         logger.logTransitionEmitting(geofenceId, transition.name)
 
-        // One transitionId shared across the per-geoset fan-out.
-        val transitionId = UUID.randomUUID().toString()
-        val name = geofenceName?.takeIf { it.isNotEmpty() }
-        // One event per geoset; no geosets → one null-geoset event. Distinct so a repeated geoset
-        // doesn't duplicate.
-        val geosets: List<String?> = geosetIds.distinct().takeIf { it.isNotEmpty() } ?: listOf(null)
-        val entries = geosets.map { geosetId ->
-            PendingGeofenceDelivery(
-                geofenceId = geofenceId,
-                transition = transition,
-                timestamp = timestampSeconds,
-                userId = userId,
-                transitionId = transitionId,
-                geofenceName = name,
-                geosetId = geosetId,
-                metadata = metadata
-            )
+        val entries = stagedEntries.ifEmpty {
+            // One transitionId shared across the per-geoset fan-out.
+            val transitionId = UUID.randomUUID().toString()
+            val name = geofenceName?.takeIf { it.isNotEmpty() }
+            // One event per geoset; no geosets → one null-geoset event. Distinct so a repeated
+            // geoset doesn't duplicate.
+            val geosets: List<String?> = geosetIds.distinct().takeIf { it.isNotEmpty() } ?: listOf(null)
+            geosets.map { geosetId ->
+                PendingGeofenceDelivery(
+                    geofenceId = geofenceId,
+                    transition = transition,
+                    timestamp = timestampSeconds,
+                    userId = userId,
+                    transitionId = transitionId,
+                    geofenceName = name,
+                    geosetId = geosetId,
+                    metadata = metadata,
+                    stateGeneration = expectedUserStateGeneration,
+                    regionRevision = expectedRegionRevision,
+                    marksEnterReported = transition == Event.GeofenceTransition.ENTER && monitorsExit
+                )
+            }.also { created ->
+                if (!regionStore.savePendingTransitionEntries(created, expectedUserStateGeneration)) {
+                    logger.logPersistFailed(geofenceId, transition.name)
+                    return@withLock Result.PERSIST_FAILED
+                }
+            }
         }
 
+        if (!olderAttemptsDrained) return@withLock Result.PERSIST_FAILED
+
         // Persist atomically before any send so an app kill mid-batch can't lose part of the fan-out.
-        // On write failure there's nothing to deliver: roll back the cooldown so the crossing retries.
+        // Staging survives a write failure or process death, and stable keys make recovery idempotent.
         if (!pendingStore.appendAll(entries)) {
             logger.logPersistFailed(geofenceId, transition.name)
-            cooldownFilter.release(userId, geofenceId, transition)
-            return false
+            return@withLock Result.PERSIST_FAILED
         }
-        // Only once the rows are durable, so a rolled-back write can't suppress its own retry.
-        if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
-            regionStore.markEnterEmitted(userId, geofenceId)
-        }
+        // Only once the rows are durable, so an interrupted write can't suppress its own retry.
+        cooldownFilter.record(userId, geofenceId, transition)
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.
             try {
@@ -95,6 +250,13 @@ internal class GeofenceTransitionEmitter(
                 logger.logSchedulerFailed(geofenceId, transition.name, e.message)
             }
         }
-        return true
+        if (!retainAttempt) {
+            regionStore.completePendingTransition(entries.first().transitionId)
+        }
+        Result.PERSISTED
+    }
+
+    private companion object {
+        val emissionMutex = Mutex()
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/di/DIGraphGeofence.kt
@@ -2,6 +2,7 @@ package io.customer.geofence.di
 
 import com.google.android.gms.location.GeofencingClient
 import com.google.android.gms.location.LocationServices
+import io.customer.geofence.GeofenceBusinessTransitionProcessor
 import io.customer.geofence.GeofenceCooldownFilter
 import io.customer.geofence.GeofenceDistanceFilter
 import io.customer.geofence.GeofenceJsonSerializer
@@ -77,7 +78,12 @@ internal val AndroidSDKComponent.geofenceDeliveryFlusher: PendingDeliveryFlusher
         PendingDeliveryFlusher(
             store = pendingGeofenceDeliveryStore,
             workManagerProvider = SDKComponent.workManagerProvider,
-            dispatchersProvider = SDKComponent.dispatchersProvider
+            dispatchersProvider = SDKComponent.dispatchersProvider,
+            // Geofence workers form one ordered continuation chain. A foreground flush removes
+            // rows from the shared outbox; queued workers then observe the miss and finish safely.
+            // Cancelling the shared chain for one row could strand a transition appended mid-flush.
+            uniqueWorkName = { null },
+            stopOnFailure = true
         )
     }
 
@@ -101,6 +107,16 @@ internal val AndroidSDKComponent.geofenceTransitionEmitter: GeofenceTransitionEm
             pendingStore = pendingGeofenceDeliveryStore,
             scheduler = geofenceEventScheduler,
             regionStore = geofenceRegionStore,
+            logger = SDKComponent.geofenceLogger
+        )
+    }
+
+internal val AndroidSDKComponent.geofenceBusinessTransitionProcessor: GeofenceBusinessTransitionProcessor
+    get() = singleton {
+        GeofenceBusinessTransitionProcessor(
+            store = geofenceRegionStore,
+            secureUserStore = secureUserStore,
+            transitionEmitter = geofenceTransitionEmitter,
             logger = SDKComponent.geofenceLogger
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -121,6 +121,15 @@ internal interface GeofenceRegionStore {
 
     /** OS registrations allowed to generate business events for the current user session. */
     fun saveRoutableRegisteredIds(ids: Set<String>)
+
+    /**
+     * Arms routing for [ids], but only while [expectedUserStateGeneration] is still current.
+     *
+     * A refresh that began before an identify must not re-arm the previous user's registrations
+     * after [beginUserSession] cleared them; the generation is the fencing token that says so.
+     * Returns whether the write happened.
+     */
+    fun saveRoutableRegisteredIdsIfCurrent(ids: Set<String>, expectedUserStateGeneration: Long): Boolean
     fun getRoutableRegisteredIds(): Set<String>
 
     /** Polygon enclosing circles currently known to contain the device. */
@@ -560,6 +569,15 @@ internal class GeofenceRegionStoreImpl(
 
     override fun saveRoutableRegisteredIds(ids: Set<String>) =
         writeJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER, ids)
+
+    override fun saveRoutableRegisteredIdsIfCurrent(
+        ids: Set<String>,
+        expectedUserStateGeneration: Long
+    ): Boolean = synchronized(enteredLock) {
+        if (expectedUserStateGeneration != currentUserStateGenerationLocked()) return@synchronized false
+        writeJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER, ids)
+        true
+    }
 
     override fun getRoutableRegisteredIds(): Set<String> {
         val hasExplicitRoutingState = prefs.read { contains(KEY_ROUTABLE_REGISTERED_IDS) } == true

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -59,7 +59,6 @@ internal interface GeofenceRegionStore {
     fun appendPendingPolygonApproachBatches(entries: List<PendingPolygonApproachBatch>): Boolean
     fun getPendingPolygonApproachBatches(): List<PendingPolygonApproachBatch>
     fun removePendingPolygonApproachBatch(id: String): Boolean
-    fun clearPendingPolygonApproachBatches()
 
     fun saveCachedRegions(regions: List<GeofenceRegion>)
     fun getCachedRegions(): List<GeofenceRegion>
@@ -100,8 +99,6 @@ internal interface GeofenceRegionStore {
     fun userStateGeneration(): Long
 
     /** Whether polygon fine monitoring belongs to a currently identified user session. */
-    fun hasActiveUserSession(): Boolean
-
     fun activeUserSessionId(): String?
 
     /** Invalidates in-flight transition work when the identified profile changes. */
@@ -292,7 +289,7 @@ internal class GeofenceRegionStoreImpl(
         if (
             entries.any { it.userStateGeneration != expectedGeneration } ||
             expectedGeneration != currentUserStateGenerationLocked() ||
-            !hasActiveUserSession()
+            !hasActiveUserSessionLocked()
         ) {
             return@synchronized false
         }
@@ -321,6 +318,9 @@ internal class GeofenceRegionStoreImpl(
         val retained = entries.filterNot { it.id == id }
         if (retained.size == entries.size) return@synchronized true
         if (retained.isEmpty()) {
+            // Explicit commit, not the KTX edit {}: the caller needs to know whether the write
+            // reached disk, and the KTX form returns Unit.
+            @Suppress("ApplySharedPref", "UseKtx")
             prefs.edit().remove(KEY_PENDING_POLYGON_APPROACH_BATCHES).commit()
         } else {
             writeEncryptedJsonCommitted(
@@ -329,11 +329,6 @@ internal class GeofenceRegionStoreImpl(
                 retained
             )
         }
-    }
-
-    override fun clearPendingPolygonApproachBatches() = synchronized(enteredLock) {
-        prefs.edit().remove(KEY_PENDING_POLYGON_APPROACH_BATCHES).commit()
-        Unit
     }
 
     override fun saveCachedRegions(regions: List<GeofenceRegion>) = synchronized(enteredLock) {
@@ -439,6 +434,8 @@ internal class GeofenceRegionStoreImpl(
         val allPending = readPendingTransitionEntries()
         val pending = allPending.filterNot { it.transitionId == transitionId }
         if (pending.size == allPending.size) return@synchronized true
+        // Explicit editor, not the KTX edit {}: the commit result is this function's return value.
+        @Suppress("UseKtx")
         val editor = prefs.edit()
         if (pending.isEmpty()) {
             editor.remove(KEY_PENDING_TRANSITION_ENTRIES)
@@ -448,6 +445,8 @@ internal class GeofenceRegionStoreImpl(
                 jsonSerializer.encode(PENDING_TRANSITIONS_SERIALIZER, pending)
             )
         }
+        // Explicit commit, not the KTX edit {}: this returns whether the write reached disk.
+        @Suppress("ApplySharedPref")
         editor.commit()
     }
 
@@ -455,9 +454,8 @@ internal class GeofenceRegionStoreImpl(
         currentUserStateGenerationLocked()
     }
 
-    override fun hasActiveUserSession(): Boolean = synchronized(enteredLock) {
+    private fun hasActiveUserSessionLocked(): Boolean =
         !prefs.read { getString(KEY_USER_STATE_OWNER, null) }.isNullOrEmpty()
-    }
 
     override fun activeUserSessionId(): String? = synchronized(enteredLock) {
         prefs.read { getString(KEY_USER_STATE_OWNER, null) }?.takeIf { it.isNotEmpty() }
@@ -472,27 +470,27 @@ internal class GeofenceRegionStoreImpl(
             // Upgrade migration: older SDKs persisted a secure user and registrations but no
             // geofence-session owner/routing key. Adopt that same persisted session without
             // discarding valid OS registrations or containment before the first callback.
-            prefs.edit()
-                .putString(KEY_USER_STATE_OWNER, userId)
-                .putLong(KEY_USER_STATE_GENERATION, nextGeneration)
-                .commit()
+            prefs.edit(commit = true) {
+                putString(KEY_USER_STATE_OWNER, userId)
+                putLong(KEY_USER_STATE_GENERATION, nextGeneration)
+            }
             return@synchronized
         }
-        prefs.edit()
-            .putString(KEY_USER_STATE_OWNER, userId)
-            .putLong(KEY_USER_STATE_GENERATION, nextGeneration)
-            .putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
-            .remove(KEY_LAST_API_FETCH_LOCATION)
-            .remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
-            .remove(KEY_PENDING_TRANSITION_ENTRIES)
-            .remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
-            .remove(KEY_ACTIVE_POLYGON_IDS)
-            .remove(KEY_COARSE_INSIDE_POLYGON_IDS)
-            .remove(KEY_ENTERED_IDS)
-            .remove(KEY_EMITTED_ENTER_IDS)
-            .remove(KEY_EMITTED_ENTER_OWNER)
-            .remove(KEY_LAST_SYNC)
-            .commit()
+        prefs.edit(commit = true) {
+            putString(KEY_USER_STATE_OWNER, userId)
+            putLong(KEY_USER_STATE_GENERATION, nextGeneration)
+            putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
+            remove(KEY_LAST_API_FETCH_LOCATION)
+            remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
+            remove(KEY_PENDING_TRANSITION_ENTRIES)
+            remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
+            remove(KEY_ACTIVE_POLYGON_IDS)
+            remove(KEY_COARSE_INSIDE_POLYGON_IDS)
+            remove(KEY_ENTERED_IDS)
+            remove(KEY_EMITTED_ENTER_IDS)
+            remove(KEY_EMITTED_ENTER_OWNER)
+            remove(KEY_LAST_SYNC)
+        }
     }
 
     override fun commitBusinessTransition(
@@ -802,35 +800,33 @@ internal class GeofenceRegionStoreImpl(
     ): Unit = synchronized(enteredLock) {
         val currentGeneration = currentUserStateGenerationLocked()
         val resetWasSuperseded = currentGeneration != expectedUserStateGeneration
-        val editor = prefs.edit()
-            .remove(KEY_LAST_API_FETCH_LOCATION)
-            .remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
-            .remove(KEY_PENDING_TRANSITION_ENTRIES)
-            .remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
-            .remove(KEY_ACTIVE_POLYGON_IDS)
-            .remove(KEY_COARSE_INSIDE_POLYGON_IDS)
-            .remove(KEY_ENTERED_IDS)
-            .remove(KEY_EMITTED_ENTER_IDS)
-            .remove(KEY_EMITTED_ENTER_OWNER)
-            .remove(KEY_LAST_SYNC)
-        if (osRegistrationsCleared) {
-            editor
-                .remove(KEY_REGISTERED_IDS)
-                .remove(KEY_ROUTABLE_REGISTERED_IDS)
-                .remove(KEY_RETAINED_REGISTERED_REGIONS)
-                .remove(KEY_LAST_REGISTRATION_UPTIME)
-                .remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
-        } else {
-            // Explicit empty is distinct from key absence. Absence is the upgrade path for SDK
-            // versions that only stored registered_ids and must remain routable until refreshed.
-            editor.putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
+        prefs.edit(commit = true) {
+            remove(KEY_LAST_API_FETCH_LOCATION)
+            remove(KEY_LAST_MOVEMENT_TRIGGER_LOCATION)
+            remove(KEY_PENDING_TRANSITION_ENTRIES)
+            remove(KEY_PENDING_POLYGON_APPROACH_BATCHES)
+            remove(KEY_ACTIVE_POLYGON_IDS)
+            remove(KEY_COARSE_INSIDE_POLYGON_IDS)
+            remove(KEY_ENTERED_IDS)
+            remove(KEY_EMITTED_ENTER_IDS)
+            remove(KEY_EMITTED_ENTER_OWNER)
+            remove(KEY_LAST_SYNC)
+            if (osRegistrationsCleared) {
+                remove(KEY_REGISTERED_IDS)
+                remove(KEY_ROUTABLE_REGISTERED_IDS)
+                remove(KEY_RETAINED_REGISTERED_REGIONS)
+                remove(KEY_LAST_REGISTRATION_UPTIME)
+                remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
+            } else {
+                // Explicit empty is distinct from key absence. Absence is the upgrade path for SDK
+                // versions that only stored registered_ids and must remain routable until refreshed.
+                putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
+            }
+            if (!resetWasSuperseded) {
+                remove(KEY_USER_STATE_OWNER)
+                putLong(KEY_USER_STATE_GENERATION, currentGeneration + 1L)
+            }
         }
-        if (!resetWasSuperseded) {
-            editor
-                .remove(KEY_USER_STATE_OWNER)
-                .putLong(KEY_USER_STATE_GENERATION, currentGeneration + 1L)
-        }
-        editor.commit()
         Unit
     }
 
@@ -870,6 +866,8 @@ internal class GeofenceRegionStoreImpl(
         // Exact route history must never take PreferenceCrypto's API 21/OEM plaintext fallback.
         // The receiver can evaluate the batch immediately when durable encryption is unavailable.
         if (encrypted == plaintext) return false
+        // Explicit commit, not the KTX edit {}: this returns whether the write reached disk.
+        @Suppress("UseKtx")
         return prefs.edit().putString(key, encrypted).commit()
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -470,10 +470,10 @@ internal class GeofenceRegionStoreImpl(
             // Upgrade migration: older SDKs persisted a secure user and registrations but no
             // geofence-session owner/routing key. Adopt that same persisted session without
             // discarding valid OS registrations or containment before the first callback.
-            prefs.edit(commit = true) {
-                putString(KEY_USER_STATE_OWNER, userId)
-                putLong(KEY_USER_STATE_GENERATION, nextGeneration)
-            }
+            // The generation deliberately stays put, because nothing changed hands. Moving it
+            // would invalidate a refresh already in flight, which would then skip the catalog
+            // write it gates on that generation after its registered-id write already landed.
+            prefs.edit(commit = true) { putString(KEY_USER_STATE_OWNER, userId) }
             return@synchronized
         }
         prefs.edit(commit = true) {

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -127,6 +127,8 @@ internal interface GeofenceRegionStore {
      * Returns whether the write happened.
      */
     fun saveRoutableRegisteredIdsIfCurrent(ids: Set<String>, expectedUserStateGeneration: Long): Boolean
+
+    /** Empty until a pass arms it: a registration only routes once a session has claimed it. */
     fun getRoutableRegisteredIds(): Set<String>
 
     /** Polygon enclosing circles currently known to contain the device. */
@@ -464,18 +466,11 @@ internal class GeofenceRegionStoreImpl(
     override fun beginUserSession(userId: String) = synchronized(enteredLock) {
         val currentOwner = prefs.read { getString(KEY_USER_STATE_OWNER, null) }
         if (currentOwner == userId) return@synchronized
+        // An absent owner means an install upgraded from a version without these keys, and nothing
+        // records who the persisted state belongs to. Adopting whoever is identified now was a guess
+        // that a late read or a replayed identify can get wrong, so an unowned session opens as a
+        // switch. OS registrations survive it, so live fences keep firing once a refresh re-arms them.
         val nextGeneration = currentUserStateGenerationLocked() + 1L
-        val hasRoutingState = prefs.read { contains(KEY_ROUTABLE_REGISTERED_IDS) } == true
-        if (currentOwner == null && !hasRoutingState) {
-            // Upgrade migration: older SDKs persisted a secure user and registrations but no
-            // geofence-session owner/routing key. Adopt that same persisted session without
-            // discarding valid OS registrations or containment before the first callback.
-            // The generation deliberately stays put, because nothing changed hands. Moving it
-            // would invalidate a refresh already in flight, which would then skip the catalog
-            // write it gates on that generation after its registered-id write already landed.
-            prefs.edit(commit = true) { putString(KEY_USER_STATE_OWNER, userId) }
-            return@synchronized
-        }
         prefs.edit(commit = true) {
             putString(KEY_USER_STATE_OWNER, userId)
             putLong(KEY_USER_STATE_GENERATION, nextGeneration)
@@ -577,11 +572,8 @@ internal class GeofenceRegionStoreImpl(
         true
     }
 
-    override fun getRoutableRegisteredIds(): Set<String> {
-        val hasExplicitRoutingState = prefs.read { contains(KEY_ROUTABLE_REGISTERED_IDS) } == true
-        if (!hasExplicitRoutingState) return getRegisteredIds()
-        return readJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
-    }
+    override fun getRoutableRegisteredIds(): Set<String> =
+        readJson(KEY_ROUTABLE_REGISTERED_IDS, ID_SET_SERIALIZER) ?: emptySet()
 
     override fun getActivePolygonIds(): Set<String> = synchronized(activePolygonLock) {
         readJson(KEY_ACTIVE_POLYGON_IDS, ID_SET_SERIALIZER) ?: emptySet()
@@ -818,8 +810,6 @@ internal class GeofenceRegionStoreImpl(
                 remove(KEY_LAST_REGISTRATION_UPTIME)
                 remove(KEY_LAST_REGISTRATION_PACKAGE_UPDATE_TIME)
             } else {
-                // Explicit empty is distinct from key absence. Absence is the upgrade path for SDK
-                // versions that only stored registered_ids and must remain routable until refreshed.
                 putString(KEY_ROUTABLE_REGISTERED_IDS, jsonSerializer.encode(ID_SET_SERIALIZER, emptySet()))
             }
             if (!resetWasSuperseded) {

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -104,6 +104,14 @@ internal interface GeofenceRegionStore {
     /** Invalidates in-flight transition work when the identified profile changes. */
     fun beginUserSession(userId: String)
 
+    /**
+     * Opens a session for [userId] only while none is recorded, checked and written under one lock.
+     *
+     * For callers that read the identified user before calling: a concurrent identify can land in
+     * between, and this must not undo it by reopening the older user.
+     */
+    fun beginUserSessionIfAbsent(userId: String)
+
     /** Atomically commits containment and clears its staged transition for this user generation. */
     fun commitBusinessTransition(
         geofenceId: String,
@@ -470,6 +478,15 @@ internal class GeofenceRegionStoreImpl(
         // records who the persisted state belongs to. Adopting whoever is identified now was a guess
         // that a late read or a replayed identify can get wrong, so an unowned session opens as a
         // switch. OS registrations survive it, so live fences keep firing once a refresh re-arms them.
+        openUserSessionLocked(userId)
+    }
+
+    override fun beginUserSessionIfAbsent(userId: String) = synchronized(enteredLock) {
+        if (hasActiveUserSessionLocked()) return@synchronized
+        openUserSessionLocked(userId)
+    }
+
+    private fun openUserSessionLocked(userId: String) {
         val nextGeneration = currentUserStateGenerationLocked() + 1L
         prefs.edit(commit = true) {
             putString(KEY_USER_STATE_OWNER, userId)

--- a/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/PendingGeofenceDelivery.kt
@@ -31,7 +31,7 @@ internal data class PendingGeofenceDelivery(
     val userId: String?,
     /**
      * Identifies the physical crossing, shared across its per-geoset fan-out (geosets differ by
-     * [geosetId]); backend dedup is keyed (transitionId, geoset). Not part of [key].
+     * [geosetId]); backend dedup is keyed (transitionId, geoset).
      */
     val transitionId: String,
     /** Null when the fired geofence isn't in the cached region set. */
@@ -47,7 +47,8 @@ internal data class PendingGeofenceDelivery(
     /** Whether committing this staged ENTER must atomically set the reboot dedupe marker. */
     val marksEnterReported: Boolean = false
 ) : PendingDeliveryStore.PendingDeliveryEntry {
-    override val key: String get() = "${geofenceId}_${transition.name}_${timestamp}_${geosetId ?: "none"}"
+    override val key: String
+        get() = "${geofenceId}_${transition.name}_${transitionId}_${geosetId ?: "none"}"
 
     /**
      * Properties carried on the tracked "Geofence Transition" event. Kept here

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventTracker.kt
@@ -87,7 +87,7 @@ internal class AsyncGeofenceEventTracker(
         }
         CoroutineScope(dispatcher.background).launch {
             try {
-                pendingStore.sendRemoveOnSuccess(entry) {
+                pendingStore.sendRemoveOnSuccess(entry, ::isRetryableDeliveryFailure) {
                     tracker.trackEvent(entry)
                 }
             } catch (e: CancellationException) {

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -14,9 +14,11 @@ import io.customer.geofence.di.pendingGeofenceDeliveryStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.di.setupAndroidComponent
+import io.customer.sdk.core.network.HttpRequestFailure
 import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.data.store.PendingDeliveryResult
 import io.customer.sdk.data.store.sendRemoveOnSuccess
+import java.io.IOException
 
 private const val ORDERED_GEOFENCE_DELIVERY_QUEUE = "cio-geofence-delivery-queue"
 
@@ -94,7 +96,7 @@ internal class GeofenceEventWorker(
             // dropping it. The duplicate this can produce (overlap with the flush, or a retry after
             // an ambiguous success) is deduped backend-side via the stable transitionId.
             when (
-                val outcome = store.sendRemoveOnSuccess(entry) {
+                val outcome = store.sendRemoveOnSuccess(entry, ::isRetryableDeliveryFailure) {
                     SDKComponent.android().geofenceEventTracker.trackEvent(entry)
                 }
             ) {
@@ -127,16 +129,36 @@ internal class GeofenceEventWorker(
                         entry.transition.name,
                         outcome.cause?.message
                     )
-                    // Deliberately not Result.failure(): a terminal node cancels every existing
-                    // dependent in a WorkManager chain, which would discard the transitions queued
-                    // behind this one. Deliberately not Result.success() either — this node may be the
-                    // last in the chain, and then nothing would ever come back for the row, stranding
-                    // the head of an ordered queue permanently. Result.retry() re-runs this same node
-                    // on a backoff, which is the only outcome that both preserves the chain and
-                    // guarantees another attempt.
+                    // A refused payload is refused identically next time, so retrying only holds the
+                    // head of an ordered queue and every transition behind it. Same disposal as the
+                    // anonymous row above: drop it and carry on. Narrow on purpose — only a terminal
+                    // HTTP status is known-permanent. Anything else (a bad state, a serialization
+                    // slip) may well succeed on the next attempt, so it keeps the row and retries.
+                    val cause = outcome.cause
+                    if (cause is HttpRequestFailure && !cause.isRetryable && store.remove(entry.key)) {
+                        continue
+                    }
+                    // Still not Result.failure(): a terminal node cancels every existing dependent in
+                    // a WorkManager chain, discarding the transitions queued behind this one. Not
+                    // Result.success() either — this node may be the last in the chain, and then
+                    // nothing would come back for the row, stranding the head of an ordered queue.
                     return Result.retry()
                 }
             }
         }
     }
+}
+
+/**
+ * A delivery failure worth attempting again.
+ *
+ * Every non-2xx arrives as an [HttpRequestFailure], so without this the default `it is IOException`
+ * predicate classifies a 400 or 401 as retryable and the row is re-sent forever. Transport failures
+ * stay retryable; anything that is not an [IOException] at all is a bug rather than a network
+ * condition, and repeating it would not help.
+ */
+internal fun isRetryableDeliveryFailure(cause: Throwable?): Boolean = when (cause) {
+    is HttpRequestFailure -> cause.isRetryable
+    is IOException -> true
+    else -> false
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -3,7 +3,6 @@ package io.customer.geofence.worker
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
-import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
@@ -19,7 +18,7 @@ import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.data.store.PendingDeliveryResult
 import io.customer.sdk.data.store.sendRemoveOnSuccess
 
-private const val KEY_ENTRY_KEY = "entry_key"
+private const val ORDERED_GEOFENCE_DELIVERY_QUEUE = "cio-geofence-delivery-queue"
 
 /**
  * Schedules a [GeofenceEventWorker] for guaranteed delivery of a geofence transition event.
@@ -30,32 +29,27 @@ internal class GeofenceEventScheduler(
     private val asyncTracker: AsyncGeofenceEventTracker
 ) {
     suspend fun schedule(entry: PendingGeofenceDelivery) {
-        // Only the store key rides through inputData; the worker loads the full row from the pending
-        // store. WorkManager caps Data at ~10 KB (a Binder/DB limit), so inlining the row — whose
-        // metadata can be large — risks an enqueue failure. The store already holds the authoritative
-        // snapshot, so carrying a copy would only risk drift anyway.
-        val input = Data.Builder()
-            .putString(KEY_ENTRY_KEY, entry.key)
-            .build()
-
         val workRequest = OneTimeWorkRequestBuilder<GeofenceEventWorker>()
             .setConstraints(
                 Constraints.Builder()
                     .setRequiredNetworkType(NetworkType.CONNECTED)
                     .build()
             )
-            .setInputData(input)
             .addTag(WORK_MANAGER_TAG_CIO)
             .addTag(WORK_MANAGER_TAG_GEOFENCE)
             .build()
 
-        // entry.key doubles as the unique-work name so the foreground flush can cancel this worker by key.
-        // Second-precision timestamp: same-second bursts collide (KEEP dedupes them);
-        // later transitions get distinct keys so an offline-queued worker can't block legitimate re-entries.
+        // Every transition joins one durable continuation chain. This prevents a later EXIT from
+        // overtaking an earlier ENTER when WorkManager has multiple workers eligible at once.
+        // APPEND_OR_REPLACE also creates a fresh chain if a prior terminal failure cancelled it.
         val workManager = workManagerProvider.getWorkManager()
         if (workManager != null) {
             // Await persistence so the BroadcastReceiver doesn't finish() before WM commits the work spec.
-            workManager.enqueueUniqueWork(entry.key, ExistingWorkPolicy.KEEP, workRequest).await()
+            workManager.enqueueUniqueWork(
+                ORDERED_GEOFENCE_DELIVERY_QUEUE,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                workRequest
+            ).await()
         } else {
             asyncTracker.trackEvent(entry)
         }
@@ -78,53 +72,70 @@ internal class GeofenceEventWorker(
         // initialized the SDK yet; without this, SDKComponent.android() would throw.
         SDKComponent.setupAndroidComponent(context = applicationContext)
         val logger = SDKComponent.geofenceLogger
-        val entryKey = inputData.getString(KEY_ENTRY_KEY)
-        if (entryKey.isNullOrEmpty()) {
-            logger.logEventInvalidInput(entryKey, null)
-            return Result.failure()
-        }
-
-        // The receiver persists the row before scheduling, so it's normally present. A miss means the
-        // foreground flush already delivered and removed it — nothing to do.
+        // Every node drains the oldest durable row, not the row that happened to schedule it. This
+        // preserves transition order even after retries, foreground handoff, or process death.
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
-        val entry = store.get(entryKey)
-        if (entry == null) {
-            logger.logEventWorkerEntryMissing(entryKey)
-            return Result.success()
-        }
+        while (true) {
+            val entry = store.loadAll().firstOrNull() ?: return Result.success()
 
-        // Shouldn't happen — the receiver drops anonymous transitions before
-        // persisting. Defensive: leave the row rather than send a track the
-        // backend would reject.
-        if (entry.userId.isNullOrEmpty()) {
-            logger.logEventDeliveryDeferredAnonymous(entry.geofenceId, entry.transition.name)
-            return Result.success()
-        }
+            // Shouldn't happen — the receiver drops anonymous transitions before persisting. It is
+            // also unrecoverable: the userId was snapshotted at queue time and no later attempt can
+            // supply one, so the row is undeliverable forever. Leaving it in place would strand the
+            // head of an ordered queue and with it every transition queued behind it, so drop it and
+            // carry on. A failed removal falls through to a backed-off retry rather than spinning.
+            if (entry.userId.isNullOrEmpty()) {
+                logger.logEventDeliveryDeferredAnonymous(entry.geofenceId, entry.transition.name)
+                if (store.remove(entry.key)) continue
+                return Result.retry()
+            }
 
-        // At-least-once delivery: keep the row until the send is confirmed, so a process death
-        // mid-request leaves it for a WorkManager retry or the foreground flush rather than
-        // dropping it. The duplicate this can produce (overlap with the flush, or a retry after
-        // an ambiguous success) is deduped backend-side via the stable transitionId.
-        return when (
-            val outcome = store.sendRemoveOnSuccess(entry) {
-                SDKComponent.android().geofenceEventTracker.trackEvent(entry)
-            }
-        ) {
-            PendingDeliveryResult.AlreadyClaimed -> {
-                logger.logEventDeliverySkippedAlreadyDelivered(entry.geofenceId, entry.transition.name)
-                Result.success()
-            }
-            PendingDeliveryResult.Delivered -> {
-                logger.logEventDelivered(entry.geofenceId, entry.transition.name)
-                Result.success()
-            }
-            is PendingDeliveryResult.Retryable -> {
-                logger.logEventDeliveryRetryable(entry.geofenceId, entry.transition.name, outcome.cause?.message)
-                Result.retry()
-            }
-            is PendingDeliveryResult.Failed -> {
-                logger.logEventDeliveryFailed(entry.geofenceId, entry.transition.name, outcome.cause?.message)
-                Result.failure()
+            // At-least-once delivery: keep the row until the send is confirmed, so a process death
+            // mid-request leaves it for a WorkManager retry or the foreground flush rather than
+            // dropping it. The duplicate this can produce (overlap with the flush, or a retry after
+            // an ambiguous success) is deduped backend-side via the stable transitionId.
+            when (
+                val outcome = store.sendRemoveOnSuccess(entry) {
+                    SDKComponent.android().geofenceEventTracker.trackEvent(entry)
+                }
+            ) {
+                PendingDeliveryResult.AlreadyClaimed ->
+                    logger.logEventDeliverySkippedAlreadyDelivered(
+                        entry.geofenceId,
+                        entry.transition.name
+                    )
+                PendingDeliveryResult.Delivered ->
+                    logger.logEventDelivered(entry.geofenceId, entry.transition.name)
+                PendingDeliveryResult.DeliveredNotRemoved -> {
+                    // Sent, but the row that proves it is still on disk. Continuing the loop would
+                    // re-read this same head entry and resend it, and again, without bound. Hand the
+                    // problem to WorkManager's backoff: at worst one delayed duplicate, deduped
+                    // backend-side on transitionId, instead of an unbounded burst of them.
+                    logger.logEventDeliveredButNotRemoved(entry.geofenceId, entry.transition.name)
+                    return Result.retry()
+                }
+                is PendingDeliveryResult.Retryable -> {
+                    logger.logEventDeliveryRetryable(
+                        entry.geofenceId,
+                        entry.transition.name,
+                        outcome.cause?.message
+                    )
+                    return Result.retry()
+                }
+                is PendingDeliveryResult.Failed -> {
+                    logger.logEventDeliveryFailed(
+                        entry.geofenceId,
+                        entry.transition.name,
+                        outcome.cause?.message
+                    )
+                    // Deliberately not Result.failure(): a terminal node cancels every existing
+                    // dependent in a WorkManager chain, which would discard the transitions queued
+                    // behind this one. Deliberately not Result.success() either — this node may be the
+                    // last in the chain, and then nothing would ever come back for the row, stranding
+                    // the head of an ordered queue permanently. Result.retry() re-runs this same node
+                    // on a backoff, which is the only outcome that both preserves the chain and
+                    // guarantees another attempt.
+                    return Result.retry()
+                }
             }
         }
     }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -89,7 +89,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             }
         )
         // Default: cooldown allows emission. Tests override this to test suppression.
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockStore.savePendingTransitionEntries(any(), any()) } returns true
+        every { mockStore.commitBusinessTransition(any(), any(), any(), any(), any()) } returns true
         // Default: an identified user is the common case; the snapshot lands on the entry.
         // Tests that need an anonymous-at-queue-time scenario override this to null.
         every { mockSecureUserStore.getUserId() } returns "user-42"
@@ -101,17 +103,29 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             "biz-2",
             "biz-geofence",
             "biz-geofence-1",
-            "biz-geofence-2"
+            "biz-geofence-2",
+            "polygon"
         )
+        every { mockStore.getRoutableRegisteredIds() } answers { mockStore.getRegisteredIds() }
+        every { mockStore.userStateGeneration() } returns 0L
+        every { mockStore.activeUserSessionId() } returns "user-42"
         // Default: the device counts as inside every fence, so the EXIT guard is a no-op.
         // Tests for the guard override.
         every { mockStore.claimExit(any()) } returns true
         // Default: containment has been recorded, i.e. not a freshly-upgraded install.
         every { mockStore.hasContainmentRecord() } returns true
+        every { mockStore.getEnteredIds() } returns setOf(
+            "biz-1",
+            "biz-2",
+            "biz-geofence",
+            "biz-geofence-1",
+            "biz-geofence-2"
+        )
         // Default: fences monitor both transitions, so the EXIT guard applies. Exit-only fences and
         // uncached ids are exempt from it and have their own tests.
         every { mockStore.getCachedRegion(any()) } returns
             GeofenceRegion("biz-geofence-2", 0.0, 0.0, 100f)
+        every { mockStore.getRegisteredRegion(any()) } returns null
         pendingStore.removeAll()
         receiver = GeofenceBroadcastReceiver()
     }
@@ -183,6 +197,46 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
+    fun dispatchTransition_givenCircleEnterWasDisabledDuringCallback_expectNoStaleEnterEvent() = runTest {
+        val oldCircle = GeofenceRegion(
+            id = "biz-1",
+            latitude = 37.7750,
+            longitude = -122.4194,
+            radius = 200f,
+            transitionTypes = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT)
+        )
+        val exitOnlyCircle = oldCircle.copy(transitionTypes = listOf(GeofenceTransitionType.EXIT))
+        every { mockStore.getCachedRegion("biz-1") } returnsMany listOf(oldCircle, exitOnlyCircle)
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-1"),
+            latitude = 37.7750,
+            longitude = -122.4194
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll().shouldBeEmpty()
+    }
+
+    @Test
+    fun dispatchTransition_givenRetiredRegionCallback_expectCleanupRetryWithoutBusinessEvent() = runTest {
+        every { mockStore.getCachedRegion("biz-1") } returns null
+        every { mockStore.getRegisteredRegion("biz-1") } returns GeofenceRegion("biz-1", 37.7750, -122.4194, 200f)
+        coEvery { mockManager.removeGeofencesByIds(listOf("biz-1")) } returns Result.success(Unit)
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-1"),
+            latitude = 37.7750,
+            longitude = -122.4194
+        )
+
+        coVerify { mockManager.removeGeofencesByIds(listOf("biz-1")) }
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
     fun dispatchTransition_givenEnterTransition_expectEntryAppendedAndScheduledButNotPublished() = runTest {
         val entrySlot = slot<PendingGeofenceDelivery>()
 
@@ -214,6 +268,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // Snapshotting at queue time is what protects A's events from being
         // reattributed to B if A signs out + B signs in before delivery.
         every { mockSecureUserStore.getUserId() } returns "user-A"
+        every { mockStore.activeUserSessionId() } returns "user-A"
         val entrySlot = slot<PendingGeofenceDelivery>()
 
         receiver.dispatchTransition(
@@ -225,6 +280,25 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 1) { mockScheduler.schedule(capture(entrySlot)) }
         entrySlot.captured.userId shouldBeEqualTo "user-A"
+    }
+
+    @Test
+    fun dispatchTransition_givenLegacyColdStartWithoutSessionOwner_expectAdoptsUserAndProcessesCallback() = runTest {
+        var sessionOwner: String? = null
+        every { mockStore.activeUserSessionId() } answers { sessionOwner }
+        every { mockStore.beginUserSession(any()) } answers {
+            sessionOwner = firstArg()
+        }
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-geofence"),
+            latitude = 1.0,
+            longitude = 2.0
+        )
+
+        verify { mockStore.beginUserSession("user-42") }
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
     }
 
     @Test
@@ -452,12 +526,13 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         scheduled.map { it.transitionId }.toSet().size shouldBeEqualTo 1
         scheduled.map { it.key }.toSet().size shouldBeEqualTo 3
         // Cooldown is a single gate for the crossing, not per geoset.
-        verify(exactly = 1) { mockCooldownFilter.tryAcquire("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
+        verify(exactly = 1) { mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
+        verify(exactly = 1) { mockCooldownFilter.record("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
         pendingStore.loadAll().size shouldBeEqualTo 3
     }
 
     @Test
-    fun dispatchTransition_givenPersistFails_expectNoScheduleAndCooldownReleased() = runTest {
+    fun dispatchTransition_givenOutboxPersistFails_expectStagedAttemptKeptAndNoSchedule() = runTest {
         every { mockStore.getCachedRegion("biz-geofence") } returns
             GeofenceRegion("biz-geofence", 0.0, 0.0, 100f)
         // Force the pending store's write to fail by turning its backing file into a directory.
@@ -472,10 +547,10 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = 0.0
         )
 
-        // Nothing durably queued: don't schedule a worker that would find no row, and roll back the
-        // cooldown so a later crossing can retry instead of being suppressed.
+        // The SharedPreferences stage is durable even though the file outbox is unavailable. Do not
+        // spend cooldown or schedule a worker; a later callback/launch recovers the stable attempt.
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
-        verify(exactly = 1) { mockCooldownFilter.release("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
+        verify(exactly = 0) { mockCooldownFilter.record(any(), any(), any()) }
     }
 
     @Test
@@ -534,7 +609,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
     @Test
     fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduled() = runTest {
-        every { mockCooldownFilter.tryAcquire("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) } returns false
+        every { mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) } returns false
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -548,7 +623,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
-    fun dispatchTransition_givenCooldownAllows_expectTryAcquireBeforeSchedule() = runTest {
+    fun dispatchTransition_givenCooldownAllows_expectCheckAndRecordBeforeSchedule() = runTest {
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
             triggeringGeofenceIds = listOf("biz-geofence"),
@@ -557,7 +632,8 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         coVerifyOrder {
-            mockCooldownFilter.tryAcquire("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
+            mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
+            mockCooldownFilter.record("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
             mockScheduler.schedule(any())
         }
     }
@@ -616,6 +692,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // reconciliation, not a crossing. Unlike an orphan ID the registration is still
         // wanted, so it must NOT be removed from the OS.
         every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getEnteredIds() } returns emptySet()
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
@@ -626,7 +703,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
-        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
         coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
     }
 
@@ -635,6 +712,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // An exit-only fence is registered without ENTER monitoring, so the OS can never report an
         // ENTER for the guard to record. Applying the guard would drop every one of its EXITs.
         every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getEnteredIds() } returns emptySet()
         every { mockStore.getCachedRegion("biz-geofence-2") } returns GeofenceRegion(
             id = "biz-geofence-2",
             latitude = 0.0,
@@ -657,6 +735,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     fun dispatchTransition_givenUnmatchedExitForUncachedFence_expectDeliveredNotDropped() = runTest {
         // No cache row means unknown transition types, which can't justify dropping a crossing.
         every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getEnteredIds() } returns emptySet()
         every { mockStore.getCachedRegion("biz-geofence-2") } returns null
 
         receiver.dispatchTransition(
@@ -675,6 +754,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         // judge against until the first registration seeds it. A fence entered before the upgrade
         // must still report its EXIT.
         every { mockStore.claimExit("biz-geofence-2") } returns false
+        every { mockStore.getEnteredIds() } returns emptySet()
         every { mockStore.hasContainmentRecord() } returns false
 
         receiver.dispatchTransition(
@@ -771,8 +851,18 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = -0.1278
         )
 
-        // Recording the ENTER is what lets the matching EXIT through later.
-        verify { mockStore.recordEntered("biz-geofence-2") }
+        // The stage and physical ENTER are one synchronous store transaction.
+        verify {
+            mockStore.savePendingTransitionEntries(
+                match { entries ->
+                    entries.all {
+                        it.geofenceId == "biz-geofence-2" &&
+                            it.transition == Event.GeofenceTransition.ENTER
+                    }
+                },
+                any()
+            )
+        }
     }
 
     @Test
@@ -788,7 +878,15 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             longitude = -0.1278
         )
 
-        verify { mockStore.recordEntered("biz-geofence-2") }
+        verify {
+            mockStore.commitBusinessTransition(
+                "biz-geofence-2",
+                Event.GeofenceTransition.ENTER,
+                null,
+                any(),
+                any()
+            )
+        }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
     }
 
@@ -822,7 +920,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
-        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
         coVerify { mockManager.removeGeofencesByIds(listOf("biz-orphan")) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -964,6 +964,61 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     }
 
     @Test
+    fun dispatchTransition_givenRegisteredIdWhileRoutingUnarmed_expectDroppedButOsRegistrationKept() = runTest {
+        // The window between an identify clearing routing and the refresh that re-arms it. The fence
+        // is live and still claimed by registeredIds, so removing it here would strand it: the
+        // completing refresh sees matching params, skips it as unchanged, and never re-adds it.
+        every { mockStore.getRegisteredIds() } returns setOf("biz-known")
+        every { mockStore.getRoutableRegisteredIds() } returns emptySet()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-known"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        pendingStore.loadAll() shouldBeEqualTo emptyList()
+        coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
+    }
+
+    @Test
+    fun dispatchTransition_givenUnarmedAndOrphanIds_expectOnlyOrphanRemoved() = runTest {
+        // Both are unroutable, but only the orphan has left the registration bookkeeping. Evicting
+        // the unarmed one alongside it is what loses a live fence for the rest of the session.
+        every { mockStore.getRegisteredIds() } returns setOf("biz-known")
+        every { mockStore.getRoutableRegisteredIds() } returns emptySet()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
+            triggeringGeofenceIds = listOf("biz-known", "biz-orphan"),
+            latitude = 0.0,
+            longitude = 0.0
+        )
+
+        coVerify(exactly = 1) { mockManager.removeGeofencesByIds(listOf("biz-orphan")) }
+    }
+
+    @Test
+    fun dispatchTransition_givenMovementTriggerExitWhileRoutingUnarmed_expectRefreshStillDriven() = runTest {
+        // The trigger is the only refresh path that runs without the app being opened. Dropping its
+        // EXIT while routing is unarmed leaves the session with nothing to re-arm it until launch.
+        every { mockStore.getRegisteredIds() } returns setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
+        every { mockStore.getRoutableRegisteredIds() } returns emptySet()
+
+        receiver.dispatchTransition(
+            gmsTransitionType = Geofence.GEOFENCE_TRANSITION_EXIT,
+            triggeringGeofenceIds = listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID),
+            latitude = 1.0,
+            longitude = 2.0
+        )
+
+        verify { mockServices.onMovementTriggerExit(1.0, 2.0) }
+        coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
+    }
+
+    @Test
     fun dispatchTransition_givenAllIdsKnown_expectNoRemoveCall() = runTest {
         // Normal (no-orphan) path: removeGeofencesByIds must NOT be called when all
         // incoming IDs are tracked.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBusinessTransitionProcessorTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBusinessTransitionProcessorTest.kt
@@ -1,0 +1,209 @@
+package io.customer.geofence
+
+import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class GeofenceBusinessTransitionProcessorTest {
+    private val store: GeofenceRegionStore = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val emitter: GeofenceTransitionEmitter = mockk(relaxed = true)
+    private val logger: GeofenceLogger = mockk(relaxed = true)
+    private val processor = GeofenceBusinessTransitionProcessor(store, secureUserStore, emitter, logger)
+
+    @Before
+    fun setUp() {
+        every { secureUserStore.getUserId() } returns "user-1"
+        every { store.getCachedRegion("polygon") } returns GeofenceRegion(
+            id = "polygon",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f
+        )
+        every { store.getEnteredIds() } returns emptySet()
+        every { store.hasContainmentRecord() } returns true
+        every { store.activeUserSessionId() } returns "user-1"
+        every { store.commitBusinessTransition(any(), any(), any(), any(), any()) } returns true
+    }
+
+    @Test
+    fun process_givenOutboxPersistenceFailure_expectContainmentNotCommittedSoFixCanRetry() = runTest {
+        coEvery { emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            GeofenceTransitionEmitter.Result.PERSIST_FAILED
+
+        processor.process("polygon", Event.GeofenceTransition.ENTER, 100L)
+
+        verify(exactly = 0) { store.commitBusinessTransition(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun process_givenOutboxFailureAfterDurableStage_expectProcessorLeavesAtomicStageUntouched() = runTest {
+        val staged = io.customer.geofence.store.PendingGeofenceDelivery(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-1"
+        )
+        coEvery { emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            GeofenceTransitionEmitter.Result.PERSIST_FAILED
+        every {
+            store.getPendingTransitionEntries("user-1", "polygon", Event.GeofenceTransition.ENTER)
+        } returns listOf(staged)
+
+        processor.process("polygon", Event.GeofenceTransition.ENTER, 100L)
+
+        verify(exactly = 0) { store.commitBusinessTransition(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { store.completePendingTransition(any()) }
+    }
+
+    @Test
+    fun process_givenPersistedAtomicStage_expectCommitsAndClearsSameAttempt() = runTest {
+        val staged = io.customer.geofence.store.PendingGeofenceDelivery(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "transition-1"
+        )
+        coEvery { emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            GeofenceTransitionEmitter.Result.PERSISTED
+        every {
+            store.getPendingTransitionEntries("user-1", "polygon", Event.GeofenceTransition.ENTER)
+        } returns listOf(staged)
+
+        processor.process("polygon", Event.GeofenceTransition.ENTER, 100L)
+
+        verify {
+            store.commitBusinessTransition(
+                "polygon",
+                Event.GeofenceTransition.ENTER,
+                "transition-1",
+                0L,
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun process_givenOlderSameDirectionStage_expectCommitsNewestPhysicalAttempt() = runTest {
+        val older = io.customer.geofence.store.PendingGeofenceDelivery(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 90L,
+            userId = "user-1",
+            transitionId = "transition-old"
+        )
+        val newest = older.copy(timestamp = 100L, transitionId = "transition-new")
+        coEvery {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns GeofenceTransitionEmitter.Result.PERSISTED
+        every {
+            store.getPendingTransitionEntries("user-1", "polygon", Event.GeofenceTransition.ENTER)
+        } returns listOf(older, newest)
+
+        processor.process("polygon", Event.GeofenceTransition.ENTER, 100L)
+
+        verify {
+            store.commitBusinessTransition(
+                "polygon",
+                Event.GeofenceTransition.ENTER,
+                "transition-new",
+                0L,
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun process_givenDetectionFromReplacedGeometry_expectDroppedBeforeEmission() = runTest {
+        val current = requireNotNull(store.getCachedRegion("polygon"))
+
+        processor.process(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestampSeconds = 100L,
+            enforceConfiguredTransition = true,
+            expectedRegionRevision = current.transitionRevision() + 1
+        )
+
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) { store.commitBusinessTransition(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun process_givenDuplicateSuppressedAfterRecovery_expectContainmentStillCommitted() = runTest {
+        coEvery { emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            GeofenceTransitionEmitter.Result.SUPPRESSED
+
+        processor.process("polygon", Event.GeofenceTransition.ENTER, 100L)
+
+        verify {
+            store.commitBusinessTransition("polygon", Event.GeofenceTransition.ENTER, null, 0L, any())
+        }
+    }
+
+    @Test
+    fun process_givenUnconfiguredPolygonEnter_expectTracksContainmentWithoutEmitting() = runTest {
+        every { store.getCachedRegion("polygon") } returns GeofenceRegion(
+            id = "polygon",
+            latitude = 0.0,
+            longitude = 0.0,
+            radius = 100f,
+            transitionTypes = listOf(GeofenceTransitionType.EXIT)
+        )
+
+        processor.process(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestampSeconds = 100L,
+            enforceConfiguredTransition = true
+        )
+
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        verify {
+            store.commitBusinessTransition("polygon", Event.GeofenceTransition.ENTER, null, 0L, any())
+        }
+    }
+
+    @Test
+    fun process_givenUserSwitchAfterOldCallbackAdmission_expectDoesNotAttributeTransitionToNewUser() = runTest {
+        var generation = 1L
+        var currentUser = "user-1"
+        every { store.userStateGeneration() } answers { generation }
+        every { secureUserStore.getUserId() } answers { currentUser }
+        every { store.activeUserSessionId() } answers { currentUser }
+        every { store.getRoutableRegisteredIds() } answers {
+            // The old callback already observed its fence as routable. User B identifies before
+            // identity and durable staging, which must invalidate this attempt.
+            generation = 2L
+            currentUser = "user-2"
+            setOf("polygon")
+        }
+
+        processor.process(
+            geofenceId = "polygon",
+            transition = Event.GeofenceTransition.ENTER,
+            timestampSeconds = 100L,
+            expectedUserStateGeneration = 1L,
+            requireRegistered = true
+        )
+
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+        verify(exactly = 0) { store.commitBusinessTransition(any(), any(), any(), any(), any()) }
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
@@ -34,23 +34,17 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
     }
 
     @Test
-    fun release_expectStoreRemovesKey() {
-        filter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER)
-
-        verify(exactly = 1) { mockStore.remove("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
-    }
-
-    @Test
-    fun tryAcquire_givenNoPreviousEmit_expectTrueAndRecorded() {
+    fun cooldown_givenNoPreviousEmit_expectTrueAndRecorded() {
         every { mockStore.getLastEmitTimestamp(any(), any(), any()) } returns null
         every { mockClock.currentTimeMillis() } returns 100_000L
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, 100_000L) }
     }
 
     @Test
-    fun tryAcquire_givenAllowedEmit_expectStalePruneSweep() {
+    fun cooldown_givenAllowedEmit_expectStalePruneSweep() {
         // Each allowed emit sweeps entries older than the max clampable cooldown —
         // they can't suppress under any config, so pruning them bounds the store
         // as fence definitions churn.
@@ -58,80 +52,85 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         val now = 100_000L + GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
 
         verify(exactly = 1) { mockStore.pruneOlderThan(now - GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS) }
     }
 
     @Test
-    fun tryAcquire_givenSuppressedEmit_expectNoPruneSweep() {
+    fun cooldown_givenSuppressedEmit_expectNoPruneSweep() {
         val lastEmit = 100_000L
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns lastEmit + 1
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
 
         verify(exactly = 0) { mockStore.pruneOlderThan(any()) }
     }
 
     @Test
-    fun tryAcquire_givenPreviousEmitWithinCooldown_expectFalseAndNotRecorded() {
+    fun cooldown_givenPreviousEmitWithinCooldown_expectFalseAndNotRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + (GeofenceConstants.DEDUPE_COOLDOWN_MS - 1)
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
         verify(exactly = 0) { mockStore.recordEmit(any(), any(), any(), any()) }
     }
 
     @Test
-    fun tryAcquire_givenPreviousEmitExactlyAtCooldownBoundary_expectTrueAndRecorded() {
+    fun cooldown_givenPreviousEmitExactlyAtCooldownBoundary_expectTrueAndRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, now) }
     }
 
     @Test
-    fun tryAcquire_givenPreviousEmitOutsideCooldown_expectTrueAndRecorded() {
+    fun cooldown_givenPreviousEmitOutsideCooldown_expectTrueAndRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS + 1
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, now) }
     }
 
     @Test
-    fun tryAcquire_givenSameGeofenceDifferentTransition_keysIndependently() {
+    fun cooldown_givenSameGeofenceDifferentTransition_keysIndependently() {
         // ENTER fired recently, EXIT never fired — EXIT should still acquire
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns 100L
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.EXIT) } returns null
         every { mockClock.currentTimeMillis() } returns 200L
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.EXIT).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.EXIT).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.EXIT)
     }
 
     @Test
-    fun tryAcquire_givenSameGeofenceDifferentUser_keysIndependently() {
+    fun cooldown_givenSameGeofenceDifferentUser_keysIndependently() {
         // Account switch: the previous user's window must not mask the new user's
         // transition on the same fence.
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns 100L
         every { mockStore.getLastEmitTimestamp("user-2", "biz-1", Event.GeofenceTransition.ENTER) } returns null
         every { mockClock.currentTimeMillis() } returns 200L
 
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
-        filter.tryAcquire("user-2", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.isAllowed("user-2", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-2", "biz-1", Event.GeofenceTransition.ENTER)
     }
 
     @Test
-    fun tryAcquire_givenCachedConfig_expectServerConfiguredCooldownUsed() {
+    fun cooldown_givenCachedConfig_expectServerConfiguredCooldownUsed() {
         // Server-pushed cooldown is shorter than the fallback. Verifies the
         // filter actually consults GeofenceConfig and isn't pinned to the constant.
         val serverCooldownMs = 5_000L
@@ -143,11 +142,12 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
 
         // Inside the server window but well outside the constant fallback → must block.
         every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs - 1
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
 
         // Past the server window but still inside the constant fallback → must allow.
         every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs + 1
-        filter.tryAcquire("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -741,6 +741,45 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenSuccessfulRegistration_expectRoutingArmedForTheSameIds() = runTest {
+        // beginUserSession writes an explicit empty routable set and getRoutableRegisteredIds stops
+        // falling back once that key exists, so a refresh that registers without arming routing
+        // leaves the receiver treating every live ID as unknown and removing it from the OS.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.userStateGeneration() } returns 7L
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        val captured = slot<List<GeofenceRegion>>()
+        coEvery { manager.replaceGeofences(capture(captured), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        val registered = captured.captured.map { it.id }.toSet()
+        verify { store.saveRoutableRegisteredIdsIfCurrent(registered, 7L) }
+    }
+
+    @Test
+    fun refresh_givenUserChangedBeforeRoutingWasArmed_expectRoutingLeftCleared() = runTest {
+        // The store refuses the stale write; the refresh must report it rather than assume it landed.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.userStateGeneration() } returns 7L
+        every { store.saveRoutableRegisteredIdsIfCurrent(any(), any()) } returns false
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        verify { logger.logSyncSkipped("user changed before routing could be armed") }
+    }
+
+    @Test
     fun refresh_givenBusinessGeofences_expectMovementTriggerPrependedAndRegistered() = runTest {
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -64,6 +64,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
         // Default: mirror real time so tests using relative timestamps work
         // without churn. Override for deterministic timing.
         every { clock.currentTimeMillis() } answers { System.currentTimeMillis() }
+        // The relaxed mock would answer false, which is the "an identify landed mid-pass" branch.
+        // Default to the ordinary outcome so only the tests that mean to exercise a refusal do.
+        every { store.saveRoutableRegisteredIdsIfCurrent(any(), any()) } returns true
         repository = buildRepository()
     }
 
@@ -762,8 +765,10 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
-    fun refresh_givenUserChangedBeforeRoutingWasArmed_expectRoutingLeftCleared() = runTest {
-        // The store refuses the stale write; the refresh must report it rather than assume it landed.
+    fun refresh_givenUserChangedBeforeRoutingWasArmed_expectSyncNotStampedFresh() = runTest {
+        // The store refuses the stale write, so routing stays cleared for the new user. Stamping the
+        // sync anyway would make that user's own refresh SKIP on this timestamp and never arm
+        // routing, and its first callback would then remove every live fence from the OS.
         every { secureUserStore.getUserId() } returns "user-42"
         every { store.getRegisteredIds() } returns emptySet()
         every { store.userStateGeneration() } returns 7L
@@ -777,6 +782,25 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
         verify { logger.logSyncSkipped("user changed before routing could be armed") }
+        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+    }
+
+    @Test
+    fun refresh_givenRoutingArmed_expectSyncStampedFresh() = runTest {
+        // Control: the stamp is skipped because routing was refused, not because it never happens.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.userStateGeneration() } returns 7L
+        every { store.saveRoutableRegisteredIdsIfCurrent(any(), any()) } returns true
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        verify { store.setLastSyncTimestamp(any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1249,6 +1249,35 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenMovementHoldingTheSlotForSameSession_expectDroppedWithoutWaiting() = runTest {
+        // The movement pass serves the same session, so a refresh behind it is a duplicate and
+        // should drop on the spot. Without the generation stamp the slot reads as NO_SESSION and
+        // this polls out the full wait before giving up.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.userStateGeneration() } returns 7L
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns emptyList()
+        val registrationEntered = CompletableDeferred<Unit>()
+        val releaseRegistration = CompletableDeferred<Unit>()
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            registrationEntered.complete(Unit)
+            releaseRegistration.await()
+            Result.success(Unit)
+        }
+
+        val movement = launch { repository.handleMovement(latitude = 1.0, longitude = 2.0) }
+        registrationEntered.await()
+        repository.refresh(latitude = 3.0, longitude = 4.0)
+        releaseRegistration.complete(Unit)
+        movement.join()
+
+        verify { logger.logSyncSkipped("refresh already in progress") }
+        verify(exactly = 0) { logger.logSyncSkipped("refresh already in progress after waiting") }
+    }
+
+    @Test
     fun refresh_givenInFlightGateCleared_expectSubsequentCallProceeds() = runTest {
         // Pins the contract that the in-flight gate is released even on failure,
         // so a follow-up refresh isn't permanently locked out.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -1169,6 +1169,85 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenStaleRemovalFails_expectDefinitionRetainedAsTombstone() = runTest {
+        // The unremoved id keeps firing after the backend deleted it. The receiver tells a retired
+        // fence from one it has no cache row for by this retained definition, so without the write
+        // that branch can never be taken and a deleted fence reports business activity.
+        val staleRegion = GeofenceRegion("biz-old", 1.0, 2.0, 150f)
+        val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf("biz-old")
+        every { store.getCachedRegions() } returns listOf(staleRegion)
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(newRegion)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        coEvery { manager.removeGeofencesByIds(any()) } returns
+            Result.failure(RuntimeException("remove boom"))
+        val retained = slot<List<GeofenceRegion>>()
+        every { store.saveRetainedRegisteredRegions(capture(retained)) } returns Unit
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        retained.captured shouldBeEqualTo listOf(staleRegion)
+    }
+
+    @Test
+    fun refresh_givenStaleRemovalFailsRepeatedly_expectTombstoneSurvivesTheCatalogDroppingIt() = runTest {
+        // The first failure is the last pass that still sees the deleted fence in the catalog: the
+        // sync that follows saves a catalog without it. Rebuilding the retained set from the catalog
+        // alone would lose the tombstone on the first retry, leaving the id registered and routable
+        // with nothing left to identify it as retired.
+        val staleRegion = GeofenceRegion("biz-old", 1.0, 2.0, 150f)
+        val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf("biz-old")
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(newRegion)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        coEvery { manager.removeGeofencesByIds(any()) } returns
+            Result.failure(RuntimeException("remove boom"))
+        val retained = mutableListOf<List<GeofenceRegion>>()
+        every { store.saveRetainedRegisteredRegions(capture(retained)) } returns Unit
+
+        // Pass 1: the catalog still holds the deleted fence, nothing retained yet.
+        every { store.getCachedRegions() } returns listOf(staleRegion)
+        every { store.getRetainedRegisteredRegions() } returns emptyList()
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Pass 2: the catalog has moved on, and the tombstone from pass 1 is all that is left.
+        every { store.getCachedRegions() } returns emptyList()
+        every { store.getRetainedRegisteredRegions() } returns listOf(staleRegion)
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Both writes, so the test documents the hand-off rather than just the surviving end of it.
+        retained.first() shouldBeEqualTo listOf(staleRegion)
+        retained.last() shouldBeEqualTo listOf(staleRegion)
+    }
+
+    @Test
+    fun refresh_givenStaleRemovalSucceeds_expectTombstonesCleared() = runTest {
+        // Nothing is orphaned in the OS, so a retained definition would outlive its purpose and keep
+        // suppressing an id a later sync may legitimately register again.
+        val newRegion = GeofenceRegion("biz-new", 0.0, 0.0, 100f)
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns setOf("biz-old")
+        every { store.getCachedRegions() } returns listOf(GeofenceRegion("biz-old", 1.0, 2.0, 150f))
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns listOf(newRegion)
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        coEvery { manager.removeGeofencesByIds(any()) } returns Result.success(Unit)
+        val retained = slot<List<GeofenceRegion>>()
+        every { store.saveRetainedRegisteredRegions(capture(retained)) } returns Unit
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        retained.captured.shouldBeEmpty()
+    }
+
+    @Test
     fun refresh_givenAllPreviousAbsentFromNew_expectBusinessRemovedButTriggerKept() = runTest {
         // No fences in this response: previously registered business IDs are removed as
         // stale, but the movement trigger stays so a later EXIT can re-fetch — the

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -744,6 +744,44 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenIdentifyWhileAnotherRefreshHoldsTheSlot_expectRoutingArmedForTheNewSession() = runTest {
+        // A's pass is parked inside GMS registration when B identifies. B's refresh cannot be dropped
+        // as a duplicate: A can only arm A's generation, so it will refuse, and beginUserSession has
+        // already cleared routing. Dropping would leave routing empty with nothing pending, and the
+        // next callback would classify every live fence as unknown and remove it.
+        every { secureUserStore.getUserId() } returns "user-b"
+        every { store.getRegisteredIds() } returns emptySet()
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        every { distanceFilter.nearest(any(), any(), any(), any(), any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+
+        // Generation 7 is A's; B's identify bumps it to 8 while A is still inside replaceGeofences.
+        every { store.userStateGeneration() } returns 7L
+        val armed = mutableListOf<Long>()
+        every { store.saveRoutableRegisteredIdsIfCurrent(any(), capture(armed)) } answers
+            { secondArg<Long>() == store.userStateGeneration() }
+        val registrationEntered = CompletableDeferred<Unit>()
+        val releaseRegistration = CompletableDeferred<Unit>()
+        coEvery { manager.replaceGeofences(any(), any()) } coAnswers {
+            registrationEntered.complete(Unit)
+            releaseRegistration.await()
+            Result.success(Unit)
+        }
+
+        val passA = launch { repository.refresh(latitude = 1.0, longitude = 2.0) }
+        registrationEntered.await()
+        every { store.userStateGeneration() } returns 8L
+        val passB = launch { repository.refresh(latitude = 1.0, longitude = 2.0) }
+        releaseRegistration.complete(Unit)
+        passA.join()
+        passB.join()
+
+        // A refused (7 is stale), then B ran and armed 8 rather than being dropped as a duplicate.
+        armed shouldBeEqualTo listOf(7L, 8L)
+    }
+
+    @Test
     fun refresh_givenSuccessfulRegistration_expectRoutingArmedForTheSameIds() = runTest {
         // beginUserSession writes an explicit empty routable set and getRoutableRegisteredIds stops
         // falling back once that key exists, so a refresh that registers without arming routing

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -416,6 +416,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
     fun refresh_givenApiFailure_expectFailurePropagatedAndNoPersistOrRegister() = runTest {
         val error = IOException("network down")
         every { secureUserStore.getUserId() } returns "user-42"
+        // Armed, so the failed pass has nothing to recover and must not re-rank. Left unarmed this
+        // would register from the cache, and the claim below would hold only for an empty catalog.
+        every { store.getRoutableRegisteredIds() } returns setOf("biz-1")
         coEvery { apiService.fetchGeofences(any()) } returns Result.failure(error)
 
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -6,6 +6,7 @@ import io.customer.sdk.core.util.Clock
 import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -139,6 +140,37 @@ class GeofenceServicesTest : RobolectricTest() {
         coVerify { repository.refresh(1.0, 2.0) }
         coVerify(exactly = 0) { repository.handleMovement(any(), any()) }
         verify { logger.logSyncTriggered("user-identified") }
+    }
+
+    @Test
+    fun onUserIdentified_expectSessionOpenedBeforeTheRefresh() = runTest(StandardTestDispatcher()) {
+        // Order is the point. beginUserSession clears routing and the last-sync stamp; opening the
+        // session first sends this refresh down the REMOTE path so it re-registers and arms routing.
+        // Left to the first OS callback instead, the identify SKIPs as fresh and that callback opens
+        // the session, reads the empty routable set it just wrote, and removes every live fence.
+        every { secureUserStore.getUserId() } returns "user-b"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        coVerifyOrder {
+            regionStore.beginUserSession("user-b")
+            repository.refresh(1.0, 2.0)
+        }
+    }
+
+    @Test
+    fun onUserIdentified_givenNoIdentifiedUser_expectNoSessionOpened() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns null
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onUserIdentified(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { regionStore.beginUserSession(any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -175,9 +175,9 @@ class GeofenceServicesTest : RobolectricTest() {
 
     @Test
     fun onAppLaunch_expectSessionOpenedBeforeTheRefresh() = runTest(StandardTestDispatcher()) {
-        // Upgraded install with no session-owner key: the first beginUserSession adopts rather than
-        // switches. Opening it here makes it name the launching user, so an identify arriving while
-        // this pass holds the slot bumps the generation and is not dropped as a duplicate of it.
+        // Upgraded install with no session-owner key: opening it here names the launching user, so
+        // the refresh below goes down the REMOTE path and arms routing instead of leaving the first
+        // OS callback to open the session and then drop the event it arrived with.
         every { secureUserStore.getUserId() } returns "user-a"
         coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)
@@ -186,9 +186,10 @@ class GeofenceServicesTest : RobolectricTest() {
         advanceUntilIdle()
 
         coVerifyOrder {
-            regionStore.beginUserSession("user-a")
+            regionStore.beginUserSessionIfAbsent("user-a")
             repository.refresh(1.0, 2.0)
         }
+        verify(exactly = 0) { regionStore.beginUserSession(any()) }
     }
 
     @Test
@@ -200,7 +201,7 @@ class GeofenceServicesTest : RobolectricTest() {
         services.onAppLaunch(latitude = 1.0, longitude = 2.0)
         advanceUntilIdle()
 
-        verify(exactly = 0) { regionStore.beginUserSession(any()) }
+        verify(exactly = 0) { regionStore.beginUserSessionIfAbsent(any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceServicesTest.kt
@@ -174,6 +174,36 @@ class GeofenceServicesTest : RobolectricTest() {
     }
 
     @Test
+    fun onAppLaunch_expectSessionOpenedBeforeTheRefresh() = runTest(StandardTestDispatcher()) {
+        // Upgraded install with no session-owner key: the first beginUserSession adopts rather than
+        // switches. Opening it here makes it name the launching user, so an identify arriving while
+        // this pass holds the slot bumps the generation and is not dropped as a duplicate of it.
+        every { secureUserStore.getUserId() } returns "user-a"
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onAppLaunch(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        coVerifyOrder {
+            regionStore.beginUserSession("user-a")
+            repository.refresh(1.0, 2.0)
+        }
+    }
+
+    @Test
+    fun onAppLaunch_givenNoIdentifiedUser_expectNoSessionOpened() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns null
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+        val services = servicesWith(this)
+
+        services.onAppLaunch(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { regionStore.beginUserSession(any()) }
+    }
+
+    @Test
     fun onAppLaunch_expectRefreshCalled() = runTest(StandardTestDispatcher()) {
         coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
         val services = servicesWith(this)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceSessionInterleavingTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceSessionInterleavingTest.kt
@@ -1,0 +1,100 @@
+package io.customer.geofence
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.GeofenceRegionStoreImpl
+import io.customer.sdk.core.util.Clock
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Session ownership is decided by two paths that can run at once, so state assertions alone do not
+ * cover it. These tests run one path against the real store while the other lands inside it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class GeofenceSessionInterleavingTest : RobolectricTest() {
+
+    private lateinit var store: GeofenceRegionStoreImpl
+
+    private val repository: GeofenceRepository = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val permissionChecker: GeofencePermissionChecker = mockk {
+        every { hasRequiredLocationPermissions() } returns true
+        every { isBackgroundDeliveryAvailable() } returns true
+    }
+    private val clock: Clock = mockk { every { elapsedRealtime() } returns 10_000L }
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { argument(ApplicationArgument(applicationMock)) })
+        store = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        )
+        store.clearAll()
+        coEvery { repository.refresh(any(), any()) } returns Result.success(Unit)
+    }
+
+    private fun servicesWith(scope: TestScope) = GeofenceServicesImpl(
+        repository = repository,
+        secureUserStore = secureUserStore,
+        regionStore = store,
+        scope = scope,
+        logger = mockk(relaxed = true),
+        permissionChecker = permissionChecker,
+        clock = clock
+    )
+
+    @Test
+    fun onAppLaunch_givenAnIdentifyLandsBetweenTheReadAndTheStore_expectTheNewerSessionKept() =
+        runTest(StandardTestDispatcher()) {
+            // Launch reads user-a, an identify for user-b opens and arms its session, then launch
+            // reaches the store. Reopening user-a here would clear routing with no pass queued to
+            // re-arm it, so the next business callback would be dropped as unarmed.
+            every { secureUserStore.getUserId() } answers {
+                store.beginUserSession(USER_B)
+                store.saveRoutableRegisteredIdsIfCurrent(setOf(FENCE), store.userStateGeneration())
+                USER_A
+            }
+            val generationBefore = store.userStateGeneration()
+
+            servicesWith(this).onAppLaunch(latitude = 1.0, longitude = 2.0)
+            advanceUntilIdle()
+
+            store.activeUserSessionId() shouldBeEqualTo USER_B
+            store.getRoutableRegisteredIds() shouldContainSame setOf(FENCE)
+            // The identify's own open is the only one that moved the generation.
+            store.userStateGeneration() shouldBeEqualTo generationBefore + 1L
+        }
+
+    @Test
+    fun onAppLaunch_givenNoSession_expectLaunchOpensOne() = runTest(StandardTestDispatcher()) {
+        every { secureUserStore.getUserId() } returns USER_A
+
+        servicesWith(this).onAppLaunch(latitude = 1.0, longitude = 2.0)
+        advanceUntilIdle()
+
+        store.activeUserSessionId() shouldBeEqualTo USER_A
+    }
+
+    private companion object {
+        const val USER_A = "user-a"
+        const val USER_B = "user-b"
+        const val FENCE = "g-1"
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -17,6 +17,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -41,6 +42,11 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         logger = mockLogger
     )
 
+    @Before
+    fun setUpTransitionStaging() {
+        every { mockRegionStore.savePendingTransitionEntries(any(), any()) } returns true
+    }
+
     /** Defaults describe the common case: an ENTER on a fence monitoring both transitions. */
     private suspend fun emit(
         geofenceId: String = "biz-1",
@@ -62,7 +68,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenCooldownSuppresses_expectFalseAndNoPersist() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns false
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns false
 
         val emitted = emit()
 
@@ -73,7 +79,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenNoGeosets_expectSingleNullGeosetEntryPersistedAndScheduled() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
@@ -90,7 +96,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenMultipleGeosets_expectPerGeosetFanoutWithSharedTransitionId() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
@@ -107,7 +113,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     fun emit_givenSchedulerThrowsForOneGeoset_expectRemainingStillScheduled() = runTest {
         // A scheduler failure for one geoset must not abandon the rest of the batch; the row is
         // already persisted, so the foreground flush still delivers the un-scheduled one.
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
         coEvery { mockScheduler.schedule(match { it.geosetId == "g1" }) } throws RuntimeException("boom")
 
@@ -120,13 +126,13 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenPersistFails_expectCooldownReleasedAndFalse() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns false
 
         val emitted = emit()
 
         emitted.shouldBeFalse()
-        verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
+        verify(exactly = 0) { mockCooldownFilter.record(any(), any(), any()) }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
     }
 
@@ -138,14 +144,14 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
         emitted.shouldBeFalse()
         // Ahead of the cooldown, so the slot stays free for the next genuine transition.
-        verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
     }
 
     @Test
     fun emit_givenEnterOnlyFenceAlreadyReported_expectDelivered() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
         val emitted = emit(monitorsExit = false)
@@ -157,7 +163,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenEnterOnlyFenceDelivered_expectNoMarkRecorded() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit(monitorsExit = false)
@@ -168,7 +174,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     @Test
     fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
         val emitted = emit(transition = Event.GeofenceTransition.EXIT)
@@ -178,18 +184,19 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
-    fun emit_givenEnterDelivered_expectMarkedReported() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+    fun emit_givenEnterDelivered_expectStageCommittedAtomically() = runTest {
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit()
 
-        verify(exactly = 1) { mockRegionStore.markEnterEmitted("user-1", "biz-1") }
+        verify(exactly = 1) { mockRegionStore.savePendingTransitionEntries(any(), any()) }
+        verify(exactly = 1) { mockRegionStore.completePendingTransition(any()) }
     }
 
     @Test
     fun emit_givenEnterPersistFails_expectNotMarkedSoRetryCanDeliver() = runTest {
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns false
 
         emit()
@@ -201,12 +208,148 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     @Test
     fun emit_givenExitDelivered_expectMarkNotTouchedHere() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns true
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit(transition = Event.GeofenceTransition.EXIT)
 
         // Re-arming belongs to `claimExit`, which runs whether or not delivery gets this far.
         verify(exactly = 0) { mockRegionStore.markEnterEmitted(any(), any()) }
+    }
+
+    @Test
+    fun recoverPendingTransitions_givenCrashBeforeOutboxAppend_expectStableRowsQueuedAndStageCompleted() = runTest {
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "stable-transition",
+            marksEnterReported = true
+        )
+        every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(staged)
+        every { mockPendingStore.appendAll(listOf(staged)) } returns true
+        every { mockRegionStore.completePendingTransition("stable-transition") } returns true
+
+        emitter.recoverPendingTransitions()
+
+        verify { mockPendingStore.appendAll(listOf(staged)) }
+        verify { mockCooldownFilter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
+        coVerify { mockScheduler.schedule(staged) }
+        verify { mockRegionStore.completePendingTransition("stable-transition") }
+    }
+
+    @Test
+    fun recoverPendingTransitions_givenOldUserGeneration_expectDeliversButDoesNotRestoreContainment() = runTest {
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "old-user",
+            transitionId = "stable-transition",
+            stateGeneration = 4L
+        )
+        every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(staged)
+        every { mockRegionStore.userStateGeneration() } returns 5L
+        every { mockPendingStore.appendAll(listOf(staged)) } returns true
+
+        emitter.recoverPendingTransitions()
+
+        verify { mockPendingStore.appendAll(listOf(staged)) }
+        coVerify { mockScheduler.schedule(staged) }
+        verify { mockRegionStore.completePendingTransition("stable-transition") }
+        verify(exactly = 0) {
+            mockRegionStore.commitBusinessTransition(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun recoverPendingTransitions_givenOlderAppendStillFails_expectLaterAttemptDoesNotOvertake() = runTest {
+        val enter = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 100L,
+            userId = "user-1",
+            transitionId = "enter-transition"
+        )
+        val exit = enter.copy(
+            transition = Event.GeofenceTransition.EXIT,
+            timestamp = 101L,
+            transitionId = "exit-transition"
+        )
+        every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(enter, exit)
+        every { mockPendingStore.appendAll(listOf(enter)) } returns false
+
+        emitter.recoverPendingTransitions().shouldBeFalse()
+
+        verify(exactly = 1) { mockPendingStore.appendAll(listOf(enter)) }
+        verify(exactly = 0) { mockPendingStore.appendAll(listOf(exit)) }
+    }
+
+    @Test
+    fun emit_givenOlderAppendStillFails_expectNewOppositeEdgeOnlyStaged() = runTest {
+        val enter = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 99L,
+            userId = "user-1",
+            transitionId = "enter-transition"
+        )
+        every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(enter)
+        every { mockPendingStore.appendAll(listOf(enter)) } returns false
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+
+        emit(transition = Event.GeofenceTransition.EXIT).shouldBeFalse()
+
+        verify {
+            mockRegionStore.savePendingTransitionEntries(
+                match { entries -> entries.all { it.transition == Event.GeofenceTransition.EXIT } },
+                any()
+            )
+        }
+        verify(exactly = 0) {
+            mockPendingStore.appendAll(
+                match { entries ->
+                    entries.any { it.transition == Event.GeofenceTransition.EXIT }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun emitWithRetainedAttempt_givenOlderSameDirectionStage_expectNewPhysicalEdgeIsStagedSeparately() = runTest {
+        val olderEnter = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 99L,
+            userId = "user-1",
+            transitionId = "older-enter"
+        )
+        every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(olderEnter)
+        every {
+            mockRegionStore.getPendingTransitionEntries("user-1", "biz-1", Event.GeofenceTransition.ENTER)
+        } returns listOf(olderEnter)
+        every { mockPendingStore.appendAll(listOf(olderEnter)) } returns false
+        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        val staged = slot<List<PendingGeofenceDelivery>>()
+
+        emitter.emitWithRetainedAttempt(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            userId = "user-1",
+            timestampSeconds = 101L,
+            geofenceName = null,
+            metadata = emptyMap(),
+            geosetIds = emptyList(),
+            monitorsExit = true,
+            expectedUserStateGeneration = 0L,
+            expectedRegionRevision = null
+        ) shouldBeEqualTo GeofenceTransitionEmitter.Result.PERSIST_FAILED
+
+        verify { mockRegionStore.savePendingTransitionEntries(capture(staged), 0L) }
+        staged.captured.single().let { newest ->
+            (newest.transitionId != olderEnter.transitionId).shouldBeTrue()
+            newest.timestamp shouldBeEqualTo 101L
+        }
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
@@ -1,0 +1,179 @@
+package io.customer.geofence
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.store.GeofenceRegionStoreImpl
+import io.customer.geofence.store.PendingGeofenceDelivery
+import io.customer.geofence.worker.GeofenceEventScheduler
+import io.customer.sdk.communication.Event
+import io.customer.sdk.data.store.PendingDeliveryStore
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Physical containment and durable delivery are two different facts, and storage can fail for either
+ * one independently. These tests pin what the device is believed to be *inside* across a full
+ * ENTER → EXIT visit while the durable outbox is unavailable — the case where getting containment
+ * wrong silently corrupts every later transition for that fence.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeofenceTransitionStagingContainmentTest : RobolectricTest() {
+
+    private val cooldownFilter: GeofenceCooldownFilter = mockk(relaxed = true)
+    private val scheduler: GeofenceEventScheduler = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val logger: GeofenceLogger = mockk(relaxed = true)
+    private lateinit var regionStore: GeofenceRegionStoreImpl
+    private lateinit var outbox: PendingDeliveryStore<PendingGeofenceDelivery>
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        regionStore = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        ).also { it.clearAll() }
+        regionStore.saveCachedRegions(listOf(region()))
+        regionStore.beginUserSession(USER_ID)
+        regionStore.saveRegisteredIds(setOf(GEOFENCE_ID))
+        regionStore.saveRoutableRegisteredIds(setOf(GEOFENCE_ID))
+        every { secureUserStore.getUserId() } returns USER_ID
+        every { cooldownFilter.isAllowed(any(), any(), any()) } returns true
+        outbox = spyk(
+            PendingDeliveryStore(
+                context = applicationMock,
+                fileName = "cio_test_staging_outbox.json",
+                elementSerializer = PendingGeofenceDelivery.serializer(),
+                logger = mockk(relaxed = true)
+            )
+        ).also { it.removeAll() }
+    }
+
+    @Test
+    fun process_givenOutboxUnavailableAcrossEnterThenExit_expectContainmentTracksPhysicalTruth() = runTest {
+        val processor = processor()
+        every { outbox.appendAll(any()) } returns false
+
+        // ENTER: the stage commits containment in the same write, so the device is INSIDE even though
+        // nothing is deliverable yet.
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.ENTER, timestampSeconds = 100L)
+
+        regionStore.getEnteredIds() shouldContainSame setOf(GEOFENCE_ID)
+        regionStore.getAllPendingTransitionEntries().map { it.transition } shouldBeEqualTo
+            listOf(Event.GeofenceTransition.ENTER)
+
+        // EXIT: still nothing deliverable, but the device really did leave. Containment must follow the
+        // physical edge; leaving it INSIDE would make the next ENTER look redundant and be dropped.
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.EXIT, timestampSeconds = 200L)
+
+        regionStore.getEnteredIds().shouldBeEmpty()
+        regionStore.getAllPendingTransitionEntries().map { it.transition } shouldBeEqualTo
+            listOf(Event.GeofenceTransition.ENTER, Event.GeofenceTransition.EXIT)
+    }
+
+    @Test
+    fun process_givenOutboxRecoversAfterEnterThenExit_expectBothDeliveredInOrderAndStagingCleared() = runTest {
+        val processor = processor()
+        every { outbox.appendAll(any()) } returns false
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.ENTER, timestampSeconds = 100L)
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.EXIT, timestampSeconds = 200L)
+
+        every { outbox.appendAll(any()) } answers { callOriginal() }
+        processor.recoverPendingTransitions().shouldBeTrue()
+
+        outbox.loadAll().map { it.transition } shouldBeEqualTo
+            listOf(Event.GeofenceTransition.ENTER, Event.GeofenceTransition.EXIT)
+        outbox.loadAll().map { it.timestamp } shouldBeEqualTo listOf(100L, 200L)
+        regionStore.getAllPendingTransitionEntries().shouldBeEmpty()
+        // Recovery only completes the delivery handoff; replaying the older ENTER's containment here
+        // would resurrect a visit the device has already left.
+        regionStore.getEnteredIds().shouldBeEmpty()
+    }
+
+    @Test
+    fun process_givenStagingWriteItselfFails_expectContainmentUnchangedSoNothingIsInvented() = runTest {
+        val stagingStore = spyk(regionStore) {
+            every { savePendingTransitionEntries(any(), any()) } returns false
+        }
+        val processor = GeofenceBusinessTransitionProcessor(
+            store = stagingStore,
+            secureUserStore = secureUserStore,
+            transitionEmitter = emitter(stagingStore),
+            logger = logger
+        )
+
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.ENTER, timestampSeconds = 100L)
+
+        // Neither the event nor the state is durable, so the device must not be believed inside. A
+        // later fix re-observes the same edge and stages it again.
+        regionStore.getEnteredIds().shouldBeEmpty()
+        outbox.loadAll().shouldBeEmpty()
+    }
+
+    @Test
+    fun process_givenEnterStagedThenExitWhileStagingFails_expectStillBelievedInsideForRetry() = runTest {
+        val processor = processor()
+        every { outbox.appendAll(any()) } returns false
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.ENTER, timestampSeconds = 100L)
+        regionStore.getEnteredIds() shouldContainSame setOf(GEOFENCE_ID)
+
+        val stagingStore = spyk(regionStore) {
+            every { savePendingTransitionEntries(any(), any()) } returns false
+        }
+        GeofenceBusinessTransitionProcessor(
+            store = stagingStore,
+            secureUserStore = secureUserStore,
+            transitionEmitter = emitter(stagingStore),
+            logger = logger
+        ).process(GEOFENCE_ID, Event.GeofenceTransition.EXIT, timestampSeconds = 200L)
+
+        // The EXIT reached nothing durable, so containment stays INSIDE and the exit remains reportable
+        // the next time a fix confirms it. Clearing it here would drop the exit permanently.
+        regionStore.getEnteredIds() shouldContainSame setOf(GEOFENCE_ID)
+    }
+
+    private fun processor() = GeofenceBusinessTransitionProcessor(
+        store = regionStore,
+        secureUserStore = secureUserStore,
+        transitionEmitter = emitter(regionStore),
+        logger = logger
+    )
+
+    private fun emitter(store: GeofenceRegionStoreImpl) = GeofenceTransitionEmitter(
+        cooldownFilter = cooldownFilter,
+        pendingStore = outbox,
+        scheduler = scheduler.also { coEvery { it.schedule(any()) } returns Unit },
+        regionStore = store,
+        logger = logger
+    )
+
+    private fun region() = GeofenceRegion(
+        id = GEOFENCE_ID,
+        latitude = 0.0,
+        longitude = 0.0,
+        radius = 100f,
+        transitionTypes = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT)
+    )
+
+    private companion object {
+        const val USER_ID = "user-1"
+        const val GEOFENCE_ID = "biz-1"
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
@@ -108,6 +108,30 @@ class GeofenceTransitionStagingContainmentTest : RobolectricTest() {
     }
 
     @Test
+    fun recoverPendingTransitions_givenExitAlreadyQueuedWhileOlderEnterIsStillStaged_expectEnterFirst() = runTest {
+        val processor = processor()
+        // ENTER stages, but its outbox append fails, so the queue never sees it.
+        every { outbox.appendAll(any()) } returns false
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.ENTER, timestampSeconds = 100L)
+
+        // The EXIT's append succeeds. Emission drains older staged attempts before appending its
+        // own, so the ENTER is restored ahead of the EXIT rather than being queued behind it — the
+        // queue can never hold the later edge alone while an earlier one is still staged.
+        every { outbox.appendAll(any()) } answers { callOriginal() }
+        processor.process(GEOFENCE_ID, Event.GeofenceTransition.EXIT, timestampSeconds = 200L)
+        outbox.loadAll().map { it.transition } shouldBeEqualTo
+            listOf(Event.GeofenceTransition.ENTER, Event.GeofenceTransition.EXIT)
+
+        // A second, explicit recovery re-appends both by key. appendAll replaces a matching row
+        // rather than duplicating it, and staged order is physical order, so the queue is stable.
+        processor.recoverPendingTransitions().shouldBeTrue()
+
+        outbox.loadAll().map { it.transition } shouldBeEqualTo
+            listOf(Event.GeofenceTransition.ENTER, Event.GeofenceTransition.EXIT)
+        outbox.loadAll().map { it.timestamp } shouldBeEqualTo listOf(100L, 200L)
+    }
+
+    @Test
     fun process_givenStagingWriteItselfFails_expectContainmentUnchangedSoNothingIsInvented() = runTest {
         val stagingStore = spyk(regionStore) {
             every { savePendingTransitionEntries(any(), any()) } returns false

--- a/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
@@ -1,0 +1,152 @@
+package io.customer.geofence
+
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.api.GeofenceApiResponse
+import io.customer.geofence.api.GeofenceApiService
+import io.customer.geofence.store.GeofenceRegionStoreImpl
+import io.customer.sdk.core.util.Clock
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The trade made by opening an unowned session as a switch, against the real store rather than a
+ * stub: registrations survive it and a refresh re-arms them. Both halves matter, so both are here.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeofenceUnownedSessionRealStoreTest : RobolectricTest() {
+
+    private lateinit var store: GeofenceRegionStoreImpl
+    private lateinit var repository: GeofenceRepositoryImpl
+
+    private val apiService: GeofenceApiService = mockk(relaxed = true)
+    private val manager: GeofenceManager = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val clock: Clock = mockk(relaxed = true)
+    private val packageInfo: GeofencePackageInfo = mockk { every { lastUpdateTimeMs() } returns null }
+    private val jsonSerializer = GeofenceJsonSerializer()
+
+    private val fence = GeofenceRegion("biz-1", 0.0, 0.0, 100f)
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { argument(ApplicationArgument(applicationMock)) })
+        store = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = jsonSerializer,
+            logger = mockk(relaxed = true)
+        )
+        store.clearAll()
+        every { secureUserStore.getUserId() } returns USER
+        every { clock.elapsedRealtime() } returns 10_000L
+        every { clock.currentTimeMillis() } returns System.currentTimeMillis()
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+        repository = GeofenceRepositoryImpl(
+            apiService = apiService,
+            store = store,
+            distanceFilter = GeofenceDistanceFilter(),
+            manager = manager,
+            secureUserStore = secureUserStore,
+            cooldownFilter = mockk(relaxed = true),
+            transitionEmitter = mockk(relaxed = true),
+            clock = clock,
+            packageInfo = packageInfo,
+            logger = mockk(relaxed = true)
+        )
+        // An install upgraded from a version that stored registrations but no session owner.
+        store.saveCachedRegions(listOf(fence))
+        store.saveCachedConfig(sampleConfig())
+        store.saveRegisteredIds(setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, fence.id))
+        store.saveLastApiFetchLocation(GeofenceLocation(0.0, 0.0))
+        store.setLastSyncTimestamp(System.currentTimeMillis())
+        store.saveLastMovementTriggerLocation(GeofenceLocation(0.0, 0.0))
+        store.setLastRegistrationUptime(clock.elapsedRealtime())
+    }
+
+    @Test
+    fun unownedSession_expectRegistrationsKeptButNothingRoutableUntilARefreshArmsThem() = runTest {
+        store.activeUserSessionId().shouldBeNull()
+        val generationBefore = store.userStateGeneration()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.success(sampleResponse())
+
+        store.beginUserSession(USER)
+
+        // Opened as a switch, not adopted: the generation moves, so a pass that began before this
+        // cannot arm routing for it. The cost is registered but unarmed, so the OS keeps reporting
+        // and nothing is attributed to this user yet.
+        store.userStateGeneration() shouldBeEqualTo generationBefore + 1L
+        store.getRegisteredIds() shouldContain fence.id
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        store.getRoutableRegisteredIds() shouldContainSame store.getRegisteredIds()
+        store.getCachedRegions().map { it.id } shouldContainSame listOf("g-1")
+        store.userStateGeneration() shouldBeEqualTo generationBefore + 1L
+    }
+
+    @Test
+    fun unownedSessionWithNoNetwork_expectMovementReArmsRoutingFromTheCache() = runTest {
+        // The justification for the trade: an upgrade with no network still recovers, because the
+        // movement trigger is exempt from the unarmed drop and its pass re-ranks from the catalog.
+        coEvery { apiService.fetchGeofences(any()) } returns Result.failure(IOException("offline"))
+
+        store.beginUserSession(USER)
+        repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Not just "empty": empty because the fetch was attempted and failed. Without this the
+        // assertion also holds when the pass never fetched at all.
+        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+
+        repository.handleMovement(latitude = 0.0, longitude = 0.0)
+
+        store.getRoutableRegisteredIds() shouldContainSame store.getRegisteredIds()
+        store.getRoutableRegisteredIds() shouldContain fence.id
+    }
+
+    private fun sampleResponse(): GeofenceApiResponse {
+        val json = """
+            {
+              "config": {
+                "local_refresh_trigger_radius": 1000,
+                "remote_fetch_refresh_trigger_radius": 5000,
+                "remote_fetch_refresh_expiry_time": 86400000,
+                "duplicate_events_expiry_time": 3600000,
+                "android": { "max_business_geofence": 19 }
+              },
+              "geofences": [
+                { "id": "g-1", "name": "n1", "latitude": 0.0, "longitude": 0.0, "radius": 100, "transition_types": ["enter"], "last_updated": 1 }
+              ]
+            }
+        """.trimIndent()
+        return jsonSerializer.decode(GeofenceApiResponse.serializer(), json)
+    }
+
+    private fun sampleConfig() = GeofenceConfig(
+        localRefreshTriggerRadius = 1_000f,
+        remoteFetchRefreshTriggerRadius = 5_000f,
+        remoteFetchRefreshExpiry = 86_400_000L,
+        duplicateEventsExpiry = 3_600_000L,
+        maxBusinessGeofences = 19,
+        maxMonitoringDistance = GeofenceConstants.NO_MONITORING_DISTANCE_CAP_METERS
+    )
+
+    private companion object {
+        const val USER = "user-42"
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldContainSame
 import org.junit.Test
@@ -100,22 +101,50 @@ class GeofenceUnownedSessionRealStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun unownedSessionWithNoNetwork_expectMovementReArmsRoutingFromTheCache() = runTest {
-        // The justification for the trade: an upgrade with no network still recovers, because the
-        // movement trigger is exempt from the unarmed drop and its pass re-ranks from the catalog.
+    fun unownedSessionWithNoNetwork_expectRoutingArmedFromTheCachedCatalog() = runTest {
+        // Without this the switch would strand an offline upgrade: fences registered, routing empty,
+        // and no completing pass to arm them until the network returns or the device leaves the
+        // trigger radius. The remote pass still reports its failure; the re-rank is what recovers.
         coEvery { apiService.fetchGeofences(any()) } returns Result.failure(IOException("offline"))
 
         store.beginUserSession(USER)
+        val result = repository.refresh(latitude = 0.0, longitude = 0.0)
+
+        // Armed because the fetch was attempted and failed, not because it never ran.
+        coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
+        result.isFailure shouldBeEqualTo true
+        store.getRoutableRegisteredIds() shouldContainSame store.getRegisteredIds()
+        store.getRoutableRegisteredIds() shouldContain fence.id
+    }
+
+    @Test
+    fun armedSessionWithNoNetwork_expectNoLocalReRank() = runTest {
+        // The re-rank recovers an unarmed session; it is not a general fallback. A session already
+        // routing must not re-register from a stale cache every time a fetch happens to fail.
+        store.beginUserSession(USER)
+        store.saveRoutableRegisteredIdsIfCurrent(store.getRegisteredIds(), store.userStateGeneration())
+            .shouldBeTrue()
+        coEvery { apiService.fetchGeofences(any()) } returns Result.failure(IOException("offline"))
+
         repository.refresh(latitude = 0.0, longitude = 0.0)
 
-        // Not just "empty": empty because the fetch was attempted and failed. Without this the
-        // assertion also holds when the pass never fetched at all.
+        // The remote attempt has to have happened, or "did not re-register" is true only because
+        // the pass never went remote at all.
         coVerify(exactly = 1) { apiService.fetchGeofences(any()) }
-        store.getRoutableRegisteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
+        store.getRoutableRegisteredIds() shouldContainSame store.getRegisteredIds()
+    }
+
+    @Test
+    fun unownedSessionWithNoNetwork_expectMovementAlsoReArmsFromTheCache() = runTest {
+        // The other half of the recovery, and the one the movement trigger's unarmed exemption
+        // exists for: a wake with no network still re-ranks rather than leaving the session dark.
+        coEvery { apiService.fetchGeofences(any()) } returns Result.failure(IOException("offline"))
+        store.beginUserSession(USER)
+        store.saveRoutableRegisteredIdsIfCurrent(emptySet(), store.userStateGeneration()).shouldBeTrue()
 
         repository.handleMovement(latitude = 0.0, longitude = 0.0)
 
-        store.getRoutableRegisteredIds() shouldContainSame store.getRegisteredIds()
         store.getRoutableRegisteredIds() shouldContain fence.id
     }
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -501,6 +501,36 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun getRoutableRegisteredIds_givenIdentifySwitchThenRefresh_expectRoutingRearmed() {
+        // The A-to-B loop end to end: A is registered and routable, identify B clears routing, and
+        // the refresh that follows re-arms it. Without the re-arm the explicit empty set persists and
+        // every later callback is classified as unknown.
+        store.beginUserSession("user-a")
+        store.saveRegisteredIds(setOf("biz-1"))
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1"), store.userStateGeneration())
+        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1")
+
+        store.beginUserSession("user-b")
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+
+        store.saveRegisteredIds(setOf("biz-2"))
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-2"), store.userStateGeneration())
+
+        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-2")
+    }
+
+    @Test
+    fun saveRoutableRegisteredIdsIfCurrent_givenStaleGeneration_expectRefusedAndRoutingLeftCleared() {
+        store.beginUserSession("user-a")
+        val staleGeneration = store.userStateGeneration()
+        store.beginUserSession("user-b")
+
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1"), staleGeneration) shouldBeEqualTo false
+
+        store.getRoutableRegisteredIds().shouldBeEmpty()
+    }
+
+    @Test
     fun saveRegisteredIds_thenGet_expectRoundTrip() {
         val ids = setOf("cio_movement_trigger", "biz-1", "biz-2")
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -1177,7 +1177,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.getCoarseInsidePolygonIds().shouldBeEmpty()
         store.getEnteredIds().shouldBeEmpty()
         store.hasEmittedEnter(USER, registered.id).shouldBeFalse()
-        store.hasActiveUserSession().shouldBeFalse()
+        store.activeUserSessionId().shouldBeNull()
         store.userStateGeneration() shouldBeEqualTo generation + 1L
         store.getLastSyncTimestamp().shouldBeNull()
 

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -421,7 +421,11 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun beginUserSession_givenLegacyRegistrationsWithoutOwnerOrRoutingKey_expectAdoptsWithoutCoverageLoss() {
+    fun beginUserSession_givenLegacyRegistrationsWithoutOwner_expectRegistrationsKeptAndSessionReopened() {
+        // Nothing records who the persisted state belongs to, so it opens as a switch rather than
+        // being adopted on the assumption that the caller names its owner. Registrations survive,
+        // so the live fences keep firing; routing and containment do not, so nothing is attributed
+        // to this user until a refresh re-arms them.
         store.saveRegisteredIds(setOf("biz-1"))
         store.recordEntered("biz-1")
         val recreated = GeofenceRegionStoreImpl(
@@ -429,13 +433,15 @@ class GeofenceRegionStoreTest : RobolectricTest() {
             jsonSerializer = GeofenceJsonSerializer(),
             logger = mockk(relaxed = true)
         )
+        val generationBefore = recreated.userStateGeneration()
 
         recreated.beginUserSession("user-1")
 
         recreated.activeUserSessionId() shouldBeEqualTo "user-1"
         recreated.getRegisteredIds() shouldBeEqualTo setOf("biz-1")
-        recreated.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1")
-        recreated.getEnteredIds() shouldBeEqualTo setOf("biz-1")
+        recreated.userStateGeneration() shouldBeEqualTo generationBefore + 1L
+        recreated.getRoutableRegisteredIds().shouldBeEmpty()
+        recreated.getEnteredIds().shouldBeEmpty()
     }
 
     @Test
@@ -501,22 +507,17 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun beginUserSession_givenLegacyInstallAdoptedMidRefresh_expectInFlightWriteStillArmsRouting() {
-        // Upgraded install: registrations persisted, no session owner and no routing key. A launch
-        // refresh snapshots the generation, then a callback adopts that same user while the refresh
-        // waits on GMS. Adoption changes no user, so it must not invalidate the pass: if it did, the
-        // pass would still save its registered ids but skip the catalog it gates on the generation,
-        // and routing falls back to those ids here, so the new fence would fire with no cached row.
+    fun beginUserSession_givenUnownedStateAndAnInFlightPass_expectThatPassRefused() {
+        // The pass began before anyone owned this state, so it cannot arm routing for the session
+        // that now does. Refusing is what sends the incoming user down its own refresh instead of
+        // inheriting a set that was ranked for someone else.
         store.saveRegisteredIds(setOf("biz-1"))
         val inFlightGeneration = store.userStateGeneration()
 
         store.beginUserSession("user-1")
 
-        store.activeUserSessionId() shouldBeEqualTo "user-1"
-        store.userStateGeneration() shouldBeEqualTo inFlightGeneration
-        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1", "biz-2"), inFlightGeneration)
-            .shouldBeTrue()
-        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1", "biz-2")
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1"), inFlightGeneration).shouldBeFalse()
+        store.getRoutableRegisteredIds().shouldBeEmpty()
     }
 
     @Test
@@ -567,10 +568,12 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun getRoutableRegisteredIds_givenPreFeatureStore_expectFallsBackToRegisteredIds() {
+    fun getRoutableRegisteredIds_givenRegistrationsNoSessionHasClaimed_expectEmpty() {
+        // A registration routes only once a pass has armed it for a known session. Falling back to
+        // the registered set would route a previous install's fences for whoever identifies next.
         store.saveRegisteredIds(setOf("biz-legacy"))
 
-        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-legacy")
+        store.getRoutableRegisteredIds().shouldBeEmpty()
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -501,6 +501,25 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun beginUserSession_givenLegacyInstallAdoptedMidRefresh_expectInFlightWriteStillArmsRouting() {
+        // Upgraded install: registrations persisted, no session owner and no routing key. A launch
+        // refresh snapshots the generation, then a callback adopts that same user while the refresh
+        // waits on GMS. Adoption changes no user, so it must not invalidate the pass: if it did, the
+        // pass would still save its registered ids but skip the catalog it gates on the generation,
+        // and routing falls back to those ids here, so the new fence would fire with no cached row.
+        store.saveRegisteredIds(setOf("biz-1"))
+        val inFlightGeneration = store.userStateGeneration()
+
+        store.beginUserSession("user-1")
+
+        store.activeUserSessionId() shouldBeEqualTo "user-1"
+        store.userStateGeneration() shouldBeEqualTo inFlightGeneration
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1", "biz-2"), inFlightGeneration)
+            .shouldBeTrue()
+        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1", "biz-2")
+    }
+
+    @Test
     fun getRoutableRegisteredIds_givenIdentifySwitchThenRefresh_expectRoutingRearmed() {
         // The A-to-B loop end to end: A is registered and routable, identify B clears routing, and
         // the refresh that follows re-arms it. Without the re-arm the explicit empty set persists and

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -445,6 +445,44 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun beginUserSessionIfAbsent_givenNoOwner_expectSessionOpened() {
+        val generationBefore = store.userStateGeneration()
+
+        store.beginUserSessionIfAbsent("user-1")
+
+        store.activeUserSessionId() shouldBeEqualTo "user-1"
+        store.userStateGeneration() shouldBeEqualTo generationBefore + 1L
+    }
+
+    @Test
+    fun beginUserSessionIfAbsent_givenADifferentOwner_expectSessionUntouched() {
+        // The whole point of the variant: a caller that read its user earlier must not undo a
+        // session opened since, so routing armed for the current owner survives.
+        store.beginUserSession("user-2")
+        val generation = store.userStateGeneration()
+        store.saveRoutableRegisteredIdsIfCurrent(setOf("biz-1"), generation).shouldBeTrue()
+
+        store.beginUserSessionIfAbsent("user-1")
+
+        store.activeUserSessionId() shouldBeEqualTo "user-2"
+        store.userStateGeneration() shouldBeEqualTo generation
+        store.getRoutableRegisteredIds() shouldBeEqualTo setOf("biz-1")
+    }
+
+    @Test
+    fun beginUserSessionIfAbsent_givenSignOutClearedTheOwner_expectSessionOpened() {
+        // Absent means no owner, not "never opened": sign-out has already moved the generation on,
+        // and a persisted re-identify still has to open a session here.
+        store.beginUserSession("user-1")
+        store.clearUserScopedState()
+        store.activeUserSessionId().shouldBeNull()
+
+        store.beginUserSessionIfAbsent("user-1")
+
+        store.activeUserSessionId() shouldBeEqualTo "user-1"
+    }
+
+    @Test
     fun completeUserReset_givenNewUserBeganWhileOsClearWasInFlight_expectPreservesNewOwner() {
         store.beginUserSession("user-A")
         val resetGeneration = store.userStateGeneration()

--- a/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/PendingGeofenceDeliveryTest.kt
@@ -18,20 +18,35 @@ class PendingGeofenceDeliveryTest {
     fun key_givenNoGeoset_expectNoneSuffix() {
         val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A", transitionId = "tid-1")
 
-        // Doubles as the WorkManager unique-work name so the flush can cancel by key.
-        // transitionId is intentionally NOT part of the key.
-        entry.key shouldBeEqualTo "biz-1_ENTER_1234_none"
+        // Doubles as the WorkManager unique-work name so the flush can cancel by key. The stable
+        // transition ID keeps distinct crossings separate even when they happen in the same second.
+        entry.key shouldBeEqualTo "biz-1_ENTER_tid-1_none"
     }
 
     @Test
     fun key_givenGeoset_expectGeosetInKey() {
-        // The per-geoset fan-out shares (geofenceId, transition, timestamp); the geoset keeps keys
+        // The per-geoset fan-out shares a transition ID; the geoset keeps keys
         // distinct so the entries don't overwrite each other in the store / WorkManager.
         val enter7 = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 1_234L, "user-A", transitionId = "tid-1", geosetId = "7")
         val enter8 = enter7.copy(geosetId = "8")
 
-        enter7.key shouldBeEqualTo "biz-1_ENTER_1234_7"
-        enter8.key shouldBeEqualTo "biz-1_ENTER_1234_8"
+        enter7.key shouldBeEqualTo "biz-1_ENTER_tid-1_7"
+        enter8.key shouldBeEqualTo "biz-1_ENTER_tid-1_8"
+    }
+
+    @Test
+    fun key_givenDistinctCrossingsInSameSecond_expectDistinctKeys() {
+        val first = PendingGeofenceDelivery(
+            "biz-1",
+            Event.GeofenceTransition.ENTER,
+            1_234L,
+            "user-A",
+            transitionId = "tid-1"
+        )
+        val second = first.copy(transitionId = "tid-2")
+
+        first.key shouldBeEqualTo "biz-1_ENTER_tid-1_none"
+        second.key shouldBeEqualTo "biz-1_ENTER_tid-2_none"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -53,7 +53,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
         // At-least-once contract: send with the snapshotted entry, remove only after success.
         coVerify(exactly = 1) { mockTracker.trackEvent(entry) }
-        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_42_none") }
+        verify(exactly = 1) { mockStore.remove("biz-1_ENTER_tid-1_none") }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventSchedulerTest.kt
@@ -65,17 +65,15 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         verify(exactly = 1) {
             workManager.enqueueUniqueWork(
                 capture(uniqueKeySlot),
-                ExistingWorkPolicy.KEEP,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
                 capture(workRequestSlot)
             )
         }
-        uniqueKeySlot.captured shouldBeEqualTo "biz-geofence-1_ENTER_1234_none"
+        uniqueKeySlot.captured shouldBeEqualTo "cio-geofence-delivery-queue"
 
-        // inputData carries only the store key; the worker loads the full row from the pending store.
+        // WorkManager carries no event data; every node drains the oldest durable store row.
         val input = workRequestSlot.captured.workSpec.input
-        input.getString("entry_key") shouldBeEqualTo "biz-geofence-1_ENTER_1234_none"
-        input.hasKeyWithValueOfType("geofence_id", String::class.java) shouldBeEqualTo false
-        input.hasKeyWithValueOfType("metadata", String::class.java) shouldBeEqualTo false
+        input.keyValueMap.size shouldBeEqualTo 0
 
         val constraints = workRequestSlot.captured.workSpec.constraints
         constraints shouldNotBe null
@@ -100,12 +98,15 @@ class GeofenceEventSchedulerTest : RobolectricTest() {
         )
 
         verify(exactly = 1) {
-            workManager.enqueueUniqueWork(capture(uniqueKeySlot), ExistingWorkPolicy.KEEP, capture(workRequestSlot))
+            workManager.enqueueUniqueWork(
+                capture(uniqueKeySlot),
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                capture(workRequestSlot)
+            )
         }
-        // Key carries the geoset so per-geoset workers don't collide under ExistingWorkPolicy.KEEP,
-        // and it's the same key inputData carries for the worker's store lookup.
-        uniqueKeySlot.captured shouldBeEqualTo "biz-geofence-1_ENTER_1234_9"
-        workRequestSlot.captured.workSpec.input.getString("entry_key") shouldBeEqualTo "biz-geofence-1_ENTER_1234_9"
+        // All transitions share one continuation chain and the outbox owns their order.
+        uniqueKeySlot.captured shouldBeEqualTo "cio-geofence-delivery-queue"
+        workRequestSlot.captured.workSpec.input.keyValueMap.size shouldBeEqualTo 0
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -11,6 +11,7 @@ import io.customer.geofence.di.pendingGeofenceDeliveryStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.network.HttpRequestFailure
 import io.customer.sdk.data.store.PendingDeliveryStore
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -159,6 +160,43 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         val entry = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
         coEvery { tracker.trackEvent(any()) } returns
             Result.failure(IllegalStateException("bad state"))
+
+        val result = createWorker(inputDataFor(entry.key)).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.retry()
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_tid-seed_none")
+    }
+
+    @Test
+    fun doWork_givenPermanentlyRejectedHead_expectItDroppedAndLaterTransitionsDelivered() = runTest {
+        // Every non-2xx reaches us as an IOException subclass, so before the status was read a 400
+        // classified as retryable and this row was resent forever. One rejected payload then blocked
+        // every later ENTER and EXIT, because each node drains the oldest row.
+        val enter = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 1L, transitionId = "tid-enter")
+        val exit = seed("biz", Event.GeofenceTransition.EXIT, timestamp = 2L, transitionId = "tid-exit")
+        val attempts = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { tracker.trackEvent(any()) } coAnswers {
+            firstArg<PendingGeofenceDelivery>().also(attempts::add)
+            if (attempts.size == 1) {
+                Result.failure(HttpRequestFailure(400, "invalid payload"))
+            } else {
+                Result.success(Unit)
+            }
+        }
+
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        // The rejected head is dropped rather than retried, and the drain continues past it.
+        attempts shouldBeEqualTo listOf(enter, exit)
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun doWork_givenRetryableHttpStatus_expectRetryAndEntryKept() = runTest {
+        // The counterpart: a 503 is the server failing, not refusing, so the row must survive.
+        val entry = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
+        coEvery { tracker.trackEvent(any()) } returns
+            Result.failure(HttpRequestFailure(503, "unavailable"))
 
         val result = createWorker(inputDataFor(entry.key)).doWork()
 

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -11,9 +11,12 @@ import io.customer.geofence.di.pendingGeofenceDeliveryStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.data.store.PendingDeliveryStore
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonElement
@@ -105,17 +108,33 @@ class GeofenceEventWorkerTest : RobolectricTest() {
     fun doWork_givenEntryAlreadyDelivered_expectSuccessWithoutTracking() = runTest {
         // No matching entry in the store (the foreground flush already delivered + removed it):
         // the worker sees it's gone, so it must not send a duplicate.
-        val result = createWorker(inputDataFor("biz-already-delivered_ENTER_0_none")).doWork()
+        val result = createWorker(inputDataFor("biz-already-delivered_ENTER_tid-missing_none")).doWork()
 
         result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
     @Test
-    fun doWork_givenMissingEntryKey_expectFailureWithoutTracking() = runTest {
+    fun pendingStore_givenDistinctSameSecondCrossings_expectBothSurvive() {
+        val first = PendingGeofenceDelivery(
+            "biz",
+            Event.GeofenceTransition.ENTER,
+            42L,
+            "user-42",
+            transitionId = "tid-first"
+        )
+        val second = first.copy(transitionId = "tid-second")
+
+        store.appendAll(listOf(first, second))
+
+        store.loadAll() shouldBeEqualTo listOf(first, second)
+    }
+
+    @Test
+    fun doWork_givenEmptyOutbox_expectSuccessWithoutTracking() = runTest {
         val result = createWorker(Data.EMPTY).doWork()
 
-        result shouldBeEqualTo ListenableWorker.Result.failure()
+        result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
@@ -129,34 +148,116 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         result shouldBeEqualTo ListenableWorker.Result.retry()
         // Left in place so a WorkManager retry — or the foreground flush — can deliver later.
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0_none")
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_tid-seed_none")
     }
 
     @Test
-    fun doWork_givenNonIOException_expectFailureAndEntryRestored() = runTest {
+    fun doWork_givenNonIOException_expectRetryScheduledAndChainPreserved() = runTest {
+        // Not Result.failure(): that cancels the dependents and discards everything queued behind
+        // this row. Not Result.success() either: this node can be the last in the chain, and then
+        // nothing would ever come back for the head, stranding it and every later transition.
         val entry = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
         coEvery { tracker.trackEvent(any()) } returns
             Result.failure(IllegalStateException("bad state"))
 
         val result = createWorker(inputDataFor(entry.key)).doWork()
 
-        result shouldBeEqualTo ListenableWorker.Result.failure()
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_0_none")
+        result shouldBeEqualTo ListenableWorker.Result.retry()
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_tid-seed_none")
     }
 
     @Test
-    fun doWork_givenNullUserId_expectDeferredWithoutTracking() = runTest {
-        // Defensive-only: the receiver drops anonymous transitions before persisting, so a
-        // null-userId row shouldn't exist. If one does, leave it rather than send a track
-        // the backend would reject.
-        val entry = seed("biz-anon", Event.GeofenceTransition.ENTER, timestamp = 0L, userId = null)
+    fun doWork_givenTerminalFailureThenRecovery_expectHeadAndLaterTransitionsBothDelivered() = runTest {
+        // The retry a terminal failure schedules must be able to drain the whole queue, not just the
+        // row that failed.
+        val enter = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 1L, transitionId = "tid-enter")
+        val exit = seed("biz", Event.GeofenceTransition.EXIT, timestamp = 2L, transitionId = "tid-exit")
+        val attempts = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { tracker.trackEvent(any()) } coAnswers {
+            firstArg<PendingGeofenceDelivery>().also(attempts::add)
+            if (attempts.size == 1) {
+                Result.failure(IllegalStateException("terminal for now"))
+            } else {
+                Result.success(Unit)
+            }
+        }
+
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.retry()
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        attempts shouldBeEqualTo listOf(enter, enter, exit)
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun doWork_givenOlderFailure_expectNewerEntryCannotOvertakeIt() = runTest {
+        val enter = seed(
+            "biz",
+            Event.GeofenceTransition.ENTER,
+            timestamp = 1L,
+            transitionId = "tid-enter"
+        )
+        val exit = seed(
+            "biz",
+            Event.GeofenceTransition.EXIT,
+            timestamp = 2L,
+            transitionId = "tid-exit"
+        )
+        val attempts = mutableListOf<PendingGeofenceDelivery>()
+        coEvery { tracker.trackEvent(any()) } coAnswers {
+            val entry = firstArg<PendingGeofenceDelivery>().also(attempts::add)
+            if (attempts.size == 1) {
+                Result.failure(IllegalStateException("temporary bad state"))
+            } else {
+                Result.success(Unit)
+            }
+        }
+
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.retry()
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        attempts shouldBeEqualTo listOf(enter, enter, exit)
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun doWork_givenNullUserId_expectDroppedWithoutTrackingSoQueueDrains() = runTest {
+        // Defensive-only: the receiver drops anonymous transitions before persisting, so a null-userId
+        // row shouldn't exist. If one does it is also undeliverable forever, because the userId was
+        // snapshotted at queue time and no retry can supply one. Leaving it at the head of an ordered
+        // queue would block every later transition, so it is dropped instead.
+        val anonymous = seed("biz-anon", Event.GeofenceTransition.ENTER, timestamp = 0L, userId = null)
+        val deliverable = seed(
+            "biz-next",
+            Event.GeofenceTransition.ENTER,
+            timestamp = 1L,
+            transitionId = "tid-next"
+        )
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+
+        val result = createWorker(inputDataFor(anonymous.key)).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.success()
+        coVerify(exactly = 1) { tracker.trackEvent(deliverable) }
+        store.loadAll().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun doWork_givenSuccessfulSendWhoseRemovalNeverPersists_expectOneSendThenBackedOffRetry() = runTest {
+        // The worker drains "the oldest row" in a loop, so a delivered row that stays on disk is read
+        // again on the next iteration. Without distinguishing "sent" from "sent and recorded" that
+        // loop resends the same transition as fast as the network allows, forever.
+        val entry = seed("biz-stuck", Event.GeofenceTransition.ENTER, timestamp = 7L)
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+        val removalNeverPersists = spyk(store) { every { remove(any()) } returns false }
+        SDKComponent.android()
+            .overrideDependency<PendingDeliveryStore<PendingGeofenceDelivery>>(removalNeverPersists)
 
         val result = createWorker(inputDataFor(entry.key)).doWork()
 
-        result shouldBeEqualTo ListenableWorker.Result.success()
-        coVerify(exactly = 0) { tracker.trackEvent(any()) }
-        // Entry must NOT be removed — flush still needs it.
-        store.loadAll().map { it.key } shouldBeEqualTo listOf("biz-anon_ENTER_0_none")
+        result shouldBeEqualTo ListenableWorker.Result.retry()
+        coVerify(exactly = 1) { tracker.trackEvent(entry) }
+        removalNeverPersists.loadAll().map { it.key } shouldBeEqualTo listOf("biz-stuck_ENTER_tid-seed_none")
     }
 
     private fun inputDataFor(key: String): Data =

--- a/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/logger/PushNotificationLogger.kt
@@ -40,6 +40,13 @@ internal class PushNotificationLogger(private val logger: Logger) {
         )
     }
 
+    fun logWorkerSuccessNotRemoved(deliveryId: String) {
+        logger.error(
+            tag = HANDOFF_TAG,
+            message = "worker success, but removing the pending entry failed so it is still queued key=$deliveryId"
+        )
+    }
+
     fun logWorkerSkippedAlreadyDelivered(deliveryId: String) {
         logger.info(
             tag = HANDOFF_TAG,

--- a/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
+++ b/messagingpush/src/main/java/io/customer/messagingpush/processor/PushDeliveryMetricsBackgroundScheduler.kt
@@ -105,6 +105,17 @@ internal class PushDeliveryMetricsWorker(
                 logger.logWorkerSuccessRemoved(deliveryId)
                 Result.success()
             }
+            PendingDeliveryResult.DeliveredNotRemoved -> {
+                // Not reachable through claimSendRestore, which removes the entry *before* sending —
+                // a successful send there is always Delivered. Handled because the result type is
+                // shared with the at-least-once helper. Success, not retry: this metric has already
+                // reached the backend, and unlike the geofence payload it carries no id the backend
+                // dedupes on, so resending would double-count the Delivered metric. Nothing is
+                // stranded either — this worker owns a single entry rather than draining a queue, so
+                // a leftover row blocks nothing and the store evicts it at capacity.
+                logger.logWorkerSuccessNotRemoved(deliveryId)
+                Result.success()
+            }
             is PendingDeliveryResult.Retryable -> {
                 logger.logWorkerRetry(deliveryId, outcome.cause)
                 Result.retry()

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -8,12 +8,16 @@ import io.customer.commontest.extensions.random
 import io.customer.messagingpush.PushDeliveryTracker
 import io.customer.messagingpush.store.PendingPushDeliveryMetric
 import io.customer.messagingpush.testutils.core.IntegrationTest
+import io.customer.sdk.data.store.PendingDeliveryResult
 import io.customer.sdk.data.store.PendingDeliveryStore
+import io.customer.sdk.data.store.claimSendRestore
 import io.customer.sdk.events.Metric
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.io.IOException
 import java.net.SocketTimeoutException
@@ -487,6 +491,30 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
         verify(exactly = 1) {
             mockPendingStore.append(PendingPushDeliveryMetric(deliveryId = deliveryId, token = deliveryToken))
         }
+    }
+
+    @Test
+    fun doWork_givenSendSucceededButEntryStillQueued_expectSuccessWithoutResend() = runTest {
+        // The shared result type also serves the at-least-once helper, so this worker must map
+        // DeliveredNotRemoved too. The metric already reached the backend and carries no id the
+        // backend dedupes on, so the outcome must be success — a retry would resend and double-count.
+        val deliveryId = String.random
+        val deliveryToken = String.random
+        val inputData = createInputData(deliveryId, deliveryToken)
+
+        mockkStatic("io.customer.sdk.data.store.PendingDeliveryClaimKt")
+        val result = try {
+            coEvery {
+                mockPendingStore.claimSendRestore<PendingPushDeliveryMetric>(any(), any(), any())
+            } returns PendingDeliveryResult.DeliveredNotRemoved
+
+            createWorker(inputData).doWork()
+        } finally {
+            unmockkStatic("io.customer.sdk.data.store.PendingDeliveryClaimKt")
+        }
+
+        result shouldBeEqualTo androidx.work.ListenableWorker.Result.success()
+        coVerify(exactly = 0) { mockPushDeliveryTracker.trackMetric(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

- [#835 polygon transition evaluation core](https://github.com/customerio/customerio-android/pull/835)
- [#836 session ownership and atomic transition staging](https://github.com/customerio/customerio-android/pull/836)
- 👉 [#837 stage transitions durably before delivery](https://github.com/customerio/customerio-android/pull/837)
- [#838 polygon location engine](https://github.com/customerio/customerio-android/pull/838)

Three more branches are ready locally and not open yet: the approach monitor + service
controller, the wiring that enables polygon monitoring, and the geofence instrumentation CI
job. Holding them until this half is reviewed.

## What this is

A geofence callback used to acquire a cooldown slot, then persist, then schedule. Three problems
follow from that order, and this changes it:

- a failed outbox write **lost the crossing** — the cooldown was rolled back, but nothing retried
- a delivery that landed after a process death could **commit containment for a user who had since
  signed out**, because nothing checked whose session observed it
- two crossings of the same fence in the same second **collided on the pending key**

Transitions are now staged in the region store first, delivered through one ordered outbox chain,
and committed only against the session generation and geometry revision that observed them. The
cooldown filter splits into `isAllowed` + `record`, so there is nothing to roll back, and the
pending key uses the transition id rather than a timestamp.

`GeofenceBusinessTransitionProcessor` is the new seam: the broadcast receiver hands it an edge and
it owns stage → deliver → commit. Touches `:core`'s pending-delivery store and `:messagingpush`
because the outbox and its flusher are shared.

## Circles only

No polygon behaviour here. This is the delivery path every already-shipped circle geofence uses, so
it is the riskiest PR in the stack and deliberately isolated.

## Tests

992 tests across geofence, core and messagingpush, 0 failures. ktlint, `lintDebug` and `apiCheck`
clean. No public API change.

## Review round

Three fixes from @Shahroz16's review, each reproduced before being changed.

**Routing was never armed.** `saveRoutableRegisteredIds` had no production caller. `beginUserSession`
writes an explicit empty routable set and `getRoutableRegisteredIds` stops falling back once that key
exists, so the first callback after an identify classified every live ID as unknown and removed it
from GMS. Registration now arms routing for the same IDs it saved, guarded by the user-state
generation.

**The session opened too late.** Arming on registration was not enough on its own: `beginUserSession`
had one production caller, the broadcast receiver, and an identify refresh SKIPs on a fresh last-sync
stamp without registering. The first callback then opened the session, wrote the empty set, read it
back in the same dispatch, and pulled every fence. The session now opens at identify, which clears
the last-sync stamp so that refresh takes the remote path and arms routing before any transition can
arrive. The receiver keeps its call for cold starts.

**A refused payload blocked the queue.** Every non-2xx reached the worker as a bare `IOException`, so
a 400 or 401 classified as retryable and its row was resent forever — and because this PR gives every
geofence event one ordered chain draining the oldest row, that blocked all later ENTERs and EXITs.
Responses now carry their status (`HttpRequestFailure`, an `IOException` subclass, so existing
predicates are unaffected) and a terminal one drops the row and continues the drain. Deliberately
narrow: an unexpected exception still keeps the row and retries.

**Store cleanup.** Eleven Android Lint warnings this PR introduced in `GeofenceRegionStore` are gone —
edit sites that discard the result use the KTX `edit(commit = true)` form; three keep an explicit
editor because they return whether the write reached disk, which the KTX form can't express. Also
drops `clearPendingPolygonApproachBatches` (no caller anywhere in the stack) and makes
`hasActiveUserSession` private, since only that file calls it.

**Identify during an in-flight refresh.** An identify landing while another refresh held the slot was
dropped as a duplicate. That pass belongs to the previous session, so it can only refuse to arm
routing for a generation it no longer serves — and `beginUserSession` has already cleared routing, so
nothing was left pending and the next callback removed every live fence. The slot now records which
session its holder serves: a caller sharing that generation still drops (identify and app-launch fire
together on the same anchor), a newer session waits, keeping anchor rather than live-fix semantics.

**Live fences removed while routing was unarmed.** Switching the receiver's orphan guard to the
routable set introduced a window of its own: an identify clears routing and only the completing
refresh re-arms it, so a callback in between saw every live fence as an orphan and removed it from
GMS — and the refresh that followed found those IDs in `registeredIds` with matching params, skipped
them as unchanged, and never re-added them. The guard now splits the unroutable IDs: ones the
registration bookkeeping still claims are dropped but left registered, and only IDs it no longer
claims are evicted.

The movement trigger is exempt and still drives its refresh. It carries no business meaning — routing
it only re-fetches — and it is the only refresh path that runs without the app being opened, so
dropping its EXIT would leave an unarmed session with nothing to re-arm it until the next launch.
That also closes the 30s slot-wait residual: a refused arm now recovers on the next trigger EXIT
rather than waiting for a launch.

**Movement pass didn't stamp the slot.** `refresh` and `refreshFromLiveFix` record which session owns
the refresh slot; `handleMovement` didn't, so while a movement pass held it the generation read as
`NO_SESSION`. A refresh serving that same session couldn't recognise the holder as its own, missed the
duplicate drop, and polled the full slot wait instead. No data loss — it waited and then skipped as
fresh — but the three slot holders now behave the same way.

**A retired fence kept reporting after its removal failed.** The receiver drops a transition for a
fence the backend deleted by looking up its retained definition, but nothing ever wrote one, so that
branch could never be taken. A deleted fence whose OS removal failed stays registered and routable,
and kept emitting business events until a later removal succeeded. The stale definitions are now
persisted when removal fails and cleared when it succeeds. They are merged with what is already
retained rather than rebuilt from the catalog, because the first failure is the last pass that still
sees the deleted fence in the catalog: rebuilding from it alone dropped the tombstone on the very
first retry.


**Session ownership, reworked rather than patched again.** @Shahroz16 found that adopting a legacy
install's persisted session moved the user-state generation, which invalidated a launch refresh
already in flight: that pass saved its registered IDs but skipped the catalog write it gates on the
generation, so a new fence fired with no name and no geoset IDs. Removing the bump fixed that and
broke something else, which he also found: the adopt branch cannot tell "adopting the persisted
user" from "a first session naming someone else", and the bump had been the only thing making a real
switch visible.

Patching it a third time was the wrong move, so the branch is gone. An unowned session opens as a
switch. The switch already kept registered IDs, retained regions and the registration stamps, so live
fences stay registered and keep reporting; they are unarmed until a refresh arms them, and the
movement trigger is exempt from the unarmed drop, so an upgrade with no network still recovers by
re-ranking from the cached catalog. Launch now opens the session before its refresh, as identify
already did, so the switch precedes the pass that has to arm routing for it.

**Launch could undo a concurrent identify.** @Shahroz16 paused launch between reading the identified
user and calling `beginUserSession`, identified a second user in that gap, then let launch resume: it
reopened the older user, clearing the routing the identify's refresh had just armed, and the next
callback was dropped with nothing queued to re-arm. Launch now uses `beginUserSessionIfAbsent`, which
does the owner check and the write under the lock that already serialises this. Identify and the
receiver keep `beginUserSession`, because they are the paths that legitimately redefine a session;
launch only ever needed to establish one.

The cost: launch no longer reconciles a stale owner against the secure user. If a process dies between
an identify's secure write and the geofence handler, the next launch runs under the older owner until
the replayed `UserChangedEvent` switches it, and a callback in that window is dropped as unarmed.

Routing no longer falls back to the registered set when the key is absent. Every session writes the
key, so the fallback was unreachable, and it encoded the policy this change deletes.

That left an offline upgrade unable to recover on its own, which is a regression this PR would have
introduced rather than a cost worth stating: registered fences, empty routing, and no completing pass
to arm them. So a failed remote pass now re-ranks from the cached catalog, the way a failed movement
pass already does. It is deliberately narrow — only when the pass failed, routing is empty *and* a
cache exists — so a session that is already routing never re-registers from a stale cache on a failed
fetch, and `refresh` still returns the remote failure either way.

What this costs, stated rather than buried. On an upgraded install the first OS callback is dropped
as unarmed where adoption would have forwarded it, and one duplicate ENTER is possible after a reboot
because the emitted-ENTER marks are cleared. Both are once per install, and both are the safe
direction: dropped rather than attributed to the wrong user.

A re-rank registers whatever the cache holds, including a fence the backend has deleted since the
last successful fetch. That is not new: every LOCAL pass and every movement re-arm already work that
way, because the cache is authoritative until a REMOTE succeeds, and the next successful one removes
it and tombstones it if the OS removal fails.

Verified: 614 geofence tests here, each new guard mutation-checked so it kills exactly one test and
nothing else — restoring the adopt branch, restoring the routing fallback, deleting the offline
re-rank, and widening its unarmed guard. The upgrade sequence is covered by unit tests against the
real store rather than a stub; none of it has been exercised on a device.
Validated on device as well as in tests: after an identify, 10 fences register, `routable_registered_ids`
matches `registered_ids`, a real ENTER routes and delivers, and no ID is dropped as unknown. The
identify-during-refresh and unarmed-window races are not reachable from the sample app, which only
exposes logout/login (a full reset); those rest on unit tests.








