### PR TITLE
chore(geofence): adopt main's geofence log diagnostics

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -160,7 +160,7 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 Geofence.GEOFENCE_TRANSITION_ENTER -> Event.GeofenceTransition.ENTER
                 Geofence.GEOFENCE_TRANSITION_EXIT -> Event.GeofenceTransition.EXIT
                 else -> {
-                    logger.logUnknownTransition(gmsTransitionType)
+                    logger.logUnknownTransition(geofenceId, gmsTransitionType)
                     return@forEach
                 }
             }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceDiagnostics.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceDiagnostics.kt
@@ -1,0 +1,51 @@
+package io.customer.geofence
+
+import android.content.pm.PackageManager
+import io.customer.sdk.core.di.SDKComponent
+
+/**
+ * Whether the SDK emits the diagnostic tail.
+ *
+ * Read from the host app's manifest, deliberately not from an API. Anything reachable — even
+ * behind an opt-in annotation — is something a customer app can switch on, and the tail is the
+ * only thing keeping coordinates out of a production log.
+ *
+ * Enable with, in the app's `AndroidManifest.xml`:
+ * ```xml
+ * <meta-data android:name="io.customer.geofence.diagnostics" android:value="true" />
+ * ```
+ */
+internal object GeofenceDiagnostics {
+    const val MANIFEST_KEY = "io.customer.geofence.diagnostics"
+
+    @Volatile
+    private var override: Boolean? = null
+
+    @Volatile
+    private var cached: Boolean? = null
+
+    val isEnabled: Boolean
+        get() {
+            override?.let { return it }
+            cached?.let { return it }
+            // Null means the context was not reachable yet — leave it uncached so a later read,
+            // once the SDK is initialized, still gets the real answer.
+            val value = readManifest() ?: return false
+            cached = value
+            return value
+        }
+
+    /** Test hook; `null` restores the manifest value. */
+    fun setEnabledForTesting(value: Boolean?) {
+        override = value
+    }
+
+    private fun readManifest(): Boolean? = runCatching {
+        val context = SDKComponent.android().applicationContext
+        val info = context.packageManager.getApplicationInfo(
+            context.packageName,
+            PackageManager.GET_META_DATA
+        )
+        info.metaData?.getBoolean(MANIFEST_KEY, false) ?: false
+    }.getOrNull()
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
@@ -1,0 +1,204 @@
+package io.customer.geofence
+
+import android.location.Location
+import android.os.Build
+import android.os.SystemClock
+import java.util.Locale
+
+/**
+ * Whether a record is something the SDK was told, decided, or neither.
+ *
+ * Stated explicitly rather than inferred from the event name: replay feeds the `in` records back
+ * and compares the `out` records, so a naming convention getting this wrong invalidates a run.
+ */
+internal enum class GeofenceLogIo(val wire: String) {
+    INPUT("in"),
+    OUTPUT("out"),
+    OBSERVATION("obs")
+}
+
+/**
+ * Builds the machine-readable tail appended to a geofence log message.
+ *
+ * ```
+ * [Geofence] Geofence 'notl_core' ENTER: queued ... || ev=transition.accepted io=out id=notl_core t=enter n=1
+ * ```
+ *
+ * Mirrors the iOS `GeofenceLog`. The key vocabulary matches; a few records are split
+ * differently per platform (registration in particular), so the parser accepts both shapes.
+ */
+internal object GeofenceLogTail {
+    /** A parser splits on the **last** occurrence, and only if the remainder is all `key=value`. */
+    const val DELIMITER = " || "
+
+    /**
+     * @param ev stable machine key. Never reworded — `msg` is the prose someone will rewrite.
+     * @param fields null values are omitted, keeping absent and empty distinct.
+     */
+    fun tail(
+        ev: String,
+        io: GeofenceLogIo,
+        fields: List<Pair<String, String?>> = emptyList()
+    ): String {
+        // The single gate for every diagnostic value. Prose is emitted by the caller either way.
+        if (!GeofenceDiagnostics.isEnabled) return ""
+
+        val parts = StringBuilder(DELIMITER).append("ev=").append(ev).append(" io=").append(io.wire)
+        for ((key, value) in fields) {
+            if (value == null) continue
+            // Sanitize by default and let the few composed keys opt out, rather than the reverse.
+            // A new field is then safe without anyone remembering to wrap it, which is how 20
+            // `id` call sites ended up unprotected the last time this was the other way round.
+            val safe = if (key in COMPOSED_KEYS) foldWhitespace(value) else sanitize(value)
+            parts.append(' ').append(key).append('=').append(safe)
+        }
+        return parts.toString()
+    }
+
+    /**
+     * Every character the format itself uses to separate things. Applied to *untrusted tokens*
+     * only — a workspace-authored id containing one of these would otherwise split a field: `=` a
+     * pair, `,` a list, `:` an `id:distance` entry in `ranked`, `|` the tail delimiter.
+     *
+     * Deliberately not applied to a finished value: `list` and `ranked` compose their separators
+     * on purpose, and folding those turns `a,b` into `a_b`.
+     */
+    private val SEPARATORS = charArrayOf('=', ',', ':', '|')
+
+    /**
+     * The only values that compose the format's separators on purpose. Everything else is treated
+     * as an untrusted token: geofence identifiers are workspace-authored and can hold anything.
+     */
+    private val COMPOSED_KEYS = setOf("ranked", "evicted", "ids", "gs", "tt")
+
+    /**
+     * Applied to every finished value. Only whitespace, which is what separates one `key=value`
+     * from the next — the value's own structure is already the caller's business.
+     */
+    fun foldWhitespace(value: String): String {
+        if (value.isEmpty()) return "_"
+        return buildString(value.length) {
+            for (character in value) append(if (character.isWhitespace()) '_' else character)
+        }
+    }
+
+    /** The parser splits on whitespace, and workspace-authored ids can contain anything. */
+    fun sanitize(value: String): String {
+        if (value.isEmpty()) return "_"
+        return buildString(value.length) {
+            for (character in value) {
+                append(if (character.isWhitespace() || character in SEPARATORS) '_' else character)
+            }
+        }
+    }
+
+    // MARK: - Value formatting
+
+    fun num(value: Double?, places: Int = 1): String? {
+        if (value == null || value.isNaN() || value.isInfinite()) return null
+        return String.format(Locale.US, "%.${places}f", value)
+    }
+
+    fun num(value: Float?, places: Int = 1): String? = num(value?.toDouble(), places)
+
+    fun int(value: Int?): String? = value?.toString()
+
+    fun bool(value: Boolean): String = if (value) "true" else "false"
+
+    /**
+     * For elements the caller has already composed, like `id:distance` — their structure is
+     * deliberate, so the untrusted part must be sanitized before composing, not after.
+     */
+    fun composedList(values: List<String>, limit: Int = 25): String? {
+        if (values.isEmpty()) return null
+        val head = values.take(maxOf(0, limit)).joinToString(",")
+        return if (values.size > limit) "$head,+${values.size - limit}" else head
+    }
+
+    /** Comma-separated, capped; the count travels separately so truncation stays honest. */
+    fun list(values: List<String>, limit: Int = 25): String? {
+        if (values.isEmpty()) return null
+        // `take` throws on a negative count; no caller passes one, but a log must not be
+        // the thing that takes the process down.
+        val head = values.take(maxOf(0, limit)).joinToString(",") { sanitize(it) }
+        return if (values.size > limit) "$head,+${values.size - limit}" else head
+    }
+
+    /** Reasons are tokens so they survive the sentence in front of them being reworded. */
+    fun token(value: String): String {
+        val out = StringBuilder(value.length)
+        var lastWasSeparator = false
+        for (character in value.lowercase(Locale.US)) {
+            if (character.isLetterOrDigit()) {
+                out.append(character)
+                lastWasSeparator = false
+            } else if (!lastWasSeparator && out.isNotEmpty()) {
+                out.append('_')
+                lastWasSeparator = true
+            }
+        }
+        while (out.isNotEmpty() && out.last() == '_') out.deleteCharAt(out.length - 1)
+        return if (out.isEmpty()) "unknown" else out.toString()
+    }
+
+    // MARK: - Fix quality and provenance
+
+    /**
+     * Where a fix came from; the log previously said only that *a* position existed.
+     *
+     * Android is better placed than iOS: `triggeringLocation` is a real fix the OS computed for
+     * this crossing, where CoreLocation supplies none and the SDK falls back to its own cache.
+     */
+    enum class FixSource(val wire: String) {
+        /** The OS's own triggering fix, attached to the crossing it reported. */
+        OS_TRIGGER("os_trigger"),
+
+        /** Last handed to or cached by the SDK — may be arbitrarily stale. */
+        CACHED("cached"),
+        FRESH_REQUEST("fresh_request"),
+        NONE("none")
+    }
+
+    /** How good the fix is and where it came from; `age` separates a measurement from a guess. */
+    fun fixQuality(location: Location?, source: FixSource): List<Pair<String, String?>> {
+        val fields = mutableListOf<Pair<String, String?>>("fixsrc" to source.wire)
+        if (location == null) return fields
+
+        if (location.hasAccuracy()) fields.add("acc" to num(location.accuracy))
+        fields.add("age" to num(fixAgeSeconds(location)))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && location.hasVerticalAccuracy()) {
+            fields.add("vacc" to num(location.verticalAccuracyMeters))
+        }
+        // Without this a bench run and a real drive are indistinguishable once files are pooled.
+        fields.add("sim" to bool(isMock(location)))
+        return fields
+    }
+
+    /** Monotonic, not wall clock: `getTime()` steps with NTP, `elapsedRealtimeNanos` cannot. */
+    private fun fixAgeSeconds(location: Location): Double =
+        (SystemClock.elapsedRealtimeNanos() - location.elapsedRealtimeNanos) / 1_000_000_000.0
+
+    @Suppress("DEPRECATION")
+    private fun isMock(location: Location): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) location.isMock else location.isFromMockProvider
+
+    // MARK: - Device position
+
+    /** Device position. Gated with the rest of the tail; no per-field switch. */
+    fun position(location: Location?): List<Pair<String, String?>> {
+        if (location == null) return emptyList()
+        return buildList {
+            add("lat" to num(location.latitude, 5))
+            add("lon" to num(location.longitude, 5))
+            if (location.hasAltitude()) add("alt" to num(location.altitude))
+            if (location.hasSpeed()) add("spd" to num(location.speed))
+            if (location.hasBearing()) add("brg" to num(location.bearing))
+        }
+    }
+
+    /** Coordinates only, for the paths that carry bare doubles rather than a full [Location]. */
+    fun position(latitude: Double?, longitude: Double?): List<Pair<String, String?>> {
+        if (latitude == null || longitude == null) return emptyList()
+        return listOf("lat" to num(latitude, 5), "lon" to num(longitude, 5))
+    }
+}

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -1,212 +1,942 @@
 package io.customer.geofence
 
+import android.location.Location
+import io.customer.geofence.GeofenceLogTail.bool
+import io.customer.geofence.GeofenceLogTail.composedList
+import io.customer.geofence.GeofenceLogTail.int
+import io.customer.geofence.GeofenceLogTail.list
+import io.customer.geofence.GeofenceLogTail.num
+import io.customer.geofence.GeofenceLogTail.token
 import io.customer.sdk.core.util.Logger
 
