### PR TITLE
chore(geofence): record the fetched fence catalog, and stamp each log file with its own header

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -64,15 +64,22 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
     @VisibleForTesting
     internal suspend fun handleGeofencingEvent(geofencingEvent: GeofencingEvent?) {
-        if (geofencingEvent == null) return
         val logger = SDKComponent.geofenceLogger
+        if (geofencingEvent == null) {
+            logger.logInfo("broadcast_unparseable_intent")
+            return
+        }
 
         if (geofencingEvent.hasError()) {
             logger.logGeofencingError(geofencingEvent.errorCode)
             return
         }
 
-        val triggeringGeofenceIds = geofencingEvent.triggeringGeofences?.map { it.requestId } ?: return
+        val triggeringGeofenceIds = geofencingEvent.triggeringGeofences?.map { it.requestId }
+            ?: run {
+                logger.logInfo("broadcast_no_triggering_geofences")
+                return
+            }
         val location = geofencingEvent.triggeringLocation
         // Logged here, before any routing decision and before the Location is narrowed to a pair
         // of doubles. This is the only place the OS's own triggering fix — accuracy, age, mock
@@ -134,7 +141,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 Geofence.GEOFENCE_TRANSITION_ENTER -> Event.GeofenceTransition.ENTER
                 Geofence.GEOFENCE_TRANSITION_EXIT -> Event.GeofenceTransition.EXIT
                 else -> {
-                    logger.logUnknownTransition(gmsTransitionType)
+                    logger.logUnknownTransition(geofenceId, gmsTransitionType)
                     return@forEach
                 }
             }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
