### PR TITLE
ci: add robust boot verification and retry for instrumentation tests

### DIFF
--- a/.github/scripts/run-instrumentation-tests.sh
+++ b/.github/scripts/run-instrumentation-tests.sh
@@ -2,14 +2,30 @@
 # run-instrumentation-tests.sh
 # Run instrumentation tests with robust boot verification.
 # Called by android-emulator-runner after emulator starts.
-
-set -e
+#
+# Exit codes:
+#   0 = tests passed
+#   1 = tests failed (genuine test failure)
+#   2 = startup/infra failure (boot timeout, device offline, etc.)
 
 SAMPLE_MODULE="$1"
 MAX_BOOT_WAIT="${2:-30}"
+FAILURE_MARKER_FILE="${GITHUB_WORKSPACE}/.emulator-startup-failed"
+
+# Clean up any previous marker
+rm -f "$FAILURE_MARKER_FILE"
+
+mark_startup_failure() {
+    echo "STARTUP_FAILURE" > "$FAILURE_MARKER_FILE"
+    echo "::error::Emulator startup failure - eligible for retry"
+    exit 2
+}
 
 echo "Waiting for device to come online..."
-adb wait-for-device
+if ! adb wait-for-device; then
+    echo "ERROR: adb wait-for-device failed"
+    mark_startup_failure
+fi
 
 echo "Sleeping to let ADB stabilize..."
 sleep 10
@@ -27,12 +43,16 @@ while [ "$boot_complete" != "1" ] && [ $attempts -lt $MAX_BOOT_WAIT ]; do
 done
 
 if [ "$boot_complete" != "1" ]; then
-    echo "ERROR: Emulator did not boot within timeout"
-    exit 1
+    echo "ERROR: Emulator did not boot within timeout ($MAX_BOOT_WAIT attempts)"
+    mark_startup_failure
 fi
 
 echo "Boot confirmed complete. Waiting for package manager..."
-adb shell pm wait-for-ready 2>/dev/null || sleep 5
+if ! adb shell pm wait-for-ready 2>/dev/null; then
+    echo "Warning: pm wait-for-ready failed, sleeping instead..."
+    sleep 5
+fi
 
 echo "Starting instrumentation tests for $SAMPLE_MODULE..."
+# Run tests. Exit code 0 = pass, non-zero = test failure (NOT startup failure)
 ./gradlew ":samples:${SAMPLE_MODULE}:connectedDebugAndroidTest" --no-daemon --stacktrace -PuseKsp=true

--- a/.github/scripts/run-instrumentation-tests.sh
+++ b/.github/scripts/run-instrumentation-tests.sh
@@ -11,9 +11,14 @@
 SAMPLE_MODULE="$1"
 MAX_BOOT_WAIT="${2:-30}"
 FAILURE_MARKER_FILE="${GITHUB_WORKSPACE}/.emulator-startup-failed"
+SCRIPT_STARTED_FILE="${GITHUB_WORKSPACE}/.script-started"
 
-# Clean up any previous marker
+# Clean up any previous markers
 rm -f "$FAILURE_MARKER_FILE"
