### PR TITLE
chore(geofence): collapse repeated positions when canonicalising a ring

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -113,10 +113,17 @@ internal class PolygonGeometry private constructor(
         private const val EARTH_RADIUS_METERS = 6_371_000.0
 
         fun from(vertices: List<PolygonCoordinate>): PolygonGeometry {
-            val canonical = if (vertices.size > 1 && vertices.first() == vertices.last()) {
-                vertices.dropLast(1)
+            // Collapse consecutive repeats before unclosing, not after. A ring whose closing
+            // position is itself repeated — [A, B, C, D, A, A] — still ends [.., A, A] if it is
+            // unclosed first, and that zero-length edge is rejected below. Repeated positions are
+            // legal GeoJSON and carry no shape, so they collapse rather than drop the region.
+            val collapsed = vertices.filterIndexed { index, vertex ->
+                index == 0 || vertex != vertices[index - 1]
+            }
+            val canonical = if (collapsed.size > 1 && collapsed.first() == collapsed.last()) {
+                collapsed.dropLast(1)
             } else {
-                vertices
+                collapsed
             }
 
             require(canonical.size >= 3) { "polygon requires at least three vertices" }


### PR DESCRIPTION
Part of: [MBL-2287](https://linear.app/customerio/issue/MBL-2287/android-add-polygon-wire-contract-and-geometry-foundation)

## Stack

- [#839 trust the backend's polygon validation](https://github.com/customerio/customerio-android/pull/839)
- 👉 this one

## What this is

Two of iOS's payload vectors still failed after #839, for one reason: repeated positions are legal
GeoJSON and we treat them as shape.

`[A, B, C, D, A, A]` — a closed ring whose closing position is itself repeated — is unclosed to
`[A, B, C, D, A]`, which leaves a zero-length edge between the last vertex and the first. That edge
is rejected, and the region is dropped.

The fix is order: collapse consecutive repeats **before** unclosing, not after. Doing it the other
way round cannot work, because unclosing removes only one of the two trailing copies.

This is ring canonicalisation rather than admission policy — the checks #839 removes are things the
backend already decided, while this is the kernel failing to read a ring it was given — so it is
separate from that PR rather than part of it.

## Parity

Against the re-baselined `test-vectors-nearest-payload-polygon-v2.json` (22 payload cases):

| | score |
|---|---|
| `feature/geofence-polygons` | 16/22 |
| #839 | 20/22 |
| this PR | **22/22** |

The two it fixes are `polygon_duplicates_past_cap_accepted` and
`polygon_duplicate_spanning_ring_wrap_accepted`. Both expected acceptance in the *previous* vector
set too, so this is a standing gap rather than something the re-baseline introduced.

## Tests

487 geofence tests, 0 failures. ktlint, `lintDebug` and `apiCheck` clean. No public API change.
