### PR TITLE
chore(geofence): report the cooldown remainder instead of a boolean

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceCooldownFilter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceCooldownFilter.kt
@@ -16,20 +16,23 @@ internal class GeofenceCooldownFilter(
     private val clock: Clock
 ) {
     /**
-     * Atomically checks the cooldown and records the emit if allowed. Returns true if the
-     * caller should proceed to emit, false if the transition is within the cooldown window.
+     * `null` when the caller should proceed to emit, otherwise the seconds still left on the
+     * window. The check already computes that figure, so returning it rather than recomputing
+     * keeps reporting a suppression free of a second store read on a background wake.
+     *
+     * Checks only. [record] is the separate write, so there is nothing to roll back.
      */
     @Synchronized
-    fun isAllowed(
+    fun suppressedForSeconds(
         userId: String,
         geofenceId: String,
         transition: Event.GeofenceTransition
-    ): Boolean {
+    ): Double? {
         val cooldownMs = regionStore.getCachedConfig()?.duplicateEventsExpiry
             ?: GeofenceConstants.DEDUPE_COOLDOWN_MS
-        val last = store.getLastEmitTimestamp(userId, geofenceId, transition)
-        val now = clock.currentTimeMillis()
-        return last == null || (now - last) >= cooldownMs
+        val last = store.getLastEmitTimestamp(userId, geofenceId, transition) ?: return null
+        val elapsed = clock.currentTimeMillis() - last
+        return if (elapsed < cooldownMs) (cooldownMs - elapsed) / 1000.0 else null
     }
 
     @Synchronized

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -195,8 +195,9 @@ internal class GeofenceTransitionEmitter(
             logger.logEnterDroppedAlreadyReported(geofenceId)
             return@withLock Result.SUPPRESSED
         }
-        if (!isRecovery && !cooldownFilter.isAllowed(userId, geofenceId, transition)) {
-            logger.logTransitionSuppressed(geofenceId, transition.name)
+        val suppressedFor = if (isRecovery) null else cooldownFilter.suppressedForSeconds(userId, geofenceId, transition)
+        if (suppressedFor != null) {
+            logger.logTransitionSuppressed(geofenceId, transition.name, suppressedFor)
             return@withLock Result.SUPPRESSED
         }
         logger.logTransitionEmitting(geofenceId, transition.name)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -89,7 +89,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
             }
         )
         // Default: cooldown allows emission. Tests override this to test suppression.
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockStore.savePendingTransitionEntries(any(), any()) } returns true
         every { mockStore.commitBusinessTransition(any(), any(), any(), any(), any()) } returns true
         // Default: an identified user is the common case; the snapshot lands on the entry.
@@ -526,7 +526,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         scheduled.map { it.transitionId }.toSet().size shouldBeEqualTo 1
         scheduled.map { it.key }.toSet().size shouldBeEqualTo 3
         // Cooldown is a single gate for the crossing, not per geoset.
-        verify(exactly = 1) { mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
+        verify(exactly = 1) { mockCooldownFilter.suppressedForSeconds("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
         verify(exactly = 1) { mockCooldownFilter.record("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) }
         pendingStore.loadAll().size shouldBeEqualTo 3
     }
@@ -609,7 +609,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
     @Test
     fun dispatchTransition_givenCooldownSuppresses_expectNothingScheduled() = runTest {
-        every { mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) } returns false
+        every { mockCooldownFilter.suppressedForSeconds("user-42", "biz-geofence", Event.GeofenceTransition.ENTER) } returns 12.0
 
         receiver.dispatchTransition(
             gmsTransitionType = Geofence.GEOFENCE_TRANSITION_ENTER,
@@ -632,7 +632,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
         )
 
         coVerifyOrder {
-            mockCooldownFilter.isAllowed("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
+            mockCooldownFilter.suppressedForSeconds("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
             mockCooldownFilter.record("user-42", "biz-geofence", Event.GeofenceTransition.ENTER)
             mockScheduler.schedule(any())
         }
@@ -703,7 +703,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
-        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) }
         coVerify(exactly = 0) { mockManager.removeGeofencesByIds(any()) }
     }
 
@@ -920,7 +920,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
-        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) }
         coVerify { mockManager.removeGeofencesByIds(listOf("biz-orphan")) }
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
@@ -10,8 +10,9 @@ import io.customer.sdk.core.util.Clock
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -38,7 +39,7 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         every { mockStore.getLastEmitTimestamp(any(), any(), any()) } returns null
         every { mockClock.currentTimeMillis() } returns 100_000L
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, 100_000L) }
     }
