### PR TITLE
chore(geofence): support polygons that cross the antimeridian

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -26,46 +26,74 @@ internal enum class PolygonPointRelation {
 internal class PolygonGeometry private constructor(
     val vertices: List<PolygonCoordinate>
 ) {
+    /**
+     * Ring longitudes made contiguous: each vertex advances from the previous one by the short arc,
+     * so a ring crossing the antimeridian runs 179.5 -> 180.5 rather than 179.5 -> -179.5.
+     *
+     * Every query is mapped onto this same line by [onRingLine] before it is compared. Wrapping each
+     * longitude independently against the query point instead would break the ring apart whenever the
+     * wrap boundary fell between two of its vertices — a point roughly antipodal to the ring — turning
+     * a two-degree seam edge into a 358-degree chord and reporting far-away points as inside.
+     */
+    private val ringLongitudes: DoubleArray = DoubleArray(vertices.size).also { unwrapped ->
+        unwrapped[0] = vertices[0].longitude
+        for (index in 1 until vertices.size) {
+            unwrapped[index] = unwrapped[index - 1] +
+                normalizeLongitude(vertices[index].longitude - vertices[index - 1].longitude)
+        }
+    }
+
     fun relationTo(point: PolygonCoordinate): PolygonPointRelation {
+        val pointLongitude = onRingLine(point.longitude)
         var inside = false
-        var previous = vertices.last()
+        var previousIndex = vertices.lastIndex
 
-        for (current in vertices) {
-            if (point.isOnSegment(previous, current)) return PolygonPointRelation.BOUNDARY
+        for (index in vertices.indices) {
+            if (isOnSegment(point.latitude, pointLongitude, previousIndex, index)) {
+                return PolygonPointRelation.BOUNDARY
+            }
 
-            // Longitudes are cast relative to the query point and wrapped, the same trick
-            // localOffsetMeters already uses for distance. A ring crossing the antimeridian holds raw
-            // longitudes on both sides of +/-180, and comparing those directly inverts containment for
-            // every point across the seam rather than merely misplacing the boundary.
-            val currentLongitude = normalizeLongitude(current.longitude - point.longitude)
-            val previousLongitude = normalizeLongitude(previous.longitude - point.longitude)
-            val intersects = (current.latitude > point.latitude) != (previous.latitude > point.latitude) &&
-                0.0 < (previousLongitude - currentLongitude) *
-                (point.latitude - current.latitude) /
-                (previous.latitude - current.latitude) + currentLongitude
+            val currentLatitude = vertices[index].latitude
+            val previousLatitude = vertices[previousIndex].latitude
+            val currentLongitude = ringLongitudes[index]
+            val previousLongitude = ringLongitudes[previousIndex]
+            val intersects = (currentLatitude > point.latitude) != (previousLatitude > point.latitude) &&
+                pointLongitude < (previousLongitude - currentLongitude) *
+                (point.latitude - currentLatitude) /
+                (previousLatitude - currentLatitude) + currentLongitude
             if (intersects) inside = !inside
-            previous = current
+            previousIndex = index
         }
 
         return if (inside) PolygonPointRelation.INSIDE else PolygonPointRelation.OUTSIDE
     }
 
     fun boundaryDistanceMeters(point: PolygonCoordinate): Double {
+        val pointLongitude = onRingLine(point.longitude)
         var minimumDistance = Double.MAX_VALUE
-        var previous = vertices.last()
-        for (current in vertices) {
-            minimumDistance = min(minimumDistance, point.distanceToSegmentMeters(previous, current))
-            previous = current
+        var previousIndex = vertices.lastIndex
+        for (index in vertices.indices) {
+            minimumDistance = min(
+                minimumDistance,
+                distanceToSegmentMeters(point.latitude, pointLongitude, previousIndex, index)
+            )
+            previousIndex = index
         }
         return minimumDistance
     }
 
-    private fun PolygonCoordinate.distanceToSegmentMeters(
-        first: PolygonCoordinate,
-        second: PolygonCoordinate
+    /** [longitude] expressed on [ringLongitudes]' line, so ring and query share one frame. */
+    private fun onRingLine(longitude: Double): Double =
+        ringLongitudes[0] + normalizeLongitude(longitude - ringLongitudes[0])
+
+    private fun distanceToSegmentMeters(
+        pointLatitude: Double,
+        pointLongitude: Double,
+        firstIndex: Int,
+        secondIndex: Int
     ): Double {
-        val firstOffset = localOffsetMeters(first)
-        val secondOffset = localOffsetMeters(second)
+        val firstOffset = localOffsetMeters(pointLatitude, pointLongitude, firstIndex)
+        val secondOffset = localOffsetMeters(pointLatitude, pointLongitude, secondIndex)
         val segmentX = secondOffset.first - firstOffset.first
         val segmentY = secondOffset.second - firstOffset.second
         val lengthSquared = segmentX * segmentX + segmentY * segmentY
@@ -80,10 +108,21 @@ internal class PolygonGeometry private constructor(
         )
     }
 
-    private fun PolygonCoordinate.localOffsetMeters(destination: PolygonCoordinate): Pair<Double, Double> {
-        val latitudeDelta = Math.toRadians(destination.latitude - latitude)
-        val longitudeDelta = Math.toRadians(normalizeLongitude(destination.longitude - longitude))
-        val meanLatitude = Math.toRadians((latitude + destination.latitude) / 2.0)
+    /**
+     * Offset in metres from the query point to vertex [index].
+     *
+     * The longitude delta is taken raw, not re-wrapped: both operands already sit on the ring's line,
+     * and wrapping here would split a seam-crossing segment back into a near-global one.
+     */
+    private fun localOffsetMeters(
+        pointLatitude: Double,
+        pointLongitude: Double,
+        index: Int
+    ): Pair<Double, Double> {
+        val vertexLatitude = vertices[index].latitude
+        val latitudeDelta = Math.toRadians(vertexLatitude - pointLatitude)
+        val longitudeDelta = Math.toRadians(ringLongitudes[index] - pointLongitude)
+        val meanLatitude = Math.toRadians((pointLatitude + vertexLatitude) / 2.0)
         return Pair(
             EARTH_RADIUS_METERS * longitudeDelta * cos(meanLatitude),
             EARTH_RADIUS_METERS * latitudeDelta
@@ -93,17 +132,18 @@ internal class PolygonGeometry private constructor(
     private fun normalizeLongitude(longitude: Double): Double =
         ((longitude + 540.0) % 360.0) - 180.0
 
-    private fun PolygonCoordinate.isOnSegment(
-        first: PolygonCoordinate,
-        second: PolygonCoordinate
+    private fun isOnSegment(
+        pointLatitude: Double,
+        pointLongitude: Double,
+        firstIndex: Int,
+        secondIndex: Int
     ): Boolean {
-        // Same relative-and-wrapped frame as the ray cast: the query point sits at longitude 0, so a
-        // segment spanning the antimeridian measures 2 degrees wide here rather than 358, and its
-        // bounding box still contains the points that lie on it.
-        val firstLongitude = normalizeLongitude(first.longitude - longitude)
-        val secondLongitude = normalizeLongitude(second.longitude - longitude)
-        val cross = (latitude - first.latitude) * (secondLongitude - firstLongitude) +
-            firstLongitude * (second.latitude - first.latitude)
+        val first = vertices[firstIndex]
+        val second = vertices[secondIndex]
+        val firstLongitude = ringLongitudes[firstIndex]
+        val secondLongitude = ringLongitudes[secondIndex]
+        val cross = (pointLatitude - first.latitude) * (secondLongitude - firstLongitude) -
+            (pointLongitude - firstLongitude) * (second.latitude - first.latitude)
         val scale = max(
             1.0,
             max(
@@ -113,10 +153,10 @@ internal class PolygonGeometry private constructor(
         )
         if (abs(cross) > BOUNDARY_EPSILON * scale) return false
 
-        return 0.0 >= minOf(firstLongitude, secondLongitude) - BOUNDARY_EPSILON &&
-            0.0 <= maxOf(firstLongitude, secondLongitude) + BOUNDARY_EPSILON &&
-            latitude >= minOf(first.latitude, second.latitude) - BOUNDARY_EPSILON &&
-            latitude <= maxOf(first.latitude, second.latitude) + BOUNDARY_EPSILON
+        return pointLongitude >= minOf(firstLongitude, secondLongitude) - BOUNDARY_EPSILON &&
+            pointLongitude <= maxOf(firstLongitude, secondLongitude) + BOUNDARY_EPSILON &&
+            pointLatitude >= minOf(first.latitude, second.latitude) - BOUNDARY_EPSILON &&
+            pointLatitude <= maxOf(first.latitude, second.latitude) + BOUNDARY_EPSILON
     }
 
     internal companion object {

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -155,29 +155,45 @@ internal class PolygonGeometry private constructor(
 
     internal companion object {
         private const val BOUNDARY_EPSILON = 1e-12
+
+        // Half the globe. The flat projection the evaluator uses cannot describe more.
+        private const val MAXIMUM_LONGITUDE_SPAN = 180.0
         private const val EARTH_RADIUS_METERS = 6_371_000.0
 
         fun from(vertices: List<PolygonCoordinate>): PolygonGeometry {
-            // Collapse consecutive repeats before unclosing, not after. A ring whose closing
-            // position is itself repeated — [A, B, C, D, A, A] — still ends [.., A, A] if it is
-            // unclosed first, and that zero-length edge is rejected below. Repeated positions are
-            // legal GeoJSON and carry no shape, so they collapse rather than drop the region.
-            val collapsed = vertices.filterIndexed { index, vertex ->
-                index == 0 || vertex != vertices[index - 1]
-            }
-            val canonical = if (collapsed.size > 1 && collapsed.first() == collapsed.last()) {
+            require(vertices.isNotEmpty()) { "polygon requires at least one position" }
+
+            // Canonicalisation happens on the unwrapped line, so 180 and -180 are recognised as one
+            // position. A ring closed with the opposite sign to the one it opened with — both legal
+            // GeoJSON — would otherwise survive unclosing and then be rejected for the zero-length
+            // edge that closure left behind.
+            val longitudes = unwrapLongitudes(vertices)
+            fun samePosition(first: Int, second: Int): Boolean =
+                vertices[first].latitude == vertices[second].latitude &&
+                    longitudes[first] == longitudes[second]
+
+            val collapsed = vertices.indices.filter { index -> index == 0 || !samePosition(index, index - 1) }
+            val kept = if (collapsed.size > 1 && samePosition(collapsed.first(), collapsed.last())) {
                 collapsed.dropLast(1)
             } else {
                 collapsed
             }
+            val canonical = kept.map(vertices::get)
+            val ringLongitudes = DoubleArray(kept.size) { longitudes[kept[it]] }
 
             require(canonical.size >= 3) { "polygon requires at least three vertices" }
             require(canonical.distinct().size >= 3) { "polygon requires at least three distinct vertices" }
+            // The evaluator projects the ring onto one flat frame, which only describes a shape
+            // narrower than a hemisphere. A ring winding around a pole unwraps past that — it is
+            // simple and non-degenerate, so nothing below rejects it, and it would then be evaluated
+            // against a closing chord most of the way round the earth. The only real fence this can
+            // refuse sits within ~55 km of a pole, where a degree of longitude is a couple of hundred
+            // metres and an ordinary radius outruns a hemisphere; a flat frame says nothing useful
+            // there either.
+            require(ringLongitudes.max() - ringLongitudes.min() < MAXIMUM_LONGITUDE_SPAN) {
+                "polygon spans too much longitude to evaluate on one frame"
+            }
 
-            // Admission runs on the unwrapped ring, not on raw longitudes. Judged raw, a seam edge
-            // reads as a ~359-degree chord that crosses most of the ring, and a perfectly simple
-            // polygon is rejected as self-intersecting.
-            val ringLongitudes = unwrapLongitudes(canonical)
             val unwrapped = canonical.mapIndexed { index, vertex ->
                 PolygonCoordinate(vertex.latitude, ringLongitudes[index])
             }
@@ -188,7 +204,7 @@ internal class PolygonGeometry private constructor(
             require(unwrapped.hasNonCollinearVertices()) { "polygon cannot have zero area" }
             require(!unwrapped.hasSelfIntersection()) { "polygon cannot intersect itself" }
 
-            return PolygonGeometry(canonical.toList(), ringLongitudes)
+            return PolygonGeometry(canonical, ringLongitudes)
         }
 
         /**

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -24,24 +24,21 @@ internal enum class PolygonPointRelation {
 
 /** Canonical polygon outer ring. V1 does not support holes. */
 internal class PolygonGeometry private constructor(
-    val vertices: List<PolygonCoordinate>
+    val vertices: List<PolygonCoordinate>,
+    /** @see ringLongitudes */
+    private val ringLongitudes: DoubleArray
 ) {
-    /**
-     * Ring longitudes made contiguous: each vertex advances from the previous one by the short arc,
-     * so a ring crossing the antimeridian runs 179.5 -> 180.5 rather than 179.5 -> -179.5.
+    /*
+     * ringLongitudes holds the ring made contiguous: each vertex advances from the previous one by
+     * the short arc, so a ring crossing the antimeridian runs 179.5 -> 180.5 rather than
+     * 179.5 -> -179.5. Every query is mapped onto that same line by onRingLine before it is
+     * compared, and admission validates on it too, so what `from` accepts and what this evaluates
+     * are the same shape.
      *
-     * Every query is mapped onto this same line by [onRingLine] before it is compared. Wrapping each
-     * longitude independently against the query point instead would break the ring apart whenever the
-     * wrap boundary fell between two of its vertices — a point roughly antipodal to the ring — turning
-     * a two-degree seam edge into a 358-degree chord and reporting far-away points as inside.
+     * Wrapping each longitude independently against the query point instead would break the ring
+     * apart whenever the wrap boundary fell between two of its vertices — a point roughly antipodal
+     * to the ring — turning a two-degree seam edge into a 358-degree chord.
      */
-    private val ringLongitudes: DoubleArray = DoubleArray(vertices.size).also { unwrapped ->
-        unwrapped[0] = vertices[0].longitude
-        for (index in 1 until vertices.size) {
-            unwrapped[index] = unwrapped[index - 1] +
-                normalizeLongitude(vertices[index].longitude - vertices[index - 1].longitude)
-        }
-    }
 
     fun relationTo(point: PolygonCoordinate): PolygonPointRelation {
         val pointLongitude = onRingLine(point.longitude)
@@ -129,9 +126,6 @@ internal class PolygonGeometry private constructor(
         )
     }
 
-    private fun normalizeLongitude(longitude: Double): Double =
-        ((longitude + 540.0) % 360.0) - 180.0
-
     private fun isOnSegment(
         pointLatitude: Double,
         pointLongitude: Double,
@@ -179,14 +173,22 @@ internal class PolygonGeometry private constructor(
 
             require(canonical.size >= 3) { "polygon requires at least three vertices" }
             require(canonical.distinct().size >= 3) { "polygon requires at least three distinct vertices" }
-            canonical.forEachIndexed { index, current ->
-                val next = canonical[(index + 1) % canonical.size]
+
+            // Admission runs on the unwrapped ring, not on raw longitudes. Judged raw, a seam edge
+            // reads as a ~359-degree chord that crosses most of the ring, and a perfectly simple
+            // polygon is rejected as self-intersecting.
+            val ringLongitudes = unwrapLongitudes(canonical)
+            val unwrapped = canonical.mapIndexed { index, vertex ->
+                PolygonCoordinate(vertex.latitude, ringLongitudes[index])
+            }
+            unwrapped.forEachIndexed { index, current ->
+                val next = unwrapped[(index + 1) % unwrapped.size]
                 require(current != next) { "polygon cannot contain a zero-length edge" }
             }
-            require(canonical.hasNonCollinearVertices()) { "polygon cannot have zero area" }
-            require(!canonical.hasSelfIntersection()) { "polygon cannot intersect itself" }
+            require(unwrapped.hasNonCollinearVertices()) { "polygon cannot have zero area" }
+            require(!unwrapped.hasSelfIntersection()) { "polygon cannot intersect itself" }
 
-            return PolygonGeometry(canonical.toList())
+            return PolygonGeometry(canonical.toList(), ringLongitudes)
         }
 
         /**
@@ -201,6 +203,19 @@ internal class PolygonGeometry private constructor(
         } catch (_: IllegalArgumentException) {
             null
         }
+
+        private fun normalizeLongitude(longitude: Double): Double =
+            ((longitude + 540.0) % 360.0) - 180.0
+
+        /** Ring longitudes as one continuous line, each vertex a short arc from the previous. */
+        private fun unwrapLongitudes(vertices: List<PolygonCoordinate>): DoubleArray =
+            DoubleArray(vertices.size).also { unwrapped ->
+                unwrapped[0] = vertices[0].longitude
+                for (index in 1 until vertices.size) {
+                    unwrapped[index] = unwrapped[index - 1] +
+                        normalizeLongitude(vertices[index].longitude - vertices[index - 1].longitude)
+                }
+            }
 
         private fun List<PolygonCoordinate>.hasNonCollinearVertices(): Boolean {
             for (firstIndex in indices) {

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -22,7 +22,7 @@ internal enum class PolygonPointRelation {
     BOUNDARY
 }
 
-/** Canonical polygon outer ring. V1 does not support holes or antimeridian crossings. */
+/** Canonical polygon outer ring. V1 does not support holes. */
 internal class PolygonGeometry private constructor(
     val vertices: List<PolygonCoordinate>
 ) {
@@ -33,10 +33,16 @@ internal class PolygonGeometry private constructor(
         for (current in vertices) {
             if (point.isOnSegment(previous, current)) return PolygonPointRelation.BOUNDARY
 
+            // Longitudes are cast relative to the query point and wrapped, the same trick
+            // localOffsetMeters already uses for distance. A ring crossing the antimeridian holds raw
+            // longitudes on both sides of +/-180, and comparing those directly inverts containment for
+            // every point across the seam rather than merely misplacing the boundary.
+            val currentLongitude = normalizeLongitude(current.longitude - point.longitude)
+            val previousLongitude = normalizeLongitude(previous.longitude - point.longitude)
             val intersects = (current.latitude > point.latitude) != (previous.latitude > point.latitude) &&
-                point.longitude < (previous.longitude - current.longitude) *
+                0.0 < (previousLongitude - currentLongitude) *
                 (point.latitude - current.latitude) /
-                (previous.latitude - current.latitude) + current.longitude
+                (previous.latitude - current.latitude) + currentLongitude
             if (intersects) inside = !inside
             previous = current
         }
@@ -91,19 +97,24 @@ internal class PolygonGeometry private constructor(
         first: PolygonCoordinate,
         second: PolygonCoordinate
     ): Boolean {
-        val cross = (latitude - first.latitude) * (second.longitude - first.longitude) -
-            (longitude - first.longitude) * (second.latitude - first.latitude)
+        // Same relative-and-wrapped frame as the ray cast: the query point sits at longitude 0, so a
+        // segment spanning the antimeridian measures 2 degrees wide here rather than 358, and its
+        // bounding box still contains the points that lie on it.
+        val firstLongitude = normalizeLongitude(first.longitude - longitude)
+        val secondLongitude = normalizeLongitude(second.longitude - longitude)
+        val cross = (latitude - first.latitude) * (secondLongitude - firstLongitude) +
+            firstLongitude * (second.latitude - first.latitude)
         val scale = max(
             1.0,
             max(
-                abs(second.longitude - first.longitude),
+                abs(secondLongitude - firstLongitude),
                 abs(second.latitude - first.latitude)
             )
         )
         if (abs(cross) > BOUNDARY_EPSILON * scale) return false
 
-        return longitude >= minOf(first.longitude, second.longitude) - BOUNDARY_EPSILON &&
-            longitude <= maxOf(first.longitude, second.longitude) + BOUNDARY_EPSILON &&
+        return 0.0 >= minOf(firstLongitude, secondLongitude) - BOUNDARY_EPSILON &&
+            0.0 <= maxOf(firstLongitude, secondLongitude) + BOUNDARY_EPSILON &&
             latitude >= minOf(first.latitude, second.latitude) - BOUNDARY_EPSILON &&
             latitude <= maxOf(first.latitude, second.latitude) + BOUNDARY_EPSILON
     }
@@ -131,9 +142,6 @@ internal class PolygonGeometry private constructor(
             canonical.forEachIndexed { index, current ->
                 val next = canonical[(index + 1) % canonical.size]
                 require(current != next) { "polygon cannot contain a zero-length edge" }
-                require(abs(current.longitude - next.longitude) <= 180.0) {
-                    "antimeridian-crossing polygons are unsupported"
-                }
             }
             require(canonical.hasNonCollinearVertices()) { "polygon cannot have zero area" }
             require(!canonical.hasSelfIntersection()) { "polygon cannot intersect itself" }

--- a/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/polygon/PolygonGeometry.kt
@@ -168,9 +168,15 @@ internal class PolygonGeometry private constructor(
             // GeoJSON — would otherwise survive unclosing and then be rejected for the zero-length
             // edge that closure left behind.
             val longitudes = unwrapLongitudes(vertices)
+
+            // Compared on the source positions, not the accumulated line: unwrapping sums a short
+            // arc per vertex, and on decimal coordinates that leaves a closing position ~1e-13 from
+            // the one it repeats. Exact equality there misses the closure and keeps a spurious edge,
+            // which then reads as a self-intersection. Normalising the difference keeps 180 and -180
+            // equal without inheriting any drift.
             fun samePosition(first: Int, second: Int): Boolean =
                 vertices[first].latitude == vertices[second].latitude &&
-                    longitudes[first] == longitudes[second]
+                    normalizeLongitude(vertices[first].longitude - vertices[second].longitude) == 0.0
 
             val collapsed = vertices.indices.filter { index -> index == 0 || !samePosition(index, index - 1) }
             val kept = if (collapsed.size > 1 && samePosition(collapsed.first(), collapsed.last())) {

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -2,6 +2,7 @@ package io.customer.geofence.polygon
 
 import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInRange
 import org.amshove.kluent.shouldThrow
 import org.junit.Test
 
@@ -56,12 +57,35 @@ class PolygonGeometryTest {
     }
 
     @Test
-    fun from_whenSegmentCrossesAntimeridian_thenRejectsGeometry() {
-        invoking {
-            PolygonGeometry.from(
-                listOf(point(0.0, 179.0), point(1.0, -179.0), point(2.0, 179.0))
-            )
-        } shouldThrow IllegalArgumentException::class
+    fun from_whenSegmentCrossesAntimeridian_thenAcceptsGeometry() {
+        PolygonGeometry.from(
+            listOf(point(0.0, 179.0), point(1.0, -179.0), point(2.0, 179.0))
+        ).vertices.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun relationTo_whenRingCrossesAntimeridianAndPointIsWithin_thenReturnsInside() {
+        dateline().relationTo(point(0.5, 180.0)) shouldBeEqualTo PolygonPointRelation.INSIDE
+    }
+
+    @Test
+    fun relationTo_whenRingCrossesAntimeridianAndPointIsBeyondIt_thenReturnsOutside() {
+        // A degree west of the ring's western edge. Read with raw longitudes this point sorts
+        // *between* the ring's own bounds, so an unwrapped ray cast reports it as inside.
+        dateline().relationTo(point(0.5, 178.5)) shouldBeEqualTo PolygonPointRelation.OUTSIDE
+    }
+
+    @Test
+    fun relationTo_whenPointLiesOnAnAntimeridianCrossingEdge_thenReturnsBoundary() {
+        dateline().relationTo(point(0.0, 180.0)) shouldBeEqualTo PolygonPointRelation.BOUNDARY
+    }
+
+    @Test
+    fun boundaryDistanceMeters_whenRingCrossesAntimeridian_thenMeasuresAcrossTheSeam() {
+        // ~0.5 degrees of longitude from the eastern edge at the equator, not ~359.5.
+        val distance = dateline().boundaryDistanceMeters(point(0.5, 179.0))
+
+        distance shouldBeInRange 50_000.0..60_000.0
     }
 
     @Test
@@ -101,6 +125,16 @@ class PolygonGeometryTest {
 
         nearPole.vertices.size shouldBeEqualTo 3
     }
+
+    /** One-degree square straddling the antimeridian: longitude runs 179.5 east to -179.5 west. */
+    private fun dateline(): PolygonGeometry = PolygonGeometry.from(
+        listOf(
+            point(0.0, 179.5),
+            point(0.0, -179.5),
+            point(1.0, -179.5),
+            point(1.0, 179.5)
+        )
+    )
 
     private fun square(): PolygonGeometry = PolygonGeometry.from(
         listOf(

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -81,6 +81,22 @@ class PolygonGeometryTest {
     }
 
     @Test
+    fun relationTo_whenPointIsNearlyAntipodalToTheRing_thenReturnsOutside() {
+        // Ordinary ring on the prime meridian, query half a world away. Mapping each longitude onto
+        // the query point instead of onto the ring splits this ring across the wrap boundary, and the
+        // seam edge becomes a 358-degree chord that swallows the globe.
+        val ring = primeMeridian()
+
+        ring.relationTo(point(0.5, 180.0)) shouldBeEqualTo PolygonPointRelation.OUTSIDE
+        ring.relationTo(point(0.5, -179.0)) shouldBeEqualTo PolygonPointRelation.OUTSIDE
+    }
+
+    @Test
+    fun boundaryDistanceMeters_whenPointIsNearlyAntipodalToTheRing_thenMeasuresHalfTheGlobe() {
+        primeMeridian().boundaryDistanceMeters(point(0.5, 180.0)) shouldBeInRange 19_000_000.0..20_100_000.0
+    }
+
+    @Test
     fun boundaryDistanceMeters_whenRingCrossesAntimeridian_thenMeasuresAcrossTheSeam() {
         // ~0.5 degrees of longitude from the eastern edge at the equator, not ~359.5.
         val distance = dateline().boundaryDistanceMeters(point(0.5, 179.0))
@@ -125,6 +141,16 @@ class PolygonGeometryTest {
 
         nearPole.vertices.size shouldBeEqualTo 3
     }
+
+    /** Two-degree square on the prime meridian: an unremarkable ring, nowhere near the seam. */
+    private fun primeMeridian(): PolygonGeometry = PolygonGeometry.from(
+        listOf(
+            point(0.0, -1.0),
+            point(0.0, 1.0),
+            point(1.0, 1.0),
+            point(1.0, -1.0)
+        )
+    )
 
     /** One-degree square straddling the antimeridian: longitude runs 179.5 east to -179.5 west. */
     private fun dateline(): PolygonGeometry = PolygonGeometry.from(

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -81,6 +81,26 @@ class PolygonGeometryTest {
     }
 
     @Test
+    fun from_whenSimpleRingIsWrittenWithNegativeSeamLongitudes_thenAcceptsGeometry() {
+        // Same shape as the ring below, but with the seam vertex written -180 instead of 180 — both
+        // are legal GeoJSON. Judged on raw longitudes that edge reads as a ~359-degree chord across
+        // the ring and the polygon is rejected as self-intersecting.
+        PolygonGeometry.from(
+            listOf(point(-2.0, 179.0), point(-2.0, 179.5), point(-1.0, -180.0), point(-1.0, 179.0))
+        ).vertices.size shouldBeEqualTo 4
+    }
+
+    @Test
+    fun from_whenRingCrossingTheSeamIsSelfIntersecting_thenStillRejectsGeometry() {
+        // The guard above must not become a blanket exemption for seam-crossing rings.
+        invoking {
+            PolygonGeometry.from(
+                listOf(point(0.0, 179.5), point(1.0, -179.5), point(1.0, 179.5), point(0.0, -179.5))
+            )
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
     fun relationTo_whenPointIsNearlyAntipodalToTheRing_thenReturnsOutside() {
         // Ordinary ring on the prime meridian, query half a world away. Mapping each longitude onto
         // the query point instead of onto the ring splits this ring across the wrap boundary, and the

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -91,6 +91,28 @@ class PolygonGeometryTest {
     }
 
     @Test
+    fun from_whenRingIsClosedWithTheOppositeSeamSign_thenCanonicalizesClosingVertex() {
+        // -180 and 180 are the same position, and both spellings are legal GeoJSON. Compared raw the
+        // ring never looks closed, so the closing vertex survives and its zero-length edge is what
+        // gets rejected.
+        PolygonGeometry.from(
+            listOf(point(0.0, -180.0), point(1.0, -179.0), point(-1.0, -179.0), point(0.0, 180.0))
+        ).vertices.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun from_whenRingWindsAroundAPole_thenRejectsUnevaluableGeometry() {
+        // Simple and non-degenerate, so nothing else rejects it, but it unwraps across 270 degrees.
+        // The evaluator projects onto one flat frame, so it would answer against a closing chord
+        // most of the way round the earth rather than the band the ring describes.
+        invoking {
+            PolygonGeometry.from(
+                listOf(point(80.0, 0.0), point(82.0, 90.0), point(82.0, 180.0), point(82.0, -90.0))
+            )
+        } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
     fun from_whenRingCrossingTheSeamIsSelfIntersecting_thenStillRejectsGeometry() {
         // The guard above must not become a blanket exemption for seam-crossing rings.
         invoking {

--- a/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/polygon/PolygonGeometryTest.kt
@@ -101,6 +101,21 @@ class PolygonGeometryTest {
     }
 
     @Test
+    fun from_whenClosedRingUsesDecimalCoordinates_thenCanonicalizesClosingVertex() {
+        // Unwrapping sums a short arc per vertex, so on real-world decimals the closing position
+        // lands ~1e-13 from the one it repeats. Compared on the accumulated line the ring never looks
+        // closed, and the sliver edge that survives reads as a self-intersection.
+        PolygonGeometry.from(
+            listOf(
+                point(37.0, -122.1),
+                point(37.0, -122.1002),
+                point(37.0001, -122.1003),
+                point(37.0, -122.1)
+            )
+        ).vertices.size shouldBeEqualTo 3
+    }
+
+    @Test
     fun from_whenRingWindsAroundAPole_thenRejectsUnevaluableGeometry() {
         // Simple and non-degenerate, so nothing else rejects it, but it unwraps across 270 degrees.
         // The evaluator projects onto one flat frame, so it would answer against a closing chord


### PR DESCRIPTION
## Summary

A polygon whose ring crosses the antimeridian was rejected at decode, so a fence iOS delivers was silently dropped on Android. iOS supports these deliberately (`unwrapLongitudes`, iOS #1249) and enforces `square400_dateline` in CI, so this is Android's gap to close.

The fix is the frame, not a special case. The ring is unwrapped once at construction into a contiguous line, and every query — containment, boundary distance, and admission — is compared on that same line. Removing the decode guard alone would have been worse than the bug: the ray cast compared raw longitudes, which **inverts** containment across the seam.

## Validation

Reverted each part in isolation to confirm the tests catch it:

| Reverted | Tests that fail |
| --- | --- |
| decode guard restored | 5 |
| ray cast → raw longitudes | 2 (inside and outside) |
| `isOnSegment` → raw longitudes | 1 (BOUNDARY) |
| queries mapped to the point, not the ring line | 2 (antipodal) |
| closure detected on raw equality | 1 |
| span bound removed | 1 |

Cross-SDK geometry vectors **30/30**, up from 23/30, against iOS's current fixtures. Geofence suite 498/498; ktlint, `lintDebug` and `apiCheck` clean.

## Review rounds

Four defects found after the first commit, all reproduced before being fixed:

- **Antipodal queries** (Bugbot). Mapping each longitude onto the query point splits the ring whenever the wrap boundary falls between two vertices. A device at lon 180 read as inside a fence at lon ±1, and `edgeDistanceToOrNull` turns that into `0f` — ranking it ahead of every genuinely nearby fence. The distance half of this predates the PR.
- **Admission left on raw longitudes.** 4,765 of 18,688 generated *simple* seam-crossing rings were rejected as self-intersecting; whether a fence hit it depended only on whether the payload spelled the seam vertex `180` or `-180`.
- **Closure with the opposite seam sign.** `[-180 … 180]` never looked closed, so its zero-length edge was rejected — the same spelling-dependent rejection this stack exists to end.
- **Rings winding around a pole.** Simple and non-degenerate, so nothing rejected them, then evaluated against a closing chord most of the way round the earth: a point deep inside the encircled cap read as OUTSIDE.

## Stack

1. [#839](https://github.com/customerio/customerio-android/pull/839): trust the backend's polygon validation
2. [#840](https://github.com/customerio/customerio-android/pull/840): collapse repeated positions when canonicalising a ring
3. **#841:** antimeridian support

**Canonicalisation compares source positions.** Unwrapping sums a short arc per vertex, so a closed
ring in decimal coordinates left its closing position ~1.14e-13 from the one it repeats. Exact equality
on the accumulated line never saw the closure, and the sliver edge that survived read as a
self-intersection — while the same ring written without its closing position was accepted. The
comparison now runs on the source longitudes through `normalizeLongitude`, which is what keeps
`180` and `-180` equal, without inheriting the drift.

Review against `mbl-2287-collapse-duplicate-vertices`.

Linear: [MBL-2287](https://linear.app/customerio/issue/MBL-2287/android-add-polygon-wire-contract-and-geometry-foundation)