### PR TITLE
chore(geofence): stamp cache freshness only for the session that fetched it

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -407,11 +407,21 @@ internal class GeofenceRepositoryImpl(
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
                     // a null parse must not clobber a previously cached value.
-                    onRegistered = {
+                    onRegistered = { userStateGeneration ->
                         store.saveCachedRegions(regions)
                         parsedConfig?.let { store.saveCachedConfig(it) }
-                        store.saveLastApiFetchLocation(GeofenceLocation(latitude, longitude))
-                        store.setLastSyncTimestamp(clock.currentTimeMillis())
+                        // Offered with the pass's own generation, not a re-read: an identify
+                        // landing after routing was armed would otherwise stamp the new session's
+                        // cache fresh off this pass, and its refresh would then SKIP and leave
+                        // routing empty until a movement EXIT re-armed it.
+                        val stamped = store.saveApiFetchStateIfCurrent(
+                            location = GeofenceLocation(latitude, longitude),
+                            syncTimestamp = clock.currentTimeMillis(),
+                            expectedUserStateGeneration = userStateGeneration
+                        )
+                        if (!stamped) {
+                            logger.logSyncSkipped("cache left stale for a session that changed mid-pass")
+                        }
                     }
                 )
             },
@@ -486,7 +496,7 @@ internal class GeofenceRepositoryImpl(
         containmentEpoch: Long,
         fixSource: FixSource,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
-        onRegistered: () -> Unit = {}
+        onRegistered: (userStateGeneration: Long) -> Unit = {}
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
         val nearest = distanceFilter.nearest(
@@ -611,7 +621,7 @@ internal class GeofenceRepositoryImpl(
                         store.clearLastMovementTriggerLocation()
                     }
                     if (routingArmed) {
-                        onRegistered()
+                        onRegistered(userStateGeneration)
                     } else {
                         // An identify landed mid-pass, so these registrations belong to the departing
                         // user and routing was left cleared for the new one. Stamping the sync fresh

--- a/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/store/GeofenceRegionStore.kt
@@ -234,7 +234,6 @@ internal interface GeofenceRegionStore {
     fun saveCachedConfig(config: GeofenceConfig)
     fun getCachedConfig(): GeofenceConfig?
 
-    fun saveLastApiFetchLocation(location: GeofenceLocation)
     fun getLastApiFetchLocation(): GeofenceLocation?
 
     fun saveLastMovementTriggerLocation(location: GeofenceLocation)
@@ -242,7 +241,17 @@ internal interface GeofenceRegionStore {
     fun clearLastMovementTriggerLocation()
 
     fun getLastSyncTimestamp(): Long?
-    fun setLastSyncTimestamp(timestamp: Long)
+
+    /**
+     * Marks the cache fresh as of [location], but only while [expectedUserStateGeneration] is still
+     * current. Anchor and timestamp move together because they describe the same fetch, and the
+     * check shares [beginUserSession]'s lock so an identify cannot land between them.
+     */
+    fun saveApiFetchStateIfCurrent(
+        location: GeofenceLocation,
+        syncTimestamp: Long,
+        expectedUserStateGeneration: Long
+    ): Boolean
 
     /**
      * Sign-out wipe. Drops the anchor, movement-trigger location, registered
@@ -771,7 +780,7 @@ internal class GeofenceRegionStoreImpl(
     override fun getCachedConfig(): GeofenceConfig? =
         readJson(KEY_CACHED_CONFIG, GeofenceConfig.serializer())
 
-    override fun saveLastApiFetchLocation(location: GeofenceLocation) =
+    private fun saveLastApiFetchLocation(location: GeofenceLocation) =
         writeEncryptedJson(KEY_LAST_API_FETCH_LOCATION, GeofenceLocation.serializer(), location)
 
     override fun getLastApiFetchLocation(): GeofenceLocation? =
@@ -791,8 +800,19 @@ internal class GeofenceRegionStoreImpl(
         if (contains(KEY_LAST_SYNC)) getLong(KEY_LAST_SYNC, 0L) else null
     }
 
-    override fun setLastSyncTimestamp(timestamp: Long) {
+    private fun setLastSyncTimestamp(timestamp: Long) {
         prefs.edit { putLong(KEY_LAST_SYNC, timestamp) }
+    }
+
+    override fun saveApiFetchStateIfCurrent(
+        location: GeofenceLocation,
+        syncTimestamp: Long,
+        expectedUserStateGeneration: Long
+    ): Boolean = synchronized(enteredLock) {
+        if (expectedUserStateGeneration != currentUserStateGenerationLocked()) return@synchronized false
+        saveLastApiFetchLocation(location)
+        setLastSyncTimestamp(syncTimestamp)
+        true
     }
 
     override fun clearUserScopedState() {

--- a/geofence/src/test/java/io/customer/geofence/GeofenceContainmentRealStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceContainmentRealStoreTest.kt
@@ -67,7 +67,11 @@ class GeofenceContainmentRealStoreTest : RobolectricTest() {
         // State a successful anchor pass leaves behind: registered and stamped, containment unjudged.
         store.saveCachedRegions(listOf(fence))
         store.saveCachedConfig(sampleConfig())
-        store.setLastSyncTimestamp(System.currentTimeMillis())
+        store.saveApiFetchStateIfCurrent(
+            location = GeofenceLocation(0.0, 0.0),
+            syncTimestamp = System.currentTimeMillis(),
+            expectedUserStateGeneration = store.userStateGeneration()
+        )
         store.saveRegisteredIds(setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, fence.id))
         store.saveLastMovementTriggerLocation(GeofenceLocation(0.0, 0.0))
         store.setLastRegistrationUptime(clock.elapsedRealtime())

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -257,8 +257,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { logger.logMovementRearmedAfterFailedRefresh() }
         // Anchor and freshness stay untouched, so the next EXIT still fetches remotely rather than
         // treating the re-rank as a successful sync.
-        verify(exactly = 0) { store.saveLastApiFetchLocation(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
     }
 
     @Test
@@ -427,7 +426,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.exceptionOrNull() shouldBeEqualTo error
         verify { logger.logSyncFailed(match { it?.contains("network down") == true }) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
     }
 
@@ -823,7 +822,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
         verify { logger.logSyncSkipped("user changed before routing could be armed") }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
     }
 
     @Test
@@ -841,7 +840,32 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
-        verify { store.setLastSyncTimestamp(any()) }
+        verify { store.saveApiFetchStateIfCurrent(any(), any(), 7L) }
+    }
+
+    @Test
+    fun refresh_givenIdentifyLandsAfterRoutingArmed_expectFreshnessOfferedForThePassGeneration() = runTest {
+        // The window this guards: routing is armed, then an identify bumps the generation before
+        // the pass stamps the cache. The pass must offer its own generation so the store refuses,
+        // rather than re-reading and stamping the new session fresh off this pass's fetch.
+        var generation = 7L
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getRegisteredIds() } returns emptySet()
+        every { store.userStateGeneration() } answers { generation }
+        every { store.saveRoutableRegisteredIdsIfCurrent(any(), any()) } answers {
+            generation = 8L
+            true
+        }
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3, localRefreshTriggerRadius = 1500f))
+        every { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) } returns
+            listOf(GeofenceRegion("biz-1", 0.0, 0.0, 100f))
+        coEvery { manager.replaceGeofences(any(), any()) } returns Result.success(Unit)
+
+        repository.refresh(latitude = 12.34, longitude = 56.78)
+
+        verify { store.saveApiFetchStateIfCurrent(any(), any(), 7L) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), 8L) }
     }
 
     @Test
@@ -858,7 +882,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val result = repository.refresh(latitude = 12.34, longitude = 56.78)
 
         result.isSuccess shouldBeEqualTo true
-        verify { store.setLastSyncTimestamp(any()) }
+        verify { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         verify { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) }
         verify { logger.logSyncSucceeded(filtered.size, movementTriggerRegistered = true) }
         // Store holds the IDs of exactly what was registered (movement trigger + business),
@@ -891,7 +915,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         val anchorSlot = slot<GeofenceLocation>()
         every { store.saveCachedRegions(capture(regionsSlot)) } returns Unit
         every { store.saveCachedConfig(capture(configSlot)) } returns Unit
-        every { store.saveLastApiFetchLocation(capture(anchorSlot)) } returns Unit
+        every { store.saveApiFetchStateIfCurrent(capture(anchorSlot), any(), any()) } returns true
 
         repository.refresh(latitude = 12.34, longitude = 56.78)
 
@@ -918,7 +942,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         verify(exactly = 0) { store.saveCachedRegions(any()) }
         verify(exactly = 0) { store.saveCachedConfig(any()) }
-        verify(exactly = 0) { store.saveLastApiFetchLocation(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
     }
 
     @Test
@@ -1295,7 +1319,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.exceptionOrNull() shouldBeEqualTo error
         coVerify(exactly = 0) { manager.removeGeofencesByIds(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         verify(exactly = 0) { logger.logSyncSucceeded(any(), any()) }
     }
 
@@ -1393,7 +1417,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
         verify { logger.logSyncSkipped(match { it.contains("user changed") }) }
     }
@@ -1749,8 +1773,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         verify(exactly = 0) { store.saveCachedRegions(any()) }
         verify(exactly = 0) { store.saveCachedConfig(any()) }
-        verify(exactly = 0) { store.saveLastApiFetchLocation(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
     }
 
     @Test
@@ -2016,8 +2039,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         repository.restoreFromCache()
 
-        verify(exactly = 0) { store.saveLastApiFetchLocation(any()) }
-        verify(exactly = 0) { store.setLastSyncTimestamp(any()) }
+        verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceUnownedSessionRealStoreTest.kt
@@ -72,8 +72,11 @@ class GeofenceUnownedSessionRealStoreTest : RobolectricTest() {
         store.saveCachedRegions(listOf(fence))
         store.saveCachedConfig(sampleConfig())
         store.saveRegisteredIds(setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, fence.id))
-        store.saveLastApiFetchLocation(GeofenceLocation(0.0, 0.0))
-        store.setLastSyncTimestamp(System.currentTimeMillis())
+        store.saveApiFetchStateIfCurrent(
+            location = GeofenceLocation(0.0, 0.0),
+            syncTimestamp = System.currentTimeMillis(),
+            expectedUserStateGeneration = store.userStateGeneration()
+        )
         store.saveLastMovementTriggerLocation(GeofenceLocation(0.0, 0.0))
         store.setLastRegistrationUptime(clock.elapsedRealtime())
     }

--- a/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/store/GeofenceRegionStoreTest.kt
@@ -491,7 +491,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.activatePolygon("biz-1")
         store.recordPolygonCoarseInside("biz-1")
         store.recordEntered("biz-1")
-        store.setLastSyncTimestamp(100L)
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 100L, resetGeneration)
 
         store.beginUserSession("user-B")
         val userBGeneration = store.userStateGeneration()
@@ -1044,22 +1044,22 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun saveLastApiFetchLocation_thenGet_expectRoundTrip() {
+    fun saveApiFetchStateIfCurrent_thenGet_expectAnchorRoundTrip() {
         val location = GeofenceLocation(latitude = 37.7749, longitude = -122.4194)
 
-        store.saveLastApiFetchLocation(location)
+        store.saveApiFetchStateIfCurrent(location, 1L, store.userStateGeneration())
 
         store.getLastApiFetchLocation() shouldBeEqualTo location
     }
 
     @Test
-    fun saveLastApiFetchLocation_givenNewStoreInstance_expectValueDecryptedCorrectly() {
+    fun saveApiFetchStateIfCurrent_givenNewStoreInstance_expectAnchorDecryptedCorrectly() {
         // Cross-instance round trip. Location snapshots are encrypted via
         // [PreferenceCrypto] (Android Keystore); a fresh store must be able to
         // decrypt what a prior store wrote — otherwise process restarts would
         // wipe the anchor and break the Tier-B distance check.
         val location = GeofenceLocation(latitude = 37.7749, longitude = -122.4194)
-        store.saveLastApiFetchLocation(location)
+        store.saveApiFetchStateIfCurrent(location, 1L, store.userStateGeneration())
 
         val newInstance = GeofenceRegionStoreImpl(
             context = applicationMock,
@@ -1114,18 +1114,53 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun setLastSyncTimestamp_thenGet_expectStoredValue() {
-        store.setLastSyncTimestamp(1_700_000_000L)
+    fun saveApiFetchStateIfCurrent_thenGet_expectTimestampStored() {
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 1_700_000_000L, store.userStateGeneration())
 
         store.getLastSyncTimestamp() shouldBeEqualTo 1_700_000_000L
     }
 
     @Test
-    fun setLastSyncTimestamp_givenSubsequentSet_expectOverwrite() {
-        store.setLastSyncTimestamp(100L)
-        store.setLastSyncTimestamp(200L)
+    fun saveApiFetchStateIfCurrent_givenSubsequentWrite_expectOverwrite() {
+        val generation = store.userStateGeneration()
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 100L, generation)
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 200L, generation)
 
         store.getLastSyncTimestamp() shouldBeEqualTo 200L
+    }
+
+    @Test
+    fun saveApiFetchStateIfCurrent_givenGenerationStillCurrent_expectAnchorAndFreshnessWritten() {
+        store.beginUserSession("user-a")
+
+        val stamped = store.saveApiFetchStateIfCurrent(
+            location = GeofenceLocation(12.34, 56.78),
+            syncTimestamp = 900L,
+            expectedUserStateGeneration = store.userStateGeneration()
+        )
+
+        stamped.shouldBeTrue()
+        store.getLastApiFetchLocation() shouldBeEqualTo GeofenceLocation(12.34, 56.78)
+        store.getLastSyncTimestamp() shouldBeEqualTo 900L
+    }
+
+    @Test
+    fun saveApiFetchStateIfCurrent_givenIdentifyLandedAfterRoutingWasArmed_expectNothingStamped() {
+        // The pass arms routing, then an identify lands before it stamps the cache. Stamping the
+        // new session fresh off this pass would make its own refresh SKIP, leaving routing empty.
+        store.beginUserSession("user-a")
+        val passGeneration = store.userStateGeneration()
+        store.beginUserSession("user-b")
+
+        val stamped = store.saveApiFetchStateIfCurrent(
+            location = GeofenceLocation(12.34, 56.78),
+            syncTimestamp = 900L,
+            expectedUserStateGeneration = passGeneration
+        )
+
+        stamped.shouldBeFalse()
+        store.getLastApiFetchLocation().shouldBeNull()
+        store.getLastSyncTimestamp().shouldBeNull()
     }
 
     // --- clearAll wipes everything ---
@@ -1146,9 +1181,8 @@ class GeofenceRegionStoreTest : RobolectricTest() {
                 maxMonitoringDistance = 1_000_000f
             )
         )
-        store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 12_345L, store.userStateGeneration())
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
-        store.setLastSyncTimestamp(12_345L)
         store.recordEntered("biz-1")
 
         store.clearAll()
@@ -1184,11 +1218,10 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.saveRetainedRegisteredRegions(listOf(GeofenceRegion("biz-stale", 1.0, 1.0, 50f)))
         store.recordEntered("biz-1")
         store.markEnterEmitted(USER, "biz-1")
-        store.saveLastApiFetchLocation(GeofenceLocation(1.0, 2.0))
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 12_345L, store.userStateGeneration())
         store.saveLastMovementTriggerLocation(GeofenceLocation(3.0, 4.0))
         store.setLastRegistrationUptime(99_999L)
         store.setLastRegistrationPackageUpdateTime(88_888L)
-        store.setLastSyncTimestamp(12_345L)
 
         store.clearUserScopedState()
 
@@ -1225,7 +1258,7 @@ class GeofenceRegionStoreTest : RobolectricTest() {
         store.recordPolygonCoarseInside(registered.id)
         store.recordEntered(registered.id)
         store.markEnterEmitted(USER, registered.id)
-        store.setLastSyncTimestamp(12_345L)
+        store.saveApiFetchStateIfCurrent(GeofenceLocation(1.0, 2.0), 12_345L, store.userStateGeneration())
 
         store.clearUserSessionRetainingOsRegistrations()
 
@@ -1343,8 +1376,12 @@ class GeofenceRegionStoreTest : RobolectricTest() {
     }
 
     @Test
-    fun saveLastApiFetchLocation_expectStableJsonKeys() {
-        store.saveLastApiFetchLocation(GeofenceLocation(latitude = 12.34, longitude = 56.78))
+    fun saveApiFetchStateIfCurrent_expectStableAnchorJsonKeys() {
+        store.saveApiFetchStateIfCurrent(
+            GeofenceLocation(latitude = 12.34, longitude = 56.78),
+            1L,
+            store.userStateGeneration()
+        )
 
         val raw = readRaw("last_api_fetch_location")
         raw shouldContain "\"latitude\""


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

- [#837 stage transitions durably before delivery](https://github.com/customerio/customerio-android/pull/837)
- 👉 this PR, and [#838 polygon location engine](https://github.com/customerio/customerio-android/pull/838), both branch from #837

## What this is

Found while sweeping for the class of bug behind the launch-time session finding on #837, and kept
separate so that review does not reopen for it.

`registerNearestAndPersist` decides `routingArmed` at `saveRoutableRegisteredIdsIfCurrent`, then runs
six more store writes before `onRegistered` stamps the cache fresh. An identify landing in that gap
takes the departing pass's fetch as the new session's freshness. That session's own refresh then sees
a fresh cache, skips, and leaves routing empty until a movement EXIT re-arms it, which is the state
#837 exists to prevent.

The pass now offers the generation it snapshotted, and the store writes the anchor and the sync
timestamp only while that generation is still current, under the same lock `beginUserSession` takes,
so the check and the write cannot be separated.

`saveLastApiFetchLocation` and `setLastSyncTimestamp` are private now. Neither had a production caller
left, and leaving them on the interface meant the next caller reaching for the obvious name reopens
the window.

## Tests

617 geofence tests, 0 failures. `lintDebug` 0 issues, `apiCheck` and ktlint clean, no compiler
warnings.

Two mutations, each killing exactly one test and nothing else: dropping the generation check kills the
store refusal test, and re-reading the generation instead of passing the snapshot kills the plumbing
test.

Worth knowing: no test drives the real store through the repository, so the production skip is pinned
in two halves, the store refusal and the offered generation, rather than end to end.