@@ -52,7 +53,7 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         val now = 100_000L + GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
 
         verify(exactly = 1) { mockStore.pruneOlderThan(now - GeofenceConstants.MAX_DUPLICATE_EVENTS_EXPIRY_MS) }
@@ -64,30 +65,43 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns lastEmit + 1
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
 
         verify(exactly = 0) { mockStore.pruneOlderThan(any()) }
     }
 
     @Test
-    fun cooldown_givenPreviousEmitWithinCooldown_expectFalseAndNotRecorded() {
+    fun cooldown_givenPreviousEmitWithinCooldown_expectRemainderReportedAndNotRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + (GeofenceConstants.DEDUPE_COOLDOWN_MS - 1)
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
         verify(exactly = 0) { mockStore.recordEmit(any(), any(), any(), any()) }
     }
 
     @Test
-    fun cooldown_givenPreviousEmitExactlyAtCooldownBoundary_expectTrueAndRecorded() {
+    fun suppressedForSeconds_givenHalfTheWindowElapsed_expectTheRemainderInSeconds() {
+        // The number goes straight into the suppression log tail, so a constant would read as a
+        // real measurement to anyone parsing it.
+        val lastEmit = 100_000L
+        val elapsed = GeofenceConstants.DEDUPE_COOLDOWN_MS / 2
+        every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
+        every { mockClock.currentTimeMillis() } returns lastEmit + elapsed
+
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo
+            (GeofenceConstants.DEDUPE_COOLDOWN_MS - elapsed) / 1000.0
+    }
+
+    @Test
+    fun cooldown_givenPreviousEmitExactlyAtCooldownBoundary_expectAllowedAndRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, now) }
     }
@@ -99,7 +113,7 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
         every { mockClock.currentTimeMillis() } returns now
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         verify(exactly = 1) { mockStore.recordEmit("user-1", "biz-1", Event.GeofenceTransition.ENTER, now) }
     }
@@ -111,8 +125,8 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.EXIT) } returns null
         every { mockClock.currentTimeMillis() } returns 200L
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.EXIT).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.EXIT).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.EXIT)
     }
 
@@ -124,8 +138,8 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         every { mockStore.getLastEmitTimestamp("user-2", "biz-1", Event.GeofenceTransition.ENTER) } returns null
         every { mockClock.currentTimeMillis() } returns 200L
 
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
-        filter.isAllowed("user-2", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
+        filter.suppressedForSeconds("user-2", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-2", "biz-1", Event.GeofenceTransition.ENTER)
     }
 
@@ -142,11 +156,11 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
 
         // Inside the server window but well outside the constant fallback → must block.
         every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs - 1
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeFalse()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
 
         // Past the server window but still inside the constant fallback → must allow.
         every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs + 1
-        filter.isAllowed("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeTrue()
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldBeNull()
         filter.record("user-1", "biz-1", Event.GeofenceTransition.ENTER)
     }
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceCooldownFilterTest.kt
@@ -35,7 +35,7 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
     }
 
     @Test
