### PR TITLE
chore(geofence): improve geofence API response decoding

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -202,7 +202,10 @@ internal fun GeofenceApiRegion.toDomain(
     polygonSupport: PolygonSupport = PolygonSupport.Disabled
 ): GeofenceRegion? {
     if (id.isBlank()) return null
-    return when (shape?.lowercase()) {
+    // Surrounding whitespace is not a shape the backend meant to name, and neither is an empty
+    // string: both are the field carrying nothing, so they route as if it were absent rather than
+    // dropping the record as an unsupported shape.
+    return when (shape?.trim()?.lowercase()?.takeIf(String::isNotEmpty)) {
         null, CIRCLE_SHAPE -> {
             if (geometry != null || enclosingCircle != null) {
                 SDKComponent.geofenceLogger.logPolygonDropped(id, "shape discriminator is missing or inconsistent")
@@ -292,7 +295,7 @@ private fun GeofenceApiRegion.toPolygonRegionOrNull(
         )
     }
     if (trigger == null) {
-        logger.logPolygonDropped(id, "backend-provided enclosing circle is invalid or does not contain the polygon")
+        logger.logPolygonDropped(id, "enclosing circle is missing, its centre is out of range, or its radius is unusable")
         return null
     }
     return GeofenceRegion(

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -161,6 +161,113 @@ class GeofenceApiResponseTest : RobolectricTest() {
     }
 
     @Test
+    fun parseAndMap_givenShapePaddedWithWhitespace_expectRoutedNotDroppedAsUnsupported() {
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                { "id": "padded", "shape": " Circle ", "latitude": 1, "longitude": 2, "radius": 100 },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("padded", "circle")
+        verify(exactly = 0) { mockLogger.logUnsupportedGeometryDropped("padded", any()) }
+    }
+
+    @Test
+    fun parseAndMap_givenBlankShape_expectTreatedAsAbsentNotUnsupported() {
+        // A field carrying only whitespace names no shape at all, so it routes the way a missing
+        // discriminator does rather than dropping the record.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                { "id": "blank", "shape": "   ", "latitude": 1, "longitude": 2, "radius": 100 },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("blank", "circle")
+        verify(exactly = 0) { mockLogger.logUnsupportedGeometryDropped("blank", any()) }
+    }
+
+    @Test
+    fun parseAndMap_givenPaddedPolygonShape_expectRoutedToPolygonBranch() {
+        // The trim has to apply to every discriminator, not just the circle one.
+        val region = parseRegions(
+            polygonAndCircleJson().replace("\"shape\": \"polygon\"", "\"shape\": \" Polygon \""),
+            EnabledPolygonSupport
+        ).single { it.id == "campus" }
+
+        region.isPolygon.shouldBeTrue()
+    }
+
+    @Test
+    fun parseAndMap_givenPaddedUnknownShape_expectRawValueReported() {
+        // The drop reason has to name what the server actually sent, not the trimmed form used for
+        // matching, or the log sends someone looking for a shape string that was never on the wire.
+        parseRegions(
+            """
+            {
+              "geofences": [
+                { "id": "odd", "shape": " Hexagon ", "latitude": 1, "longitude": 2, "radius": 100 },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        verify { mockLogger.logUnsupportedGeometryDropped("odd", " Hexagon ") }
+    }
+
+    @Test
+    fun parseAndMap_givenBlankShapeCarryingGeometry_expectDroppedAsInconsistentNotRegistered() {
+        // Routing a blank discriminator as absent must not weaken the inconsistency guard: the
+        // record still carries geometry, so falling back to its circle fields would register a
+        // fence the backend never described.
+        val regions = parseRegions(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "blank-with-geometry",
+                  "shape": " ",
+                  "latitude": 37.775,
+                  "longitude": -122.419,
+                  "radius": 250,
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                      [-122.4200, 37.7745],
+                      [-122.4188, 37.7745],
+                      [-122.4188, 37.7755],
+                      [-122.4200, 37.7755],
+                      [-122.4200, 37.7745]
+                    ]]
+                  }
+                },
+                { "id": "circle", "latitude": 0, "longitude": 0, "radius": 100 }
+              ]
+            }
+            """.trimIndent(),
+            EnabledPolygonSupport
+        )
+
+        regions.map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
+        verify {
+            mockLogger.logPolygonDropped("blank-with-geometry", "shape discriminator is missing or inconsistent")
+        }
+    }
+
+    @Test
     fun parseAndMap_givenPolygonPositionThatIsNotFinite_expectRecordDroppedNotWholeSync() {
         // Positions decode as JsonElement, so the literal "NaN" becomes a Double and passes every
         // geometry check — each one compares, and every comparison against NaN is false. It would
@@ -217,7 +324,7 @@ class GeofenceApiResponseTest : RobolectricTest() {
         verify {
             mockLogger.logPolygonDropped(
                 "bad-center",
-                "backend-provided enclosing circle is invalid or does not contain the polygon"
+                "enclosing circle is missing, its centre is out of range, or its radius is unusable"
             )
         }
     }


### PR DESCRIPTION
Part of: [MBL-2388](https://linear.app/customerio/issue/MBL-2388/android-improve-geofence-api-response-decoding)

## What this is

Two decoding defects found by the iOS team during a cross-platform parity audit. Independent of
the MBL-2288 stack: this branch sits directly on `feature/geofence-polygons`.

**A padded shape discriminator dropped the record.** `toDomain` matched on `shape?.lowercase()`
with no trim, so `" circle "` missed the circle branch and fell through to the unsupported-shape
path. It now trims before matching, and a value that is empty afterwards routes the way a missing
field does — an empty string names no shape, so failing closed as if it named an unknown one was
wrong. iOS hit the same bug and fixed it on their side last week.

Two observable consequences worth stating. A response whose records all carried a blank shape used
to drop every record, throw "all N regions dropped", fail the refresh and preserve live state;
those records now map as circles and the refresh succeeds. The error-level unsupported-geometry log
for blank shapes also disappears. That safety net was incidental rather than chosen, and blank is
absent, so the new behaviour is the intended one.

Nothing the backend did not describe can register: the circle branch still drops a record carrying
`geometry` or `enclosing_circle`, and `toCircleRegionOrNull` still requires a valid centre and a
positive radius.

**A drop reason claimed a check that does not exist.** When a polygon's enclosing circle was
rejected the log read "backend-provided enclosing circle is invalid or does not contain the
polygon". There is no containment check on that path: `PolygonWakeCircleValidator` derives no
enclosing circle and re-checks no coverage, it only verifies the centre is in range and the radius
is finite, positive and inside the OS limit. It now names what is actually checked, covering all
four ways that branch is reached including an out-of-range centre.

Note for review order: #838 carries the same stale line, so whichever lands second reconciles it
and should take this wording.

## Tests

938 tests across geofence, core and messagingpush, 0 failures. ktlint, `lintDebug` and `apiCheck`
clean. No public API change.

Mutation-tested: reverting the trim fails exactly the padded and blank cases and nothing else.
Covers a padded circle, a padded polygon, a blank shape, a blank shape carrying geometry (which
must stay dropped), and an unknown shape asserting the raw server value reaches the log.

The 11 `lintDebug` warnings on this branch are all pre-existing in `GeofenceRegionStore.kt`, none
in the file this touches. Their cleanup lives in #837.
