### PR TITLE
chore(geofence): drop blank geoset ids from the transition fan-out

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -206,9 +206,11 @@ internal class GeofenceTransitionEmitter(
             // One transitionId shared across the per-geoset fan-out.
             val transitionId = UUID.randomUUID().toString()
             val name = geofenceName?.takeIf { it.isNotEmpty() }
-            // One event per geoset; no geosets → one null-geoset event. Distinct so a repeated
-            // geoset doesn't duplicate.
-            val geosets: List<String?> = geosetIds.distinct().takeIf { it.isNotEmpty() } ?: listOf(null)
+            // One event per geoset; no geosets → one null-geoset event. Blanks dropped as well as
+            // duplicates, matching iOS: a catalog row carrying "" otherwise persists a row with an
+            // empty geosetId and reports two events where iOS reports one.
+            val geosets: List<String?> = geosetIds.filter { it.isNotEmpty() }.distinct()
+                .takeIf { it.isNotEmpty() } ?: listOf(null)
             geosets.map { geosetId ->
                 PendingGeofenceDelivery(
                     geofenceId = geofenceId,

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -112,6 +112,35 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
+    fun emit_givenBlankGeosetAlongsideReal_expectBlankDropped() = runTest {
+        // A catalog row carrying "" would otherwise persist an entry with an empty geosetId and
+        // report two events where iOS reports one, which reads as a platform difference that isn't.
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
+        every { mockPendingStore.appendAll(any()) } returns true
+        val entries = slot<List<PendingGeofenceDelivery>>()
+
+        emit(geosetIds = listOf("", "g1"))
+
+        verify { mockPendingStore.appendAll(capture(entries)) }
+        entries.captured.map { it.geosetId } shouldBeEqualTo listOf("g1")
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
+    fun emit_givenEveryGeosetBlank_expectOneNullGeosetEvent() = runTest {
+        // Dropping every id must land on the no-geosets path rather than emitting nothing at all.
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
+        every { mockPendingStore.appendAll(any()) } returns true
+        val entries = slot<List<PendingGeofenceDelivery>>()
+
+        emit(geosetIds = listOf("", ""))
+
+        verify { mockPendingStore.appendAll(capture(entries)) }
+        entries.captured.map { it.geosetId } shouldBeEqualTo listOf(null)
+        coVerify(exactly = 1) { mockScheduler.schedule(any()) }
+    }
+
+    @Test
     fun emit_givenSchedulerThrowsForOneGeoset_expectRemainingStillScheduled() = runTest {
         // A scheduler failure for one geoset must not abandon the rest of the batch; the row is
         // already persisted, so the foreground flush still delivers the un-scheduled one.


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

Bringing `main` into `feature/geofence-polygons`. The merge conflicts in 9 files because both sides rewrote the geofence delivery path, so main's content lands as reviewed PRs first. Correction, added after the merge: this did not shrink the merge (37 hunks became 44). What it bought is that every production conflict resolved to ours, and main's diagnostics arrived already reviewed instead of being ported inside an unreviewed conflict resolution.

- [#851 adopt main's geofence log diagnostics](https://github.com/customerio/customerio-android/pull/851)
- [#852 report the cooldown remainder instead of a boolean](https://github.com/customerio/customerio-android/pull/852)
- 👉 **this PR** — drop blank geoset ids
- next — main's remaining repository/emitter diagnostics
- then — `git merge origin/main`, pushed directly so git records the ancestry a squash would lose

## What this is

The one **behaviour** change in the whole merge, which is why it is on its own rather than folded into a diagnostics PR.

A catalog row carrying an empty geoset id persisted an entry with an empty `geosetId` and reported two events where iOS reports one. Blanks are now dropped alongside duplicates, matching main and iOS.

Dropping every id falls through to the existing no-geosets path, so one null-geoset event is still emitted rather than none.

Matches main exactly, including that `isNotEmpty()` is not `isBlank()`: an id of `" "` is still kept on both platforms. Deliberately not "improved" here, since divergence is the thing this sequence is removing.

## Tests

1050 across geofence, core and messagingpush, 0 failures. `lintDebug` 0 issues, `apiCheck` and ktlint clean.

Two new cases, and removing the filter kills exactly those two: `emit_givenBlankGeosetAlongsideReal_expectBlankDropped` and `emit_givenEveryGeosetBlank_expectOneNullGeosetEvent`.

Not exercised on a device.