-    fun cooldown_givenNoPreviousEmit_expectTrueAndRecorded() {
+    fun cooldown_givenNoPreviousEmit_expectAllowedAndRecorded() {
         every { mockStore.getLastEmitTimestamp(any(), any(), any()) } returns null
         every { mockClock.currentTimeMillis() } returns 100_000L
 
@@ -107,7 +107,7 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
     }
 
     @Test
-    fun cooldown_givenPreviousEmitOutsideCooldown_expectTrueAndRecorded() {
+    fun cooldown_givenPreviousEmitOutsideCooldown_expectAllowedAndRecorded() {
         val lastEmit = 100_000L
         val now = lastEmit + GeofenceConstants.DEDUPE_COOLDOWN_MS + 1
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
@@ -154,9 +154,11 @@ class GeofenceCooldownFilterTest : RobolectricTest() {
         val lastEmit = 100_000L
         every { mockStore.getLastEmitTimestamp("user-1", "biz-1", Event.GeofenceTransition.ENTER) } returns lastEmit
 
-        // Inside the server window but well outside the constant fallback → must block.
-        every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs - 1
-        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER).shouldNotBeNull()
+        // Inside the server window but well outside the constant fallback → must block, and the
+        // remainder must be measured against the server window rather than the fallback constant.
+        every { mockClock.currentTimeMillis() } returns lastEmit + 1_000
+        filter.suppressedForSeconds("user-1", "biz-1", Event.GeofenceTransition.ENTER) shouldBeEqualTo
+            (serverCooldownMs - 1_000) / 1000.0
 
         // Past the server window but still inside the constant fallback → must allow.
         every { mockClock.currentTimeMillis() } returns lastEmit + serverCooldownMs + 1

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -242,6 +242,30 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
+    fun emit_givenStagedAttemptWithinTheCooldown_expectDeliveredNotSuppressed() = runTest {
+        // A staged row is a crossing already accepted whose outbox append failed. Its own first
+        // attempt recorded the cooldown, so running the check over the retry would let that window
+        // eat the crossing outright.
+        val staged = PendingGeofenceDelivery(
+            geofenceId = "biz-1",
+            transition = Event.GeofenceTransition.ENTER,
+            timestamp = 99L,
+            userId = "user-1",
+            transitionId = "staged-enter"
+        )
+        every {
+            mockRegionStore.getPendingTransitionEntries("user-1", "biz-1", Event.GeofenceTransition.ENTER)
+        } returns listOf(staged)
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns 12.0
+        every { mockPendingStore.appendAll(listOf(staged)) } returns true
+
+        emit()
+
+        verify { mockPendingStore.appendAll(listOf(staged)) }
+        verify(exactly = 0) { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) }
+    }
+
+    @Test
     fun recoverPendingTransitions_givenOldUserGeneration_expectDeliversButDoesNotRestoreContainment() = runTest {
         val staged = PendingGeofenceDelivery(
             geofenceId = "biz-1",

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -68,18 +68,20 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenCooldownSuppresses_expectFalseAndNoPersist() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns false
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns 12.0
 
         val emitted = emit()
 
         emitted.shouldBeFalse()
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
+        // The remainder the filter reported has to reach the log, not a placeholder.
+        verify(exactly = 1) { mockLogger.logTransitionSuppressed("biz-1", "ENTER", 12.0) }
     }
 
     @Test
     fun emit_givenNoGeosets_expectSingleNullGeosetEntryPersistedAndScheduled() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
@@ -96,7 +98,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenMultipleGeosets_expectPerGeosetFanoutWithSharedTransitionId() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
         val entries = slot<List<PendingGeofenceDelivery>>()
 
@@ -113,7 +115,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     fun emit_givenSchedulerThrowsForOneGeoset_expectRemainingStillScheduled() = runTest {
         // A scheduler failure for one geoset must not abandon the rest of the batch; the row is
         // already persisted, so the foreground flush still delivers the un-scheduled one.
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
         coEvery { mockScheduler.schedule(match { it.geosetId == "g1" }) } throws RuntimeException("boom")
 
@@ -126,7 +128,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenPersistFails_expectCooldownReleasedAndFalse() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns false
 
         val emitted = emit()
@@ -144,14 +146,14 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
         emitted.shouldBeFalse()
         // Ahead of the cooldown, so the slot stays free for the next genuine transition.
-        verify(exactly = 0) { mockCooldownFilter.isAllowed(any(), any(), any()) }
+        verify(exactly = 0) { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) }
         verify(exactly = 0) { mockPendingStore.appendAll(any()) }
     }
 
     @Test
     fun emit_givenEnterOnlyFenceAlreadyReported_expectDelivered() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
 
         val emitted = emit(monitorsExit = false)
@@ -163,7 +165,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenEnterOnlyFenceDelivered_expectNoMarkRecorded() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit(monitorsExit = false)
@@ -174,7 +176,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     @Test
     fun emit_givenExitWhileEnterReported_expectDelivered() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
 
         val emitted = emit(transition = Event.GeofenceTransition.EXIT)
@@ -185,7 +187,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenEnterDelivered_expectStageCommittedAtomically() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit()
@@ -196,7 +198,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
 
     @Test
     fun emit_givenEnterPersistFails_expectNotMarkedSoRetryCanDeliver() = runTest {
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns false
 
         emit()
@@ -208,7 +210,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     @Test
     fun emit_givenExitDelivered_expectMarkNotTouchedHere() = runTest {
         every { mockRegionStore.hasEmittedEnter("user-1", "biz-1") } returns true
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockPendingStore.appendAll(any()) } returns true
 
         emit(transition = Event.GeofenceTransition.EXIT)
@@ -297,7 +299,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
         )
         every { mockRegionStore.getAllPendingTransitionEntries() } returns listOf(enter)
         every { mockPendingStore.appendAll(listOf(enter)) } returns false
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
 
         emit(transition = Event.GeofenceTransition.EXIT).shouldBeFalse()
 
@@ -330,7 +332,7 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
             mockRegionStore.getPendingTransitionEntries("user-1", "biz-1", Event.GeofenceTransition.ENTER)
         } returns listOf(olderEnter)
         every { mockPendingStore.appendAll(listOf(olderEnter)) } returns false
-        every { mockCooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         val staged = slot<List<PendingGeofenceDelivery>>()
 
         emitter.emitWithRetainedAttempt(

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionStagingContainmentTest.kt
@@ -55,7 +55,7 @@ class GeofenceTransitionStagingContainmentTest : RobolectricTest() {
         regionStore.saveRegisteredIds(setOf(GEOFENCE_ID))
         regionStore.saveRoutableRegisteredIds(setOf(GEOFENCE_ID))
         every { secureUserStore.getUserId() } returns USER_ID
-        every { cooldownFilter.isAllowed(any(), any(), any()) } returns true
+        every { cooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         outbox = spyk(
             PendingDeliveryStore(
                 context = applicationMock,


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

Bringing `main` into `feature/geofence-polygons`. The merge conflicts in 9 files because both sides rewrote the geofence delivery path, so main's content lands as reviewed PRs first. Correction, added after the merge: this did not shrink the merge (37 hunks became 44). What it bought is that every production conflict resolved to ours, and main's diagnostics arrived already reviewed instead of being ported inside an unreviewed conflict resolution.

- [#851 adopt main's geofence log diagnostics](https://github.com/customerio/customerio-android/pull/851)
- 👉 **this PR** — the cooldown reports its remainder
- next — drop blank geoset ids
- next — main's remaining repository/emitter diagnostics
- then — `git merge origin/main`, pushed directly so git records the ancestry a squash would lose

## What this is

main's suppression log carries `cooldownRemainingSeconds`. That field has no source on this branch: #837 replaced the cooldown's claim-and-rollback with an `isAllowed` check plus a separate `record` write, and the check returned a `Boolean`.

`suppressedForSeconds` returns `null` to proceed, otherwise the seconds left on the window. The check already computes that figure, so returning it costs no second store read on a background wake.

**Not named `tryAcquire` like main.** Nothing is acquired here, and `record()` remains the separate write with nothing to roll back. Reusing main's name would re-import the confusion #837 removed.

## The boundary is unchanged

Old: proceed when `last == null || (now - last) >= cooldownMs`. New: `null` when there is no previous emit, or when `elapsed >= cooldownMs`. Same decision at `elapsed == cooldownMs`, still covered by `cooldown_givenPreviousEmitExactlyAtCooldownBoundary_expectAllowedAndRecorded`.

## Tests

1048 across geofence, core and messagingpush, 0 failures. `lintDebug` 0 issues, `apiCheck` clean, ktlint clean.

About 35 stubs moved from `returns true/false` to `returns null/12.0`, which is where an inverted sense would hide, so two assertions now pin the value rather than its nullness: `suppressedForSeconds_givenHalfTheWindowElapsed_expectTheRemainderInSeconds`, and an emitter check that the reported figure reaches `logTransitionSuppressed`. Replacing the remainder with a constant kills exactly the first.

Two test names said `expectTrue`/`expectFalse` and now describe the returned remainder instead.

Not exercised on a device.