+
+# Write script-started breadcrumb immediately
+# Workflow uses this to detect action-level failures vs script failures
+date -Iseconds > "$SCRIPT_STARTED_FILE"
 
 mark_startup_failure() {
     echo "STARTUP_FAILURE" > "$FAILURE_MARKER_FILE"
@@ -21,9 +26,12 @@ mark_startup_failure() {
     exit 2
 }
 
-echo "Waiting for device to come online..."
-if ! adb wait-for-device; then
-    echo "ERROR: adb wait-for-device failed"
+# Bounded ADB wait-for-device with timeout
+# If emulator drops offline after action's boot check, this prevents infinite hang
+ADB_WAIT_TIMEOUT=120
+echo "Waiting for device to come online (timeout: ${ADB_WAIT_TIMEOUT}s)..."
+if ! timeout "$ADB_WAIT_TIMEOUT" adb wait-for-device; then
+    echo "ERROR: adb wait-for-device timed out after ${ADB_WAIT_TIMEOUT}s"
     mark_startup_failure
 fi
 
@@ -33,7 +41,7 @@ sleep 10
 echo "Verifying boot completion..."
 boot_complete=""
 attempts=0
-while [ "$boot_complete" != "1" ] && [ $attempts -lt $MAX_BOOT_WAIT ]; do
+while [ "$boot_complete" != "1" ] && [ $attempts -lt "$MAX_BOOT_WAIT" ]; do
     boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
     if [ "$boot_complete" != "1" ]; then
         sleep 2
@@ -47,10 +55,32 @@ if [ "$boot_complete" != "1" ]; then
     mark_startup_failure
 fi
 
-echo "Boot confirmed complete. Waiting for package manager..."
-if ! adb shell pm wait-for-ready 2>/dev/null; then
-    echo "Warning: pm wait-for-ready failed, sleeping instead..."
-    sleep 5
+echo "Boot confirmed complete. Verifying package manager readiness..."
+
+# Bounded package-manager readiness probe
+# pm wait-for-ready is not supported on API 31 - use pm path android instead
+# This command returns success once package manager is ready to respond
+PM_READY_TIMEOUT=30
+pm_attempts=0
+pm_ready=false
+
+while [ $pm_attempts -lt $PM_READY_TIMEOUT ]; do
+    # pm path android succeeds once package manager is operational
+    if adb shell pm path android 2>/dev/null | grep -q "package:"; then
+        pm_ready=true
+        echo "Package manager ready after $pm_attempts attempts"
+        break
+    fi
+    sleep 1
+    pm_attempts=$((pm_attempts + 1))
+    if [ $((pm_attempts % 5)) -eq 0 ]; then
+        echo "Package manager check attempt $pm_attempts/$PM_READY_TIMEOUT..."
+    fi
+done
+
+if [ "$pm_ready" != "true" ]; then
+    echo "ERROR: Package manager did not become ready within ${PM_READY_TIMEOUT}s"
+    mark_startup_failure
 fi
 
 echo "Starting instrumentation tests for $SAMPLE_MODULE..."

--- a/.github/scripts/run-instrumentation-tests.sh
+++ b/.github/scripts/run-instrumentation-tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# run-instrumentation-tests.sh
+# Run instrumentation tests with robust boot verification.
+# Called by android-emulator-runner after emulator starts.
+
+set -e
+
+SAMPLE_MODULE="$1"
+MAX_BOOT_WAIT="${2:-30}"
+
+echo "Waiting for device to come online..."
+adb wait-for-device
+
+echo "Sleeping to let ADB stabilize..."
+sleep 10
+
+echo "Verifying boot completion..."
+boot_complete=""
+attempts=0
+while [ "$boot_complete" != "1" ] && [ $attempts -lt $MAX_BOOT_WAIT ]; do
+    boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+    if [ "$boot_complete" != "1" ]; then
+        sleep 2
+        attempts=$((attempts + 1))
+        echo "Boot check attempt $attempts/$MAX_BOOT_WAIT..."
+    fi
+done
+
+if [ "$boot_complete" != "1" ]; then
+    echo "ERROR: Emulator did not boot within timeout"
+    exit 1
+fi
+
+echo "Boot confirmed complete. Waiting for package manager..."
+adb shell pm wait-for-ready 2>/dev/null || sleep 5
+
+echo "Starting instrumentation tests for $SAMPLE_MODULE..."
+./gradlew ":samples:${SAMPLE_MODULE}:connectedDebugAndroidTest" --no-daemon --stacktrace -PuseKsp=true

--- a/.github/scripts/run-instrumentation-tests.sh
+++ b/.github/scripts/run-instrumentation-tests.sh
@@ -18,7 +18,12 @@ rm -f "$FAILURE_MARKER_FILE"
 
 # Write script-started breadcrumb immediately
 # Workflow uses this to detect action-level failures vs script failures
-date -Iseconds > "$SCRIPT_STARTED_FILE"
+# Fail fast if write fails - prevents misclassifying Gradle failures as boot failures
+if ! date -Iseconds > "$SCRIPT_STARTED_FILE"; then
+    echo "ERROR: Failed to write script-started breadcrumb to $SCRIPT_STARTED_FILE"
+    echo "::error::Cannot write breadcrumb file - aborting to prevent misclassification"
+    exit 1
+fi
 
 mark_startup_failure() {
     echo "STARTUP_FAILURE" > "$FAILURE_MARKER_FILE"

--- a/.github/scripts/run-instrumentation-tests.sh
+++ b/.github/scripts/run-instrumentation-tests.sh
@@ -22,6 +22,8 @@ rm -f "$FAILURE_MARKER_FILE"
 if ! date -Iseconds > "$SCRIPT_STARTED_FILE"; then
     echo "ERROR: Failed to write script-started breadcrumb to $SCRIPT_STARTED_FILE"
     echo "::error::Cannot write breadcrumb file - aborting to prevent misclassification"
+    # Remove empty/partial breadcrumb so workflow doesn't misclassify as test failure
+    rm -f "$SCRIPT_STARTED_FILE"
     exit 1
 fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,28 +99,12 @@ jobs:
           script: |
             echo "Waiting for device to come online..."
             adb wait-for-device
-            
             echo "Waiting for boot to complete..."
-            boot_complete=""
-            attempts=0
-            max_attempts=60
-            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do
-              boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
-              if [ "$boot_complete" != "1" ]; then
-                sleep 2
-                attempts=$((attempts + 1))
-                echo "Boot check attempt $attempts/$max_attempts..."
-              fi
-            done
-            
-            if [ "$boot_complete" != "1" ]; then
-              echo "ERROR: Emulator did not boot within timeout"
-              exit 1
-            fi
-            
+            boot_complete=""; attempts=0; max_attempts=60
+            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r'); if [ "$boot_complete" != "1" ]; then sleep 2; attempts=$((attempts + 1)); echo "Boot check attempt $attempts/$max_attempts..."; fi; done
+            if [ "$boot_complete" != "1" ]; then echo "ERROR: Emulator did not boot within timeout"; exit 1; fi
             echo "Device booted. Waiting for package manager..."
             adb shell pm wait-for-ready 2>/dev/null || sleep 5
-            
             echo "Running instrumentation tests..."
             ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
@@ -139,28 +123,12 @@ jobs:
           script: |
             echo "Retry: Waiting for device to come online..."
             adb wait-for-device
-            
             echo "Retry: Waiting for boot to complete..."
-            boot_complete=""
-            attempts=0
-            max_attempts=90
-            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do
-              boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
-              if [ "$boot_complete" != "1" ]; then
-                sleep 2
-                attempts=$((attempts + 1))
-                echo "Boot check attempt $attempts/$max_attempts..."
-              fi
-            done
-            
-            if [ "$boot_complete" != "1" ]; then
-              echo "ERROR: Emulator did not boot within timeout"
-              exit 1
-            fi
-            
+            boot_complete=""; attempts=0; max_attempts=90
+            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r'); if [ "$boot_complete" != "1" ]; then sleep 2; attempts=$((attempts + 1)); echo "Boot check attempt $attempts/$max_attempts..."; fi; done
+            if [ "$boot_complete" != "1" ]; then echo "ERROR: Emulator did not boot within timeout"; exit 1; fi
             echo "Device booted. Waiting for package manager..."
             adb shell pm wait-for-ready 2>/dev/null || sleep 10
-            
             echo "Running instrumentation tests (retry)..."
             ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,11 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
+      # Clear script-started breadcrumb before each attempt
+      # Used to distinguish action-level failures from script/test failures
+      - name: Clear script-started marker
+        run: rm -f .script-started
+
       # Run the actual tests with extended boot timeout for cold runners
       # continue-on-error allows retry step to run and potentially rescue a startup failure
       - name: Run instrumentation tests
@@ -98,11 +103,38 @@ jobs:
           emulator-boot-timeout: 900
           script: bash .github/scripts/run-instrumentation-tests.sh ${{ matrix.sample }} 30
 
-      # Retry ONLY on emulator startup failures (indicated by marker file)
+      # Determine if failure is eligible for retry
+      # Startup failure = marker file present OR (action failed AND script never started)
+      # Genuine failure = script started, no startup marker, and step failed
+      - name: Check retry eligibility
+        id: check-retry
+        if: steps.run-tests.outcome == 'failure'
+        run: |
+          if [ -f ".emulator-startup-failed" ]; then
+            echo "Startup failure detected via marker file"
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+          elif [ ! -f ".script-started" ]; then
+            echo "Action-level failure detected: script never started (no .script-started breadcrumb)"
+            echo "This indicates the emulator action failed before invoking our script"
+            echo "should_retry=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Script started but failed without startup marker"
+            echo "This indicates a genuine test or Gradle failure"
+            echo "should_retry=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Clear markers before retry attempt
+      - name: Clear markers before retry
+        if: steps.run-tests.outcome == 'failure' && steps.check-retry.outputs.should_retry == 'true'
+        run: |
+          rm -f .emulator-startup-failed
+          rm -f .script-started
+
+      # Retry ONLY on emulator startup failures (marker file OR action-level failure)
       # Does NOT retry genuine test failures - those fail fast as expected
       - name: Retry instrumentation tests on startup failure
         id: retry-tests
-        if: steps.run-tests.outcome == 'failure' && hashFiles('.emulator-startup-failed') != ''
+        if: steps.run-tests.outcome == 'failure' && steps.check-retry.outputs.should_retry == 'true'
         uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
@@ -125,8 +157,11 @@ jobs:
           elif [ "${{ steps.retry-tests.outcome }}" == "success" ]; then
             echo "✅ Tests passed on retry (startup failure recovered)"
             exit 0
+          elif [ "${{ steps.check-retry.outputs.should_retry }}" == "false" ]; then
+            echo "❌ Tests failed (genuine test/Gradle failure, retry not attempted)"
+            exit 1
           elif [ "${{ steps.retry-tests.outcome }}" == "skipped" ] && [ "${{ steps.run-tests.outcome }}" == "failure" ]; then
-            echo "❌ Tests failed (genuine test failure, retry not attempted)"
+            echo "❌ Tests failed (retry was not eligible)"
             exit 1
           else
             echo "❌ Tests failed on both attempts"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,9 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      # Run the actual tests
+      # Run the actual tests with robust boot verification
       - name: Run instrumentation tests
+        id: run-tests
         uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
@@ -92,8 +93,76 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # Run the instrumentation tests on the emulator.
-          script: ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
+          # Wait for full boot before running tests. The emulator-runner checks
+          # sys.boot_completed but can start polling before the device is online,
+          # causing "device offline" errors on cold runners.
+          script: |
+            echo "Waiting for device to come online..."
+            adb wait-for-device
+            
+            echo "Waiting for boot to complete..."
+            boot_complete=""
+            attempts=0
+            max_attempts=60
+            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do
+              boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+              if [ "$boot_complete" != "1" ]; then
+                sleep 2
+                attempts=$((attempts + 1))
+                echo "Boot check attempt $attempts/$max_attempts..."
+              fi
+            done
+            
+            if [ "$boot_complete" != "1" ]; then
+              echo "ERROR: Emulator did not boot within timeout"
+              exit 1
+            fi
+            
+            echo "Device booted. Waiting for package manager..."
+            adb shell pm wait-for-ready 2>/dev/null || sleep 5
+            
+            echo "Running instrumentation tests..."
+            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
+
+      # Retry on emulator startup failures only
+      - name: Retry instrumentation tests on startup failure
+        if: failure() && steps.run-tests.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          target: google_apis
+          ram-size: 4096M
+          force-avd-creation: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            echo "Retry: Waiting for device to come online..."
+            adb wait-for-device
+            
+            echo "Retry: Waiting for boot to complete..."
+            boot_complete=""
+            attempts=0
+            max_attempts=90
+            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do
+              boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+              if [ "$boot_complete" != "1" ]; then
+                sleep 2
+                attempts=$((attempts + 1))
+                echo "Boot check attempt $attempts/$max_attempts..."
+              fi
+            done
+            
+            if [ "$boot_complete" != "1" ]; then
+              echo "ERROR: Emulator did not boot within timeout"
+              exit 1
+            fi
+            
+            echo "Device booted. Waiting for package manager..."
+            adb shell pm wait-for-ready 2>/dev/null || sleep 10
+            
+            echo "Running instrumentation tests (retry)..."
+            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,10 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       # Run the actual tests with extended boot timeout for cold runners
+      # continue-on-error allows retry step to run and potentially rescue a startup failure
       - name: Run instrumentation tests
         id: run-tests
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
@@ -96,9 +98,11 @@ jobs:
           emulator-boot-timeout: 900
           script: bash .github/scripts/run-instrumentation-tests.sh ${{ matrix.sample }} 30
 
-      # Retry on emulator startup failures only
+      # Retry ONLY on emulator startup failures (indicated by marker file)
+      # Does NOT retry genuine test failures - those fail fast as expected
       - name: Retry instrumentation tests on startup failure
-        if: failure() && steps.run-tests.outcome == 'failure'
+        id: retry-tests
+        if: steps.run-tests.outcome == 'failure' && hashFiles('.emulator-startup-failed') != ''
         uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
@@ -110,6 +114,24 @@ jobs:
           disable-animations: true
           emulator-boot-timeout: 1200
           script: bash .github/scripts/run-instrumentation-tests.sh ${{ matrix.sample }} 60
+
+      # Final verdict: pass if either attempt succeeded, fail otherwise
+      - name: Check test results
+        if: always()
+        run: |
+          if [ "${{ steps.run-tests.outcome }}" == "success" ]; then
+            echo "✅ Tests passed on first attempt"
+            exit 0
+          elif [ "${{ steps.retry-tests.outcome }}" == "success" ]; then
+            echo "✅ Tests passed on retry (startup failure recovered)"
+            exit 0
+          elif [ "${{ steps.retry-tests.outcome }}" == "skipped" ] && [ "${{ steps.run-tests.outcome }}" == "failure" ]; then
+            echo "❌ Tests failed (genuine test failure, retry not attempted)"
+            exit 1
+          else
+            echo "❌ Tests failed on both attempts"
+            exit 1
+          fi
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
 
-      # Run the actual tests with robust boot verification
+      # Run the actual tests with extended boot timeout for cold runners
       - name: Run instrumentation tests
         id: run-tests
         uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
@@ -93,19 +93,24 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # Wait for full boot before running tests. The emulator-runner checks
-          # sys.boot_completed but can start polling before the device is online,
-          # causing "device offline" errors on cold runners.
+          # Extended boot timeout to handle cold runner delays
+          emulator-boot-timeout: 900
           script: |
-            echo "Waiting for device to come online..."
+            # Wait for ADB to stabilize after emulator-runner's boot check
             adb wait-for-device
-            echo "Waiting for boot to complete..."
-            boot_complete=""; attempts=0; max_attempts=60
-            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r'); if [ "$boot_complete" != "1" ]; then sleep 2; attempts=$((attempts + 1)); echo "Boot check attempt $attempts/$max_attempts..."; fi; done
-            if [ "$boot_complete" != "1" ]; then echo "ERROR: Emulator did not boot within timeout"; exit 1; fi
-            echo "Device booted. Waiting for package manager..."
+            sleep 10
+            # Verify boot is really complete
+            for i in 1 2 3 4 5; do
+              if adb shell getprop sys.boot_completed | grep -q "1"; then
+                echo "Boot confirmed complete"
+                break
+              fi
+              echo "Waiting for boot... attempt $i"
+              sleep 5
+            done
+            # Wait for package manager to be ready
             adb shell pm wait-for-ready 2>/dev/null || sleep 5
-            echo "Running instrumentation tests..."
+            echo "Starting instrumentation tests..."
             ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
       # Retry on emulator startup failures only
@@ -120,16 +125,23 @@ jobs:
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          emulator-boot-timeout: 1200
           script: |
-            echo "Retry: Waiting for device to come online..."
+            # Wait for ADB to stabilize after emulator-runner's boot check
             adb wait-for-device
-            echo "Retry: Waiting for boot to complete..."
-            boot_complete=""; attempts=0; max_attempts=90
-            while [ "$boot_complete" != "1" ] && [ $attempts -lt $max_attempts ]; do boot_complete=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r'); if [ "$boot_complete" != "1" ]; then sleep 2; attempts=$((attempts + 1)); echo "Boot check attempt $attempts/$max_attempts..."; fi; done
-            if [ "$boot_complete" != "1" ]; then echo "ERROR: Emulator did not boot within timeout"; exit 1; fi
-            echo "Device booted. Waiting for package manager..."
+            sleep 15
+            # Verify boot is really complete
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              if adb shell getprop sys.boot_completed | grep -q "1"; then
+                echo "Boot confirmed complete"
+                break
+              fi
+              echo "Waiting for boot... attempt $i"
+              sleep 5
+            done
+            # Wait for package manager to be ready
             adb shell pm wait-for-ready 2>/dev/null || sleep 10
-            echo "Running instrumentation tests (retry)..."
+            echo "Starting instrumentation tests (retry)..."
             ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
 
       - name: Publish test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,25 +93,8 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # Extended boot timeout to handle cold runner delays
           emulator-boot-timeout: 900
-          script: |
-            # Wait for ADB to stabilize after emulator-runner's boot check
-            adb wait-for-device
-            sleep 10
-            # Verify boot is really complete
-            for i in 1 2 3 4 5; do
-              if adb shell getprop sys.boot_completed | grep -q "1"; then
-                echo "Boot confirmed complete"
-                break
-              fi
-              echo "Waiting for boot... attempt $i"
-              sleep 5
-            done
-            # Wait for package manager to be ready
-            adb shell pm wait-for-ready 2>/dev/null || sleep 5
-            echo "Starting instrumentation tests..."
-            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
+          script: bash .github/scripts/run-instrumentation-tests.sh ${{ matrix.sample }} 30
 
       # Retry on emulator startup failures only
       - name: Retry instrumentation tests on startup failure
@@ -126,23 +109,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           emulator-boot-timeout: 1200
-          script: |
-            # Wait for ADB to stabilize after emulator-runner's boot check
-            adb wait-for-device
-            sleep 15
-            # Verify boot is really complete
-            for i in 1 2 3 4 5 6 7 8 9 10; do
-              if adb shell getprop sys.boot_completed | grep -q "1"; then
-                echo "Boot confirmed complete"
-                break
-              fi
-              echo "Waiting for boot... attempt $i"
-              sleep 5
-            done
-            # Wait for package manager to be ready
-            adb shell pm wait-for-ready 2>/dev/null || sleep 10
-            echo "Starting instrumentation tests (retry)..."
-            ./gradlew :samples:${{ matrix.sample }}:connectedDebugAndroidTest --no-daemon --stacktrace -PuseKsp=true
+          script: bash .github/scripts/run-instrumentation-tests.sh ${{ matrix.sample }} 60
 
       - name: Publish test results
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1


### PR DESCRIPTION
Adds explicit boot verification before running instrumentation tests. The android-emulator-runner action checks `sys.boot_completed` but can start polling before the device is online, causing "device offline" errors on cold CI runners.

27 combined failures in 8 weeks across kotlin_compose and java_layout instrumentation jobs. Root cause: cold-runner boot race where tests start before emulator fully boots, plus MemoryLeakageInstrumentedTest crash on uninitialized SDK during LeakCanary teardown.

Changes:
- `adb wait-for-device` before boot check
- Polling loop for `sys.boot_completed` with explicit timeout
- Package manager readiness wait
- Retry step with `force-avd-creation` for startup failures (longer timeout on retry)

Proof: two consecutive green runs on this branch required.

[MBL-2408](https://linear.app/customerio/issue/MBL-2408)