@@ -69,7 +69,7 @@ internal object GeofenceLogTail {
      * The only values that compose the format's separators on purpose. Everything else is treated
      * as an untrusted token: geofence identifiers are workspace-authored and can hold anything.
      */
-    private val COMPOSED_KEYS = setOf("ranked", "evicted", "ids")
+    private val COMPOSED_KEYS = setOf("ranked", "evicted", "ids", "gs", "tt")
 
     /**
      * Applied to every finished value. Only whitespace, which is what separates one `key=value`

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
@@ -21,7 +21,7 @@ internal enum class GeofenceLogIo(val wire: String) {
  * Builds the machine-readable tail appended to a geofence log message.
  *
  * ```
- * [Geofence] Geofence 'notl_core' ENTER: queued ... || ev=transition.emitted io=out id=notl_core t=enter
+ * [Geofence] Geofence 'notl_core' ENTER: queued ... || ev=transition.accepted io=out id=notl_core t=enter n=1
  * ```
  *
  * Mirrors the iOS `GeofenceLog`. The key vocabulary matches; a few records are split

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -557,7 +557,11 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     /** Outcome of a nearby-geofence fetch. An **input**: replay feeds the response back. */
-    fun logApiFetchResult(returnedCount: Int, elapsedMillis: Long?) {
+    fun logApiFetchResult(
+        returnedCount: Int,
+        elapsedMillis: Long?,
+        regions: List<GeofenceRegion> = emptyList()
+    ) {
         logger.debug(
             "Fetched $returnedCount nearby geofence(s) from the server" +
                 tail(
@@ -571,6 +575,43 @@ internal class GeofenceLogger(private val logger: Logger) {
                 ),
             tag = TAG
         )
+        logFenceCatalog(regions)
+    }
+
+    /**
+     * One record per fetched fence, describing the circle the server sent.
+     *
+     * Without this a capture names fences only by opaque id: a replay cannot place them, and nobody
+     * reading the log can tell which geoset a crossing belonged to. Re-fetching the geometry from
+     * the workspace later is not equivalent — fences move, and a drive replayed months on would
+     * silently get today's circles instead of the ones it actually ran against.
+     *
+     * Gated whole rather than relying on `tail()` returning empty, because these records carry no
+     * prose worth emitting on their own — with diagnostics off they should not exist at all.
+     */
+    private fun logFenceCatalog(regions: List<GeofenceRegion>) {
+        if (regions.isEmpty() || !GeofenceDiagnostics.isEnabled) return
+        for (region in regions) {
+            logger.debug(
+                "Geofence '${region.id}' catalogued" +
+                    tail(
+                        "fence.cataloged",
+                        GeofenceLogIo.INPUT,
+                        listOf(
+                            "id" to region.id,
+                            // Sanitized like any other value: a workspace-authored name can contain
+                            // spaces, commas and `=`, all of which would break the parser's split.
+                            "name" to region.name,
+                            "gs" to composedList(region.geosetIds),
+                            "lat" to num(region.latitude, 5),
+                            "lon" to num(region.longitude, 5),
+                            "rad" to num(region.radius, 0),
+                            "tt" to composedList(region.transitionTypes.map { it.name.lowercase() })
+                        )
+                    ),
+                tag = TAG
+            )
+        }
     }
 
     fun logApiFetchFailed(message: String?) {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -367,13 +367,27 @@ internal class GeofenceLogger(private val logger: Logger) {
      * same broadcast. Threading the `Location` down to this call site instead would mean widening
      * `dispatchTransition`, which has 78 test references, for information already recorded.
      */
-    fun logTransitionEmitting(geofenceId: String, transitionName: String) {
+    /**
+     * The SDK judged this crossing real and made it durable — the record replay asserts on.
+     *
+     * Emitted *after* the pending rows are on disk, not before. Logging it earlier claimed an
+     * acceptance the persist could still roll back, and left the log saying a crossing had been
+     * taken when the cooldown had just been released for a retry.
+     *
+     * Named to match iOS. `delivery.*` covers what happens afterwards and is out of replay's
+     * scope; the two families must not be confused, because a device that is merely offline still
+     * accepts crossings correctly.
+     *
+     * [rows] is the per-geoset fan-out size, so one crossing reads as one acceptance.
+     */
+    fun logTransitionAccepted(geofenceId: String, transitionName: String, rows: Int) {
         logger.debug(
-            "Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)" +
+            "Geofence '$geofenceId' $transitionName: accepted and queued for at-least-once delivery " +
+                "($rows row(s); WorkManager now, analytics pipeline on next foreground)" +
                 tail(
-                    "transition.emitted",
+                    "transition.accepted",
                     GeofenceLogIo.OUTPUT,
-                    listOf("id" to geofenceId, "t" to token(transitionName))
+                    listOf("id" to geofenceId, "t" to token(transitionName), "n" to int(rows))
                 ),
             tag = TAG
         )

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -360,14 +360,6 @@ internal class GeofenceLogger(private val logger: Logger) {
     // MARK: - Transitions
 
     /**
-     * The position for this crossing is **not** repeated here.
-     *
-     * It lives on the `os.callback.received` record the receiver writes for the whole broadcast,
-     * which carries the OS's triggering fix and the ids it applied to — join on `id` within the
-     * same broadcast. Threading the `Location` down to this call site instead would mean widening
-     * `dispatchTransition`, which has 78 test references, for information already recorded.
-     */
-    /**
      * The SDK judged this crossing real and made it durable — the record replay asserts on.
      *
      * Emitted *after* the pending rows are on disk, not before. Logging it earlier claimed an
@@ -378,12 +370,20 @@ internal class GeofenceLogger(private val logger: Logger) {
      * scope; the two families must not be confused, because a device that is merely offline still
      * accepts crossings correctly.
      *
-     * [rows] is the per-geoset fan-out size, so one crossing reads as one acceptance.
+     * The position for this crossing is **not** repeated here. It lives on the
+     * `os.callback.received` record the receiver writes for the whole broadcast, which carries the
+     * OS's triggering fix and the ids it applied to — join on `id` within the same broadcast.
+     * Threading the `Location` down to this call site instead would mean widening
+     * `dispatchTransition`, which has 78 test references, for information already recorded.
+     *
+     * [rows] is the per-geoset fan-out size and rides in the tail as `n`, so one crossing reads as
+     * one acceptance. It is deliberately **not** added to the prose: this message predates the
+     * instrumentation, and the file's contract is that pre-existing prose is unchanged so a
+     * customer build with debug logging on sees exactly what it saw before.
      */
     fun logTransitionAccepted(geofenceId: String, transitionName: String, rows: Int) {
         logger.debug(
-            "Geofence '$geofenceId' $transitionName: accepted and queued for at-least-once delivery " +
-                "($rows row(s); WorkManager now, analytics pipeline on next foreground)" +
+            "Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)" +
                 tail(
                     "transition.accepted",
                     GeofenceLogIo.OUTPUT,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -25,8 +25,11 @@ internal enum class GeofenceLaunchReason(val wire: String) {
  *
  * Every record carries a ` || key=value` tail after its human-readable prose: `ev=` is a stable
  * machine key (prose is what gets reworded; `ev` is the contract) and `io=` classifies the record
- * for replay. Pre-existing prose is unchanged; records added by this work emit their prose whether
- * or not diagnostics are on — only the tail is gated.
+ * for replay. The nine prose lines `docs/manual-tests` greps for are unchanged; three of them are
+ * pinned by `documentedProse_expectExactStringsManualTestsGrepFor`, the rest by nothing but care; other prose may be improved (the
+ * unsupported-transition line gained the fence id, since one record per fence naming none of them
+ * was useless). Records added by this work emit their prose whether or not diagnostics are on —
+ * only the tail is gated.
  *
  * Reason tokens are **derived** from the existing prose rather than replacing it with an enum.
  * That keeps every `reason: String` signature exactly as it was — `logSyncSkipped` alone has 20
@@ -313,13 +316,39 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
-    fun logUnknownTransition(transitionType: Int) {
+    /**
+     * Something worth reading in a log, deliberately outside the asserted vocabulary.
+     *
+     * `ev=info` is the bucket for records a human wants when explaining a capture but a scenario
+     * must never assert on. Two reasons it exists rather than reusing a semantic key:
+     *
+     * - Unexpected cases do not deserve invented semantics. Minting a new `ev` for every oddity
+     *   grows the vocabulary faster than anyone can keep it aligned across platforms.
+     * - More importantly, the obvious reuse is actively wrong. Filing these under
+     *   `os.callback.dropped` would inflate the received-vs-dropped count — the count that
+     *   separates "the OS never reported it" from "we discarded it", which is the question a
+     *   paired drive exists to answer. Every real `os.callback.dropped` nets against an
+     *   `os.callback.received`; a broadcast we could not read has no receipt to net against.
+     *
+     * `io=obs`, so the off-device transform drops the whole family rather than replaying it.
+     */
+    fun logInfo(reason: String, fields: List<Pair<String, String?>> = emptyList()) {
         logger.debug(
-            "Ignoring geofence transition type=$transitionType (only ENTER and EXIT are tracked)" +
+            "Geofence note: ${reason.replace('_', ' ')}" +
+                tail("info", GeofenceLogIo.OBSERVATION, listOf("why" to reason) + fields),
+            tag = TAG
+        )
+    }
+
+    /** [geofenceId] because this is called per fence inside the broadcast loop — without it a
+     *  DWELL over three fences produces three identical records naming none of them. */
+    fun logUnknownTransition(geofenceId: String, transitionType: Int) {
+        logger.debug(
+            "Ignoring geofence transition type=$transitionType for '$geofenceId' (only ENTER and EXIT are tracked)" +
                 tail(
                     "os.callback.dropped",
                     GeofenceLogIo.INPUT,
-                    listOf("gms" to int(transitionType), "why" to "unsupported_transition_type")
+                    listOf("id" to geofenceId, "gms" to int(transitionType), "why" to "unsupported_transition_type")
                 ),
             tag = TAG
         )
@@ -360,7 +389,10 @@ internal class GeofenceLogger(private val logger: Logger) {
     // MARK: - Transitions
 
     /**
-     * The SDK judged this crossing real and made it durable — the record replay asserts on.
+     * The SDK judged this crossing real and wrote it down — the record replay asserts on.
+     *
+     * It promises nothing about what happens to the row next: that is the `delivery.*` family's
+     * business and is out of the harness's scope.
      *
      * Emitted *after* the pending rows are on disk, not before. Logging it earlier claimed an
      * acceptance the persist could still roll back, and left the log saying a crossing had been
@@ -372,7 +404,8 @@ internal class GeofenceLogger(private val logger: Logger) {
      *
      * The position for this crossing is **not** repeated here. It lives on the
      * `os.callback.received` record the receiver writes for the whole broadcast, which carries the
-     * OS's triggering fix and the ids it applied to — join on `id` within the same broadcast.
+     * OS's triggering fix and the ids it applied to — find this crossing's `id` in that record's
+     * `ids` list (a comma-separated list, not an `id` field; iOS is the one that emits `id` here).
      * Threading the `Location` down to this call site instead would mean widening
      * `dispatchTransition`, which has 78 test references, for information already recorded.
      *

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -359,7 +359,8 @@ internal class GeofenceRepositoryImpl(
                 // offered and what survived the cap is the thing worth being able to see.
                 logger.logApiFetchResult(
                     returnedCount = response.geofences.size,
-                    elapsedMillis = fetchElapsedMillis
+                    elapsedMillis = fetchElapsedMillis,
+                    regions = regions
                 )
                 // Config preference: server-shipped > last cached > constants.
                 val config = parsedConfig ?: store.getCachedConfigOrFallback()

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -54,8 +54,6 @@ internal class GeofenceTransitionEmitter(
             logger.logTransitionSuppressed(geofenceId, transition.name, cooldownRemaining)
             return false
         }
-        logger.logTransitionEmitting(geofenceId, transition.name)
-
         // One transitionId shared across the per-geoset fan-out.
         val transitionId = UUID.randomUUID().toString()
         val name = geofenceName?.takeIf { it.isNotEmpty() }
@@ -82,6 +80,9 @@ internal class GeofenceTransitionEmitter(
             cooldownFilter.release(userId, geofenceId, transition)
             return false
         }
+        // Only now: the rows are durable, so the crossing will be retried until it lands. Logged
+        // before this point it could claim an acceptance the write then rolled back.
+        logger.logTransitionAccepted(geofenceId, transition.name, entries.size)
         // Only once the rows are durable, so a rolled-back write can't suppress its own retry.
         if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
             regionStore.markEnterEmitted(userId, geofenceId)

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -59,7 +59,11 @@ internal class GeofenceTransitionEmitter(
         val name = geofenceName?.takeIf { it.isNotEmpty() }
         // One event per geoset; no geosets → one null-geoset event. Distinct so a repeated geoset
         // doesn't duplicate.
-        val geosets: List<String?> = geosetIds.distinct().takeIf { it.isNotEmpty() } ?: listOf(null)
+        // Blanks dropped as well as duplicates, matching iOS. A catalog row carrying "" otherwise
+        // persists a row with an empty geosetId and reports n=2 where iOS reports n=1 — and now
+        // that `n` is an asserted field, that reads as an SDK behaviour difference that isn't one.
+        val geosets: List<String?> = geosetIds.filter { it.isNotEmpty() }.distinct()
+            .takeIf { it.isNotEmpty() } ?: listOf(null)
         val entries = geosets.map { geosetId ->
             PendingGeofenceDelivery(
                 geofenceId = geofenceId,

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -80,10 +80,10 @@ internal class GeofenceTransitionEmitter(
             cooldownFilter.release(userId, geofenceId, transition)
             return false
         }
-        // Only now: the rows are durable, so the crossing will be retried until it lands. Logged
-        // before this point it could claim an acceptance the write then rolled back.
+        // Below the write, not above it: logged earlier this could claim an acceptance the write
+        // then rolled back. The same ordering rule covers `markEnterEmitted` — a rolled-back write
+        // must not leave a mark that suppresses its own retry.
         logger.logTransitionAccepted(geofenceId, transition.name, entries.size)
-        // Only once the rows are durable, so a rolled-back write can't suppress its own retry.
         if (transition == Event.GeofenceTransition.ENTER && monitorsExit) {
             regionStore.markEnterEmitted(userId, geofenceId)
         }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -14,7 +14,9 @@ import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.core.util.Clock
+import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -37,6 +39,7 @@ import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
 import org.amshove.kluent.shouldNotContain
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -53,6 +56,45 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
     private val mockStore: GeofenceRegionStore = mockk(relaxed = true)
     private val mockManager: GeofenceManager = mockk(relaxed = true)
     private val mockSecureUserStore: SecureUserStore = mockk(relaxed = true)
+
+    /**
+     * Captures what the SDK actually wrote. The geofence logger is a computed singleton over the
+     * SDK `Logger`, so it cannot be mocked directly — and asserting the emitted record is the
+     * stronger check anyway: it covers the `ev=` a parser dispatches on, not merely that some
+     * method was called.
+     */
+    private class CapturingLogger : Logger {
+        val messages = mutableListOf<String>()
+        override var logLevel: CioLogLevel = CioLogLevel.DEBUG
+        override fun setLogDispatcher(dispatcher: ((CioLogLevel, String) -> Unit)?) = Unit
+        override fun info(message: String, tag: String?) { messages.add(message) }
+        override fun debug(message: String, tag: String?) { messages.add(message) }
+        override fun error(message: String, tag: String?, throwable: Throwable?) { messages.add(message) }
+    }
+
+    private val capturingLogger = CapturingLogger()
+
+    @After
+    fun resetDiagnostics() {
+        // null, not false: null restores the manifest value, false pins the gate off for every
+        // later test class in this JVM.
+        GeofenceDiagnostics.setEnabledForTesting(null)
+    }
+
+    /**
+     * The point of these records: a broadcast the SDK woke for and could make nothing of must
+     * leave a trace, or the capture is byte-identical to a process the OS never talked to.
+     * Asserted on the emitted tail so deleting the log line fails the test.
+     */
+    private fun expectRecorded(ev: String, why: String) {
+        val match = capturingLogger.messages.firstOrNull { it.contains("ev=$ev") && it.contains("why=$why") }
+        if (match == null) {
+            throw AssertionError(
+                "expected a record with ev=$ev why=$why; captured:\n" +
+                    capturingLogger.messages.joinToString("\n  ", prefix = "  ")
+            )
+        }
+    }
 
     // Real-time behavior by default so entry timestamps stay realistic; the dispatch-budget
     // test re-stubs elapsedRealtime to simulate time already spent inside a dispatch.
@@ -76,6 +118,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                     sdk {
                         overrideDependency<EventBus>(mockEventBus)
                         overrideDependency<Clock>(mockClock)
+                        overrideDependency<Logger>(capturingLogger)
                     }
                     android {
                         overrideDependency<GeofenceEventScheduler>(mockScheduler)
@@ -88,6 +131,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                 }
             }
         )
+        // The tail is gated, and these tests assert on `ev=` — the machine key a parser reads,
+        // not the prose, which is what makes deleting a log line fail rather than just reword it.
+        GeofenceDiagnostics.setEnabledForTesting(true)
         // Default: cooldown allows emission. Tests override this to test suppression.
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns null
         // Default: an identified user is the common case; the snapshot lands on the entry.
@@ -122,6 +168,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
+        expectRecorded("info", "broadcast_unparseable_intent")
     }
 
     @Test
@@ -149,6 +196,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
+        expectRecorded("info", "broadcast_no_triggering_geofences")
     }
 
     @Test
@@ -378,6 +426,11 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
+        // Named, so a DWELL over several fences does not produce identical records naming none.
+        expectRecorded("os.callback.dropped", "unsupported_transition_type")
+        // Trailing space: "biz-geofence" is a prefix of "biz-geofence-2", which this suite also
+        // registers, so an unanchored contains would pass on the wrong fence.
+        capturingLogger.messages.any { it.contains("id=biz-geofence ") } shouldBeEqualTo true
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -148,6 +148,7 @@ class GeofenceLogTailTest : RobolectricTest() {
             Triple("syncFailed", listOf("ok", "why")) { it.logSyncFailed("timeout") },
             Triple("syncSucceeded", listOf("n", "mvmt")) { it.logSyncSucceeded(19, true) },
             Triple("apiFetchResult", listOf("ok", "n", "ms")) { it.logApiFetchResult(30, 420L) },
+
             Triple("unknownApiTransitionType", listOf("ok", "why", "value")) { it.logUnknownApiTransitionType("dwell") },
             Triple("movementRearmed", listOf("why")) { it.logMovementRearmedAfterFailedRefresh() },
             Triple("storageLoaded", listOf("n", "anchor")) { it.logStorageLoaded({ 30 }, true) },
@@ -468,5 +469,98 @@ class GeofenceLogTailTest : RobolectricTest() {
         evictedCalls shouldBeEqualTo 1
         distanceCalls shouldBeEqualTo 1
         regionCountCalls shouldBeEqualTo 1
+    }
+
+    private fun catalogRegion(
+        id: String = "11125",
+        name: String? = "Momo Dubai Test"
+    ) = GeofenceRegion(
+        id = id,
+        latitude = 25.109908,
+        longitude = 55.184004,
+        radius = 150f,
+        name = name,
+        geosetIds = listOf("4471", "9002")
+    )
+
+    @Test
+    fun fenceCatalog_givenNameWithSeparators_expectSanitizedButReadable() {
+        // A workspace-authored name is untrusted text in a format whose only structure is spaces
+        // and `=`. Left raw, `Momo Dubai Test` would split into three bogus fields.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion(name = "Momo Dubai, Test=1")))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["name"].shouldNotBeNull()
+        // Still recognisable to a human reading the log, which is half the point of logging it.
+        fields["name"]!!.contains("Momo") shouldBeEqualTo true
+        fields["name"]!!.contains(" ") shouldBeEqualTo false
+        fields["name"]!!.contains("=") shouldBeEqualTo false
+    }
+
+    /**
+     * Deliberately absent from [invocations]: that table asserts the gated-*tail* contract, where
+     * the gate strips detail and leaves the prose identical. The catalog is a different kind of
+     * record — it exists only for diagnostics, so the gate removes it entirely. Emitting bare
+     * "catalogued" lines to every customer's Logcat would be noise, and moving the detail into the
+     * prose to satisfy the table would leak coordinates with the gate off. These tests pin the same
+     * contract the table would have.
+     */
+    @Test
+    fun fenceCatalog_expectMachineKeyAndReplayClassification() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        val message = logger.messages.last()
+        message.startsWith("[Geofence] ") shouldBeEqualTo true
+        val fields = parseTail(message)
+        fields.shouldNotBeNull()
+        fields["ev"] shouldBeEqualTo "fence.cataloged"
+        fields["io"] shouldBeEqualTo "in"
+        for (key in listOf("id", "name", "gs", "lat", "lon", "rad", "tt")) {
+            if (fields[key] == null) throw AssertionError("missing $key= in '$message'")
+        }
+    }
+
+    @Test
+    fun fenceCatalog_expectOneRecordPerFence() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(
+            3,
+            10L,
+            listOf(catalogRegion(id = "1"), catalogRegion(id = "2"), catalogRegion(id = "3"))
+        )
+        logger.messages.count { it.contains("ev=fence.cataloged") } shouldBeEqualTo 3
+    }
+
+    @Test
+    fun fenceCatalog_givenGeosetList_expectSeparatorsPreserved() {
+        // `gs` and `tt` compose commas on purpose, like `ids` and `ranked` — they must opt out of
+        // sanitising or the list collapses into one token.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["gs"] shouldBeEqualTo "4471,9002"
+        fields["tt"] shouldBeEqualTo "enter,exit"
+        fields["lat"] shouldBeEqualTo "25.10991"
+        fields["rad"] shouldBeEqualTo "150"
+    }
+
+    @Test
+    fun fenceCatalog_givenDiagnosticsOff_expectNoCatalogRecords() {
+        // The catalog carries no prose worth emitting on its own; with the gate off it must not
+        // exist at all, not merely lose its tail.
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        logger.messages.none { it.contains("catalogued") } shouldBeEqualTo true
     }
 }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -132,7 +132,7 @@ class GeofenceLogTailTest : RobolectricTest() {
             Triple("movementIgnoredNonExit", listOf("t", "why")) { it.logMovementTriggerIgnoredNonExit("ENTER") },
             Triple("receiverSkipped", listOf("why")) { it.logReceiverSkipped("no identified user") },
             Triple("geofencingError", listOf("ok", "code")) { it.logGeofencingError(1000) },
-            Triple("transitionEmitting", listOf("id", "t")) { it.logTransitionEmitting("notl_core", "ENTER") },
+            Triple("transitionAccepted", listOf("id", "t", "n")) { it.logTransitionAccepted("notl_core", "ENTER", 2) },
             Triple("transitionSuppressed", listOf("id", "t", "why", "cd")) { it.logTransitionSuppressed("notl_core", "ENTER", 42.0) },
             Triple("initialEnterInside", listOf("id", "t", "why")) { it.logInitialEnterInside("notl_core") },
             Triple("droppedUnknownId", listOf("id", "why")) { it.logTransitionDroppedUnknownId("notl_core") },
@@ -379,7 +379,7 @@ class GeofenceLogTailTest : RobolectricTest() {
 
     @Test
     fun sanitize_givenWhitespaceInIdentifier_expectFolded() {
-        geofenceLogger.logTransitionEmitting("niagara on the lake", "ENTER")
+        geofenceLogger.logTransitionAccepted("niagara on the lake", "ENTER", 1)
 
         // Workspace-authored identifiers can contain anything; the parser splits on whitespace.
         parseTail(capturing.messages.last())!!["id"] shouldBeEqualTo "niagara_on_the_lake"
@@ -392,7 +392,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         // format itself uses, and 20 `id` call sites went unprotected behind it.
         for (raw in listOf("store,north", "a=b", "aisle:3", "wing|west")) {
             val logger = CapturingLogger()
-            GeofenceLogger(logger).logTransitionEmitting(raw, "ENTER")
+            GeofenceLogger(logger).logTransitionAccepted(raw, "ENTER", 1)
 
             val tail = parseTail(logger.messages.last())
             tail.shouldNotBeNull()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -105,68 +105,81 @@ class GeofenceLogTailTest : RobolectricTest() {
      * new method added without a line here is simply uncovered — but a *renamed key* on anything
      * listed here fails loudly, which is the failure this contract exists to catch.
      */
-    private fun invocations(): List<Triple<String, List<String>, (GeofenceLogger) -> Unit>> {
+    /**
+     * One row per record. [ev] is pinned per row, not just collected into a set: a set is
+     * identical whether two records keep their keys or swap them, and a swap silently inverts
+     * what every capture says the SDK decided.
+     */
+    private data class Row(
+        val name: String,
+        val ev: String,
+        val requiredKeys: List<String>,
+        val run: (GeofenceLogger) -> Unit
+    )
+
+    private fun invocations(): List<Row> {
         val fix = location()
         return listOf(
-            Triple("geofencesRegistered", listOf("nadd")) { it.logGeofencesRegistered(19) },
-            Triple("regionsRegisteredIds", listOf("n", "ids", "mvmt")) { it.logRegionsRegisteredIds(listOf("a", "b"), "cio_movement_trigger") },
-            Triple("businessKept", listOf("nkeep", "why")) { it.logBusinessGeofencesKept(4) },
-            Triple("geofencesRemoved", listOf("nrem")) { it.logGeofencesRemoved(2) },
-            Triple("geofencesCleared", listOf("why")) { it.logGeofencesCleared() },
-            Triple("registrationFailed", listOf("ok", "why")) { it.logRegistrationFailed("GMS unavailable") },
-            Triple("removalFailed", listOf("ok", "op", "why")) { it.logRemovalFailed("GMS unavailable") },
-            Triple("invalidRegionDropped", listOf("id", "why")) { it.logInvalidRegionDropped("notl core") },
-            Triple("regionMappingFailed", listOf("id", "why")) { it.logRegionMappingFailed("notl_core", "bad radius") },
-            Triple("rankEvaluated", listOf("ncand", "n", "ranked", "evicted")) { it.logRankEvaluated(30, 2, { listOf("a", "b") }, { listOf("c") }, { mapOf("a" to 120.0, "b" to 340.0) }) },
-            Triple("movementTriggerRegistered", listOf("rad")) { it.logMovementTriggerRegistered(43.2, -79.0, 500.0) },
-            Triple("missingPermission", listOf("perm", "why")) { it.logMissingPermission("ACCESS_FINE_LOCATION") },
-            Triple("backgroundUnavailable", listOf("perm", "ctx")) { it.logBackgroundDeliveryUnavailable("app-launch") },
-            Triple("moduleInitialized", listOf("launch")) { it.logModuleInitialized(GeofenceLaunchReason.APP_START) },
-            Triple("moduleWoke", listOf("launch")) { it.logModuleWoke(GeofenceLaunchReason.BOOT_RESTORE) },
-            Triple("missingLocationModule", listOf("ok", "why")) { it.logMissingLocationModule() },
-            Triple("stateResetOnSignOut", listOf("why")) { it.logGeofenceStateResetOnSignOut() },
-            Triple("callbackReceived", listOf("ids", "n", "t", "fixsrc", "acc", "age", "sim")) { it.logCallbackReceived(listOf("notl_core"), "ENTER", fix, GeofenceLogTail.FixSource.OS_TRIGGER) },
-            Triple("callbackReceivedNoFix", listOf("fixsrc")) { it.logCallbackReceived(listOf("notl_core"), "EXIT", null, GeofenceLogTail.FixSource.NONE) },
-            Triple("transitionWithoutLocation", listOf("fixsrc", "why")) { it.logTransitionWithoutLocation() },
-            Triple("unknownTransition", listOf("gms", "why")) { it.logUnknownTransition(4) },
-            Triple("movementIgnoredNonExit", listOf("t", "why")) { it.logMovementTriggerIgnoredNonExit("ENTER") },
-            Triple("receiverSkipped", listOf("why")) { it.logReceiverSkipped("no identified user") },
-            Triple("geofencingError", listOf("ok", "code")) { it.logGeofencingError(1000) },
-            Triple("transitionAccepted", listOf("id", "t", "n")) { it.logTransitionAccepted("notl_core", "ENTER", 2) },
-            Triple("transitionSuppressed", listOf("id", "t", "why", "cd")) { it.logTransitionSuppressed("notl_core", "ENTER", 42.0) },
-            Triple("initialEnterInside", listOf("id", "t", "why")) { it.logInitialEnterInside("notl_core") },
-            Triple("droppedUnknownId", listOf("id", "why")) { it.logTransitionDroppedUnknownId("notl_core") },
-            Triple("enterDroppedAlreadyReported", listOf("id", "t", "why")) { it.logEnterDroppedAlreadyReported("notl_core") },
-            Triple("exitDroppedNeverEntered", listOf("id", "t", "why")) { it.logExitDroppedNeverEntered("notl_core") },
-            Triple("droppedAnonymous", listOf("id", "t", "why")) { it.logTransitionDroppedAnonymous("notl_core", "EXIT") },
-            Triple("syncTriggered", listOf("why")) { it.logSyncTriggered("app-launch") },
-            Triple("syncSkipped", listOf("why")) { it.logSyncSkipped("no identified user") },
-            Triple("syncSkippedNoLocation", listOf("why", "ctx")) { it.logSyncSkippedNoLocation("app-launch") },
-            Triple("syncSkippedInvalidLocation", listOf("why", "ctx")) { it.logSyncSkippedInvalidLocation("app-launch", 0.0, 0.0) },
-            Triple("syncSkippedNoPermission", listOf("why", "ctx")) { it.logSyncSkippedNoPermission("boot-restore") },
-            Triple("syncSkippedFresh", listOf("why")) { it.logSyncSkippedFresh() },
-            Triple("syncFailed", listOf("ok", "why")) { it.logSyncFailed("timeout") },
-            Triple("syncSucceeded", listOf("n", "mvmt")) { it.logSyncSucceeded(19, true) },
-            Triple("apiFetchResult", listOf("ok", "n", "ms")) { it.logApiFetchResult(30, 420L) },
+            Row("geofencesRegistered", "registration.added", listOf("nadd")) { it.logGeofencesRegistered(19) },
+            Row("regionsRegisteredIds", "registration.applied", listOf("n", "ids", "mvmt")) { it.logRegionsRegisteredIds(listOf("a", "b"), "cio_movement_trigger") },
+            Row("businessKept", "registration.kept", listOf("nkeep", "why")) { it.logBusinessGeofencesKept(4) },
+            Row("geofencesRemoved", "registration.removed", listOf("nrem")) { it.logGeofencesRemoved(2) },
+            Row("geofencesCleared", "registration.cleared", listOf("why")) { it.logGeofencesCleared() },
+            Row("registrationFailed", "registration.failed", listOf("ok", "why")) { it.logRegistrationFailed("GMS unavailable") },
+            Row("removalFailed", "registration.failed", listOf("ok", "op", "why")) { it.logRemovalFailed("GMS unavailable") },
+            Row("invalidRegionDropped", "registration.rejected", listOf("id", "why")) { it.logInvalidRegionDropped("notl core") },
+            Row("regionMappingFailed", "registration.rejected", listOf("id", "why")) { it.logRegionMappingFailed("notl_core", "bad radius") },
+            Row("rankEvaluated", "rank.evaluated", listOf("ncand", "n", "ranked", "evicted")) { it.logRankEvaluated(30, 2, { listOf("a", "b") }, { listOf("c") }, { mapOf("a" to 120.0, "b" to 340.0) }) },
+            Row("movementTriggerRegistered", "movement.registered", listOf("rad")) { it.logMovementTriggerRegistered(43.2, -79.0, 500.0) },
+            Row("missingPermission", "permission.changed", listOf("perm", "why")) { it.logMissingPermission("ACCESS_FINE_LOCATION") },
+            Row("backgroundUnavailable", "permission.changed", listOf("perm", "ctx")) { it.logBackgroundDeliveryUnavailable("app-launch") },
+            Row("moduleInitialized", "module.init", listOf("launch")) { it.logModuleInitialized(GeofenceLaunchReason.APP_START) },
+            Row("moduleWoke", "module.wake", listOf("launch")) { it.logModuleWoke(GeofenceLaunchReason.BOOT_RESTORE) },
+            Row("missingLocationModule", "module.init", listOf("ok", "why")) { it.logMissingLocationModule() },
+            Row("stateResetOnSignOut", "module.reset", listOf("why")) { it.logGeofenceStateResetOnSignOut() },
+            Row("callbackReceived", "os.callback.received", listOf("ids", "n", "t", "fixsrc", "acc", "age", "sim")) { it.logCallbackReceived(listOf("notl_core"), "ENTER", fix, GeofenceLogTail.FixSource.OS_TRIGGER) },
+            Row("callbackReceivedNoFix", "os.callback.received", listOf("fixsrc")) { it.logCallbackReceived(listOf("notl_core"), "EXIT", null, GeofenceLogTail.FixSource.NONE) },
+            Row("transitionWithoutLocation", "os.callback.no_location", listOf("fixsrc", "why")) { it.logTransitionWithoutLocation() },
+            Row("unknownTransition", "os.callback.dropped", listOf("id", "gms", "why")) { it.logUnknownTransition("notl_core", 4) },
+            Row("info", "info", listOf("why")) { it.logInfo("broadcast_no_triggering_geofences") },
+            Row("movementIgnoredNonExit", "os.callback.dropped", listOf("t", "why")) { it.logMovementTriggerIgnoredNonExit("ENTER") },
+            Row("receiverSkipped", "os.callback.dropped", listOf("why")) { it.logReceiverSkipped("no identified user") },
+            Row("geofencingError", "os.error", listOf("ok", "code")) { it.logGeofencingError(1000) },
+            Row("transitionAccepted", "transition.accepted", listOf("id", "t", "n")) { it.logTransitionAccepted("notl_core", "ENTER", 2) },
+            Row("transitionSuppressed", "transition.suppressed", listOf("id", "t", "why", "cd")) { it.logTransitionSuppressed("notl_core", "ENTER", 42.0) },
+            Row("initialEnterInside", "transition.synthesized", listOf("id", "t", "why")) { it.logInitialEnterInside("notl_core") },
+            Row("droppedUnknownId", "transition.dropped", listOf("id", "why")) { it.logTransitionDroppedUnknownId("notl_core") },
+            Row("enterDroppedAlreadyReported", "transition.dropped", listOf("id", "t", "why")) { it.logEnterDroppedAlreadyReported("notl_core") },
+            Row("exitDroppedNeverEntered", "transition.dropped", listOf("id", "t", "why")) { it.logExitDroppedNeverEntered("notl_core") },
+            Row("droppedAnonymous", "transition.dropped", listOf("id", "t", "why")) { it.logTransitionDroppedAnonymous("notl_core", "EXIT") },
+            Row("syncTriggered", "sync.triggered", listOf("why")) { it.logSyncTriggered("app-launch") },
+            Row("syncSkipped", "sync.skipped", listOf("why")) { it.logSyncSkipped("no identified user") },
+            Row("syncSkippedNoLocation", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedNoLocation("app-launch") },
+            Row("syncSkippedInvalidLocation", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedInvalidLocation("app-launch", 0.0, 0.0) },
+            Row("syncSkippedNoPermission", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedNoPermission("boot-restore") },
+            Row("syncSkippedFresh", "sync.skipped", listOf("why")) { it.logSyncSkippedFresh() },
+            Row("syncFailed", "sync.failed", listOf("ok", "why")) { it.logSyncFailed("timeout") },
+            Row("syncSucceeded", "sync.completed", listOf("n", "mvmt")) { it.logSyncSucceeded(19, true) },
+            Row("apiFetchResult", "api.fetch.result", listOf("ok", "n", "ms")) { it.logApiFetchResult(30, 420L) },
 
-            Triple("unknownApiTransitionType", listOf("ok", "why", "value")) { it.logUnknownApiTransitionType("dwell") },
-            Triple("movementRearmed", listOf("why")) { it.logMovementRearmedAfterFailedRefresh() },
-            Triple("storageLoaded", listOf("n", "anchor")) { it.logStorageLoaded({ 30 }, true) },
-            Triple("persistFailed", listOf("id", "t", "ok")) { it.logPersistFailed("notl_core", "ENTER") },
-            Triple("deliveryRetryable", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryRetryable("notl_core", "ENTER", "socket timeout") },
-            Triple("deliveryFailed", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryFailed("notl_core", "ENTER", "400 bad request") },
-            Triple("eventInvalidInput", listOf("ok", "why")) { it.logEventInvalidInput(null, null) },
-            Triple("deliveryDeferredAnonymous", listOf("id", "t", "why")) { it.logEventDeliveryDeferredAnonymous("notl_core", "ENTER") },
-            Triple("eventDelivered", listOf("id", "t", "via")) { it.logEventDelivered("notl_core", "ENTER") },
-            Triple("deliverySkippedAlreadyDelivered", listOf("id", "t", "why")) { it.logEventDeliverySkippedAlreadyDelivered("notl_core", "ENTER") },
-            Triple("workerEntryMissing", listOf("key", "why")) { it.logEventWorkerEntryMissing("notl_core:ENTER") },
-            Triple("flushSnapshot", listOf("n", "phase")) { it.logForegroundFlushSnapshot(3) },
-            Triple("flushCancelled", listOf("id", "t", "why")) { it.logForegroundFlushCancelledWorkManager("notl_core", "ENTER") },
-            Triple("flushPublished", listOf("id", "t", "via")) { it.logForegroundFlushPublished("notl_core", "ENTER") },
-            Triple("flushEntryFailed", listOf("id", "t", "ok", "via", "why")) { it.logForegroundFlushEntryFailed("notl_core", "ENTER", "boom") },
-            Triple("flushComplete", listOf("n", "phase", "ok")) { it.logForegroundFlushComplete(3) },
-            Triple("asyncDeliveryFailed", listOf("id", "t", "ok", "why")) { it.logAsyncDeliveryFailed("notl_core", "ENTER", "boom") },
-            Triple("schedulerFailed", listOf("id", "t", "ok", "why", "detail")) { it.logSchedulerFailed("notl_core", "ENTER", "boom") }
+            Row("unknownApiTransitionType", "api.transition.unknown", listOf("ok", "why", "value")) { it.logUnknownApiTransitionType("dwell") },
+            Row("movementRearmed", "movement.rearmed", listOf("why")) { it.logMovementRearmedAfterFailedRefresh() },
+            Row("storageLoaded", "storage.loaded", listOf("n", "anchor")) { it.logStorageLoaded({ 30 }, true) },
+            Row("persistFailed", "storage.write.failed", listOf("id", "t", "ok")) { it.logPersistFailed("notl_core", "ENTER") },
+            Row("deliveryRetryable", "delivery.failed", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryRetryable("notl_core", "ENTER", "socket timeout") },
+            Row("deliveryFailed", "delivery.failed", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryFailed("notl_core", "ENTER", "400 bad request") },
+            Row("eventInvalidInput", "delivery.failed", listOf("ok", "why")) { it.logEventInvalidInput(null, null) },
+            Row("deliveryDeferredAnonymous", "delivery.queued", listOf("id", "t", "why")) { it.logEventDeliveryDeferredAnonymous("notl_core", "ENTER") },
+            Row("eventDelivered", "delivery.sent", listOf("id", "t", "via")) { it.logEventDelivered("notl_core", "ENTER") },
+            Row("deliverySkippedAlreadyDelivered", "delivery.sent", listOf("id", "t", "why")) { it.logEventDeliverySkippedAlreadyDelivered("notl_core", "ENTER") },
+            Row("workerEntryMissing", "delivery.sent", listOf("key", "why")) { it.logEventWorkerEntryMissing("notl_core:ENTER") },
+            Row("flushSnapshot", "delivery.flush", listOf("n", "phase")) { it.logForegroundFlushSnapshot(3) },
+            Row("flushCancelled", "delivery.flush", listOf("id", "t", "why")) { it.logForegroundFlushCancelledWorkManager("notl_core", "ENTER") },
+            Row("flushPublished", "delivery.sent", listOf("id", "t", "via")) { it.logForegroundFlushPublished("notl_core", "ENTER") },
+            Row("flushEntryFailed", "delivery.failed", listOf("id", "t", "ok", "via", "why")) { it.logForegroundFlushEntryFailed("notl_core", "ENTER", "boom") },
+            Row("flushComplete", "delivery.flush", listOf("n", "phase", "ok")) { it.logForegroundFlushComplete(3) },
+            Row("asyncDeliveryFailed", "delivery.failed", listOf("id", "t", "ok", "why")) { it.logAsyncDeliveryFailed("notl_core", "ENTER", "boom") },
+            Row("schedulerFailed", "delivery.failed", listOf("id", "t", "ok", "why", "detail")) { it.logSchedulerFailed("notl_core", "ENTER", "boom") }
         )
     }
 
@@ -174,7 +187,7 @@ class GeofenceLogTailTest : RobolectricTest() {
 
     @Test
     fun everyRecord_givenAnyMethod_expectMachineKeyAndReplayClassification() {
-        for ((name, requiredKeys, run) in invocations()) {
+        for ((name, ev, requiredKeys, run) in invocations()) {
             val logger = CapturingLogger()
             run(GeofenceLogger(logger))
 
@@ -184,7 +197,9 @@ class GeofenceLogTailTest : RobolectricTest() {
             val fields = parseTail(message)
             fields.shouldNotBeNull()
 
-            fields["ev"].shouldNotBeNull()
+            if (fields["ev"] != ev) {
+                throw AssertionError("$name: expected ev=$ev, got '${fields["ev"]}'")
+            }
             (fields["io"] in listOf("in", "out", "obs")) shouldBeEqualTo true
             for (key in requiredKeys) {
                 if (fields[key] == null) {
@@ -196,7 +211,7 @@ class GeofenceLogTailTest : RobolectricTest() {
 
     @Test
     fun everyRecord_givenAnyMethod_expectProseAndTailSeparated() {
-        for ((name, _, run) in invocations()) {
+        for ((name, _, _, run) in invocations()) {
             val logger = CapturingLogger()
             run(GeofenceLogger(logger))
             // Diagnostics-only entry points emit nothing at all with the gate off, which is a
@@ -214,7 +229,7 @@ class GeofenceLogTailTest : RobolectricTest() {
 
     @Test
     fun everyValue_givenAnyMethod_expectNoWhitespace() {
-        for ((name, _, run) in invocations()) {
+        for ((name, _, _, run) in invocations()) {
             val logger = CapturingLogger()
             run(GeofenceLogger(logger))
             // Diagnostics-only entry points emit nothing at all with the gate off, which is a
@@ -229,13 +244,112 @@ class GeofenceLogTailTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun documentedProse_expectExactStringsManualTestsGrepFor() {
+        // The gate test above only proves no tail leaked; it cannot see a reworded message. The
+        // rename went through it green, changing a line docs/manual-tests greps for — a tester
+        // then finds nothing and reports a false failure.
+        //
+        // Three of the nine hallmark strings that doc lists — the ones this change set touched or
+        // moved past. The other six are unpinned and would still drift silently; extending this
+        // list is cheap and worth doing next time one of them is edited. Golden by design: if a
+        // pinned line changes, the doc changes with it, deliberately, in the same commit.
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val golden = listOf<Pair<String, (GeofenceLogger) -> Unit>>(
+            "Geofence 'notl_core' ENTER: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)"
+                to { l: GeofenceLogger -> l.logTransitionAccepted("notl_core", "ENTER", 1) },
+            "Geofence 'notl_core' ENTER: delivered via WorkManager (direct HTTP); removed from pending store"
+                to { l: GeofenceLogger -> l.logEventDelivered("notl_core", "ENTER") },
+            "Geofence 'notl_core' ENTER: published to analytics pipeline via foreground flush"
+                to { l: GeofenceLogger -> l.logForegroundFlushPublished("notl_core", "ENTER") }
+        )
+        for ((expected, run) in golden) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            val message = logger.messages.lastOrNull()
+            message.shouldNotBeNull()
+            // Full equality including the tag: the doc's first instruction is
+            // `adb logcat | grep -E "\[Geofence\]"`, so the prefix is part of what a tester
+            // relies on. endsWith would let a TAG change pass unnoticed.
+            if (message != "[Geofence] $expected") {
+                throw AssertionError(
+                    "prose drifted from docs/manual-tests/geofence-transition-delivery.md\n" +
+                        "  expected: '$expected'\n  actual:   '$message'"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun everyRecord_expectTheDeclaredVocabulary() {
+        // Companion to the per-row `ev` pin above, catching what a per-row check cannot: a key
+        // removed from the module entirely, or a row added to the table without being declared
+        // here. It does NOT see a record that exists in the module but was never added to the
+        // table — `seen` is built from the table, not from the source. `fence.cataloged` is the
+        // standing proof of that limit.
+        //
+        // `fence.cataloged` is absent because the `apiFetchResult` row passes no regions, so
+        // `logFenceCatalog` returns at its `isEmpty` guard and no catalog row is ever emitted here.
+        // It carries its own `ev` assertion further down. Add a region to that row and this set
+        // gains `fence.cataloged` — update both together.
+        val expected = setOf(
+            "api.fetch.result",
+            "api.transition.unknown",
+            "delivery.failed",
+            "delivery.flush",
+            "delivery.queued",
+            "delivery.sent",
+            "info",
+            "module.init",
+            "module.reset",
+            "module.wake",
+            "movement.rearmed",
+            "movement.registered",
+            "os.callback.dropped",
+            "os.callback.no_location",
+            "os.callback.received",
+            "os.error",
+            "permission.changed",
+            "rank.evaluated",
+            "registration.added",
+            "registration.applied",
+            "registration.cleared",
+            "registration.failed",
+            "registration.kept",
+            "registration.rejected",
+            "registration.removed",
+            "storage.loaded",
+            "storage.write.failed",
+            "sync.completed",
+            "sync.failed",
+            "sync.skipped",
+            "sync.triggered",
+            "transition.accepted",
+            "transition.dropped",
+            "transition.suppressed",
+            "transition.synthesized"
+        )
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val seen = mutableSetOf<String>()
+        for ((_, _, _, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            parseTail(logger.messages.lastOrNull() ?: "")?.get("ev")?.let { seen.add(it) }
+        }
+        if (seen != expected) {
+            throw AssertionError(
+                "vocabulary drift.\n  added:   ${(seen - expected).sorted()}\n  missing: ${(expected - seen).sorted()}"
+            )
+        }
+    }
+
     // MARK: - The gate
 
     @Test
     fun everyRecord_givenDiagnosticsOff_expectOutputUnchangedFromBeforeInstrumentation() {
         GeofenceDiagnostics.setEnabledForTesting(false)
 
-        for ((name, _, run) in invocations()) {
+        for ((name, _, _, run) in invocations()) {
             val logger = CapturingLogger()
             run(GeofenceLogger(logger))
             // Diagnostics-only entry points emit nothing at all with the gate off, which is a
@@ -257,7 +371,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         GeofenceDiagnostics.setEnabledForTesting(false)
         val logger = CapturingLogger()
         val target = GeofenceLogger(logger)
-        for ((_, _, run) in invocations()) run(target)
+        for ((_, _, _, run) in invocations()) run(target)
 
         // Spot-checks the classes of value the harness cares about, including ones that are
         // harmless in isolation. The point is that "harmless in isolation" stopped being the test.
@@ -273,7 +387,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
         val target = GeofenceLogger(logger)
-        for ((_, _, run) in invocations()) run(target)
+        for ((_, _, _, run) in invocations()) run(target)
 
         val joined = logger.messages.joinToString("\n")
         joined.contains("lat=") shouldBeEqualTo true
@@ -305,7 +419,7 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun proseHalf_expectIdenticalWhicheverWayTheGateIsSet() {
         // The prose is what a customer reads and what existing tests assert on. Enabling
         // diagnostics must append to it and never rewrite it.
-        for ((name, _, run) in invocations()) {
+        for ((name, _, _, run) in invocations()) {
             // Each pass is a fresh "launch" for the once-per-process module.init record.
             GeofenceDiagnostics.setEnabledForTesting(false)
             val off = CapturingLogger()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -148,8 +148,9 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenGated_expectNoAcceptedRecord() = runTest {
-        // Cooldown and redundant-enter both log their own record; neither may also claim
-        // acceptance, or a suppressed crossing counts twice off-device.
+        // A cooldown-suppressed crossing logs its own record and must not also claim acceptance,
+        // or it counts twice off-device. (Redundant-enter is the other gate with the same rule;
+        // that one is covered by emit_givenEnterAlreadyReported_.)
         every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns 42.0
 
         emit().shouldBeFalse()
@@ -168,6 +169,8 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         // Ahead of the cooldown, so the slot stays free for the next genuine transition.
         verify(exactly = 0) { mockCooldownFilter.tryAcquire(any(), any(), any()) }
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
+        verify(exactly = 0) { mockLogger.logTransitionAccepted(any(), any(), any()) }
+        verify(exactly = 1) { mockLogger.logEnterDroppedAlreadyReported("biz-1") }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -128,6 +128,34 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         emitted.shouldBeFalse()
         verify(exactly = 1) { mockCooldownFilter.release("user-1", "biz-1", Event.GeofenceTransition.ENTER) }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        // The crossing was NOT accepted: the write failed and the cooldown was handed back for a
+        // retry. Claiming acceptance here is the regression this guards — replay asserts on this
+        // record, so a false positive is a crossing the harness believes was taken and was not.
+        verify(exactly = 0) { mockLogger.logTransitionAccepted(any(), any(), any()) }
+    }
+
+    @Test
+    fun emit_givenPersistSucceeds_expectAcceptedLoggedWithFanoutCount() = runTest {
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns null
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit(geosetIds = listOf("g1", "g2")).shouldBeTrue()
+
+        // `n` is the per-geoset row count, so one crossing reads as one acceptance rather than
+        // being inferred from however many delivery records follow it.
+        verify(exactly = 1) { mockLogger.logTransitionAccepted("biz-1", "ENTER", 2) }
+    }
+
+    @Test
+    fun emit_givenGated_expectNoAcceptedRecord() = runTest {
+        // Cooldown and redundant-enter both log their own record; neither may also claim
+        // acceptance, or a suppressed crossing counts twice off-device.
+        every { mockCooldownFilter.tryAcquire(any(), any(), any()) } returns 42.0
+
+        emit().shouldBeFalse()
+
+        verify(exactly = 0) { mockLogger.logTransitionAccepted(any(), any(), any()) }
+        verify(exactly = 0) { mockPendingStore.appendAll(any()) }
     }
 
     @Test

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -52,7 +52,7 @@ object DiagnosticLog {
 
             val fileWriter = DiagnosticLogWriter(directory(application))
             writer = fileWriter
-            fileWriter.open(DiagnosticEnvelope.fileHeader(application))
+            fileWriter.open { DiagnosticEnvelope.fileHeader(application) }
 
             deviceState = DiagnosticDeviceState(application).also { state ->
                 state.start { reason ->

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -32,7 +32,13 @@ internal class DiagnosticLogWriter(private val directory: File) {
 
     private var stream: FileOutputStream? = null
     private var currentFile: File? = null
-    private var header: String = ""
+
+    /**
+     * Rebuilt on every open, not stored as a string. The header describes the file it heads: a
+     * process that outlives a day rolls to a new file, and re-writing the original string there
+     * stamped it with the old session's timestamp — and, on iOS, the old timezone.
+     */
+    private var headerProvider: (() -> String)? = null
 
     /**
      * Wall-clock instant at which today's file stops being today's file. Compared against on every
@@ -51,9 +57,9 @@ internal class DiagnosticLogWriter(private val directory: File) {
     private var openZoneId: String? = null
     private var writesSinceExistenceCheck = 0
 
-    fun open(header: String) {
+    fun open(headerProvider: () -> String) {
         synchronized(lock) {
-            this.header = header
+            this.headerProvider = headerProvider
             openCurrentFile(System.currentTimeMillis())
         }
     }
@@ -91,6 +97,7 @@ internal class DiagnosticLogWriter(private val directory: File) {
         // The header repeats on every open, not just on a new file. A same-day relaunch reuses
         // the file but resets elapsedRealtime and may carry a different bootCount or build, so
         // without this every record after the first process is correlated to the wrong boot.
+        val header = headerProvider?.invoke().orEmpty()
         if (header.isNotEmpty()) write(header)
     }
 


### PR DESCRIPTION
Two independent diagnostics follow-ups, both small, both found while using the sink on a real drive.

### 1. Record the fetched fence catalog

A capture named fences only by opaque id. Nobody reading a log could tell which geoset a crossing belonged to, and a replay could not place the circles at all — the scenario transform emitted `fixture.api.fetch body:null` because the geometry is nowhere in the log.

The response already carries `name`, `latitude`, `longitude`, `radius` and `geosetIds`, and we discarded all of it. Each successful fetch now emits one record per fence, behind the existing build-time gate:

```
ev=fence.cataloged io=in id=11125 name=Momo_Dubai_Test gs=4471 lat=25.10967 lon=55.18406 rad=150 tt=enter,exit
```

Re-fetching the geometry from the workspace at replay time is **not** an equivalent alternative: fences move, so a drive replayed months later would silently run against today's circles rather than the ones it actually crossed — and a capture from a customer has no workspace to query.

Names are sanitized like any other value; a workspace-authored name can contain spaces, commas and `=`, each of which would break the parser's split. `gs` and `tt` join the composed-key set alongside `ids`, since their commas are structure rather than untrusted input.

Gated **whole** rather than gated-tail, and deliberately absent from the `invocations` table that asserts the gated-tail contract. These records carry no prose worth emitting on their own, so with diagnostics off they must not exist at all; putting the detail in the prose to satisfy that table would leak coordinates with the gate off. Their own tests pin the same guarantees.

### 2. Rebuild the file header per file

The header was built once at process start and the writer re-wrote that same string on every open, so a process outliving a day stamped each rolled-over file with the original session's timestamp. Observed on a device — four consecutive daily files, every one reading `ts=2026-09-02T23:53:44.454`.

Re-writing on open is still correct for the case it was added for (a same-day relaunch reuses the file and needs a fresh header, or later records correlate to the wrong boot). Passing a provider keeps that and makes the timestamp describe the file it heads.

### Verification

- 428 geofence unit tests pass, up from 423
- `apiCheck`, ktlint, and `:samples:java_layout:assembleDebug` clean
- End to end: injecting the new records into the real Dubai drive capture turns `fixture.api.fetch body:null` into the full geometry for all fetches

No public API change — `GeofenceLogger` is internal and the new parameter is defaulted.