### PR TITLE
chore(geofence): trust the backend's polygon validation

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -275,13 +275,13 @@ private fun GeofenceApiRegion.toPolygonRegionOrNull(
         return null
     }
     val baseRadiusMeters = enclosingCircle.baseRadiusMeters
-    val wakeCenter = PolygonCoordinate.fromOrNull(enclosingCircle.latitude, enclosingCircle.longitude)
-    val trigger = if (wakeCenter == null || baseRadiusMeters == null) {
+    val wakeLatitude = enclosingCircle.latitude
+    val wakeLongitude = enclosingCircle.longitude
+    val trigger = if (wakeLatitude == null || wakeLongitude == null || baseRadiusMeters == null) {
         null
     } else {
         PolygonWakeCircleValidator().prepareOrNull(
-            geometry = polygon,
-            wakeCircle = PolygonWakeCircle(wakeCenter, baseRadiusMeters)
+            PolygonWakeCircle(PolygonCoordinate(wakeLatitude, wakeLongitude), baseRadiusMeters)
         )
     }
     if (trigger == null) {
@@ -333,7 +333,7 @@ private fun JsonElement.toPolygonVerticesOrNull(): List<PolygonCoordinate>? {
         if (position.size < 2) return null
         val longitude = (position[0] as? JsonPrimitive)?.doubleOrNull ?: return null
         val latitude = (position[1] as? JsonPrimitive)?.doubleOrNull ?: return null
-        PolygonCoordinate.fromOrNull(latitude, longitude) ?: return null
+        PolygonCoordinate(latitude, longitude)
     }
 }
 

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -277,7 +277,14 @@ private fun GeofenceApiRegion.toPolygonRegionOrNull(
     val baseRadiusMeters = enclosingCircle.baseRadiusMeters
     val wakeLatitude = enclosingCircle.latitude
     val wakeLongitude = enclosingCircle.longitude
-    val trigger = if (wakeLatitude == null || wakeLongitude == null || baseRadiusMeters == null) {
+    val trigger = if (
+        wakeLatitude == null || wakeLongitude == null || baseRadiusMeters == null ||
+        // Not a geometry rule the backend owns — a platform precondition. Geofence.Builder throws on
+        // an out-of-range centre, and registration builds the whole business batch in one map, so a
+        // single bad record fails every fence in the sync and rolls the movement trigger back with
+        // it. Checking here isolates the record instead.
+        !LocationCoordinates.isValid(wakeLatitude, wakeLongitude)
+    ) {
         null
     } else {
         PolygonWakeCircleValidator().prepareOrNull(

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -340,6 +340,11 @@ private fun JsonElement.toPolygonVerticesOrNull(): List<PolygonCoordinate>? {
         if (position.size < 2) return null
         val longitude = (position[0] as? JsonPrimitive)?.doubleOrNull ?: return null
         val latitude = (position[1] as? JsonPrimitive)?.doubleOrNull ?: return null
+        // Not a range rule — the backend owns those. A position is decoded as a JsonElement, so the
+        // literal "NaN" parses to a Double and then passes every geometry check, because each of
+        // them compares and every comparison against NaN is false. It only surfaces later, in the
+        // strict cache encoder, by which point the sync has already registered.
+        if (!longitude.isFinite() || !latitude.isFinite()) return null
         PolygonCoordinate(latitude, longitude)
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -121,9 +121,6 @@ internal class PolygonGeometry private constructor(
 
             require(canonical.size >= 3) { "polygon requires at least three vertices" }
             require(canonical.distinct().size >= 3) { "polygon requires at least three distinct vertices" }
-            require(canonical.all { abs(it.latitude) <= MAXIMUM_ABSOLUTE_LATITUDE }) {
-                "polygons above the supported latitude are unsupported"
-            }
             canonical.forEachIndexed { index, current ->
                 val next = canonical[(index + 1) % canonical.size]
                 require(current != next) { "polygon cannot contain a zero-length edge" }
@@ -213,9 +210,5 @@ internal class PolygonGeometry private constructor(
                 longitude <= maxOf(first.longitude, second.longitude) + BOUNDARY_EPSILON &&
                 latitude >= minOf(first.latitude, second.latitude) - BOUNDARY_EPSILON &&
                 latitude <= maxOf(first.latitude, second.latitude) + BOUNDARY_EPSILON
-
-        // Keeps the coordinate-linear ring inside the conservative geodesic trigger circle.
-        // Near a pole an edge interior can be farther from the projected center than every vertex.
-        private const val MAXIMUM_ABSOLUTE_LATITUDE = 85.0
     }
 }

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -14,24 +14,7 @@ internal data class PolygonCoordinate(
     val latitude: Double,
     @SerialName("longitude")
     val longitude: Double
-) {
-    internal val isInRange: Boolean
-        get() = latitude.isFinite() && latitude in -90.0..90.0 &&
-            longitude.isFinite() && longitude in -180.0..180.0
-
-    internal companion object {
-        /**
-         * Range checking lives here rather than in an `init` block: the constructor is the
-         * deserializer's, so throwing there fails the whole `List<GeofenceRegion>` decode and
-         * `readJson` then drops every cached region for one bad stored coordinate.
-         * [PolygonGeometry.from] rejects out-of-range vertices, isolating the bad ring instead.
-         */
-        fun fromOrNull(latitude: Double?, longitude: Double?): PolygonCoordinate? {
-            if (latitude == null || longitude == null) return null
-            return PolygonCoordinate(latitude, longitude).takeIf { it.isInRange }
-        }
-    }
-}
+)
 
 internal enum class PolygonPointRelation {
     INSIDE,
@@ -136,11 +119,7 @@ internal class PolygonGeometry private constructor(
                 vertices
             }
 
-            require(canonical.all { it.isInRange }) { "polygon vertex is out of range" }
             require(canonical.size >= 3) { "polygon requires at least three vertices" }
-            require(canonical.size <= MAX_VERTEX_COUNT) {
-                "polygon exceeds the maximum vertex count"
-            }
             require(canonical.distinct().size >= 3) { "polygon requires at least three distinct vertices" }
             require(canonical.all { abs(it.latitude) <= MAXIMUM_ABSOLUTE_LATITUDE }) {
                 "polygons above the supported latitude are unsupported"
@@ -154,7 +133,6 @@ internal class PolygonGeometry private constructor(
             }
             require(canonical.hasNonCollinearVertices()) { "polygon cannot have zero area" }
             require(!canonical.hasSelfIntersection()) { "polygon cannot intersect itself" }
-            require(canonical.isConvex()) { "concave polygons are unsupported in v1" }
 
             return PolygonGeometry(canonical.toList())
         }
@@ -196,25 +174,6 @@ internal class PolygonGeometry private constructor(
             return false
         }
 
-        private fun List<PolygonCoordinate>.isConvex(): Boolean {
-            var direction = 0
-            for (index in indices) {
-                val turn = orientation(
-                    this[index],
-                    this[(index + 1) % size],
-                    this[(index + 2) % size]
-                )
-                if (abs(turn) <= BOUNDARY_EPSILON) continue
-                val currentDirection = if (turn > 0.0) 1 else -1
-                if (direction == 0) {
-                    direction = currentDirection
-                } else if (direction != currentDirection) {
-                    return false
-                }
-            }
-            return direction != 0
-        }
-
         private fun segmentsAreAdjacent(firstIndex: Int, secondIndex: Int, size: Int): Boolean =
             secondIndex == firstIndex + 1 || firstIndex == 0 && secondIndex == size - 1
 
@@ -254,8 +213,6 @@ internal class PolygonGeometry private constructor(
                 longitude <= maxOf(first.longitude, second.longitude) + BOUNDARY_EPSILON &&
                 latitude >= minOf(first.latitude, second.latitude) - BOUNDARY_EPSILON &&
                 latitude <= maxOf(first.latitude, second.latitude) + BOUNDARY_EPSILON
-
-        private const val MAX_VERTEX_COUNT = 500
 
         // Keeps the coordinate-linear ring inside the conservative geodesic trigger circle.
         // Near a pole an edge interior can be farther from the projected center than every vertex.

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonWakeCircle.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonWakeCircle.kt
@@ -1,10 +1,5 @@
 package io.customer.geofence.polygon
 
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.sin
-import kotlin.math.sqrt
-
 internal data class PolygonWakeCircle(
     val center: PolygonCoordinate,
     val baseRadiusMeters: Double
@@ -16,32 +11,16 @@ internal data class PolygonTriggerCircle(
 )
 
 /**
- * Validates and pads the canonical wake circle supplied by the backend.
+ * Pads the canonical wake circle supplied by the backend.
  *
- * The SDK deliberately does not derive a new enclosing circle. The backend owns geometry
- * admission and the canonical base circle; Android only checks that the payload is usable and that
- * every admitted vertex is contained before applying the platform wake margin.
+ * The SDK derives no enclosing circle and re-checks no coverage: the backend owns geometry
+ * admission and the canonical base circle. What remains here is what the platform needs to register
+ * the trigger — a usable radius, padded by the wake margin and inside the OS limit.
  */
 internal class PolygonWakeCircleValidator {
-    fun prepare(
-        geometry: PolygonGeometry,
-        wakeCircle: PolygonWakeCircle
-    ): PolygonTriggerCircle {
+    fun prepare(wakeCircle: PolygonWakeCircle): PolygonTriggerCircle {
         require(wakeCircle.baseRadiusMeters.isFinite() && wakeCircle.baseRadiusMeters > 0.0) {
             "polygon wake-circle radius must be finite and positive"
-        }
-        // Any sphere disagrees with the backend's ellipsoid by a fraction of the distance, not by a
-        // fixed amount, so the slack has to scale too: a flat 1 m rejected a vertex sitting exactly
-        // on a valid 1 km circle, and the gap grew with radius. Over-admitting is the safe
-        // direction — the platform margin below absorbs it, while under-admitting drops the polygon.
-        val containmentTolerance = maxOf(
-            CONTAINMENT_TOLERANCE_METERS,
-            wakeCircle.baseRadiusMeters * CONTAINMENT_TOLERANCE_FRACTION
-        )
-        geometry.vertices.forEach { vertex ->
-            require(wakeCircle.center.distanceMetersTo(vertex) <= wakeCircle.baseRadiusMeters + containmentTolerance) {
-                "polygon wake circle does not contain every vertex"
-            }
         }
         val registeredRadius = wakeCircle.baseRadiusMeters + PLATFORM_WAKE_MARGIN_METERS
         require(registeredRadius <= MAXIMUM_TRIGGER_RADIUS_METERS) {
@@ -53,42 +32,15 @@ internal class PolygonWakeCircleValidator {
         )
     }
 
-    fun prepareOrNull(
-        geometry: PolygonGeometry,
-        wakeCircle: PolygonWakeCircle
-    ): PolygonTriggerCircle? = try {
-        prepare(geometry, wakeCircle)
+    fun prepareOrNull(wakeCircle: PolygonWakeCircle): PolygonTriggerCircle? = try {
+        prepare(wakeCircle)
     } catch (_: IllegalArgumentException) {
         null
-    }
-
-    private fun PolygonCoordinate.distanceMetersTo(other: PolygonCoordinate): Double {
-        val firstLatitude = Math.toRadians(latitude)
-        val secondLatitude = Math.toRadians(other.latitude)
-        val latitudeDelta = secondLatitude - firstLatitude
-        val longitudeDelta = Math.toRadians(other.longitude - longitude)
-        val haversine = sin(latitudeDelta / 2.0) * sin(latitudeDelta / 2.0) +
-            cos(firstLatitude) * cos(secondLatitude) *
-            sin(longitudeDelta / 2.0) * sin(longitudeDelta / 2.0)
-        val clamped = haversine.coerceIn(0.0, 1.0)
-        val centralAngle = 2.0 * atan2(sqrt(clamped), sqrt(1.0 - clamped))
-        return EARTH_RADIUS_METERS * centralAngle
     }
 
     internal companion object {
         // Prototype policy value. Field calibration freezes the versioned production margin.
         const val PLATFORM_WAKE_MARGIN_METERS = 1_000.0
         const val MAXIMUM_TRIGGER_RADIUS_METERS = 100_000.0
-        const val CONTAINMENT_TOLERANCE_METERS = 1.0
-
-        // Bounds the sphere-vs-ellipsoid disagreement: Earth's radius varies by ~0.34% about the
-        // mean, so half a percent covers any latitude with room to spare.
-        const val CONTAINMENT_TOLERANCE_FRACTION = 0.005
-
-        // Matches PolygonGeometry's radius. The previous 6,400,000 was rounded up past every real
-        // radius, which is the wrong direction here: overstating a distance makes containment
-        // reject. The tolerance above is what admits a boundary vertex; this only stops the module
-        // measuring the same geometry two different ways.
-        private const val EARTH_RADIUS_METERS = 6_371_000.0
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -186,7 +186,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
-    fun parseAndMap_givenConcavePolygon_expectDroppedByV1Envelope() {
+    fun parseAndMap_givenConcavePolygon_expectMapped() {
         val regions = parseRegions(
             """
             {
@@ -207,8 +207,9 @@ class GeofenceApiResponseTest : RobolectricTest() {
             EnabledPolygonSupport
         )
 
-        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
-        verify { mockLogger.logPolygonDropped(eq("concave"), any()) }
+        // The backend admits concave rings and the ray cast handles them, so re-checking convexity
+        // here only put the SDK out of step with the payload it was sent.
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("concave", "circle")
     }
 
     @Test
@@ -352,7 +353,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
-    fun parseAndMap_givenPolygonBeyondMaxVertexCount_expectDroppedWithoutCostingOtherRegions() {
+    fun parseAndMap_givenPolygonBeyondTheFormerVertexCap_expectMapped() {
         val ring = (0 until 600).joinToString(",") { index ->
             val angle = 2.0 * Math.PI * index / 600.0
             "[${0.002 * kotlin.math.cos(angle)}, ${0.002 * kotlin.math.sin(angle)}]"
@@ -374,8 +375,9 @@ class GeofenceApiResponseTest : RobolectricTest() {
             EnabledPolygonSupport
         )
 
-        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
-        verify { mockLogger.logPolygonDropped(eq("too-many"), any()) }
+        // Vertex count is the backend's admission policy, not something the ring needs to be usable.
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("too-many", "circle")
+        regions.first().polygonVertices?.size shouldBeEqualTo 600
     }
 
     // ---------- region shape ----------

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -161,6 +161,39 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parseAndMap_givenPolygonWithOutOfRangeWakeCircleCenter_expectRecordDroppedNotWholeSync() {
+        // Geofence.Builder throws on an out-of-range centre and registration builds the batch in one
+        // map, so letting this through fails every fence in the sync, not just this record.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "bad-center",
+                  "shape": "polygon",
+                  "enclosing_circle": { "latitude": 91.0, "longitude": 0.0, "base_radius_m": 100 },
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0.01, 0], [0.01, 0.01], [0, 0.01], [0, 0]]]
+                  }
+                },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
+        verify {
+            mockLogger.logPolygonDropped(
+                "bad-center",
+                "backend-provided enclosing circle is invalid or does not contain the polygon"
+            )
+        }
+    }
+
+    @Test
     fun parseAndMap_givenPolygonWithoutBackendWakeCircle_expectDropped() {
         val regions = parseRegions(
             """

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -161,6 +161,35 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parseAndMap_givenPolygonPositionThatIsNotFinite_expectRecordDroppedNotWholeSync() {
+        // Positions decode as JsonElement, so the literal "NaN" becomes a Double and passes every
+        // geometry check — each one compares, and every comparison against NaN is false. It would
+        // surface only in the strict cache encoder, after the sync had already registered.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "not-a-number",
+                  "shape": "polygon",
+                  "enclosing_circle": { "latitude": 0.0, "longitude": 0.0, "base_radius_m": 100 },
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 0], [1, 1], [0, "NaN"], [0, 0]]]
+                  }
+                },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
+        verify { mockLogger.logPolygonDropped("not-a-number", "ring is malformed, unsupported or fails validation") }
+    }
+
+    @Test
     fun parseAndMap_givenPolygonWithOutOfRangeWakeCircleCenter_expectRecordDroppedNotWholeSync() {
         // Geofence.Builder throws on an out-of-range centre and registration builds the batch in one
         // map, so letting this through fails every fence in the sync, not just this record.

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -7,19 +7,23 @@ import org.junit.Test
 
 class PolygonGeometryTest {
     @Test
-    fun from_whenPolygonIsConcave_thenRejectsV1Geometry() {
-        invoking {
-            PolygonGeometry.from(
-                listOf(
-                    point(0.0, 0.0),
-                    point(0.0, 3.0),
-                    point(1.0, 3.0),
-                    point(1.0, 1.0),
-                    point(3.0, 1.0),
-                    point(3.0, 0.0)
-                )
+    fun from_whenPolygonIsConcave_thenAcceptsAndAnswersInsideTheNotch() {
+        // Concavity is the backend's call, not ours. What matters is that the ray cast still gets
+        // the reflex corner right: the notch of an L is outside, both arms are inside.
+        val lShape = PolygonGeometry.from(
+            listOf(
+                point(0.0, 0.0),
+                point(0.0, 3.0),
+                point(1.0, 3.0),
+                point(1.0, 1.0),
+                point(3.0, 1.0),
+                point(3.0, 0.0)
             )
-        } shouldThrow IllegalArgumentException::class
+        )
+
+        lShape.relationTo(point(2.0, 2.0)) shouldBeEqualTo PolygonPointRelation.OUTSIDE
+        lShape.relationTo(point(0.5, 2.5)) shouldBeEqualTo PolygonPointRelation.INSIDE
+        lShape.relationTo(point(2.5, 0.5)) shouldBeEqualTo PolygonPointRelation.INSIDE
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -88,16 +88,18 @@ class PolygonGeometryTest {
     }
 
     @Test
-    fun from_whenPolygonApproachesGeographicPole_thenRejectsUnsupportedGeometry() {
-        invoking {
-            PolygonGeometry.from(
-                listOf(
-                    point(89.92593569795733, -145.18356655630183),
-                    point(89.8623631437237, 16.93650091099056),
-                    point(89.9222388615163, 60.8667321459084)
-                )
+    fun from_whenPolygonApproachesGeographicPole_thenAccepted() {
+        // Circles at the pole were always registerable; rejecting a polygon there was the SDK
+        // holding the payload to a stricter rule than the backend or the rest of the module.
+        val nearPole = PolygonGeometry.from(
+            listOf(
+                point(89.92, 10.0),
+                point(89.86, 11.0),
+                point(89.92, 12.0)
             )
-        } shouldThrow IllegalArgumentException::class
+        )
+
+        nearPole.vertices.size shouldBeEqualTo 3
     }
 
     private fun square(): PolygonGeometry = PolygonGeometry.from(

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonShapeAdversarialIntegrationTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonShapeAdversarialIntegrationTest.kt
@@ -5,24 +5,26 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
-import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldThrow
 import org.junit.Test
 
 class PolygonShapeAdversarialIntegrationTest {
     @Test
-    fun geometry_givenConcaveLShape_expectRejectedByV1Envelope() {
-        invoking {
-            geometry(
-                point(-0.002, -0.002),
-                point(-0.002, 0.002),
-                point(-0.0005, 0.002),
-                point(-0.0005, -0.0005),
-                point(0.002, -0.0005),
-                point(0.002, -0.002)
-            )
-        } shouldThrow IllegalArgumentException::class
+    fun geometry_givenConcaveLShape_expectAcceptedAndAnsweringInsideTheNotch() {
+        val lShape = geometry(
+            point(-0.002, -0.002),
+            point(-0.002, 0.002),
+            point(-0.0005, 0.002),
+            point(-0.0005, -0.0005),
+            point(0.002, -0.0005),
+            point(0.002, -0.002)
+        )
+
+        lShape.vertices.size shouldBeEqualTo 6
+        // In the bar of the L.
+        lShape.relationTo(point(-0.001, 0.0)) shouldBeEqualTo PolygonPointRelation.INSIDE
+        // In the notch the L wraps around — accepting the shape is only useful if this stays out.
+        lShape.relationTo(point(0.001, 0.001)) shouldBeEqualTo PolygonPointRelation.OUTSIDE
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonWakeCircleValidatorTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonWakeCircleValidatorTest.kt
@@ -6,15 +6,6 @@ import org.amshove.kluent.shouldThrow
 import org.junit.Test
 
 class PolygonWakeCircleValidatorTest {
-    private val geometry = PolygonGeometry.from(
-        listOf(
-            point(37.0, -122.0),
-            point(37.0, -121.999),
-            point(37.001, -121.999),
-            point(37.001, -122.0)
-        )
-    )
-
     @Test
     fun prepare_givenBackendCircleContainingPolygon_expectPlatformMarginAppliedWithoutRecentering() {
         val wakeCircle = PolygonWakeCircle(
@@ -22,59 +13,23 @@ class PolygonWakeCircleValidatorTest {
             baseRadiusMeters = 100.0
         )
 
-        val trigger = PolygonWakeCircleValidator().prepare(geometry, wakeCircle)
+        val trigger = PolygonWakeCircleValidator().prepare(wakeCircle)
 
         trigger.center shouldBeEqualTo wakeCircle.center
         trigger.radiusMeters shouldBeEqualTo 1_100f
     }
 
     @Test
-    fun prepare_givenVertexExactlyOnALargeBackendCircle_expectAccepted() {
-        // The case the fixed 1 m tolerance rejected: a sphere measures a vertex on a backend-valid
-        // circle slightly long, and the overshoot grows with the radius. 1,004 m against a 1,000 m
-        // circle is inside the 0.5% slack but well outside a flat metre.
-        val center = point(37.0, -122.0)
-        val justOutside = point(37.0 + METRES_1004 / METRES_PER_DEGREE_LATITUDE, -122.0)
-        val ring = PolygonGeometry.from(
-            listOf(justOutside, point(36.995, -122.005), point(36.995, -121.995))
-        )
-
-        val trigger = PolygonWakeCircleValidator().prepare(
-            ring,
-            PolygonWakeCircle(center = center, baseRadiusMeters = 1_000.0)
-        )
-
-        trigger.radiusMeters shouldBeEqualTo 2_000f
-    }
-
-    @Test
-    fun prepare_givenVertexWellBeyondTheProportionalTolerance_expectRejected() {
-        // The tolerance scales, but it must stay a tolerance: 5% out is a circle that genuinely
-        // does not contain the ring.
-        val center = point(37.0, -122.0)
-        val farNorth = point(37.0 + METRES_1050 / METRES_PER_DEGREE_LATITUDE, -122.0)
-        val ring = PolygonGeometry.from(
-            listOf(farNorth, point(36.995, -122.005), point(36.995, -121.995))
-        )
-
-        invoking {
-            PolygonWakeCircleValidator().prepare(
-                ring,
-                PolygonWakeCircle(center = center, baseRadiusMeters = 1_000.0)
-            )
-        } shouldThrow IllegalArgumentException::class
-    }
-
-    @Test
-    fun prepare_givenBackendCircleThatMissesVertex_expectRejected() {
+    fun prepare_givenBackendCircleSmallerThanTheRing_expectAcceptedAtTheStatedRadius() {
         val wakeCircle = PolygonWakeCircle(
             center = point(37.0005, -121.9995),
             baseRadiusMeters = 10.0
         )
 
-        invoking {
-            PolygonWakeCircleValidator().prepare(geometry, wakeCircle)
-        } shouldThrow IllegalArgumentException::class
+        val trigger = PolygonWakeCircleValidator().prepare(wakeCircle)
+
+        trigger.radiusMeters shouldBeEqualTo
+            (10.0 + PolygonWakeCircleValidator.PLATFORM_WAKE_MARGIN_METERS).toFloat()
     }
 
     @Test
@@ -85,17 +40,10 @@ class PolygonWakeCircleValidatorTest {
         )
 
         invoking {
-            PolygonWakeCircleValidator().prepare(geometry, wakeCircle)
+            PolygonWakeCircleValidator().prepare(wakeCircle)
         } shouldThrow IllegalArgumentException::class
     }
 
     private fun point(latitude: Double, longitude: Double) =
         PolygonCoordinate(latitude, longitude)
-
-    private companion object {
-        // The validator's own model, so a vertex lands where the test says it does.
-        const val METRES_PER_DEGREE_LATITUDE = 111_194.93
-        const val METRES_1004 = 1_004.0
-        const val METRES_1050 = 1_050.0
-    }
 }

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -1164,7 +1164,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     // --- Schema-drift / corruption safety ---
 
     @Test
-    fun getCachedRegions_givenOneOutOfRangePolygonVertex_expectTheValidCircleSurvives() {
+    fun getCachedRegions_givenAnUnusualPolygonVertex_expectEveryRegionSurvives() {
         // Range checks used to live in PolygonCoordinate's init, which is the deserializer's
         // constructor: one bad stored vertex threw mid-list, readJson wiped the key, and every
         // valid cached region went with it. The bad ring must cost only itself.
@@ -1195,8 +1195,9 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         val cached = store.getCachedRegions()
 
         cached.map { it.id } shouldContain "good-circle"
-        // The ring is still rejected — just at use, not by taking the cache down with it.
-        cached.first { it.id == "bad-polygon" }.polygonGeometryOrNull().shouldBeNull()
+        // The coordinate is no longer judged here — the backend admitted the ring — but the point
+        // of the test stands: one odd stored region must not take the whole cache down with it.
+        cached.map { it.id } shouldContain "bad-polygon"
     }
 
     @Test


### PR DESCRIPTION
Part of: [MBL-2287](https://linear.app/customerio/issue/MBL-2287/android-add-polygon-wire-contract-and-geometry-foundation)

## Stack

- 👉 [#839 trust the backend's polygon validation](https://github.com/customerio/customerio-android/pull/839)
- [#840 collapse repeated positions when canonicalising a ring](https://github.com/customerio/customerio-android/pull/840)
- [#841 support polygons that cross the antimeridian](https://github.com/customerio/customerio-android/pull/841)

Mirrors the same removal @Shahroz16 is making on iOS, from @mahmoud's review point: the backend
already admits or rejects a polygon before it reaches an SDK, so re-implementing its rules on the
device only creates ways for iOS, Android and the backend to disagree about the same payload — and
puts any rule change behind an SDK release.

## Dropped

- per-vertex coordinate range
- the 500-vertex cap
- the covering-circle coverage test (every vertex within `base_radius_m` + slack)
- convexity
- the 85° latitude cap

Convexity is the clearest of them: the backend admits concave rings, our ray cast handles them, and
we rejected them anyway. The latitude cap is a second commit because it wasn't on iOS's list — its
only stated reason was to keep a coordinate-linear ring inside the coverage check being removed
here, and it held polygons to a stricter rule than the rest of the module, where a circle at the
pole was always registerable. iOS then re-baselined the shared vectors to accept that case, which
settled it.

With coverage gone the wake-circle validator no longer looks at the ring at all, so it loses its
`geometry` parameter and its haversine helper with it.

## Kept

What the region needs to exist: a `position` with at least two elements, a ring the geometry kernel
can use (three distinct vertices after unclosing, no self-intersection, non-zero area), and a wake
radius the platform can register.

## Parity

Against the re-baselined `test-vectors-nearest-payload-polygon-v2.json` (22 payload cases):

| | score |
|---|---|
| `feature/geofence-polygons` | 16/22 |
| after the four removals | 19/22 |
| after the latitude cap | 20/22 |
| with #840 on top | 22/22 |

Worth recording that we were never at 25/25 on the old 25-case set either — 21/25 was the standing
number before any of this.

## Tests

487 geofence tests, 0 failures. ktlint, `lintDebug` and `apiCheck` clean. No public API change.

Seven tests pinned the removed rules; each is rewritten to state the new contract rather than
deleted, and the concave one now also asserts the ray cast answers correctly inside the reflex
notch — that being the actual risk of accepting concave rings.

Rewriting the near-pole test turned up that its fixture spans 205° of longitude, so it was really an
antimeridian case: it still fails on the antimeridian guard, which nothing here touches. Its
replacement isolates latitude.

## Effect on the open stack

Independent of #835–#838, which share this base. When this lands they rebase onto it, and #838 needs
its coordinate-range guard reinstated inline in `toPolygonLocationFix`: that one validates an
OS-reported fix rather than a backend payload, so it survives this change.

## Review round

@Shahroz16 asked to keep the platform-validity check on the enclosing circle's **centre**, and he was
right — it is not a geometry rule the backend owns. Removing the coverage check took away the only
thing that incidentally rejected an out-of-range centre, and `registerBatch` builds the whole
business batch in one `map`, so `Geofence.Builder` throwing on one bad record fails **every** fence
in that sync and rolls the movement trigger back with it. Checking the centre isolates the record.
iOS keeps the equivalent check (`CLLocationCoordinate2DIsValid`), so this stays at parity.

`PolygonShapeAdversarialIntegrationTest` asserted the V1 envelope rejects a concave L — the rule this
PR removes. Rewritten to assert the shape is accepted and the notch it wraps around still answers
OUTSIDE.

**Positions that are not numbers.** Positions decode as `JsonElement`, so the literal `"NaN"` parses to
a `Double` and passes every geometry check — each one compares, and all comparisons against NaN are
false. The record registered and failed later in the strict cache encoder, interrupting the catalog
update after the sync had run. Non-finite positions are now dropped at the wire boundary. This is not
one of the coordinate-range rules the backend owns; it is whether the value is a number at all.