-/** Structured logger for geofence operations, tagged for logcat filtering. */
+/**
+ * How the SDK came to be running.
+ *
+ * Nothing marks a cold background wake today, which makes it impossible to tell "the SDK was never
+ * running" apart from "the SDK ran and decided not to act" when reading a drive afterwards.
+ */
+internal enum class GeofenceLaunchReason(val wire: String) {
+    APP_START("app_start"),
+    BOOT_RESTORE("boot_restore")
+}
+
+/**
+ * Structured logger for geofence operations, tagged for logcat filtering.
+ *
+ * Every record carries a ` || key=value` tail after its human-readable prose: `ev=` is a stable
+ * machine key (prose is what gets reworded; `ev` is the contract) and `io=` classifies the record
+ * for replay. The nine prose lines `docs/manual-tests` greps for are unchanged; three of them are
+ * pinned by `documentedProse_expectExactStringsManualTestsGrepFor`, the rest by nothing but care; other prose may be improved (the
+ * unsupported-transition line gained the fence id, since one record per fence naming none of them
+ * was useless). Records added by this work emit their prose whether or not diagnostics are on —
+ * only the tail is gated.
+ *
+ * Reason tokens are **derived** from the existing prose rather than replacing it with an enum.
+ * That keeps every `reason: String` signature exactly as it was — `logSyncSkipped` alone has 20
+ * test references — while still yielding a stable `why=` for tooling. The specific tokens are
+ * pinned by `GeofenceLogTailTest` so a reworded sentence fails loudly instead of silently changing
+ * what analysis groups on.
+ */
 internal class GeofenceLogger(private val logger: Logger) {
 
+    /** Short name for [GeofenceLogTail.tail]; the call sites below are dense with it. */
+    private fun tail(
+        ev: String,
+        io: GeofenceLogIo,
+        fields: List<Pair<String, String?>> = emptyList()
+    ): String = GeofenceLogTail.tail(ev, io, fields)
+
+    // MARK: - Registration
+
     fun logGeofencesRegistered(count: Int) {
-        logger.debug("Registered $count geofences with OS", tag = TAG)
+        logger.debug(
+            "Registered $count geofences with OS" +
+                tail("registration.added", GeofenceLogIo.OUTPUT, listOf("nadd" to int(count))),
+            tag = TAG
+        )
+    }
+
+    /**
+     * Which regions the OS is actually monitoring, by identifier.
+     *
+     * Counts alone cannot answer the first question anyone asks of a drive that missed a crossing —
+     * "was this geofence even being monitored when I drove through it?" — so the identifiers travel
+     * too. A separate method rather than widening [logSyncSucceeded], whose five `verify` blocks
+     * would all need updating for no benefit.
+     */
+    fun logRegionsRegisteredIds(ids: List<String>, movementTriggerId: String?) {
+        logger.debug(
+            "Monitoring ${ids.size} region(s) with the OS" +
+                tail(
+                    "registration.applied",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "n" to int(ids.size),
+                        "ids" to list(ids.sorted()),
+                        "mvmt" to movementTriggerId
+                    )
+                ),
+            tag = TAG
+        )
     }
 
     fun logBusinessGeofencesKept(count: Int) {
         logger.debug(
-            "Kept $count business geofences unchanged in OS; skipped re-upsert to avoid GMS state reconciliation",
+            "Kept $count business geofences unchanged in OS; skipped re-upsert to avoid GMS state reconciliation" +
+                tail(
+                    "registration.kept",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("nkeep" to int(count), "why" to "unchanged")
+                ),
             tag = TAG
         )
     }
 
     fun logGeofencesRemoved(count: Int) {
-        logger.debug("Removed $count geofences from OS", tag = TAG)
+        logger.debug(
+            "Removed $count geofences from OS" +
+                tail("registration.removed", GeofenceLogIo.OUTPUT, listOf("nrem" to int(count))),
+            tag = TAG
+        )
     }
 
     fun logGeofencesCleared() {
-        logger.debug("Cleared all geofences from OS", tag = TAG)
+        logger.debug(
+            "Cleared all geofences from OS" +
+                tail("registration.cleared", GeofenceLogIo.OUTPUT, listOf("why" to "cleared")),
+            tag = TAG
+        )
     }
 
     fun logRegistrationFailed(message: String?) {
-        logger.error("Failed to register geofences: $message", tag = TAG)
+        logger.error(
+            "Failed to register geofences: $message" +
+                tail(
+                    "registration.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("ok" to bool(false), "why" to token(message ?: "unknown"))
+                ),
+            tag = TAG
+        )
     }
 
     fun logRemovalFailed(message: String?) {
-        logger.error("Failed to remove geofences: $message", tag = TAG)
-    }
-
-    fun logGmsCallTimedOut(description: String) {
-        logger.error("GMS $description gave no callback before the deadline — treating as failed; Play Services may be updating or unresponsive", tag = TAG)
-    }
-
-    fun logMissingPermission(permission: String) {
-        logger.error("Cannot register geofences: $permission not granted. Host app must request this permission.", tag = TAG)
-    }
-
-    fun logTransitionEmitting(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
-    }
-
-    fun logTransitionSuppressed(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: suppressed — same transition fired within the cooldown window", tag = TAG)
-    }
-
-    fun logInitialEnterInside(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId': device already inside a newly-registered fence — synthesizing ENTER (GMS INITIAL_TRIGGER_ENTER is unreliable)", tag = TAG)
+        logger.error(
+            "Failed to remove geofences: $message" +
+                tail(
+                    "registration.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("ok" to bool(false), "op" to "remove", "why" to token(message ?: "unknown"))
+                ),
+            tag = TAG
+        )
     }
 
     fun logInvalidRegionDropped(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' dropped — invalid coordinates or radius, not registerable with the OS", tag = TAG)
-    }
-
-    fun logPolygonDroppedUnsupportedRuntime(geofenceId: String) {
-        logger.info(
-            "Geofence '$geofenceId' dropped — it is a polygon, and this SDK build monitors circles only. The record was decoded and validated but never registered; its enclosing circle is a proximity trigger, not the fence, so registering it would report transitions for the wrong area.",
-            tag = TAG
-        )
-    }
-
-    fun logUnsupportedGeometryDropped(geofenceId: String, type: String) {
-        logger.error(
-            "Geofence '$geofenceId' dropped — unsupported geometry type='$type' (only Polygon is understood). Not degraded to a circle; check SDK / backend version alignment.",
-            tag = TAG
-        )
-    }
-
-    fun logPolygonDropped(geofenceId: String, reason: String) {
-        logger.error("Geofence '$geofenceId' dropped — polygon rejected: $reason", tag = TAG)
-    }
-
-    fun logPolygonRegionNotRanked(geofenceId: String, reason: String) {
         logger.debug(
-            "Geofence '$geofenceId' excluded from ranking — $reason. It stays cached and is never registered as its enclosing circle.",
+            "Geofence '$geofenceId' dropped — invalid coordinates or radius, not registerable with the OS" +
+                tail(
+                    "registration.rejected",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "why" to "invalid_geometry")
+                ),
             tag = TAG
         )
     }
 
     fun logRegionMappingFailed(geofenceId: String, message: String?) {
-        logger.error("Geofence '$geofenceId' dropped — mapping failed unexpectedly: $message", tag = TAG)
+        logger.error(
+            "Geofence '$geofenceId' dropped — mapping failed unexpectedly: $message" +
+                tail(
+                    "registration.rejected",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "why" to token(message ?: "mapping_failed"))
+                ),
+            tag = TAG
+        )
     }
 
