### PR TITLE
chore(geofence): add the polygon location engine

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -263,6 +263,13 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
+    fun logPolygonFixNotUsable(reason: String) {
+        logger.debug(
+            "Polygon fix ignored — $reason. Responsive monitoring is best-effort: it decides only from fixes that are decisive on their own.",
+            tag = TAG
+        )
+    }
+
     companion object {
         private const val TAG = "Geofence"
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/AndroidPolygonLocation.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/AndroidPolygonLocation.kt
@@ -1,0 +1,26 @@
+package io.customer.geofence.polygon
+
+import android.location.Location
+
+internal data class AndroidPolygonLocationFix(
+    val sample: PolygonLocationSample,
+    val elapsedRealtimeNanos: Long,
+    val timestampMillis: Long
+)
+
+internal fun Location.toPolygonLocationFix(): AndroidPolygonLocationFix? {
+    if (!hasAccuracy() || !accuracy.isFinite() || accuracy <= 0f || elapsedRealtimeNanos <= 0L) return null
+
+    // fromOrNull, not the constructor: PolygonCoordinate is a wire type and stays passive, so an
+    // out-of-range fix is rejected here rather than carried into the evaluator as a real position.
+    val coordinate = PolygonCoordinate.fromOrNull(latitude, longitude) ?: return null
+
+    return AndroidPolygonLocationFix(
+        sample = PolygonLocationSample(
+            coordinate = coordinate,
+            horizontalAccuracyMeters = accuracy.toDouble()
+        ),
+        elapsedRealtimeNanos = elapsedRealtimeNanos,
+        timestampMillis = time
+    )
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/AndroidPolygonLocation.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/AndroidPolygonLocation.kt
@@ -10,14 +10,15 @@ internal data class AndroidPolygonLocationFix(
 
 internal fun Location.toPolygonLocationFix(): AndroidPolygonLocationFix? {
     if (!hasAccuracy() || !accuracy.isFinite() || accuracy <= 0f || elapsedRealtimeNanos <= 0L) return null
-
-    // fromOrNull, not the constructor: PolygonCoordinate is a wire type and stays passive, so an
-    // out-of-range fix is rejected here rather than carried into the evaluator as a real position.
-    val coordinate = PolygonCoordinate.fromOrNull(latitude, longitude) ?: return null
+    // The range check belongs to this path, not to PolygonCoordinate: a backend payload is the
+    // backend's to validate, but a provider can report a position the earth does not have, and
+    // carrying one into the evaluator would judge containment against a point that cannot exist.
+    if (!latitude.isFinite() || latitude !in -90.0..90.0) return null
+    if (!longitude.isFinite() || longitude !in -180.0..180.0) return null
 
     return AndroidPolygonLocationFix(
         sample = PolygonLocationSample(
-            coordinate = coordinate,
+            coordinate = PolygonCoordinate(latitude, longitude),
             horizontalAccuracyMeters = accuracy.toDouble()
         ),
         elapsedRealtimeNanos = elapsedRealtimeNanos,

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
@@ -1,0 +1,296 @@
+package io.customer.geofence.polygon
+
+import android.location.Location
+import android.os.SystemClock
+import io.customer.geofence.GeofenceBusinessTransitionProcessor
+import io.customer.geofence.GeofenceLogger
+import io.customer.geofence.GeofenceRegion
+import io.customer.geofence.store.GeofenceRegionStore
+import io.customer.geofence.transitionRevision
+import io.customer.sdk.communication.Event
+import io.customer.sdk.core.util.Clock
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Decides polygon containment from fixes admitted by the wake-scoped responsive runtime.
+ *
+ * ## What this engine is
+ *
+ * It never asks the OS for location. Every fix it sees came from a GMS wake callback or the bounded
+ * [PolygonApproachMonitor] session opened after that callback. The engine decides whether a fix is
+ * decisive enough to move committed containment ([PolygonEvidencePolicy.DECISIVE_SINGLE_FIX]).
+ *
+ * ## Best-effort boundary — read before relying on it
+ *
+ * This is deliberately bounded, and that has consequences it does not hide:
+ *
+ * - **Unobserved crossings are missed.** If neither an enclosing-circle nor adaptive-movement wake
+ *   produces a usable fix, the engine has no evidence and emits no transition.
+ * - **A fix near the boundary decides nothing.** [PolygonAccuracyEvaluator.decisiveEvidenceFor]
+ *   requires the whole accuracy circle, plus an anti-jitter margin, to be on one side of the ring.
+ *   Fixes coarser than the decisive accuracy ceiling, and fixes whose uncertainty straddles the
+ *   boundary, are ignored rather than guessed at — a wrong ENTER is worse than a late one.
+ * - **Small polygons may never be decided at all.** A ring narrower than roughly twice
+ *   (fix accuracy + margin) has no interior point far enough from its own boundary to be decisive.
+ *   Such a polygon can only produce transitions from unusually accurate fixes, and on a device
+ *   reporting typical background accuracy it will produce none. That is a reported limitation, not a
+ *   defect to be tuned around here.
+ *
+ * V1 deliberately has no continuous or foreground-service mode. The bounded session stops as soon
+ * as a safe adaptive movement trigger can take over, or when its time budget expires.
+ */
+internal class PolygonLocationEngine(
+    private val store: GeofenceRegionStore,
+    private val transitionProcessor: GeofenceBusinessTransitionProcessor,
+    private val clock: Clock,
+    private val logger: GeofenceLogger
+) {
+    private val routeProcessor = PolygonRouteProcessor()
+    private var sessionStartElapsedRealtimeNanos: Long? = null
+    private val processingMutex = Mutex()
+    private val stateLock = Any()
+    private val geometryCache = mutableMapOf<String, CachedGeometry>()
+    private var cachedActiveIds: Set<String> = emptySet()
+    private var cachedFences: List<PolygonFence> = emptyList()
+
+    /**
+     * Discards the current evaluation session. Called when no polygon is active any more, or when
+     * user-scoped state is invalidated, so a later fix cannot be judged against a stale session.
+     */
+    fun stop() = synchronized(stateLock) {
+        routeProcessor.clear()
+        geometryCache.clear()
+        invalidateFenceCacheLocked()
+        sessionStartElapsedRealtimeNanos = null
+    }
+
+    fun activate(polygonId: String) = synchronized(stateLock) {
+        resetEvidenceLocked(polygonId)
+        armSessionLocked(restartSession = true)
+    }
+
+    /**
+     * Arms evaluation from the fix that caused a passive approach session to begin. Background
+     * delivery can batch recent locations, so using only the normal trigger grace would discard an
+     * observed crossing merely because Play services delivered the batch late.
+     */
+    fun activateFromApproach(polygonId: String, firstFixElapsedRealtimeNanos: Long) =
+        synchronized(stateLock) {
+            resetEvidenceLocked(polygonId)
+            armSessionLocked(
+                restartSession = true,
+                observedSessionStartElapsedRealtimeNanos = firstFixElapsedRealtimeNanos
+            )
+        }
+
+    fun resetEvidence(polygonId: String) = synchronized(stateLock) {
+        resetEvidenceLocked(polygonId)
+    }
+
+    private fun resetEvidenceLocked(polygonId: String) {
+        routeProcessor.clear(polygonId)
+        geometryCache.remove(polygonId)
+        invalidateFenceCacheLocked()
+    }
+
+    fun deactivate(polygonId: String) = synchronized(stateLock) {
+        resetEvidenceLocked(polygonId)
+    }
+
+    /**
+     * Evaluates one fix that arrived from a low-power source, moving containment only when that
+     * single fix is decisive on its own. See the class documentation for what this deliberately
+     * cannot see.
+     */
+    suspend fun processResponsiveLocation(
+        location: Location,
+        expectedUserStateGeneration: Long = store.userStateGeneration()
+    ): Boolean = processLocations(
+        locations = listOf(location),
+        expectedUserStateGeneration = expectedUserStateGeneration,
+        evidencePolicy = PolygonEvidencePolicy.DECISIVE_SINGLE_FIX
+    )
+
+    /**
+     * Ordered evaluation of a batch of fixes under [evidencePolicy].
+     *
+     * V1 calls this through [processResponsiveLocation], one fix at a time under
+     * [PolygonEvidencePolicy.DECISIVE_SINGLE_FIX].
+     */
+    private suspend fun processLocations(
+        locations: List<Location>,
+        expectedUserStateGeneration: Long,
+        evidencePolicy: PolygonEvidencePolicy
+    ): Boolean = processingMutex.withLock {
+        if (locations.isEmpty()) return@withLock false
+        if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+        // Every active location batch is also an autonomous outbox-recovery opportunity. Do not
+        // evaluate a newer edge while an older one is still unable to reach the durable file queue.
+        if (!transitionProcessor.recoverPendingTransitions()) return@withLock false
+        if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+        val sessionArmed = synchronized(stateLock) {
+            if (store.userStateGeneration() != expectedUserStateGeneration) {
+                false
+            } else {
+                armSessionLocked()
+                true
+            }
+        }
+        if (!sessionArmed) return@withLock false
+        var acceptedFix = false
+        for (location in locations.sortedBy(Location::getElapsedRealtimeNanos)) {
+            if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+            val fix = location.toPolygonLocationFix()
+            if (fix == null) {
+                logger.logPolygonFixNotUsable("it carries no usable accuracy or monotonic timestamp")
+                continue
+            }
+            val detections = synchronized(stateLock) {
+                if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+                if (!isCurrentSessionFixLocked(fix.elapsedRealtimeNanos)) {
+                    logger.logPolygonFixNotUsable("it predates the current evaluation session or is too old")
+                    null
+                } else {
+                    val fences = activePolygonFencesLocked()
+                    if (fences.isEmpty()) {
+                        emptyList()
+                    } else {
+                        acceptedFix = true
+                        val committedStates = store.getEnteredIds()
+                            .associateWith { PolygonCommittedState.INSIDE }
+                        routeProcessor.process(
+                            fences = fences,
+                            sample = fix.sample,
+                            elapsedRealtimeNanos = fix.elapsedRealtimeNanos,
+                            committedStates = committedStates,
+                            evidencePolicy = evidencePolicy
+                        )
+                    }
+                }
+            } ?: continue
+            detections.forEach { detection ->
+                if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+                val transition = when (detection.transition) {
+                    PolygonTransition.ENTER -> Event.GeofenceTransition.ENTER
+                    PolygonTransition.EXIT -> Event.GeofenceTransition.EXIT
+                }
+                transitionProcessor.process(
+                    geofenceId = detection.polygonId,
+                    transition = transition,
+                    timestampSeconds = observedTimestampSeconds(fix),
+                    enforceConfiguredTransition = true,
+                    expectedRegionRevision = detection.regionRevision,
+                    expectedUserStateGeneration = expectedUserStateGeneration,
+                    requireRegistered = true
+                )
+                if (store.userStateGeneration() != expectedUserStateGeneration) return@withLock false
+                if (detection.transition == PolygonTransition.EXIT) {
+                    synchronized(stateLock) {
+                        if (store.userStateGeneration() != expectedUserStateGeneration) {
+                            return@withLock false
+                        }
+                        if (
+                            detection.polygonId !in store.getCoarseInsidePolygonIds() &&
+                            detection.polygonId !in store.getEnteredIds() &&
+                            store.deactivatePolygonIfCurrent(
+                                detection.polygonId,
+                                expectedUserStateGeneration
+                            )
+                        ) {
+                            resetEvidenceLocked(detection.polygonId)
+                        }
+                    }
+                }
+            }
+        }
+        acceptedFix
+    }
+
+    private fun observedTimestampSeconds(fix: AndroidPolygonLocationFix): Long {
+        val nowMillis = clock.currentTimeMillis()
+        val monotonicAgeMillis =
+            (SystemClock.elapsedRealtimeNanos() - fix.elapsedRealtimeNanos).coerceAtLeast(0L) /
+                NANOS_PER_MILLISECOND
+        val monotonicTimestampMillis = (nowMillis - monotonicAgeMillis).coerceAtLeast(0L)
+        val sourceTimestampMillis = fix.timestampMillis
+        val earliestSaneSourceMillis =
+            (monotonicTimestampMillis - MAX_SOURCE_CLOCK_DRIFT_MILLIS).coerceAtLeast(1L)
+        val latestSaneSourceMillis = monotonicTimestampMillis + MAX_SOURCE_CLOCK_DRIFT_MILLIS
+        val normalizedMillis = if (
+            sourceTimestampMillis in earliestSaneSourceMillis..latestSaneSourceMillis
+        ) {
+            sourceTimestampMillis
+        } else {
+            monotonicTimestampMillis
+        }
+        return normalizedMillis / MILLIS_PER_SECOND
+    }
+
+    private fun activePolygonFencesLocked(): List<PolygonFence> {
+        val activeIds = store.getActivePolygonIds()
+        if (activeIds == cachedActiveIds) return cachedFences
+        val regions = activeIds.mapNotNull(store::getCachedRegion).filter(GeofenceRegion::isPolygon)
+        geometryCache.keys.retainAll(regions.mapTo(mutableSetOf()) { it.id })
+        cachedActiveIds = activeIds
+        cachedFences = regions.mapNotNull { region ->
+            val vertices = requireNotNull(region.polygonVertices)
+            val cached = geometryCache[region.id]
+            val geometry = if (cached != null && cached.vertices == vertices) {
+                cached.geometry
+            } else {
+                PolygonGeometry.fromOrNull(vertices).also {
+                    geometryCache[region.id] = CachedGeometry(vertices, it)
+                }
+            }
+            if (geometry == null) {
+                // A ring that no longer validates must not fall back to its enclosing circle: that
+                // circle is a coarse trigger, kilometres wider than the fence.
+                logger.logPolygonRegionNotRanked(region.id, "the cached ring no longer validates")
+                null
+            } else {
+                PolygonFence(region.id, geometry, region.transitionRevision())
+            }
+        }
+        return cachedFences
+    }
+
+    private fun invalidateFenceCacheLocked() {
+        cachedActiveIds = emptySet()
+        cachedFences = emptyList()
+    }
+
+    private fun armSessionLocked(
+        restartSession: Boolean = false,
+        observedSessionStartElapsedRealtimeNanos: Long? = null
+    ) {
+        if (sessionStartElapsedRealtimeNanos != null && !restartSession) return
+        val now = SystemClock.elapsedRealtimeNanos()
+        val normalTriggerStart = now - TRIGGER_LOCATION_GRACE_NANOS
+        sessionStartElapsedRealtimeNanos = observedSessionStartElapsedRealtimeNanos
+            ?.let { minOf(it, normalTriggerStart) }
+            ?: normalTriggerStart
+    }
+
+    private fun isCurrentSessionFixLocked(elapsedRealtimeNanos: Long): Boolean {
+        val now = SystemClock.elapsedRealtimeNanos()
+        val sessionStart = sessionStartElapsedRealtimeNanos ?: return false
+        return elapsedRealtimeNanos >= sessionStart &&
+            elapsedRealtimeNanos <= now + FUTURE_FIX_TOLERANCE_NANOS &&
+            now - elapsedRealtimeNanos <= MAXIMUM_FIX_AGE_NANOS
+    }
+
+    private companion object {
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+        const val MILLIS_PER_SECOND = 1_000L
+        const val MAX_SOURCE_CLOCK_DRIFT_MILLIS = 5 * 60 * 1_000L
+        const val TRIGGER_LOCATION_GRACE_NANOS = 30_000_000_000L
+        const val MAXIMUM_FIX_AGE_NANOS = 120_000_000_000L
+        const val FUTURE_FIX_TOLERANCE_NANOS = 5_000_000_000L
+    }
+
+    private data class CachedGeometry(
+        val vertices: List<PolygonCoordinate>,
+        val geometry: PolygonGeometry?
+    )
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.os.SystemClock
 import io.customer.geofence.GeofenceBusinessTransitionProcessor
 import io.customer.geofence.GeofenceLogger
-import io.customer.geofence.GeofenceRegion
 import io.customer.geofence.store.GeofenceRegionStore
 import io.customer.geofence.transitionRevision
 import io.customer.sdk.communication.Event
@@ -51,7 +50,11 @@ internal class PolygonLocationEngine(
     private val processingMutex = Mutex()
     private val stateLock = Any()
     private val geometryCache = mutableMapOf<String, CachedGeometry>()
-    private var cachedActiveIds: Set<String> = emptySet()
+
+    // Keyed on the rings themselves, not on the active id set: a sync can replace a polygon's
+    // geometry without changing which polygons are active, and evaluating the ring it replaced
+    // reports the device inside a fence that has moved.
+    private var cachedFenceSignature: Map<String, List<PolygonCoordinate>?> = emptyMap()
     private var cachedFences: List<PolygonFence> = emptyList()
 
     /**
@@ -229,10 +232,13 @@ internal class PolygonLocationEngine(
 
     private fun activePolygonFencesLocked(): List<PolygonFence> {
         val activeIds = store.getActivePolygonIds()
-        if (activeIds == cachedActiveIds) return cachedFences
-        val regions = activeIds.mapNotNull(store::getCachedRegion).filter(GeofenceRegion::isPolygon)
+        // One catalog read. getCachedRegion decodes the whole catalog per call, so reading once and
+        // filtering costs less than the per-id lookups this used to do on every rebuild.
+        val regions = store.getCachedRegions().filter { it.id in activeIds && it.isPolygon }
+        val signature = regions.associate { it.id to it.polygonVertices }
+        if (signature == cachedFenceSignature) return cachedFences
         geometryCache.keys.retainAll(regions.mapTo(mutableSetOf()) { it.id })
-        cachedActiveIds = activeIds
+        cachedFenceSignature = signature
         cachedFences = regions.mapNotNull { region ->
             val vertices = requireNotNull(region.polygonVertices)
             val cached = geometryCache[region.id]
@@ -256,7 +262,7 @@ internal class PolygonLocationEngine(
     }
 
     private fun invalidateFenceCacheLocked() {
-        cachedActiveIds = emptySet()
+        cachedFenceSignature = emptyMap()
         cachedFences = emptyList()
     }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonLocationEngine.kt
@@ -54,7 +54,7 @@ internal class PolygonLocationEngine(
     // Keyed on the rings themselves, not on the active id set: a sync can replace a polygon's
     // geometry without changing which polygons are active, and evaluating the ring it replaced
     // reports the device inside a fence that has moved.
-    private var cachedFenceSignature: Map<String, List<PolygonCoordinate>?> = emptyMap()
+    private var cachedFenceSignature: Map<String, Int> = emptyMap()
     private var cachedFences: List<PolygonFence> = emptyList()
 
     /**
@@ -235,7 +235,9 @@ internal class PolygonLocationEngine(
         // One catalog read. getCachedRegion decodes the whole catalog per call, so reading once and
         // filtering costs less than the per-id lookups this used to do on every rebuild.
         val regions = store.getCachedRegions().filter { it.id in activeIds && it.isPolygon }
-        val signature = regions.associate { it.id to it.polygonVertices }
+        // Keyed on the transition revision, not just the ring: it also covers the enclosing circle,
+        // and a fence rebuilt from a stale revision has its detections dropped as replaced geometry.
+        val signature = regions.associate { it.id to it.transitionRevision() }
         if (signature == cachedFenceSignature) return cachedFences
         geometryCache.keys.retainAll(regions.mapTo(mutableSetOf()) { it.id })
         cachedFenceSignature = signature

--- a/geofence/src/test/java/io/customer/geofence/polygon/AndroidPolygonLocationTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/AndroidPolygonLocationTest.kt
@@ -1,0 +1,54 @@
+package io.customer.geofence.polygon
+
+import android.location.Location
+import android.os.SystemClock
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidPolygonLocationTest : RobolectricTest() {
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { })
+    }
+
+    @Test
+    fun toPolygonLocationFix_givenCoordinateOutsideTheValidRange_expectRejected() {
+        // A provider can report a corrupt position. Carrying it forward would let the evaluator
+        // judge containment against a point that cannot exist.
+        location(latitude = 95.0).toPolygonLocationFix() shouldBeEqualTo null
+        location(longitude = -181.0).toPolygonLocationFix() shouldBeEqualTo null
+        location(latitude = Double.NaN).toPolygonLocationFix() shouldBeEqualTo null
+    }
+
+    @Test
+    fun toPolygonLocationFix_givenCoordinateInRange_expectAccepted() {
+        // Control for the case above: same fix, coordinates the earth actually has.
+        location().toPolygonLocationFix() shouldNotBeEqualTo null
+    }
+
+    @Test
+    fun toPolygonLocationFix_givenUnusableAccuracyOrTimestamp_expectRejected() {
+        location(accuracyMeters = 0f).toPolygonLocationFix() shouldBeEqualTo null
+        location(elapsedRealtimeNanos = 0L).toPolygonLocationFix() shouldBeEqualTo null
+    }
+
+    private fun location(
+        latitude: Double = 37.7750,
+        longitude: Double = -122.4194,
+        accuracyMeters: Float = 5f,
+        elapsedRealtimeNanos: Long = SystemClock.elapsedRealtimeNanos()
+    ) = Location("test").apply {
+        this.latitude = latitude
+        this.longitude = longitude
+        this.accuracy = accuracyMeters
+        this.elapsedRealtimeNanos = elapsedRealtimeNanos
+        this.time = 100_000L
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
@@ -85,6 +85,35 @@ class PolygonLocationEngineTest : RobolectricTest() {
         )
     }
 
+    // ---------- the catalog can change under an unchanged active set ----------
+
+    @Test
+    fun processResponsiveLocation_givenTheRingMovedUnderTheSameId_expectJudgedAgainstTheNewRing() = runTest {
+        // A sync replaces a polygon's geometry without changing which polygons are active. Caching
+        // the built fences on the active id set alone would keep evaluating the ring that moved,
+        // and report the device inside a fence it is nowhere near.
+        engine.processResponsiveLocation(insideFix())
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+
+        // Same id, same active set, ring moved ~1 km north. The old fix is now well outside it.
+        store.saveCachedRegions(
+            listOf(
+                polygonRegion().copy(
+                    polygonVertices = listOf(
+                        PolygonCoordinate(37.7845, -122.4200),
+                        PolygonCoordinate(37.7845, -122.4188),
+                        PolygonCoordinate(37.7855, -122.4188),
+                        PolygonCoordinate(37.7855, -122.4200)
+                    )
+                )
+            )
+        )
+
+        engine.processResponsiveLocation(insideFix(elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()))
+
+        store.getEnteredIds().shouldBeEmpty()
+    }
+
     // ---------- what a single decisive fix does ----------
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
@@ -1,0 +1,471 @@
+package io.customer.geofence.polygon
+
+import android.location.Location
+import android.os.SystemClock
+import io.customer.commontest.config.ApplicationArgument
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.GeofenceBusinessTransitionProcessor
+import io.customer.geofence.GeofenceJsonSerializer
+import io.customer.geofence.GeofenceLogger
+import io.customer.geofence.GeofenceRegion
+import io.customer.geofence.GeofenceTransitionEmitter
+import io.customer.geofence.store.GeofenceRegionStoreImpl
+import io.customer.sdk.communication.Event
+import io.customer.sdk.core.util.Clock
+import io.customer.sdk.data.store.SecureUserStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Duration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldContainSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowSystemClock
+
+/**
+ * The engine only ever sees fixes some other component already received, and only ever decides from
+ * one fix at a time. These tests cover that surface — including what it deliberately refuses to
+ * decide, which is as much a part of the contract as what it commits.
+ */
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class PolygonLocationEngineTest : RobolectricTest() {
+    private val emitter: GeofenceTransitionEmitter = mockk(relaxed = true)
+    private val secureUserStore: SecureUserStore = mockk(relaxed = true)
+    private val logger: GeofenceLogger = mockk(relaxed = true)
+    private val clock: Clock = mockk(relaxed = true)
+    private lateinit var store: GeofenceRegionStoreImpl
+    private lateinit var engine: PolygonLocationEngine
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(
+            testConfigurationDefault {
+                argument(ApplicationArgument(applicationMock))
+            }
+        )
+        store = GeofenceRegionStoreImpl(
+            context = applicationMock,
+            jsonSerializer = GeofenceJsonSerializer(),
+            logger = mockk(relaxed = true)
+        ).also { it.clearAll() }
+        ShadowSystemClock.advanceBy(Duration.ofMinutes(1))
+        store.saveCachedRegions(listOf(polygonRegion()))
+        store.beginUserSession("user-1")
+        store.saveRegisteredIds(setOf(POLYGON_ID))
+        store.saveRoutableRegisteredIds(setOf(POLYGON_ID))
+        store.activatePolygon(POLYGON_ID)
+        store.recordPolygonCoarseInside(POLYGON_ID)
+        every { secureUserStore.getUserId() } returns "user-1"
+        every { clock.currentTimeSeconds() } returns 100L
+        every { clock.currentTimeMillis() } returns 100_000L
+        coEvery { emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns
+            GeofenceTransitionEmitter.Result.PERSISTED
+        coEvery { emitter.recoverPendingTransitions() } returns true
+        engine = PolygonLocationEngine(
+            store = store,
+            transitionProcessor = GeofenceBusinessTransitionProcessor(
+                store,
+                secureUserStore,
+                emitter,
+                logger
+            ),
+            clock = clock,
+            logger = logger
+        )
+    }
+
+    // ---------- what a single decisive fix does ----------
+
+    @Test
+    fun processResponsiveLocation_givenOneDecisiveInsideFix_expectCommittedEnter() = runTest {
+        engine.processResponsiveLocation(insideFix())
+
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                POLYGON_ID,
+                Event.GeofenceTransition.ENTER,
+                "user-1",
+                100L,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenSameFixRepeated_expectExactlyOneEnter() = runTest {
+        val fix = insideFix()
+
+        repeat(3) { engine.processResponsiveLocation(fix) }
+
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                any(),
+                Event.GeofenceTransition.ENTER,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenConcurrentDeliveriesOfSameFix_expectSerializedSingleEnter() = runTest {
+        val fix = insideFix()
+
+        coroutineScope {
+            List(8) { async { engine.processResponsiveLocation(fix) } }.awaitAll()
+        }
+
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                any(),
+                Event.GeofenceTransition.ENTER,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenDelayedApproachFix_expectObservedFixCanArmSession() = runTest {
+        // Play services batches background deliveries. A fix older than the normal 30-second trigger
+        // grace is still valid evidence when the approach session was armed from that same fix.
+        val observedAt = SystemClock.elapsedRealtimeNanos() - 50_000_000_000L
+        engine.activateFromApproach(POLYGON_ID, observedAt)
+
+        engine.processResponsiveLocation(insideFix(elapsedRealtimeNanos = observedAt))
+
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+    }
+
+    @Test
+    fun processResponsiveLocation_givenDelayedFix_expectTransitionUsesOriginalFixTime() = runTest {
+        val observedAt = SystemClock.elapsedRealtimeNanos() - 50_000_000_000L
+        every { clock.currentTimeMillis() } returns 200_000L
+        engine.activateFromApproach(POLYGON_ID, observedAt)
+
+        engine.processResponsiveLocation(
+            insideFix(elapsedRealtimeNanos = observedAt, timestampMillis = 150_000L)
+        )
+
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                POLYGON_ID,
+                Event.GeofenceTransition.ENTER,
+                "user-1",
+                150L,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    // ---------- best-effort boundary: fixes the engine refuses to decide from ----------
+
+    @Test
+    fun processResponsiveLocation_givenAccuracyCircleStraddlingTheRing_expectNoTransition() = runTest {
+        // Realistic background accuracy inside a ~110 m polygon: the device is genuinely inside, but
+        // its uncertainty circle plus the anti-jitter margin reaches past the ring, so "inside" is not
+        // established. A guess here would report ENTER for a device that may be on the pavement.
+        engine.processResponsiveLocation(insideFix(accuracyMeters = 45f))
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenFixCoarserThanTheDecisiveCeiling_expectIgnoredAndLogged() = runTest {
+        engine.processResponsiveLocation(insideFix(accuracyMeters = 120f))
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenPolygonSmallerThanTypicalAccuracy_expectNoEnterEverCommitted() = runTest {
+        // A ~40 m ring has no interior point more than ~20 m from its own boundary, so a fix with
+        // ordinary background accuracy can never be decisive anywhere inside it. The device sits dead
+        // centre and still produces nothing — and must not fall back to the enclosing trigger circle,
+        // which is hundreds of metres wide.
+        store.saveCachedRegions(listOf(smallPolygonRegion()))
+        store.saveRegisteredIds(setOf(SMALL_POLYGON_ID))
+        store.saveRoutableRegisteredIds(setOf(SMALL_POLYGON_ID))
+        store.activatePolygon(SMALL_POLYGON_ID)
+        store.recordPolygonCoarseInside(SMALL_POLYGON_ID)
+
+        engine.processResponsiveLocation(
+            fix(37.7750, -122.4194, accuracyMeters = 20f)
+        )
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenVisitEntirelyBetweenTwoFixes_expectMissedRatherThanInvented() = runTest {
+        // Approach fixes are displacement-gated and minutes apart. The device drove in and out between
+        // them; both fixes it delivered are outside. There is no evidence of a visit, so none is
+        // reported — the low-power path reports what it saw, not what it can infer.
+        val base = SystemClock.elapsedRealtimeNanos() - 10_000_000_000L
+
+        engine.processResponsiveLocation(fix(37.7750, -122.4175, elapsedRealtimeNanos = base))
+        engine.processResponsiveLocation(
+            fix(37.7750, -122.4175, elapsedRealtimeNanos = base + 5_000_000_000L)
+        )
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenFixWithNoAccuracy_expectIgnoredAndLogged() = runTest {
+        val unusable = Location("test").apply {
+            latitude = 37.7750
+            longitude = -122.4194
+            elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos() - 1_000_000_000L
+            time = 100_000L
+        }
+
+        engine.processResponsiveLocation(unusable)
+
+        store.getEnteredIds().shouldBeEmpty()
+        verify { logger.logPolygonFixNotUsable(any()) }
+    }
+
+    // ---------- identity, generation and catalog fencing ----------
+
+    @Test
+    fun processResponsiveLocation_givenFixFromPreviousUserGeneration_expectDoesNotAffectNewSession() = runTest {
+        val previousGeneration = store.userStateGeneration()
+        store.beginUserSession("user-2")
+        store.saveRegisteredIds(setOf(POLYGON_ID))
+        store.saveRoutableRegisteredIds(setOf(POLYGON_ID))
+        store.activatePolygon(POLYGON_ID)
+        store.recordPolygonCoarseInside(POLYGON_ID)
+        every { secureUserStore.getUserId() } returns "user-2"
+
+        engine.processResponsiveLocation(
+            location = insideFix(),
+            expectedUserStateGeneration = previousGeneration
+        )
+
+        store.getEnteredIds().shouldBeEmpty()
+        store.getActivePolygonIds() shouldContainSame setOf(POLYGON_ID)
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenRemovalFailedAndOnlyRetainedDefinitionExists_expectDoesNotEvaluateRetiredPolygon() = runTest {
+        store.saveCachedRegions(emptyList())
+        store.saveRetainedRegisteredRegions(listOf(polygonRegion()))
+
+        engine.processResponsiveLocation(insideFix())
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenCachedRingThatNoLongerValidates_expectPolygonSkippedNotTreatedAsItsCircle() = runTest {
+        // Self-intersecting ring: the region still carries a wide enclosing trigger circle, and the fix
+        // is well inside that circle. Falling back to it would report ENTER for the wrong area.
+        store.saveCachedRegions(
+            listOf(
+                GeofenceRegion(
+                    id = POLYGON_ID,
+                    latitude = 37.7750,
+                    longitude = -122.4194,
+                    radius = 5_000f,
+                    polygonVertices = listOf(
+                        PolygonCoordinate(37.7745, -122.4200),
+                        PolygonCoordinate(37.7755, -122.4188),
+                        PolygonCoordinate(37.7745, -122.4188),
+                        PolygonCoordinate(37.7755, -122.4200)
+                    )
+                )
+            )
+        )
+        engine.resetEvidence(POLYGON_ID)
+
+        engine.processResponsiveLocation(insideFix())
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenOlderStageStillUnavailable_expectNewEdgeDoesNotOvertakeIt() = runTest {
+        coEvery { emitter.recoverPendingTransitions() } returns false
+
+        engine.processResponsiveLocation(insideFix())
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun resetEvidence_givenInactiveEditThenLaterActivation_expectPreActivationFixesRejected() = runTest {
+        store.deactivatePolygon(POLYGON_ID)
+        engine.stop()
+        val beforeActivation = SystemClock.elapsedRealtimeNanos()
+
+        engine.resetEvidence(POLYGON_ID)
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(60))
+        store.activatePolygon(POLYGON_ID)
+        engine.activate(POLYGON_ID)
+        engine.processResponsiveLocation(insideFix(elapsedRealtimeNanos = beforeActivation))
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 0) {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    // ---------- exits ----------
+
+    @Test
+    fun processResponsiveLocation_givenCoarseExitThenDecisivePolygonExit_expectSessionTerminates() = runTest {
+        store.recordEntered(POLYGON_ID)
+        store.recordPolygonCoarseOutside(POLYGON_ID)
+
+        engine.processResponsiveLocation(outsideFix())
+
+        store.getEnteredIds().shouldBeEmpty()
+        store.getActivePolygonIds().shouldBeEmpty()
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                any(),
+                Event.GeofenceTransition.EXIT,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun processResponsiveLocation_givenFineExitCannotPersist_expectSessionRemainsActiveForRetry() = runTest {
+        store.recordEntered(POLYGON_ID)
+        store.recordPolygonCoarseOutside(POLYGON_ID)
+        coEvery {
+            emitter.emitWithRetainedAttempt(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        } returns GeofenceTransitionEmitter.Result.PERSIST_FAILED
+
+        engine.processResponsiveLocation(outsideFix())
+
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+        store.getActivePolygonIds() shouldContainSame setOf(POLYGON_ID)
+    }
+
+    private fun insideFix(
+        elapsedRealtimeNanos: Long = SystemClock.elapsedRealtimeNanos() - 2_000_000_000L,
+        timestampMillis: Long = 100_000L,
+        accuracyMeters: Float = 5f
+    ) = fix(37.7750, -122.4194, elapsedRealtimeNanos, timestampMillis, accuracyMeters)
+
+    private fun outsideFix(
+        elapsedRealtimeNanos: Long = SystemClock.elapsedRealtimeNanos() - 2_000_000_000L
+    ) = fix(37.7750, -122.4175, elapsedRealtimeNanos)
+
+    private fun fix(
+        latitude: Double,
+        longitude: Double,
+        elapsedRealtimeNanos: Long = SystemClock.elapsedRealtimeNanos() - 2_000_000_000L,
+        timestampMillis: Long = 100_000L,
+        accuracyMeters: Float = 5f
+    ) = Location("test").apply {
+        this.latitude = latitude
+        this.longitude = longitude
+        accuracy = accuracyMeters
+        this.elapsedRealtimeNanos = elapsedRealtimeNanos
+        time = timestampMillis
+    }
+
+    // Roughly 110 m x 105 m, so its centre sits ~52 m from the nearest edge.
+    private fun polygonRegion() = GeofenceRegion(
+        id = POLYGON_ID,
+        latitude = 37.7750,
+        longitude = -122.4194,
+        radius = 200f,
+        polygonVertices = listOf(
+            PolygonCoordinate(37.7745, -122.4200),
+            PolygonCoordinate(37.7745, -122.4188),
+            PolygonCoordinate(37.7755, -122.4188),
+            PolygonCoordinate(37.7755, -122.4200)
+        )
+    )
+
+    // Roughly 39 m x 35 m — a single retail unit. Centre is under 20 m from the nearest edge.
+    private fun smallPolygonRegion() = GeofenceRegion(
+        id = SMALL_POLYGON_ID,
+        latitude = 37.7750,
+        longitude = -122.4194,
+        radius = 400f,
+        polygonVertices = listOf(
+            PolygonCoordinate(37.77482, -122.41960),
+            PolygonCoordinate(37.77482, -122.41920),
+            PolygonCoordinate(37.77517, -122.41920),
+            PolygonCoordinate(37.77517, -122.41960)
+        )
+    )
+
+    private companion object {
+        const val POLYGON_ID = "campus"
+        const val SMALL_POLYGON_ID = "retail-unit"
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonLocationEngineTest.kt
@@ -341,6 +341,34 @@ class PolygonLocationEngineTest : RobolectricTest() {
     }
 
     @Test
+    fun processResponsiveLocation_givenEnclosingCircleEditedButRingUnchanged_expectTransitionStillCommitted() = runTest {
+        // The transition revision covers the enclosing circle as well as the ring, so a catalog sync
+        // that only retunes the wake radius still bumps it. A fence cache keyed on the ring alone
+        // would keep serving the old revision, and the processor drops those as replaced geometry.
+        engine.processResponsiveLocation(insideFix())
+        store.getEnteredIds() shouldContainSame setOf(POLYGON_ID)
+        store.saveCachedRegions(listOf(polygonRegion().copy(radius = 900f)))
+
+        engine.processResponsiveLocation(outsideFix(elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()))
+
+        store.getEnteredIds().shouldBeEmpty()
+        coVerify(exactly = 1) {
+            emitter.emitWithRetainedAttempt(
+                POLYGON_ID,
+                Event.GeofenceTransition.EXIT,
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
     fun processResponsiveLocation_givenCachedRingThatNoLongerValidates_expectPolygonSkippedNotTreatedAsItsCircle() = runTest {
         // Self-intersecting ring: the region still carries a wide enclosing trigger circle, and the fix
         // is well inside that circle. Falling back to it would report ENTER for the wrong area.


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

- [#835 polygon transition evaluation core](https://github.com/customerio/customerio-android/pull/835)
- [#836 session ownership and atomic transition staging](https://github.com/customerio/customerio-android/pull/836)
- [#837 stage transitions durably before delivery](https://github.com/customerio/customerio-android/pull/837)
- 👉 [#838 polygon location engine](https://github.com/customerio/customerio-android/pull/838)

Three more branches are ready locally and not open yet: the approach monitor + service
controller, the wiring that enables polygon monitoring, and the geofence instrumentation CI
job. Holding them until this half is reviewed.

## What this is

Drives the evaluation core from a stream of Android fixes: caches parsed geometry per polygon,
decides whether a fix is usable at all, and hands committed transitions to the business transition
processor from #837.

`toPolygonLocationFix` is the boundary where an `android.location.Location` becomes something the
evaluator will trust, so it is also where an unusable one is rejected.

Still unreachable — nothing starts the engine yet.

## Two real fixes

The conversion used to wrap `PolygonCoordinate(...)` in `try/catch (IllegalArgumentException)`. That
constructor validated its range until #833 moved the check to `fromOrNull`, so the catch could no
longer fire and a provider reporting latitude 95 was accepted as a real position. It asks
`fromOrNull` now.

Found by running `:geofence:connectedDebugAndroidTest` on an emulator, which had never run before —
the androidTest suite that catches it arrives with the CI job further up the stack.

The fence cache also keyed its signature on the ring alone, while `transitionRevision()` covers the
enclosing circle too. A catalog sync that only retuned a wake radius left the signature unchanged, so
the cache kept serving fences built from the old revision and the business transition processor
dropped their detections as replaced geometry. Keyed on the revision now; the parsed ring is still
reused, so a circle-only sync rebuilds the fences without re-parsing.

## Tests

1014 tests across geofence, core and messagingpush, 0 failures. ktlint, `lintDebug` and `apiCheck`
clean. No public API change.

The coordinate fix has its own unit tests with an in-range control, mutation-tested both ways.






