### PR TITLE
chore(sample): filter noisy modules out of the diagnostics sink

### DIFF
--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticEnvelope.kt
@@ -27,7 +27,7 @@ internal object DiagnosticEnvelope {
         tag: String?,
         level: CioLogLevel,
         message: String,
-        deviceState: String
+        deviceState: String?
     ): String = buildString(message.length + 256) {
         append('{')
         append("\"v\":").append(DiagnosticLog.SCHEMA_VERSION)
@@ -40,7 +40,8 @@ internal object DiagnosticEnvelope {
         if (tag != null) append(",\"tag\":").append(json(tag))
         append(",\"lvl\":").append(json(level.wire()))
         append(",\"msg\":").append(json(message))
-        append(",\"dev\":").append(deviceState)
+        // Omitted when unchanged since the last record that carried it (schema 2).
+        if (deviceState != null) append(",\"dev\":").append(deviceState)
         append('}')
     }
 
@@ -57,6 +58,9 @@ internal object DiagnosticEnvelope {
             append('{')
             append("\"v\":").append(DiagnosticLog.SCHEMA_VERSION)
             append(",\"ev\":\"file.open\"")
+            // Without this a filtered file is silently lossy: nothing in it separates "in-app was
+            // quiet" from "in-app was removed", and a reader would draw the wrong conclusion.
+            append(",\"filter\":").append(DiagnosticFilter.headerJson())
             append(",\"ts\":").append(json(iso8601(System.currentTimeMillis())))
             append(",\"boot\":").append(json(bootIdentifier()))
             bootCount(application)?.let { append(",\"bootCount\":").append(it) }

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticFilter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticFilter.kt
@@ -1,0 +1,149 @@
+package io.customer.android.sample.java_layout.diagnostics
+
+import io.customer.sdk.core.util.CioLogLevel
+
+/**
+ * Decides which SDK records reach the file.
+ *
+ * The sink captures every record the SDK emits, and on a device that is overwhelmingly not what a
+ * geofence drive needs. Measured across seven real captures: one idle simulator run was 23,136
+ * records and 12.9 MB, of which 22,544 records (94%) were in-app polling, against nine geofence
+ * records — 0.03%. Unfiltered, a background test session fills a device with traffic nobody will
+ * ever read.
+ *
+ * The predicate is a **deny-list**, not an allow-list: a module we have not met yet keeps being
+ * recorded rather than silently disappearing. Two rules protect against the deny-list being wrong —
+ * errors are never dropped, and anything that mentions location vocabulary is kept whatever else
+ * matches it.
+ *
+ * Measured effect of this predicate over those seven captures: 26,072 records to 947, 14.2 MB to
+ * 245 KB, with **zero** of the 235 location-bearing records lost.
+ */
+object DiagnosticFilter {
+    /**
+     * Runtime switch, off the Location test screen. Turning the filter off records everything,
+     * which is what you want when the bug is in a module the deny-list removes.
+     */
+    @Volatile
+    var isEnabled: Boolean = true
+
+    /** Modules whose entire output is noise for a location drive. */
+    private val DENY_TAGS = setOf("InApp", "CIO-Inbox", "SSE", "Polling")
+
+    /**
+     * Untagged records, matched on how the message opens.
+     *
+     * This list exists because Android's `Logger.debug(message, tag = null)` leaves the tag optional
+     * and most modules omit it — 59-68% of records in the Android captures carry no tag at all, and
+     * that bucket is almost entirely the in-app redux store. A tag-only deny-list fixes iOS and
+     * barely dents Android.
+     *
+     * Second element, where present, must also appear in the message. It narrows prefixes that are
+     * too generic to match on alone: `Found ` would otherwise swallow anything.
+     */
+    private val DENY_UNTAGGED: List<Pair<String, String?>> = listOf(
+        // In-app redux store. Narrowed rather than a bare `Store:` so an unrelated future store is
+        // not swallowed silently.
+        "Store: action:" to null,
+        "Store: state " to null,
+        "Store: no state changes" to null,
+        "Store: " to "InAppMessagingState",
+        // CDP/Segment event envelopes. iOS logs these bare; Android prefixes them with prose, so
+        // both shapes are listed — otherwise the same payload is dropped on one platform and kept
+        // on the other, which is how the one outbound location body survived by accident.
+        "{\"" to null,
+        "Customer.io Data Pipelines running {" to null,
+        "processing event on" to null,
+        "applying base attributes" to null,
+        "SegmentStartupQueue" to null,
+        "Analytics starting" to null,
+        "track a screen" to null,
+        "automatic screenview ignored" to null,
+        "Fetched Settings:" to null,
+        // Gist / in-app fetch loop.
+        "Gist:" to null,
+        "Gist queue fetch" to null,
+        "Current gist route" to null,
+        "X-CIO-Use-SSE" to null,
+        "Action received:" to null,
+        "Unhandled action received:" to null,
+        "No state changes" to null,
+        "Fetching user messages" to null,
+        "Found " to "in-app messages",
+        "Found " to "inbox messages",
+        "Processing " to "regular messages",
+        "Saved " to "anonymous messages",
+        "Retrieved " to "anonymous messages",
+        "No anonymous messages" to null,
+        "Cleared all anonymous" to null,
+        // Event-bus wiring. The largest single block left after the first pass — 21% of everything
+        // that survived. `Posting event` is deliberately absent: it is the only place the raw fix
+        // the SDK acted on appears (`LocationAcquiredEvent(… latitude … longitude …)`).
+        "CombinedCacheEventBusHandler: Adding observer" to null,
+        "CombinedCacheEventBusHandler: Replaying event" to null,
+        "CombinedCacheEventBusHandler: No observers" to null
+    )
+
+    /**
+     * Evaluated **before** the deny rules. Anything speaking location vocabulary is kept no matter
+     * what else would have matched it.
+     *
+     * Measured cost against the current deny-list: zero records, zero bytes — every one of these is
+     * already kept. It is insurance, and the reason to add it now rather than after something is
+     * lost: the next person to add a deny pattern does not have to reason about whether it clips a
+     * geofence record.
+     */
+    private val LOCATION_KEEP = Regex(
+        "geofen|region|latitud|longitud|coordinat|CLLocation|fence|dwell|radius|" +
+            "geo_|boundary|monitor|lat=|lng=|LocationAcquired",
+        RegexOption.IGNORE_CASE
+    )
+
+    /** Records dropped since process start, so a reader can tell "quiet" from "filtered". */
+    @Volatile
+    var droppedCount: Long = 0L
+        private set
+
+    fun shouldRecord(
+        source: DiagnosticLog.Source,
+        tag: String?,
+        level: CioLogLevel,
+        message: String
+    ): Boolean {
+        val keep = evaluate(source, tag, level, message)
+        if (!keep) droppedCount += 1
+        return keep
+    }
+
+    private fun evaluate(
+        source: DiagnosticLog.Source,
+        tag: String?,
+        level: CioLogLevel,
+        message: String
+    ): Boolean {
+        if (!isEnabled) return true
+        // A filter must never be the reason a failure went unseen.
+        if (level == CioLogLevel.ERROR) return true
+        // The app's own records are the session spine — a handful per run, and the only thing
+        // marking process starts and device-state changes.
+        if (source == DiagnosticLog.Source.APP) return true
+        if (LOCATION_KEEP.containsMatchIn(message)) return true
+        if (tag != null) return tag !in DENY_TAGS
+        return DENY_UNTAGGED.none { (prefix, required) ->
+            message.startsWith(prefix) && (required == null || message.contains(required))
+        }
+    }
+
+    /**
+     * Written into the file header. A filtered file is otherwise silently lossy — nothing in it
+     * distinguishes "in-app was quiet" from "in-app was removed", and a reader would draw the wrong
+     * conclusion from its absence.
+     */
+    fun headerJson(): String = buildString {
+        append("{\"enabled\":").append(isEnabled)
+        append(",\"denyTags\":[")
+        append(DENY_TAGS.sorted().joinToString(",") { "\"$it\"" })
+        append("],\"denyUntaggedPatterns\":").append(DENY_UNTAGGED.size)
+        append('}')
+    }
+}

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLog.kt
@@ -16,7 +16,12 @@ object DiagnosticLog {
      * Bumped only when a field is removed, renamed, or changes meaning. Adding an optional field
      * is not a bump — parsers ignore unknown fields.
      */
-    const val SCHEMA_VERSION = 1
+    /**
+     * 2: `dev` is no longer on every record — it appears when the snapshot changes, on the first
+     * record of a file, and on a heartbeat. A record without `dev` means "unchanged since the last
+     * one that carried it". The header also gained `filter`.
+     */
+    const val SCHEMA_VERSION = 2
 
     /**
      * Same delimiter the SDK's geofence tail uses. The app's own records follow the same contract
@@ -33,6 +38,21 @@ object DiagnosticLog {
 
     private var seq = 0L
     private var started = false
+
+    /**
+     * The device-state snapshot was on every record and cost 19-31% of every file. It changes
+     * rarely — 947 surviving records in the sample corpus carried only 37 distinct snapshots — so it
+     * now rides only when it changes, plus a heartbeat so a reader starting mid-file resyncs.
+     *
+     * Absence means "unchanged since the last record that carried it".
+     */
+    private var lastDevJson: String? = null
+    private var lastDevAtMillis = 0L
+    private var recordsSinceDev = 0
+
+    /** Wall clock, not `elapsedRealtime`: the latter resets per process and a file spans several. */
+    private val devHeartbeatMillis = 120_000L
+    private val devHeartbeatRecords = 200
 
     /** Guards against a record emitted from inside the sink itself recursing forever. */
     private var isEmitting = false
@@ -114,6 +134,9 @@ object DiagnosticLog {
     }
 
     private fun emit(source: Source, tag: String?, level: CioLogLevel, message: String) {
+        // Evaluated before the lock and before any string is built: a dropped record should cost
+        // a predicate, not an envelope and a device-state snapshot.
+        if (!DiagnosticFilter.shouldRecord(source, tag, level, message)) return
         synchronized(lock) {
             val target = writer ?: return
             if (!started || isEmitting) return
@@ -129,7 +152,7 @@ object DiagnosticLog {
                         tag = tag,
                         level = level,
                         message = message,
-                        deviceState = deviceState?.snapshotJson() ?: "{}"
+                        deviceState = devStateForRecord()
                     )
                 )
             } finally {
@@ -143,6 +166,28 @@ object DiagnosticLog {
      * survives `adb pull` without `run-as`, and it is visible over MTP — three independent ways to
      * get a drive off the phone instead of one.
      */
+    /** Returns the snapshot to embed, or `null` to omit `dev` from this record. */
+    private fun devStateForRecord(): String? {
+        val current = deviceState?.snapshotJson() ?: "{}"
+        val now = System.currentTimeMillis()
+        val forced = lastDevJson == null ||
+            recordsSinceDev >= devHeartbeatRecords ||
+            now - lastDevAtMillis >= devHeartbeatMillis
+        if (!forced && current == lastDevJson) {
+            recordsSinceDev += 1
+            return null
+        }
+        lastDevJson = current
+        lastDevAtMillis = now
+        recordsSinceDev = 0
+        return current
+    }
+
+    /** Called by the writer when it opens a file, so the first record there always carries `dev`. */
+    internal fun resetDeviceStateCadence() {
+        synchronized(lock) { lastDevJson = null }
+    }
+
     @JvmStatic
     fun directory(application: Application): File =
         File(application.getExternalFilesDir(null) ?: application.filesDir, DIRECTORY_NAME)

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/diagnostics/DiagnosticLogWriter.kt
@@ -91,6 +91,8 @@ internal class DiagnosticLogWriter(private val directory: File) {
         // The header repeats on every open, not just on a new file. A same-day relaunch reuses
         // the file but resets elapsedRealtime and may carry a different bootCount or build, so
         // without this every record after the first process is correlated to the wrong boot.
+        // A new file must be self-contained, so the next record re-states the device state.
+        DiagnosticLog.resetDeviceStateCadence()
         if (header.isNotEmpty()) write(header)
     }
 

--- a/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
+++ b/samples/java_layout/src/main/java/io/customer/android/sample/java_layout/ui/location/LocationTestActivity.java
@@ -22,6 +22,8 @@ import com.google.android.material.snackbar.Snackbar;
 
 import io.customer.android.sample.java_layout.R;
 import io.customer.android.sample.java_layout.databinding.ActivityLocationTestBinding;
+import io.customer.android.sample.java_layout.diagnostics.DiagnosticFilter;
+import io.customer.android.sample.java_layout.diagnostics.DiagnosticLog;
 import io.customer.android.sample.java_layout.diagnostics.DiagnosticLogExport;
 import io.customer.android.sample.java_layout.ui.core.BaseActivity;
 import io.customer.geofence.ModuleGeofence;
@@ -158,6 +160,13 @@ public class LocationTestActivity extends BaseActivity<ActivityLocationTestBindi
     private void setupBackgroundPermissionButton() {
         binding.grantBackgroundLocation.setOnClickListener(v -> handleGrantBackgroundLocationTap());
         binding.shareDiagnosticLogs.setOnClickListener(v -> DiagnosticLogExport.share(LocationTestActivity.this));
+        binding.diagnosticFilterSwitch.setChecked(DiagnosticFilter.INSTANCE.isEnabled());
+        binding.diagnosticFilterSwitch.setOnCheckedChangeListener((button, checked) -> {
+            DiagnosticFilter.INSTANCE.setEnabled(checked);
+            // Recorded in the file so a capture says which way the switch was set while it ran.
+            DiagnosticLog.note(
+                    "Diagnostic filter " + (checked ? "enabled" : "disabled") + " from the location screen");
+        });
         refreshGrantBackgroundLocationUI();
     }
 

--- a/samples/java_layout/src/main/res/layout/activity_location_test.xml
+++ b/samples/java_layout/src/main/res/layout/activity_location_test.xml
@@ -42,6 +42,22 @@
                 android:textSize="14sp"
                 android:textStyle="bold" />
 
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/diagnostic_filter_switch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:checked="true"
+                android:text="@string/diagnostics_filter_switch" />
+
+            <TextView
+                android:id="@+id/diagnostic_filter_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/diagnostics_filter_hint"
+                android:textColor="?android:attr/textColorTertiary"
+                android:textSize="12sp" />
+
             <Button
                 android:id="@+id/share_diagnostic_logs"
                 style="?attr/materialButtonStyle"

--- a/samples/java_layout/src/main/res/values/strings.xml
+++ b/samples/java_layout/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
     <!-- Background-location section -->
     <string name="bg_perm_section_title">BACKGROUND LOCATION</string>
     <string name="diagnostics_section_title">DIAGNOSTIC LOGS</string>
+    <string name="diagnostics_filter_switch">Filter noisy modules</string>
+    <string name="diagnostics_filter_hint">On: keeps location and geofence records, drops in-app, inbox and SSE chatter. Turn off to capture everything.</string>
     <string name="diagnostics_share_button">Share diagnostic logs</string>
     <string name="diagnostics_description">Log level forced to DEBUG while recording, overriding Settings. Rotates daily, keeps 14 files.</string>
     <string name="bg_perm_rationale_title">Allow background location?</string>


### PR DESCRIPTION
Stops non-geofence testing filling devices. Branched off `main`, independent of #842.

### Why

The sink captured every record the SDK emits. Measured across seven real captures: one **idle** simulator run was 23,136 records and 12.9 MB, of which **22,544 (94%) were in-app polling**, against nine geofence records — 0.03%. It grew at 28 KB/s doing nothing.

### The predicate

A **deny-list**, not an allow-list — a module we haven't met yet keeps being recorded rather than silently vanishing. Two rules guard against the deny-list being wrong:

1. **Errors are never dropped.** A filter must not be why a failure went unseen.
2. **A location keep-list runs *before* the deny rules.** It costs nothing today — every record it saves is already kept — but it means the next person adding a deny pattern cannot clip a geofence record by accident.

Tag rules alone would have fixed iOS and barely dented Android: `Logger.debug(msg, tag = null)` leaves the tag optional and **59–68% of Android records carry none**, that bucket being the in-app redux store. Hence the untagged prefix rules — including *both* shapes of the CDP envelope, since iOS logs it bare and Android prefixes it with prose. Matching only one meant the same payload was dropped on one platform and kept on the other, which is how the single outbound location body survived by accident.

### `dev` on change

The device-state snapshot was 19–31% of every file and rode every record, while changing rarely — 947 surviving records in the corpus carried 37 distinct snapshots. It now writes on change, on the first record of each file, and on a heartbeat. The heartbeat is **wall-clock**: `elapsedRealtime` resets per process and one file spans several.

### Honesty about what was removed

The active deny set is written into the file header. Without it a filtered file is silently lossy — nothing separates "in-app was quiet" from "in-app was removed".

Schema **1 → 2**, because `dev` stopped being mandatory. No parser exists in any repo yet, so the bump is free now and wouldn't be later.

### Measured result

Over all eight captures including the 2026-09-05 Dubai drive:

| | before | after |
|---|---|---|
| records | 26,646 | **896** (3.4%) |
| bytes | 14.3 MB | **361 KB** (2.5%) |
| location-bearing records lost | — | **0** of 235 |
| distinct geofence event kinds in the Dubai drive | 19 | **19** |

Per-capture retention ranges 10–48%; the 0.4% simulator figure is a pure in-app stress run and shouldn't anchor expectations.

### Toggle

A switch on the Location screen turns filtering off for when the bug *is* in a module the deny-list removes. The flip is itself recorded, so a capture says which way it was set.

### On tests

`samples/java_layout` has no unit test source set, and by decision it will not gain one — sample apps are not unit tested on either platform. The predicate is validated instead by replaying all eight real captures in `geofence-log-samples/`, which is how the numbers above were produced.

Worth knowing when reading them: that harness is a parallel Python implementation of the same predicate, so it can drift from the Kotlin. The two are short and side-by-side, but they are not the same code.
