### PR TITLE
fix(deps): update Faraday security pin to 1.10.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 # Security pins for transitive deps (MBL-1694)
 gem 'webrick', '1.8.2'
-gem 'faraday', '1.10.5'
+gem 'faraday', '1.10.6'
 gem 'rexml', '3.3.3'
 gem 'aws-sdk-s3', '1.208.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     emoji_regex (3.2.3)
     excon (1.7.0)
       logger
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -247,7 +247,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (= 1.208.0)
-  faraday (= 1.10.5)
+  faraday (= 1.10.6)
   fastlane
   fastlane-plugin-find_firebase_app_id
   fastlane-plugin-firebase_app_distribution


### PR DESCRIPTION
Updates the Fastlane build dependency from Faraday 1.10.5 to 1.10.6, the patched 1.x release for [CVE-2026-54297](https://rubysec.com/advisories/CVE-2026-54297/). Regenerated the lockfile conservatively; no other dependency versions changed.

Verified a frozen bundle install, exact Faraday 1.10.6 resolution, and Fastlane 2.237.0 loading and CLI startup with Ruby 3.4.4. Android formatting/lint and `:core:assembleDebug` also passed.

This changes Ruby build tooling only. Mobile runtime behavior and deployment targets are unchanged.