-    fun logTransitionDroppedUnknownId(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' transition dropped — id not in registered store", tag = TAG)
+    /**
+     * The N-of-M selection, which happens silently today: a geofence never registered because it
+     * ranked past the cap is indistinguishable from one registered that simply never fired.
+     *
+     * [selected], [evicted] and [edgeDistances] are lambdas: producing them costs a distance
+     * computation per region plus a filter over every candidate, on a background wake path, and
+     * none of it is wanted unless the tail will carry it.
+     */
+    fun logRankEvaluated(
+        candidates: Int,
+        selectedCount: Int,
+        selected: () -> List<String>,
+        evicted: () -> List<String>,
+        edgeDistances: () -> Map<String, Double>
+    ) {
+        val detail = if (GeofenceDiagnostics.isEnabled) {
+            val distances = edgeDistances()
+            val ranked = selected().map { id ->
+                distances[id]?.let { "${GeofenceLogTail.sanitize(id)}:${it.toInt()}" } ?: GeofenceLogTail.sanitize(id)
+            }
+            tail(
+                "rank.evaluated",
+                GeofenceLogIo.OUTPUT,
+                listOf(
+                    "ncand" to int(candidates),
+                    "n" to int(selectedCount),
+                    "ranked" to composedList(ranked),
+                    "evicted" to list(evicted())
+                )
+            )
+        } else {
+            ""
+        }
+        logger.debug("Ranked $candidates candidate(s), selected $selectedCount" + detail, tag = TAG)
     }
 
-    fun logTransitionDroppedUnarmedId(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' transition dropped — registered but routing is not armed for this session; OS registration kept", tag = TAG)
+    /** The re-centred movement bubble's own geometry, derived from the device's position. */
+    fun logMovementTriggerRegistered(latitude: Double, longitude: Double, radiusMeters: Double) {
+        logger.debug(
+            "Movement trigger registered with radius ${radiusMeters.toInt()} m" +
+                tail(
+                    "movement.registered",
+                    GeofenceLogIo.OUTPUT,
+                    GeofenceLogTail.position(latitude, longitude).map { (k, v) ->
+                        (if (k == "lat") "rlat" else if (k == "lon") "rlon" else k) to v
+                    } + listOf("rad" to num(radiusMeters, 0))
+                ),
+            tag = TAG
+        )
     }
 
-    fun logTransitionDroppedRetiredId(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' transition dropped — backend removed it and OS cleanup is pending", tag = TAG)
-    }
+    // MARK: - Permissions and lifecycle
 
-    fun logEnterDroppedAlreadyReported(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' ENTER: dropped — already reported as entered and no exit since, so the OS is re-reporting a state we already sent", tag = TAG)
-    }
-
-    fun logExitDroppedNeverEntered(geofenceId: String) {
-        logger.debug("Geofence '$geofenceId' EXIT: dropped — no record of the device being inside, so the OS is reconciling its own state", tag = TAG)
-    }
-
-    fun logTransitionDroppedAnonymous(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: dropped — no identified user (geofencing is identified-only)", tag = TAG)
-    }
-
-    fun logUnknownTransition(transitionType: Int) {
-        logger.debug("Ignoring geofence transition type=$transitionType (only ENTER and EXIT are tracked)", tag = TAG)
-    }
-
-    fun logUnknownApiTransitionType(value: String) {
-        logger.error("API response contained unknown transition_type='$value' (expected enter/exit). Region's affected types dropped — check SDK / backend version alignment.", tag = TAG)
-    }
-
-    fun logTransitionWithoutLocation() {
-        logger.debug("Geofence transition fired but OS provided no triggering location; a movement-trigger refresh cannot run without it", tag = TAG)
-    }
-
-    fun logMovementTriggerIgnoredNonExit(transitionName: String) {
-        logger.debug("Movement trigger geofence fired with transition=$transitionName; only EXIT triggers a sync", tag = TAG)
-    }
-
-    fun logSyncTriggered(reason: String) {
-        logger.debug("Geofence sync triggered: $reason", tag = TAG)
-    }
-
-    fun logSyncSkippedNoLocation(reason: String) {
-        logger.debug("Geofence sync skipped ($reason): no location available", tag = TAG)
-    }
-
-    fun logSyncSkippedInvalidLocation(reason: String, latitude: Double, longitude: Double) {
-        logger.error("Geofence sync skipped ($reason): OS reported an unusable fix ($latitude, $longitude)", tag = TAG)
-    }
-
-    fun logSyncSkippedNoPermission(reason: String) {
-        logger.debug("Geofence sync skipped ($reason): location permissions not granted", tag = TAG)
+    fun logMissingPermission(permission: String) {
+        logger.error(
+            "Cannot register geofences: $permission not granted. Host app must request this permission." +
+                tail(
+                    "permission.changed",
+                    GeofenceLogIo.OBSERVATION,
+                    listOf("perm" to token(permission), "why" to "not_granted")
+                ),
+            tag = TAG
+        )
     }
 
     fun logBackgroundDeliveryUnavailable(reason: String) {
-        logger.info("Geofence sync ($reason): ACCESS_BACKGROUND_LOCATION not granted — transitions will only fire while the app is in the foreground", tag = TAG)
+        logger.info(
+            "Geofence sync ($reason): ACCESS_BACKGROUND_LOCATION not granted — transitions will only fire while the app is in the foreground" +
+                tail(
+                    "permission.changed",
+                    GeofenceLogIo.OBSERVATION,
+                    listOf("perm" to "foreground_only", "ctx" to token(reason))
+                ),
+            tag = TAG
+        )
+    }
+
+    /** Process start and why. A background wake and a user opening the app look identical today. */
+    /**
+     * The module came up. A cold wake announces itself separately via [logModuleWoke] rather than
+     * racing this one for a single record — the OS decides their order, not us.
+     */
+    fun logModuleInitialized(launchReason: GeofenceLaunchReason) {
+        logger.info(
+            "Geofence module initialized (${launchReason.wire})" +
+                tail("module.init", GeofenceLogIo.OBSERVATION, listOf("launch" to launchReason.wire)),
+            tag = TAG
+        )
+    }
+
+    /** The process was started *by* something — a boot restore today. */
+    fun logModuleWoke(launchReason: GeofenceLaunchReason) {
+        logger.info(
+            "Geofence module woken (${launchReason.wire})" +
+                tail("module.wake", GeofenceLogIo.OBSERVATION, listOf("launch" to launchReason.wire)),
+            tag = TAG
+        )
+    }
+
+    fun logMissingLocationModule() {
+        logger.error(
+            "ModuleGeofence requires ModuleLocation to be registered alongside it. Add ModuleLocation to CustomerIOConfigBuilder; geofencing will not function until then." +
+                tail(
+                    "module.init",
+                    GeofenceLogIo.OBSERVATION,
+                    listOf("ok" to bool(false), "why" to "missing_location_module")
+                ),
+            tag = TAG
+        )
     }
 
     fun logGeofenceStateResetOnSignOut() {
-        logger.debug("Geofence state reset on user sign-out: clearing persisted regions and OS registrations", tag = TAG)
+        logger.debug(
+            "Geofence state reset on user sign-out: clearing persisted regions and OS registrations" +
+                tail("module.reset", GeofenceLogIo.OUTPUT, listOf("why" to "sign_out")),
+            tag = TAG
+        )
     }
 
-    fun logSyncSkippedFresh() {
-        logger.debug("Geofence sync skipped: last successful sync is still within the freshness window", tag = TAG)
+    // MARK: - OS callbacks
+
+    /**
+     * A crossing as the OS reported it, with the fix the OS computed for it.
+     *
+     * Android is better placed than iOS here: `GeofencingEvent.triggeringLocation` is a real fix
+     * attached to the crossing, where CoreLocation supplies no position with a geofence event at
+     * all. Logged at the receiver, before any routing decision, and before the whole `Location` is
+     * narrowed to a latitude and longitude pair.
+     */
+    fun logCallbackReceived(
+        geofenceIds: List<String>,
+        transitionName: String,
+        location: Location?,
+        source: GeofenceLogTail.FixSource
+    ) {
+        logger.debug(
+            "OS reported $transitionName for ${geofenceIds.size} region(s)" +
+                tail(
+                    "os.callback.received",
+                    GeofenceLogIo.INPUT,
+                    listOf("ids" to list(geofenceIds), "n" to int(geofenceIds.size), "t" to token(transitionName)) +
+                        GeofenceLogTail.fixQuality(location, source) +
+                        GeofenceLogTail.position(location)
+                ),
+            tag = TAG
+        )
     }
 
-    fun logContainmentJudged(insideCount: Int) {
-        logger.debug("Judged containment from the live fix: inside $insideCount region(s)", tag = TAG)
+    fun logTransitionWithoutLocation() {
+        logger.debug(
+            "Geofence transition fired but OS provided no triggering location; a movement-trigger refresh cannot run without it" +
+                tail(
+                    "os.callback.no_location",
+                    GeofenceLogIo.OBSERVATION,
+                    listOf("fixsrc" to GeofenceLogTail.FixSource.NONE.wire, "why" to "no_triggering_location")
+                ),
+            tag = TAG
+        )
+    }
+
+    /**
+     * Something worth reading in a log, deliberately outside the asserted vocabulary.
+     *
+     * `ev=info` is the bucket for records a human wants when explaining a capture but a scenario
+     * must never assert on. Two reasons it exists rather than reusing a semantic key:
+     *
+     * - Unexpected cases do not deserve invented semantics. Minting a new `ev` for every oddity
+     *   grows the vocabulary faster than anyone can keep it aligned across platforms.
+     * - More importantly, the obvious reuse is actively wrong. Filing these under
+     *   `os.callback.dropped` would inflate the received-vs-dropped count — the count that
+     *   separates "the OS never reported it" from "we discarded it", which is the question a
+     *   paired drive exists to answer. Every real `os.callback.dropped` nets against an
+     *   `os.callback.received`; a broadcast we could not read has no receipt to net against.
+     *
+     * `io=obs`, so the off-device transform drops the whole family rather than replaying it.
+     */
+    fun logInfo(reason: String, fields: List<Pair<String, String?>> = emptyList()) {
+        logger.debug(
+            "Geofence note: ${reason.replace('_', ' ')}" +
+                tail("info", GeofenceLogIo.OBSERVATION, listOf("why" to reason) + fields),
+            tag = TAG
+        )
+    }
+
+    /** [geofenceId] because this is called per fence inside the broadcast loop — without it a
+     *  DWELL over three fences produces three identical records naming none of them. */
+    fun logUnknownTransition(geofenceId: String, transitionType: Int) {
+        logger.debug(
+            "Ignoring geofence transition type=$transitionType for '$geofenceId' (only ENTER and EXIT are tracked)" +
+                tail(
+                    "os.callback.dropped",
+                    GeofenceLogIo.INPUT,
+                    listOf("id" to geofenceId, "gms" to int(transitionType), "why" to "unsupported_transition_type")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logMovementTriggerIgnoredNonExit(transitionName: String) {
+        logger.debug(
+            "Movement trigger geofence fired with transition=$transitionName; only EXIT triggers a sync" +
+                tail(
+                    "os.callback.dropped",
+                    GeofenceLogIo.INPUT,
+                    listOf("t" to token(transitionName), "why" to "movement_trigger_not_exit")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logReceiverSkipped(reason: String) {
+        logger.debug(
+            "Geofence receiver skipped: $reason" +
+                tail("os.callback.dropped", GeofenceLogIo.INPUT, listOf("why" to token(reason))),
+            tag = TAG
+        )
     }
 
     fun logGeofencingError(errorCode: Int) {
-        logger.error("OS reported geofencing error (code=$errorCode); see GeofenceStatusCodes for meaning", tag = TAG)
+        logger.error(
+            "OS reported geofencing error (code=$errorCode); see GeofenceStatusCodes for meaning" +
+                tail(
+                    "os.error",
+                    GeofenceLogIo.INPUT,
+                    listOf("ok" to bool(false), "code" to int(errorCode))
+                ),
+            tag = TAG
+        )
+    }
+
+    // MARK: - Transitions
+
+    /**
+     * The SDK judged this crossing real and wrote it down — the record replay asserts on.
+     *
+     * It promises nothing about what happens to the row next: that is the `delivery.*` family's
+     * business and is out of the harness's scope.
+     *
+     * Emitted *after* the pending rows are on disk, not before. Logging it earlier claimed an
+     * acceptance the persist could still roll back, and left the log saying a crossing had been
+     * taken when the cooldown had just been released for a retry.
+     *
+     * Named to match iOS. `delivery.*` covers what happens afterwards and is out of replay's
+     * scope; the two families must not be confused, because a device that is merely offline still
+     * accepts crossings correctly.
+     *
+     * The position for this crossing is **not** repeated here. It lives on the
+     * `os.callback.received` record the receiver writes for the whole broadcast, which carries the
+     * OS's triggering fix and the ids it applied to — find this crossing's `id` in that record's
+     * `ids` list (a comma-separated list, not an `id` field; iOS is the one that emits `id` here).
+     * Threading the `Location` down to this call site instead would mean widening
+     * `dispatchTransition`, which has 78 test references, for information already recorded.
+     *
+     * [rows] is the per-geoset fan-out size and rides in the tail as `n`, so one crossing reads as
+     * one acceptance. It is deliberately **not** added to the prose: this message predates the
+     * instrumentation, and the file's contract is that pre-existing prose is unchanged so a
+     * customer build with debug logging on sees exactly what it saw before.
+     */
+    fun logTransitionAccepted(geofenceId: String, transitionName: String, rows: Int) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)" +
+                tail(
+                    "transition.accepted",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "n" to int(rows))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logTransitionSuppressed(
+        geofenceId: String,
+        transitionName: String,
+        cooldownRemainingSeconds: Double? = null
+    ) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: suppressed — same transition fired within the cooldown window" +
+                tail(
+                    "transition.suppressed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "why" to "cooldown",
+                        "cd" to num(cooldownRemainingSeconds)
+                    )
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logInitialEnterInside(geofenceId: String) {
+        logger.debug(
+            "Geofence '$geofenceId': device already inside a newly-registered fence — synthesizing ENTER (GMS INITIAL_TRIGGER_ENTER is unreliable)" +
+                tail(
+                    "transition.synthesized",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to "enter", "why" to "initial_enter_inside")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logTransitionDroppedUnknownId(geofenceId: String) {
+        logger.debug(
+            "Geofence '$geofenceId' transition dropped — id not in registered store" +
+                tail(
+                    "transition.dropped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "why" to "unknown_id")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logEnterDroppedAlreadyReported(geofenceId: String) {
+        logger.debug(
+            "Geofence '$geofenceId' ENTER: dropped — already reported as entered and no exit since, so the OS is re-reporting a state we already sent" +
+                tail(
+                    "transition.dropped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to "enter", "why" to "already_reported")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logExitDroppedNeverEntered(geofenceId: String) {
+        logger.debug(
+            "Geofence '$geofenceId' EXIT: dropped — no record of the device being inside, so the OS is reconciling its own state" +
+                tail(
+                    "transition.dropped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to "exit", "why" to "never_entered")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logTransitionDroppedAnonymous(geofenceId: String, transitionName: String) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: dropped — no identified user (geofencing is identified-only)" +
+                tail(
+                    "transition.dropped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "why" to "no_identified_user")
+                ),
+            tag = TAG
+        )
+    }
+
+    // MARK: - Sync
+
+    fun logSyncTriggered(reason: String) {
+        logger.debug(
+            "Geofence sync triggered: $reason" +
+                tail("sync.triggered", GeofenceLogIo.OUTPUT, listOf("why" to token(reason))),
+            tag = TAG
+        )
+    }
+
+    fun logSyncSkipped(reason: String) {
+        logger.debug(
+            "Geofence sync skipped: $reason" +
+                tail("sync.skipped", GeofenceLogIo.OUTPUT, listOf("why" to token(reason))),
+            tag = TAG
+        )
+    }
+
+    fun logSyncSkippedNoLocation(reason: String) {
+        logger.debug(
+            "Geofence sync skipped ($reason): no location available" +
+                tail(
+                    "sync.skipped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("why" to "no_location", "ctx" to token(reason))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logSyncSkippedInvalidLocation(reason: String, latitude: Double, longitude: Double) {
+        logger.error(
+            "Geofence sync skipped ($reason): OS reported an unusable fix ($latitude, $longitude)" +
+                tail(
+                    "sync.skipped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("why" to "invalid_location", "ctx" to token(reason)) +
+                        GeofenceLogTail.position(latitude, longitude)
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logSyncSkippedNoPermission(reason: String) {
+        logger.debug(
+            "Geofence sync skipped ($reason): location permissions not granted" +
+                tail(
+                    "sync.skipped",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("why" to "no_permission", "ctx" to token(reason))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logSyncSkippedFresh() {
+        logger.debug(
+            "Geofence sync skipped: last successful sync is still within the freshness window" +
+                tail("sync.skipped", GeofenceLogIo.OUTPUT, listOf("why" to "within_freshness_window")),
+            tag = TAG
+        )
     }
 
     fun logSyncFailed(message: String?) {
-        logger.error("Geofence sync failed: $message", tag = TAG)
+        logger.error(
+            "Geofence sync failed: $message" +
+                tail(
+                    "sync.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("ok" to bool(false), "why" to token(message ?: "unknown"))
+                ),
+            tag = TAG
+        )
     }
 
-    fun logMovementRearmedAfterFailedRefresh() {
-        logger.debug("Movement refresh failed; re-ranking from cache to re-arm the movement trigger", tag = TAG)
-    }
-
-    fun logSyncSucceeded(count: Int, movementTriggerRegistered: Boolean) {
+    fun logSyncSucceeded(count: Int, movementTriggerRegistered: Boolean, elapsedMillis: Long? = null) {
         val trigger = if (movementTriggerRegistered) {
             " + 1 movement trigger"
         } else {
             "; monitoring disabled (max business geofences is 0)"
         }
-        logger.debug("Geofence sync succeeded: $count regions registered$trigger", tag = TAG)
+        logger.debug(
+            "Geofence sync succeeded: $count regions registered$trigger" +
+                tail(
+                    "sync.completed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "n" to int(count),
+                        "mvmt" to bool(movementTriggerRegistered),
+                        "ms" to elapsedMillis?.toString()
+                    )
+                ),
+            tag = TAG
+        )
     }
 
-    fun logSyncSkipped(reason: String) {
-        logger.debug("Geofence sync skipped: $reason", tag = TAG)
+    /** Outcome of a nearby-geofence fetch. An **input**: replay feeds the response back. */
+    fun logApiFetchResult(
+        returnedCount: Int,
+        elapsedMillis: Long?,
+        regions: List<GeofenceRegion> = emptyList()
+    ) {
+        logger.debug(
+            "Fetched $returnedCount nearby geofence(s) from the server" +
+                tail(
+                    "api.fetch.result",
+                    GeofenceLogIo.INPUT,
+                    listOf(
+                        "ok" to bool(true),
+                        "n" to int(returnedCount),
+                        "ms" to elapsedMillis?.toString()
+                    )
+                ),
+            tag = TAG
+        )
+        logFenceCatalog(regions)
     }
 
-    fun logReceiverSkipped(reason: String) {
-        logger.debug("Geofence receiver skipped: $reason", tag = TAG)
+    /**
+     * One record per fetched fence, describing the circle the server sent.
+     *
+     * Without this a capture names fences only by opaque id: a replay cannot place them, and nobody
+     * reading the log can tell which geoset a crossing belonged to. Re-fetching the geometry from
+     * the workspace later is not equivalent — fences move, and a drive replayed months on would
+     * silently get today's circles instead of the ones it actually ran against.
+     *
+     * Gated whole rather than relying on `tail()` returning empty, because these records carry no
+     * prose worth emitting on their own — with diagnostics off they should not exist at all.
+     */
+    private fun logFenceCatalog(regions: List<GeofenceRegion>) {
+        if (regions.isEmpty() || !GeofenceDiagnostics.isEnabled) return
+        for (region in regions) {
+            logger.debug(
+                "Geofence '${region.id}' catalogued" +
+                    tail(
+                        "fence.cataloged",
+                        GeofenceLogIo.INPUT,
+                        listOf(
+                            "id" to region.id,
+                            // Sanitized like any other value: a workspace-authored name can contain
+                            // spaces, commas and `=`, all of which would break the parser's split.
+                            "name" to region.name,
+                            "gs" to composedList(region.geosetIds),
+                            "lat" to num(region.latitude, 5),
+                            "lon" to num(region.longitude, 5),
+                            "rad" to num(region.radius, 0),
+                            "tt" to composedList(region.transitionTypes.map { it.name.lowercase() })
+                        )
+                    ),
+                tag = TAG
+            )
+        }
     }
+
+    fun logApiFetchFailed(message: String?) {
+        logger.error(
+            "Sync fetch failed: $message" +
+                tail(
+                    "api.fetch.result",
+                    GeofenceLogIo.INPUT,
+                    listOf("ok" to bool(false), "why" to token(message ?: "unknown"))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logUnknownApiTransitionType(value: String) {
+        logger.error(
+            "API response contained unknown transition_type='$value' (expected enter/exit). Region's affected types dropped — check SDK / backend version alignment." +
+                tail(
+                    "api.transition.unknown",
+                    GeofenceLogIo.INPUT,
+                    listOf("ok" to bool(false), "why" to "unknown_transition_type", "value" to token(value))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logMovementRearmedAfterFailedRefresh() {
+        logger.debug(
+            "Movement refresh failed; re-ranking from cache to re-arm the movement trigger" +
+                tail("movement.rearmed", GeofenceLogIo.OUTPUT, listOf("why" to "refresh_failed")),
+            tag = TAG
+        )
+    }
+
+    // MARK: - Storage
+
+    /** What survived a cold start. Answers whether a background wake had anything to work from. */
+    /**
+     * Diagnostics-only, and the gate lives here rather than at the call sites: the count is in the
+     * prose, and producing it costs a deserialization of the cached region list on a background
+     * wake. A lambda keeps that read off the path entirely when nothing will read the record.
+     */
+    fun logStorageLoaded(regionCount: () -> Int, hasAnchor: Boolean) {
+        if (!GeofenceDiagnostics.isEnabled) return
+        val count = regionCount()
+        logger.debug(
+            "Loaded $count cached region(s) from storage" +
+                tail(
+                    "storage.loaded",
+                    GeofenceLogIo.INPUT,
+                    listOf("n" to int(count), "anchor" to bool(hasAnchor))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logPersistFailed(geofenceId: String, transitionName: String) {
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: file outbox unavailable — kept durable staging for recovery" +
+                tail(
+                    "storage.write.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "ok" to bool(false))
+                ),
+            tag = TAG
+        )
+    }
+
+    // MARK: - Delivery
+    //
+    // Classified `out` and namespaced under `delivery.` so replay can drop the whole family: what
+    // replay checks is that the SDK *emitted* a transition, not that it reached the backend.
 
     fun logEventDeliveryRetryable(geofenceId: String, transitionName: String, message: String?) {
-        logger.debug("Geofence '$geofenceId' $transitionName: HTTP delivery hit network error ($message); WorkManager will retry", tag = TAG)
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: HTTP delivery hit network error ($message); WorkManager will retry" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "ok" to bool(false),
+                        "retry" to bool(true),
+                        "why" to token(message ?: "network_error")
+                    )
+                ),
+            tag = TAG
+        )
     }
 
-    fun logEventDeliveryFailed(geofenceId: String, transitionName: String, message: String?) {
+    fun logEventDeliveryFailed(
+        geofenceId: String,
+        transitionName: String,
+        message: String?,
+        willRetry: Boolean
+    ) {
+        val disposal = if (willRetry) "retained at the head of the ordered outbox" else "dropped, refusal is permanent"
         logger.error(
-            "Geofence '$geofenceId' $transitionName: HTTP delivery failed; retained at the head of the ordered outbox — $message",
+            "Geofence '$geofenceId' $transitionName: HTTP delivery failed; $disposal — $message" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "ok" to bool(false),
+                        "retry" to bool(willRetry),
+                        "why" to token(message ?: "unknown")
+                    )
+                ),
             tag = TAG
         )
     }
 
     fun logEventInvalidInput(geofenceId: String?, transitionName: String?) {
-        logger.error("Geofence event worker dropped: required field missing (geofenceId='$geofenceId', transition='$transitionName')", tag = TAG)
+        logger.error(
+            "Geofence event worker dropped: required field missing (geofenceId='$geofenceId', transition='$transitionName')" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("ok" to bool(false), "why" to "missing_required_field")
+                ),
+            tag = TAG
+        )
     }
 
     fun logEventDeliveryDeferredAnonymous(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: no identified user at queue time — HTTP path deferred to foreground flush (analytics pipeline)", tag = TAG)
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: no identified user at queue time — HTTP path deferred to foreground flush (analytics pipeline)" +
+                tail(
+                    "delivery.queued",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "why" to "no_identified_user")
+                ),
+            tag = TAG
+        )
     }
 
     fun logEventDelivered(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: delivered via WorkManager (direct HTTP); removed from pending store", tag = TAG)
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: delivered via WorkManager (direct HTTP); removed from pending store" +
+                tail(
+                    "delivery.sent",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "via" to "work_manager")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logEventDeliverySkippedAlreadyDelivered(geofenceId: String, transitionName: String) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: worker skipped — entry no longer in store (already delivered via the analytics pipeline)" +
+                tail(
+                    "delivery.sent",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "why" to "already_delivered")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logEventWorkerEntryMissing(key: String) {
+        logger.debug(
+            "Geofence event worker skipped: no pending entry for '$key' (already delivered via the analytics pipeline)" +
+                tail(
+                    "delivery.sent",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("key" to key, "why" to "already_delivered")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logForegroundFlushSnapshot(count: Int) {
+        logger.debug(
+            "Geofence foreground flush: $count pending transition(s) to hand off to the analytics pipeline" +
+                tail(
+                    "delivery.flush",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("n" to int(count), "phase" to "start")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logForegroundFlushCancelledWorkManager(geofenceId: String, transitionName: String) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: cancelled pending WorkManager delivery before flush" +
+                tail(
+                    "delivery.flush",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "why" to "cancelled_work_manager")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logForegroundFlushPublished(geofenceId: String, transitionName: String) {
+        logger.debug(
+            "Geofence '$geofenceId' $transitionName: published to analytics pipeline via foreground flush" +
+                tail(
+                    "delivery.sent",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("id" to geofenceId, "t" to token(transitionName), "via" to "foreground_flush")
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logForegroundFlushEntryFailed(geofenceId: String, transitionName: String, message: String?) {
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: foreground flush failed; left in store for next flush — $message" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "ok" to bool(false),
+                        "via" to "foreground_flush",
+                        "why" to token(message ?: "unknown")
+                    )
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logForegroundFlushComplete(count: Int) {
+        logger.debug(
+            "Geofence foreground flush complete: $count transition(s) handed off this run" +
+                tail(
+                    "delivery.flush",
+                    GeofenceLogIo.OUTPUT,
+                    listOf("n" to int(count), "phase" to "complete", "ok" to bool(true))
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logAsyncDeliveryFailed(geofenceId: String, transitionName: String, message: String?) {
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: async delivery failed unexpectedly; left in pending store for the foreground flush — $message" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "ok" to bool(false),
+                        "why" to token(message ?: "async_failure")
+                    )
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logSchedulerFailed(geofenceId: String, transitionName: String, message: String?) {
+        logger.error(
+            "Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; left in pending store for the foreground flush — $message" +
+                tail(
+                    "delivery.failed",
+                    GeofenceLogIo.OUTPUT,
+                    listOf(
+                        "id" to geofenceId,
+                        "t" to token(transitionName),
+                        "ok" to bool(false),
+                        "why" to "scheduler_failed",
+                        "detail" to token(message ?: "unknown")
+                    )
+                ),
+            tag = TAG
+        )
+    }
+
+    fun logContainmentJudged(insideCount: Int) {
+        logger.debug("Judged containment from the live fix: inside $insideCount region(s)", tag = TAG)
     }
 
     fun logEventDeliveredButNotRemoved(geofenceId: String, transitionName: String) {
@@ -216,49 +946,17 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
-    fun logEventDeliverySkippedAlreadyDelivered(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: worker skipped — entry no longer in store (already delivered via the analytics pipeline)", tag = TAG)
+    fun logGmsCallTimedOut(description: String) {
+        logger.error("GMS $description gave no callback before the deadline — treating as failed; Play Services may be updating or unresponsive", tag = TAG)
     }
 
-    fun logPersistFailed(geofenceId: String, transitionName: String) {
-        logger.error("Geofence '$geofenceId' $transitionName: file outbox unavailable — kept durable staging for recovery", tag = TAG)
+    fun logPolygonDropped(geofenceId: String, reason: String) {
+        logger.error("Geofence '$geofenceId' dropped — polygon rejected: $reason", tag = TAG)
     }
 
-    fun logEventWorkerEntryMissing(key: String) {
-        logger.debug("Geofence event worker skipped: no pending entry for '$key' (already delivered via the analytics pipeline)", tag = TAG)
-    }
-
-    fun logForegroundFlushSnapshot(count: Int) {
-        logger.debug("Geofence foreground flush: $count pending transition(s) to hand off to the analytics pipeline", tag = TAG)
-    }
-
-    fun logForegroundFlushCancelledWorkManager(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: cancelled pending WorkManager delivery before flush", tag = TAG)
-    }
-
-    fun logForegroundFlushPublished(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: published to analytics pipeline via foreground flush", tag = TAG)
-    }
-
-    fun logForegroundFlushEntryFailed(geofenceId: String, transitionName: String, message: String?) {
-        logger.error("Geofence '$geofenceId' $transitionName: foreground flush failed; left in store for next flush — $message", tag = TAG)
-    }
-
-    fun logForegroundFlushComplete(count: Int) {
-        logger.debug("Geofence foreground flush complete: $count transition(s) handed off this run", tag = TAG)
-    }
-
-    fun logAsyncDeliveryFailed(geofenceId: String, transitionName: String, message: String?) {
-        logger.error("Geofence '$geofenceId' $transitionName: async delivery failed unexpectedly; left in pending store for the foreground flush — $message", tag = TAG)
-    }
-
-    fun logSchedulerFailed(geofenceId: String, transitionName: String, message: String?) {
-        logger.error("Geofence '$geofenceId' $transitionName: WorkManager scheduling failed; left in pending store for the foreground flush — $message", tag = TAG)
-    }
-
-    fun logMissingLocationModule() {
-        logger.error(
-            "ModuleGeofence requires ModuleLocation to be registered alongside it. Add ModuleLocation to CustomerIOConfigBuilder; geofencing will not function until then.",
+    fun logPolygonDroppedUnsupportedRuntime(geofenceId: String) {
+        logger.info(
+            "Geofence '$geofenceId' dropped — it is a polygon, and this SDK build monitors circles only. The record was decoded and validated but never registered; its enclosing circle is a proximity trigger, not the fence, so registering it would report transitions for the wrong area.",
             tag = TAG
         )
     }
@@ -266,6 +964,32 @@ internal class GeofenceLogger(private val logger: Logger) {
     fun logPolygonFixNotUsable(reason: String) {
         logger.debug(
             "Polygon fix ignored — $reason. Responsive monitoring is best-effort: it decides only from fixes that are decisive on their own.",
+            tag = TAG
+        )
+    }
+
+    fun logPolygonRegionNotRanked(geofenceId: String, reason: String) {
+        logger.debug(
+            "Geofence '$geofenceId' excluded from ranking — $reason. It stays cached and is never registered as its enclosing circle.",
+            tag = TAG
+        )
+    }
+
+    fun logTransitionDroppedRetiredId(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' transition dropped — backend removed it and OS cleanup is pending", tag = TAG)
+    }
+
+    fun logTransitionDroppedUnarmedId(geofenceId: String) {
+        logger.debug("Geofence '$geofenceId' transition dropped — registered but routing is not armed for this session; OS registration kept", tag = TAG)
+    }
+
+    fun logTransitionEmitting(geofenceId: String, transitionName: String) {
+        logger.debug("Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
+    }
+
+    fun logUnsupportedGeometryDropped(geofenceId: String, type: String) {
+        logger.error(
+            "Geofence '$geofenceId' dropped — unsupported geometry type='$type' (only Polygon is understood). Not degraded to a circle; check SDK / backend version alignment.",
             tag = TAG
         )
     }

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -124,18 +124,20 @@ internal class GeofenceEventWorker(
                     return Result.retry()
                 }
                 is PendingDeliveryResult.Failed -> {
-                    logger.logEventDeliveryFailed(
-                        entry.geofenceId,
-                        entry.transition.name,
-                        outcome.cause?.message
-                    )
                     // A refused payload is refused identically next time, so retrying only holds the
                     // head of an ordered queue and every transition behind it. Same disposal as the
                     // anonymous row above: drop it and carry on. Narrow on purpose — only a terminal
                     // HTTP status is known-permanent. Anything else (a bad state, a serialization
                     // slip) may well succeed on the next attempt, so it keeps the row and retries.
                     val cause = outcome.cause
-                    if (cause is HttpRequestFailure && !cause.isRetryable && store.remove(entry.key)) {
+                    val dropped = cause is HttpRequestFailure && !cause.isRetryable && store.remove(entry.key)
+                    logger.logEventDeliveryFailed(
+                        entry.geofenceId,
+                        entry.transition.name,
+                        cause?.message,
+                        willRetry = !dropped
+                    )
+                    if (dropped) {
                         continue
                     }
                     // Still not Result.failure(): a terminal node cancels every existing dependent in

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -1,0 +1,680 @@
+package io.customer.geofence
+
+import android.location.Location
+import io.customer.commontest.config.TestConfig
+import io.customer.commontest.config.testConfigurationDefault
+import io.customer.commontest.core.RobolectricTest
+import io.customer.sdk.core.util.CioLogLevel
+import io.customer.sdk.core.util.Logger
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Producer-side contract for the geofence diagnostics tail.
+ *
+ * The tail is an untyped string contract consumed by a parser that lives off-device and in another
+ * language, so there is no round trip to assert. What can be asserted here is the half we own: that
+ * every geofence logger method emits a machine key and a replay classification, that no value can
+ * break the parser's whitespace split, and — the load-bearing one — that with the gate off the
+ * output is exactly what it was before any of this instrumentation existed.
+ *
+ * It also pins the derived `why=` tokens. Those are computed from the existing prose rather than
+ * from an enum — which is what keeps `logSyncSkipped`'s 20 test references untouched — and the
+ * price of that choice is that a reworded sentence would silently change what analysis groups on.
+ * Pinning them here converts that into a failing test.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GeofenceLogTailTest : RobolectricTest() {
+
+    /** Captures formatted messages. What these tests need is the exact string, not a call count. */
+    private class CapturingLogger : Logger {
+        val messages = mutableListOf<String>()
+        override var logLevel: CioLogLevel = CioLogLevel.DEBUG
+
+        override fun setLogDispatcher(dispatcher: ((CioLogLevel, String) -> Unit)?) = Unit
+
+        override fun info(message: String, tag: String?) = record(message, tag)
+        override fun debug(message: String, tag: String?) = record(message, tag)
+        override fun error(message: String, tag: String?, throwable: Throwable?) = record(message, tag)
+
+        private fun record(message: String, tag: String?) {
+            messages.add(if (tag != null) "[$tag] $message" else message)
+        }
+    }
+
+    private lateinit var capturing: CapturingLogger
+    private lateinit var geofenceLogger: GeofenceLogger
+
+    override fun setup(testConfig: TestConfig) {
+        super.setup(testConfigurationDefault { })
+        capturing = CapturingLogger()
+        geofenceLogger = GeofenceLogger(capturing)
+        GeofenceDiagnostics.setEnabledForTesting(true)
+    }
+
+    @After
+    fun resetDiagnostics() {
+        // null, not false: null restores the manifest value, false pins the gate off for every
+        // later test class in this JVM.
+        GeofenceDiagnostics.setEnabledForTesting(null)
+    }
+
+    /**
+     * Mirrors what the off-device parser does: split on the **last** delimiter, then accept the
+     * remainder only if every token is a `key=value` pair.
+     */
+    private fun parseTail(message: String): Map<String, String>? {
+        val index = message.lastIndexOf(GeofenceLogTail.DELIMITER)
+        if (index < 0) return null
+        val tail = message.substring(index + GeofenceLogTail.DELIMITER.length)
+        val fields = mutableMapOf<String, String>()
+        for (token in tail.split(" ")) {
+            val parts = token.split("=", limit = 2)
+            if (parts.size != 2) return null
+            fields[parts[0]] = parts[1]
+        }
+        return fields.ifEmpty { null }
+    }
+
+    private fun location(
+        accuracy: Float = 48f,
+        speed: Float = 18.3f,
+        bearing: Float = 91f,
+        mock: Boolean = false
+    ): Location = Location("test").apply {
+        latitude = 43.2557
+        longitude = -79.0713
+        altitude = 95.0
+        this.accuracy = accuracy
+        this.speed = speed
+        this.bearing = bearing
+        time = System.currentTimeMillis()
+        elapsedRealtimeNanos = android.os.SystemClock.elapsedRealtimeNanos()
+        if (mock) isMock = true
+    }
+
+    /**
+     * One entry per logger method, paired with the keys its record must carry.
+     *
+     * Enumerated by hand because there is no reflection over an extension of behaviour like this. A
+     * new method added without a line here is simply uncovered — but a *renamed key* on anything
+     * listed here fails loudly, which is the failure this contract exists to catch.
+     */
+    /**
+     * One row per record. [ev] is pinned per row, not just collected into a set: a set is
+     * identical whether two records keep their keys or swap them, and a swap silently inverts
+     * what every capture says the SDK decided.
+     */
+    private data class Row(
+        val name: String,
+        val ev: String,
+        val requiredKeys: List<String>,
+        val run: (GeofenceLogger) -> Unit
+    )
+
+    private fun invocations(): List<Row> {
+        val fix = location()
+        return listOf(
+            Row("geofencesRegistered", "registration.added", listOf("nadd")) { it.logGeofencesRegistered(19) },
+            Row("regionsRegisteredIds", "registration.applied", listOf("n", "ids", "mvmt")) { it.logRegionsRegisteredIds(listOf("a", "b"), "cio_movement_trigger") },
+            Row("businessKept", "registration.kept", listOf("nkeep", "why")) { it.logBusinessGeofencesKept(4) },
+            Row("geofencesRemoved", "registration.removed", listOf("nrem")) { it.logGeofencesRemoved(2) },
+            Row("geofencesCleared", "registration.cleared", listOf("why")) { it.logGeofencesCleared() },
+            Row("registrationFailed", "registration.failed", listOf("ok", "why")) { it.logRegistrationFailed("GMS unavailable") },
+            Row("removalFailed", "registration.failed", listOf("ok", "op", "why")) { it.logRemovalFailed("GMS unavailable") },
+            Row("invalidRegionDropped", "registration.rejected", listOf("id", "why")) { it.logInvalidRegionDropped("notl core") },
+            Row("regionMappingFailed", "registration.rejected", listOf("id", "why")) { it.logRegionMappingFailed("notl_core", "bad radius") },
+            Row("rankEvaluated", "rank.evaluated", listOf("ncand", "n", "ranked", "evicted")) { it.logRankEvaluated(30, 2, { listOf("a", "b") }, { listOf("c") }, { mapOf("a" to 120.0, "b" to 340.0) }) },
+            Row("movementTriggerRegistered", "movement.registered", listOf("rad")) { it.logMovementTriggerRegistered(43.2, -79.0, 500.0) },
+            Row("missingPermission", "permission.changed", listOf("perm", "why")) { it.logMissingPermission("ACCESS_FINE_LOCATION") },
+            Row("backgroundUnavailable", "permission.changed", listOf("perm", "ctx")) { it.logBackgroundDeliveryUnavailable("app-launch") },
+            Row("moduleInitialized", "module.init", listOf("launch")) { it.logModuleInitialized(GeofenceLaunchReason.APP_START) },
+            Row("moduleWoke", "module.wake", listOf("launch")) { it.logModuleWoke(GeofenceLaunchReason.BOOT_RESTORE) },
+            Row("missingLocationModule", "module.init", listOf("ok", "why")) { it.logMissingLocationModule() },
+            Row("stateResetOnSignOut", "module.reset", listOf("why")) { it.logGeofenceStateResetOnSignOut() },
+            Row("callbackReceived", "os.callback.received", listOf("ids", "n", "t", "fixsrc", "acc", "age", "sim")) { it.logCallbackReceived(listOf("notl_core"), "ENTER", fix, GeofenceLogTail.FixSource.OS_TRIGGER) },
+            Row("callbackReceivedNoFix", "os.callback.received", listOf("fixsrc")) { it.logCallbackReceived(listOf("notl_core"), "EXIT", null, GeofenceLogTail.FixSource.NONE) },
+            Row("transitionWithoutLocation", "os.callback.no_location", listOf("fixsrc", "why")) { it.logTransitionWithoutLocation() },
+            Row("unknownTransition", "os.callback.dropped", listOf("id", "gms", "why")) { it.logUnknownTransition("notl_core", 4) },
+            Row("info", "info", listOf("why")) { it.logInfo("broadcast_no_triggering_geofences") },
+            Row("movementIgnoredNonExit", "os.callback.dropped", listOf("t", "why")) { it.logMovementTriggerIgnoredNonExit("ENTER") },
+            Row("receiverSkipped", "os.callback.dropped", listOf("why")) { it.logReceiverSkipped("no identified user") },
+            Row("geofencingError", "os.error", listOf("ok", "code")) { it.logGeofencingError(1000) },
+            Row("transitionAccepted", "transition.accepted", listOf("id", "t", "n")) { it.logTransitionAccepted("notl_core", "ENTER", 2) },
+            Row("transitionSuppressed", "transition.suppressed", listOf("id", "t", "why", "cd")) { it.logTransitionSuppressed("notl_core", "ENTER", 42.0) },
+            Row("initialEnterInside", "transition.synthesized", listOf("id", "t", "why")) { it.logInitialEnterInside("notl_core") },
+            Row("droppedUnknownId", "transition.dropped", listOf("id", "why")) { it.logTransitionDroppedUnknownId("notl_core") },
+            Row("enterDroppedAlreadyReported", "transition.dropped", listOf("id", "t", "why")) { it.logEnterDroppedAlreadyReported("notl_core") },
+            Row("exitDroppedNeverEntered", "transition.dropped", listOf("id", "t", "why")) { it.logExitDroppedNeverEntered("notl_core") },
+            Row("droppedAnonymous", "transition.dropped", listOf("id", "t", "why")) { it.logTransitionDroppedAnonymous("notl_core", "EXIT") },
+            Row("syncTriggered", "sync.triggered", listOf("why")) { it.logSyncTriggered("app-launch") },
+            Row("syncSkipped", "sync.skipped", listOf("why")) { it.logSyncSkipped("no identified user") },
+            Row("syncSkippedNoLocation", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedNoLocation("app-launch") },
+            Row("syncSkippedInvalidLocation", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedInvalidLocation("app-launch", 0.0, 0.0) },
+            Row("syncSkippedNoPermission", "sync.skipped", listOf("why", "ctx")) { it.logSyncSkippedNoPermission("boot-restore") },
+            Row("syncSkippedFresh", "sync.skipped", listOf("why")) { it.logSyncSkippedFresh() },
+            Row("syncFailed", "sync.failed", listOf("ok", "why")) { it.logSyncFailed("timeout") },
+            Row("syncSucceeded", "sync.completed", listOf("n", "mvmt")) { it.logSyncSucceeded(19, true) },
+            Row("apiFetchResult", "api.fetch.result", listOf("ok", "n", "ms")) { it.logApiFetchResult(30, 420L) },
+
+            Row("unknownApiTransitionType", "api.transition.unknown", listOf("ok", "why", "value")) { it.logUnknownApiTransitionType("dwell") },
+            Row("movementRearmed", "movement.rearmed", listOf("why")) { it.logMovementRearmedAfterFailedRefresh() },
+            Row("storageLoaded", "storage.loaded", listOf("n", "anchor")) { it.logStorageLoaded({ 30 }, true) },
+            Row("persistFailed", "storage.write.failed", listOf("id", "t", "ok")) { it.logPersistFailed("notl_core", "ENTER") },
+            Row("deliveryRetryable", "delivery.failed", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryRetryable("notl_core", "ENTER", "socket timeout") },
+            Row("deliveryFailed", "delivery.failed", listOf("id", "t", "ok", "retry", "why")) { it.logEventDeliveryFailed("notl_core", "ENTER", "400 bad request", willRetry = false) },
+            Row("eventInvalidInput", "delivery.failed", listOf("ok", "why")) { it.logEventInvalidInput(null, null) },
+            Row("deliveryDeferredAnonymous", "delivery.queued", listOf("id", "t", "why")) { it.logEventDeliveryDeferredAnonymous("notl_core", "ENTER") },
+            Row("eventDelivered", "delivery.sent", listOf("id", "t", "via")) { it.logEventDelivered("notl_core", "ENTER") },
+            Row("deliverySkippedAlreadyDelivered", "delivery.sent", listOf("id", "t", "why")) { it.logEventDeliverySkippedAlreadyDelivered("notl_core", "ENTER") },
+            Row("workerEntryMissing", "delivery.sent", listOf("key", "why")) { it.logEventWorkerEntryMissing("notl_core:ENTER") },
+            Row("flushSnapshot", "delivery.flush", listOf("n", "phase")) { it.logForegroundFlushSnapshot(3) },
+            Row("flushCancelled", "delivery.flush", listOf("id", "t", "why")) { it.logForegroundFlushCancelledWorkManager("notl_core", "ENTER") },
+            Row("flushPublished", "delivery.sent", listOf("id", "t", "via")) { it.logForegroundFlushPublished("notl_core", "ENTER") },
+            Row("flushEntryFailed", "delivery.failed", listOf("id", "t", "ok", "via", "why")) { it.logForegroundFlushEntryFailed("notl_core", "ENTER", "boom") },
+            Row("flushComplete", "delivery.flush", listOf("n", "phase", "ok")) { it.logForegroundFlushComplete(3) },
+            Row("asyncDeliveryFailed", "delivery.failed", listOf("id", "t", "ok", "why")) { it.logAsyncDeliveryFailed("notl_core", "ENTER", "boom") },
+            Row("schedulerFailed", "delivery.failed", listOf("id", "t", "ok", "why", "detail")) { it.logSchedulerFailed("notl_core", "ENTER", "boom") }
+        )
+    }
+
+    // MARK: - Contract
+
+    @Test
+    fun everyRecord_givenAnyMethod_expectMachineKeyAndReplayClassification() {
+        for ((name, ev, requiredKeys, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+
+            // Last message, not first: the precise-location warning would precede a gated record.
+            val message = logger.messages.lastOrNull()
+            message.shouldNotBeNull()
+            val fields = parseTail(message)
+            fields.shouldNotBeNull()
+
+            if (fields["ev"] != ev) {
+                throw AssertionError("$name: expected ev=$ev, got '${fields["ev"]}'")
+            }
+            (fields["io"] in listOf("in", "out", "obs")) shouldBeEqualTo true
+            for (key in requiredKeys) {
+                if (fields[key] == null) {
+                    throw AssertionError("$name: missing $key= in '$message'")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun everyRecord_givenAnyMethod_expectProseAndTailSeparated() {
+        for ((name, _, _, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            // Diagnostics-only entry points emit nothing at all with the gate off, which is a
+            // stronger guarantee than emitting unchanged prose.
+            val message = logger.messages.lastOrNull() ?: continue
+
+            // Prose in front, machine-readable behind. A record that is all tail has lost the
+            // human-readable half Logcat still depends on.
+            val head = message.substringBefore(GeofenceLogTail.DELIMITER)
+            if (!head.startsWith("[Geofence] ") || head.length <= "[Geofence] ".length || head.contains("ev=")) {
+                throw AssertionError("$name: prose half is wrong — '$message'")
+            }
+        }
+    }
+
+    @Test
+    fun everyValue_givenAnyMethod_expectNoWhitespace() {
+        for ((name, _, _, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            // Diagnostics-only entry points emit nothing at all with the gate off, which is a
+            // stronger guarantee than emitting unchanged prose.
+            val message = logger.messages.lastOrNull() ?: continue
+            val tail = message.substring(message.lastIndexOf(GeofenceLogTail.DELIMITER) + GeofenceLogTail.DELIMITER.length)
+            for (token in tail.split(" ")) {
+                if (token.split("=", limit = 2).size != 2) {
+                    throw AssertionError("$name: token '$token' is not key=value — a value contained a space")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun documentedProse_expectExactStringsManualTestsGrepFor() {
+        // The gate test above only proves no tail leaked; it cannot see a reworded message. The
+        // rename went through it green, changing a line docs/manual-tests greps for — a tester
+        // then finds nothing and reports a false failure.
+        //
+        // Three of the nine hallmark strings that doc lists — the ones this change set touched or
+        // moved past. The other six are unpinned and would still drift silently; extending this
+        // list is cheap and worth doing next time one of them is edited. Golden by design: if a
+        // pinned line changes, the doc changes with it, deliberately, in the same commit.
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val golden = listOf<Pair<String, (GeofenceLogger) -> Unit>>(
+            "Geofence 'notl_core' ENTER: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)"
+                to { l: GeofenceLogger -> l.logTransitionAccepted("notl_core", "ENTER", 1) },
+            "Geofence 'notl_core' ENTER: delivered via WorkManager (direct HTTP); removed from pending store"
+                to { l: GeofenceLogger -> l.logEventDelivered("notl_core", "ENTER") },
+            "Geofence 'notl_core' ENTER: published to analytics pipeline via foreground flush"
+                to { l: GeofenceLogger -> l.logForegroundFlushPublished("notl_core", "ENTER") }
+        )
+        for ((expected, run) in golden) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            val message = logger.messages.lastOrNull()
+            message.shouldNotBeNull()
+            // Full equality including the tag: the doc's first instruction is
+            // `adb logcat | grep -E "\[Geofence\]"`, so the prefix is part of what a tester
+            // relies on. endsWith would let a TAG change pass unnoticed.
+            if (message != "[Geofence] $expected") {
+                throw AssertionError(
+                    "prose drifted from docs/manual-tests/geofence-transition-delivery.md\n" +
+                        "  expected: '$expected'\n  actual:   '$message'"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun everyRecord_expectTheDeclaredVocabulary() {
+        // Companion to the per-row `ev` pin above, catching what a per-row check cannot: a key
+        // removed from the module entirely, or a row added to the table without being declared
+        // here. It does NOT see a record that exists in the module but was never added to the
+        // table — `seen` is built from the table, not from the source. `fence.cataloged` is the
+        // standing proof of that limit.
+        //
+        // `fence.cataloged` is absent because the `apiFetchResult` row passes no regions, so
+        // `logFenceCatalog` returns at its `isEmpty` guard and no catalog row is ever emitted here.
+        // It carries its own `ev` assertion further down. Add a region to that row and this set
+        // gains `fence.cataloged` — update both together.
+        val expected = setOf(
+            "api.fetch.result",
+            "api.transition.unknown",
+            "delivery.failed",
+            "delivery.flush",
+            "delivery.queued",
+            "delivery.sent",
+            "info",
+            "module.init",
+            "module.reset",
+            "module.wake",
+            "movement.rearmed",
+            "movement.registered",
+            "os.callback.dropped",
+            "os.callback.no_location",
+            "os.callback.received",
+            "os.error",
+            "permission.changed",
+            "rank.evaluated",
+            "registration.added",
+            "registration.applied",
+            "registration.cleared",
+            "registration.failed",
+            "registration.kept",
+            "registration.rejected",
+            "registration.removed",
+            "storage.loaded",
+            "storage.write.failed",
+            "sync.completed",
+            "sync.failed",
+            "sync.skipped",
+            "sync.triggered",
+            "transition.accepted",
+            "transition.dropped",
+            "transition.suppressed",
+            "transition.synthesized"
+        )
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val seen = mutableSetOf<String>()
+        for ((_, _, _, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            parseTail(logger.messages.lastOrNull() ?: "")?.get("ev")?.let { seen.add(it) }
+        }
+        if (seen != expected) {
+            throw AssertionError(
+                "vocabulary drift.\n  added:   ${(seen - expected).sorted()}\n  missing: ${(expected - seen).sorted()}"
+            )
+        }
+    }
+
+    // MARK: - The gate
+
+    @Test
+    fun everyRecord_givenDiagnosticsOff_expectOutputUnchangedFromBeforeInstrumentation() {
+        GeofenceDiagnostics.setEnabledForTesting(false)
+
+        for ((name, _, _, run) in invocations()) {
+            val logger = CapturingLogger()
+            run(GeofenceLogger(logger))
+            // Diagnostics-only entry points emit nothing at all with the gate off, which is a
+            // stronger guarantee than emitting unchanged prose.
+            val message = logger.messages.lastOrNull() ?: continue
+
+            // The whole guarantee in one assertion: a customer build that ships with debug logging
+            // left on sees exactly the prose it saw before this instrumentation existed. Not "sees
+            // only the safe fields" — sees nothing new at all, so a field added to the tail later
+            // needs no privacy review of its own.
+            if (message.contains(GeofenceLogTail.DELIMITER) || message.contains("ev=")) {
+                throw AssertionError("$name: emitted diagnostics with the gate off — '$message'")
+            }
+        }
+    }
+
+    @Test
+    fun everyRecord_givenDiagnosticsOff_expectNoDiagnosticKeyAnywhere() {
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val logger = CapturingLogger()
+        val target = GeofenceLogger(logger)
+        for ((_, _, _, run) in invocations()) run(target)
+
+        // Spot-checks the classes of value the harness cares about, including ones that are
+        // harmless in isolation. The point is that "harmless in isolation" stopped being the test.
+        for (message in logger.messages) {
+            for (key in listOf("lat=", "lon=", "alt=", "spd=", "brg=", "rlat=", "rlon=", "acc=", "age=", "fixsrc=", "io=", "why=")) {
+                if (message.contains(key)) throw AssertionError("$key leaked with the gate off: '$message'")
+            }
+        }
+    }
+
+    @Test
+    fun everyRecord_givenDiagnosticsOn_expectFullDetail() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        val target = GeofenceLogger(logger)
+        for ((_, _, _, run) in invocations()) run(target)
+
+        val joined = logger.messages.joinToString("\n")
+        joined.contains("lat=") shouldBeEqualTo true
+        joined.contains("lon=") shouldBeEqualTo true
+        joined.contains("fixsrc=") shouldBeEqualTo true
+    }
+
+    @Test
+    fun listValues_expectSeparatorsSurviveTheTailBuilder() {
+        // Regression: sanitize folds the format's separators so an untrusted id cannot split a
+        // field, but it must not be applied to a value that composed those separators on purpose.
+        // Folding them turned ids=a,b into ids=a_b and ranked=x:120 into ranked=x_120, which no
+        // unit test noticed and a device capture did.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logRankEvaluated(
+            3,
+            2,
+            { listOf("alpha", "beta") },
+            { listOf("gamma") },
+            { mapOf("alpha" to 120.0, "beta" to 340.0) }
+        )
+        val message = logger.messages.last()
+        message.contains("ranked=alpha:120,beta:340") shouldBeEqualTo true
+        message.contains("evicted=gamma") shouldBeEqualTo true
+    }
+
+    @Test
+    fun proseHalf_expectIdenticalWhicheverWayTheGateIsSet() {
+        // The prose is what a customer reads and what existing tests assert on. Enabling
+        // diagnostics must append to it and never rewrite it.
+        for ((name, _, _, run) in invocations()) {
+            // Each pass is a fresh "launch" for the once-per-process module.init record.
+            GeofenceDiagnostics.setEnabledForTesting(false)
+            val off = CapturingLogger()
+            run(GeofenceLogger(off))
+
+            GeofenceDiagnostics.setEnabledForTesting(true)
+            val on = CapturingLogger()
+            run(GeofenceLogger(on))
+
+            val onProse = on.messages.last().substringBefore(GeofenceLogTail.DELIMITER)
+            // Nothing with the gate off means nothing to compare — see above.
+            val offProse = off.messages.lastOrNull() ?: continue
+            if (onProse != offProse) {
+                throw AssertionError("$name: prose differs between gate states\n  off: $offProse\n  on:  $onProse")
+            }
+        }
+    }
+
+    @Test
+    fun fixQuality_givenDiagnosticsOn_expectQualityAndProvenance() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        geofenceLogger.logCallbackReceived(listOf("notl_core"), "ENTER", location(), GeofenceLogTail.FixSource.OS_TRIGGER)
+
+        val fields = parseTail(capturing.messages.last())!!
+        fields["acc"] shouldBeEqualTo "48.0"
+        fields["fixsrc"] shouldBeEqualTo "os_trigger"
+        fields["sim"] shouldBeEqualTo "false"
+        fields["age"].shouldNotBeNull()
+    }
+
+    @Test
+    fun fixQuality_givenMockLocation_expectSimTrue() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        geofenceLogger.logCallbackReceived(listOf("notl_core"), "ENTER", location(mock = true), GeofenceLogTail.FixSource.OS_TRIGGER)
+
+        // A fix injected by `adb emu geo fix` or a route driver must be distinguishable from a real
+        // one, or a bench corpus and a drive corpus silently merge.
+        parseTail(capturing.messages.last())!!["sim"] shouldBeEqualTo "true"
+    }
+
+    // MARK: - Derived tokens, pinned
+
+    @Test
+    fun token_givenProse_expectSnakeCase() {
+        GeofenceLogTail.token("No identified user") shouldBeEqualTo "no_identified_user"
+        GeofenceLogTail.token("boot-restore") shouldBeEqualTo "boot_restore"
+        GeofenceLogTail.token("user changed during refresh — initial-enter synthesis skipped") shouldBeEqualTo
+            "user_changed_during_refresh_initial_enter_synthesis_skipped"
+        GeofenceLogTail.token("") shouldBeEqualTo "unknown"
+    }
+
+    @Test
+    fun syncSkipped_givenKnownReasons_expectPinnedTokens() {
+        // Every literal passed to logSyncSkipped in the geofence module. These tokens are what
+        // analysis groups on, so a reworded sentence must fail here rather than quietly split one
+        // bucket into two.
+        val expected = mapOf(
+            "no cached state to restore" to "no_cached_state_to_restore",
+            "no identified user" to "no_identified_user",
+            "refresh already in progress" to "refresh_already_in_progress",
+            "refresh already in progress after waiting" to "refresh_already_in_progress_after_waiting",
+            "reset superseded by signed-in user" to "reset_superseded_by_signed_in_user",
+            "user changed during refresh" to "user_changed_during_refresh"
+        )
+        for ((prose, token) in expected) {
+            val logger = CapturingLogger()
+            GeofenceLogger(logger).logSyncSkipped(prose)
+            parseTail(logger.messages.last())!!["why"] shouldBeEqualTo token
+        }
+    }
+
+    @Test
+    fun sanitize_givenWhitespaceInIdentifier_expectFolded() {
+        geofenceLogger.logTransitionAccepted("niagara on the lake", "ENTER", 1)
+
+        // Workspace-authored identifiers can contain anything; the parser splits on whitespace.
+        parseTail(capturing.messages.last())!!["id"] shouldBeEqualTo "niagara_on_the_lake"
+    }
+
+    @Test
+    fun sanitize_givenSeparatorsInIdentifier_expectFolded() {
+        // Regression: the whitespace test above passes whether or not token fields are sanitized,
+        // because tail() folds whitespace for every value. It never covered the characters the
+        // format itself uses, and 20 `id` call sites went unprotected behind it.
+        for (raw in listOf("store,north", "a=b", "aisle:3", "wing|west")) {
+            val logger = CapturingLogger()
+            GeofenceLogger(logger).logTransitionAccepted(raw, "ENTER", 1)
+
+            val tail = parseTail(logger.messages.last())
+            tail.shouldNotBeNull()
+            tail["id"].shouldNotBeNull()
+            tail["id"]!!.none { it in charArrayOf('=', ',', ':', '|') } shouldBeEqualTo true
+            tail["t"] shouldBeEqualTo "enter"
+        }
+    }
+
+    @Test
+    fun composedValues_givenSeparatorsOnPurpose_expectPreserved() {
+        // The other half of the same contract: sanitizing by default must not touch the values
+        // that build their own structure.
+        geofenceLogger.logRankEvaluated(
+            candidates = 3,
+            selectedCount = 2,
+            selected = { listOf("alpha", "beta") },
+            evicted = { listOf("gamma") },
+            edgeDistances = { mapOf("alpha" to 120.0, "beta" to 340.0) }
+        )
+        val tail = parseTail(capturing.messages.last())!!
+        tail["ranked"] shouldBeEqualTo "alpha:120,beta:340"
+        tail["evicted"] shouldBeEqualTo "gamma"
+    }
+
+    @Test
+    fun list_givenMoreThanLimit_expectTruncationMarker() {
+        val values = (1..30).map { "id$it" }
+        GeofenceLogTail.list(values, limit = 25)!!.endsWith(",+5") shouldBeEqualTo true
+        GeofenceLogTail.list(emptyList()).shouldBeNull()
+    }
+
+    @Test
+    fun expensiveFields_givenDiagnosticsOff_expectNeverEvaluated() {
+        // The gate's worth on these two paths is that the work is never *done*, not merely never
+        // printed. Every other test here asserts on output, so moving the gate below the lambda
+        // call would leave them all green while a background wake still pays for a distance map
+        // over every candidate and a deserialization of the cached region list.
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val logger = CapturingLogger()
+        val subject = GeofenceLogger(logger)
+        var selectedCalls = 0
+        var evictedCalls = 0
+        var distanceCalls = 0
+        var regionCountCalls = 0
+
+        subject.logRankEvaluated(
+            candidates = 50,
+            selectedCount = 19,
+            selected = { selectedCalls++; listOf("alpha") },
+            evicted = { evictedCalls++; listOf("beta") },
+            edgeDistances = { distanceCalls++; mapOf("alpha" to 120.0) }
+        )
+        subject.logStorageLoaded(regionCount = { regionCountCalls++; 100 }, hasAnchor = true)
+
+        selectedCalls shouldBeEqualTo 0
+        evictedCalls shouldBeEqualTo 0
+        distanceCalls shouldBeEqualTo 0
+        regionCountCalls shouldBeEqualTo 0
+
+        // Proves the counts above are zero because of the gate, not because the lambdas are
+        // unreachable. logStorageLoaded is diagnostics-only, so it also gains its prose here.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        subject.logRankEvaluated(
+            candidates = 50,
+            selectedCount = 19,
+            selected = { selectedCalls++; listOf("alpha") },
+            evicted = { evictedCalls++; listOf("beta") },
+            edgeDistances = { distanceCalls++; mapOf("alpha" to 120.0) }
+        )
+        subject.logStorageLoaded(regionCount = { regionCountCalls++; 100 }, hasAnchor = true)
+
+        selectedCalls shouldBeEqualTo 1
+        evictedCalls shouldBeEqualTo 1
+        distanceCalls shouldBeEqualTo 1
+        regionCountCalls shouldBeEqualTo 1
+    }
+
+    private fun catalogRegion(
+        id: String = "11125",
+        name: String? = "Momo Dubai Test"
+    ) = GeofenceRegion(
+        id = id,
+        latitude = 25.109908,
+        longitude = 55.184004,
+        radius = 150f,
+        name = name,
+        geosetIds = listOf("4471", "9002")
+    )
+
+    @Test
+    fun fenceCatalog_givenNameWithSeparators_expectSanitizedButReadable() {
+        // A workspace-authored name is untrusted text in a format whose only structure is spaces
+        // and `=`. Left raw, `Momo Dubai Test` would split into three bogus fields.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion(name = "Momo Dubai, Test=1")))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["name"].shouldNotBeNull()
+        // Still recognisable to a human reading the log, which is half the point of logging it.
+        fields["name"]!!.contains("Momo") shouldBeEqualTo true
+        fields["name"]!!.contains(" ") shouldBeEqualTo false
+        fields["name"]!!.contains("=") shouldBeEqualTo false
+    }
+
+    /**
+     * Deliberately absent from [invocations]: that table asserts the gated-*tail* contract, where
+     * the gate strips detail and leaves the prose identical. The catalog is a different kind of
+     * record — it exists only for diagnostics, so the gate removes it entirely. Emitting bare
+     * "catalogued" lines to every customer's Logcat would be noise, and moving the detail into the
+     * prose to satisfy the table would leak coordinates with the gate off. These tests pin the same
+     * contract the table would have.
+     */
+    @Test
+    fun fenceCatalog_expectMachineKeyAndReplayClassification() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        val message = logger.messages.last()
+        message.startsWith("[Geofence] ") shouldBeEqualTo true
+        val fields = parseTail(message)
+        fields.shouldNotBeNull()
+        fields["ev"] shouldBeEqualTo "fence.cataloged"
+        fields["io"] shouldBeEqualTo "in"
+        for (key in listOf("id", "name", "gs", "lat", "lon", "rad", "tt")) {
+            if (fields[key] == null) throw AssertionError("missing $key= in '$message'")
+        }
+    }
+
+    @Test
+    fun fenceCatalog_expectOneRecordPerFence() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(
+            3,
+            10L,
+            listOf(catalogRegion(id = "1"), catalogRegion(id = "2"), catalogRegion(id = "3"))
+        )
+        logger.messages.count { it.contains("ev=fence.cataloged") } shouldBeEqualTo 3
+    }
+
+    @Test
+    fun fenceCatalog_givenGeosetList_expectSeparatorsPreserved() {
+        // `gs` and `tt` compose commas on purpose, like `ids` and `ranked` — they must opt out of
+        // sanitising or the list collapses into one token.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["gs"] shouldBeEqualTo "4471,9002"
+        fields["tt"] shouldBeEqualTo "enter,exit"
+        fields["lat"] shouldBeEqualTo "25.10991"
+        fields["rad"] shouldBeEqualTo "150"
+    }
+
+    @Test
+    fun fenceCatalog_givenDiagnosticsOff_expectNoCatalogRecords() {
+        // The catalog carries no prose worth emitting on its own; with the gate off it must not
+        // exist at all, not merely lose its tail.
+        GeofenceDiagnostics.setEnabledForTesting(false)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        logger.messages.none { it.contains("catalogued") } shouldBeEqualTo true
+    }
+}

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -7,11 +7,15 @@ import io.customer.commontest.config.ApplicationArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.GeofenceDiagnostics
+import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.di.pendingGeofenceDeliveryStore
 import io.customer.geofence.store.PendingGeofenceDelivery
 import io.customer.sdk.communication.Event
 import io.customer.sdk.core.di.SDKComponent
 import io.customer.sdk.core.network.HttpRequestFailure
+import io.customer.sdk.core.util.CioLogLevel
+import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.store.PendingDeliveryStore
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -24,6 +28,8 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldContain
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -33,6 +39,21 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
     private val tracker: GeofenceEventTracker = mockk(relaxed = true)
 
+    /** Captures formatted messages: the tail's value is the assertion, not a call count. */
+    private class CapturingLogger : Logger {
+        val messages = mutableListOf<String>()
+        override var logLevel: CioLogLevel = CioLogLevel.DEBUG
+        override fun setLogDispatcher(dispatcher: ((CioLogLevel, String) -> Unit)?) = Unit
+        override fun info(message: String, tag: String?) = record(message)
+        override fun debug(message: String, tag: String?) = record(message)
+        override fun error(message: String, tag: String?, throwable: Throwable?) = record(message)
+        private fun record(message: String) {
+            messages.add(message)
+        }
+    }
+
+    private val capturing = CapturingLogger()
+
     private val store get() = SDKComponent.android().pendingGeofenceDeliveryStore
 
     override fun setup(testConfig: TestConfig) {
@@ -40,11 +61,27 @@ class GeofenceEventWorkerTest : RobolectricTest() {
             testConfigurationDefault {
                 argument(ApplicationArgument(applicationMock))
                 diGraph {
+                    sdk { overrideDependency<GeofenceLogger>(GeofenceLogger(capturing)) }
                     android { overrideDependency<GeofenceEventTracker>(tracker) }
                 }
             }
         )
         store.removeAll()
+        GeofenceDiagnostics.setEnabledForTesting(true)
+    }
+
+    @After
+    fun resetDiagnostics() {
+        // null, not false: false would pin the gate off for every later test class in this JVM.
+        GeofenceDiagnostics.setEnabledForTesting(null)
+    }
+
+    private fun deliveryFailedTail(): String {
+        // Filtered on the machine key plus the field, not the prose: logEventDeliveryRetryable also
+        // emits ev=delivery.failed, and matching on wording turns a reword into a confusing throw.
+        val matches = capturing.messages.filter { "ev=delivery.failed" in it && "retry=" in it }
+        matches.size shouldBeEqualTo 1
+        return matches.first()
     }
 
     // inputData carries only the store key; the worker loads the full row from the pending store, so
@@ -189,6 +226,9 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         // The rejected head is dropped rather than retried, and the drain continues past it.
         attempts shouldBeEqualTo listOf(enter, exit)
         store.loadAll().isEmpty().shouldBeTrue()
+        // The tail has to say what actually happened to the row, or a replay run reads a dropped
+        // transition as one still queued.
+        deliveryFailedTail() shouldContain "retry=false"
     }
 
     @Test
@@ -202,6 +242,26 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         result shouldBeEqualTo ListenableWorker.Result.retry()
         store.loadAll().map { it.key } shouldBeEqualTo listOf("biz_ENTER_tid-seed_none")
+    }
+
+    @Test
+    fun doWork_givenTerminalRejectionWhoseRemovalFails_expectRowKeptAndTailSaysItWillRetry() = runTest {
+        // The case the retry field exists for. The payload is refused permanently, but the row that
+        // proves it could not be removed, so it is still queued and the tail must not report it as
+        // dropped. Reading retry=false here would send someone looking for a transition that is
+        // still on disk.
+        val entry = seed("biz", Event.GeofenceTransition.ENTER, timestamp = 0L)
+        val failingRemoval = spyk(store) { every { remove(any()) } returns false }
+        SDKComponent.android()
+            .overrideDependency<PendingDeliveryStore<PendingGeofenceDelivery>>(failingRemoval)
+        coEvery { tracker.trackEvent(any()) } returns
+            Result.failure(HttpRequestFailure(400, "invalid payload"))
+
+        val result = createWorker(inputDataFor(entry.key)).doWork()
+
+        result shouldBeEqualTo ListenableWorker.Result.retry()
+        failingRemoval.loadAll().map { it.key } shouldBeEqualTo listOf(entry.key)
+        deliveryFailedTail() shouldContain "retry=true"
     }
 
     @Test
@@ -221,6 +281,8 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         }
 
         createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.retry()
+        // Same log method as the permanent-rejection case, opposite disposal: this row survives.
+        deliveryFailedTail() shouldContain "retry=true"
         createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
 
         attempts shouldBeEqualTo listOf(enter, enter, exit)


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Why this exists

`feature/geofence-polygons` is 17 commits behind `main`, and the merge conflicts in 8 files / 498 lines. Both sides rewrote the same geofence delivery path: main added structured `key=value` log tails, this branch replaced the cooldown claim/rollback with a split `isAllowed` + `record`.

Resolving that inside one direct-push merge would put a lot of judgement somewhere nobody reviews it. So main's content lands here as reviewed PRs first.

Correction, added after the merge: this stack did not shrink the merge (37 hunks became 44). What it bought is that every production conflict resolved to ours, and main's diagnostics arrived already reviewed. Without #854 the merge would have silently auto-applied main's `logRankEvaluated` calling `edgeDistanceTo`, which does not exist on this branch.

- 👉 **this PR** — the diagnostics: `GeofenceDiagnostics`, `GeofenceLogTail`, `GeofenceLogger`
- next — `isAllowed` returns remaining seconds, so `cooldownRemainingSeconds` has a source
- next — drop blank geoset ids, matching main and iOS
- next — main's remaining repository/emitter diagnostics
- then — `git merge origin/main`, pushed directly so git records the ancestry a squash would lose

## What this is

`GeofenceDiagnostics.kt`, `GeofenceLogTail.kt` and `GeofenceLogTailTest.kt` are taken verbatim from main. `GeofenceLogger.kt` is main's file plus the 11 log methods that exist only on this branch.

Verified rather than assumed: the three new files are byte-identical to main, the logger diff against main is **+59 / −0** with zero removed lines, and both sides carry **63** `tail(` sites. All 71 methods across both parents are present, with bodies and doc comments intact.

## Two of main's methods described behaviour this branch deleted

Taking main's version wholesale imported prose, and in one case a machine field, that contradicts the code here.

**`logPersistFailed`** claimed it "rolled back cooldown so a later crossing can retry". There is no cooldown rollback on this branch. Kept this branch's wording, with main's tail.

**`logEventDeliveryFailed`** claimed HTTP delivery "will not retry", and emitted `retry=false`. On this branch a refused row is dropped only when the cause is a terminal `HttpRequestFailure` **and** `store.remove` succeeds; a non-terminal cause or a failed removal keeps the row and returns `Result.retry()`. So a constant is wrong in one direction or the other. It now takes `willRetry`, computed from the same expression that decides disposal, so the field and the behaviour cannot drift.

`logUnknownTransition` gained a required `geofenceId` on main. Its one call site is updated.

## What is deliberately not here

**14 of main's log methods have no production caller yet** (`logModuleInitialized`, `logCallbackReceived`, `logRegionsRegisteredIds`, `logTransitionAccepted` and others). Their callers live in the files the later pieces touch, so a diagnostics-enabled log will not yet mark a launch or a callback. Expected, not a bug.

**The 11 methods carried from this branch emit no tail.** Writing new diagnostic schemas is a change worth designing, not something to bury in a merge-prep PR. Three of them (`logTransitionDroppedUnarmedId`, `logTransitionDroppedRetiredId`, `logGmsCallTimedOut`) leave a replay gap, since a callback ending in an unarmed or retired drop produces no `out` record; those are worth doing when the delivery path is reconciled.

## Tests

1047 across geofence, core and messagingpush, 0 failures. `lintDebug` 0 issues, `apiCheck` and ktlint clean, no new compiler warnings.

`GeofenceLogTailTest` asserts field *names* only, so nothing pinned the new `retry` value. `GeofenceEventWorkerTest` now captures the emitted log, and three mutants each kill exactly one test: hardcoding `retry` false, hardcoding it true, and dropping the row regardless of whether the removal succeeded.

Not exercised on a device.

