### PR TITLE
chore(geofence): port main's remaining geofence diagnostics

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBootReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBootReceiver.kt
@@ -32,6 +32,7 @@ class GeofenceBootReceiver : BroadcastReceiver() {
         try {
             SDKComponent.setupAndroidComponent(context = context)
             val scope = SDKComponent.scopeProvider.geofenceScope
+            logger.logModuleWoke(GeofenceLaunchReason.BOOT_RESTORE)
             logger.logSyncTriggered(REASON_BOOT_RESTORE)
             scope.launch {
                 try {

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceBroadcastReceiver.kt
@@ -61,16 +61,32 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
 
     @VisibleForTesting
     internal suspend fun handleGeofencingEvent(geofencingEvent: GeofencingEvent?) {
-        if (geofencingEvent == null) return
         val logger = SDKComponent.geofenceLogger
+        if (geofencingEvent == null) {
+            logger.logInfo("broadcast_unparseable_intent")
+            return
+        }
 
         if (geofencingEvent.hasError()) {
             logger.logGeofencingError(geofencingEvent.errorCode)
             return
         }
 
-        val triggeringGeofenceIds = geofencingEvent.triggeringGeofences?.map { it.requestId } ?: return
+        val triggeringGeofenceIds = geofencingEvent.triggeringGeofences?.map { it.requestId }
+            ?: run {
+                logger.logInfo("broadcast_no_triggering_geofences")
+                return
+            }
         val location = geofencingEvent.triggeringLocation
+        // Logged here, before any routing decision and before the Location is narrowed to a pair
+        // of doubles. This is the only place the OS's own triggering fix — accuracy, age, mock
+        // flag and all — still exists.
+        logger.logCallbackReceived(
+            geofenceIds = triggeringGeofenceIds,
+            transitionName = transitionName(geofencingEvent.geofenceTransition),
+            location = location,
+            source = if (location != null) GeofenceLogTail.FixSource.OS_TRIGGER else GeofenceLogTail.FixSource.NONE
+        )
         if (location == null) {
             logger.logTransitionWithoutLocation()
         }

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -186,14 +186,22 @@ internal class GeofenceRepositoryImpl(
         // from the last registration (the movement-trigger center). Null (never set) → 0 → within radius.
         val distanceFromLastFetch = store.getLastApiFetchLocation()
             ?.distanceTo(location.latitude, location.longitude) ?: 0f
-        val distanceFromLastRegistration = store.getLastMovementTriggerLocation()
+        val restoreAnchor = store.getLastMovementTriggerLocation()
+        val distanceFromLastRegistration = restoreAnchor
             ?.distanceTo(location.latitude, location.longitude) ?: 0f
+        // Lazy on purpose. Deserializing the cached list is the most expensive thing here and most
+        // background wakes resolve on the first arm below without needing it, so an eager read for
+        // a log count would put that cost on every wake. Still one read when both want it.
+        val cachedRegions by lazy { store.getCachedRegions() }
+        // Before the `when`, which short-circuits: a cold start with a stale cache took the first
+        // arm and never logged what it had to work from, which is the case the record exists for.
+        logger.logStorageLoaded(regionCount = { cachedRegions.size }, hasAnchor = restoreAnchor != null)
 
         return when {
             isStaleInTime(config) -> RefreshAction.REMOTE
             movedBeyondFetchRadius(distanceFromLastFetch, config) -> RefreshAction.REMOTE
             isRankingStale(distanceFromLastRegistration, config) -> RefreshAction.LOCAL
-            hasUnregisteredCache() -> RefreshAction.LOCAL
+            hasUnregisteredCache(cachedRegions) -> RefreshAction.LOCAL
             // Without this a fresh-cache launch after a reboot or app update would SKIP —
             // registeredIds survive but GMS state doesn't, leaving nothing monitored.
             osStateWiped() -> RefreshAction.LOCAL
@@ -219,8 +227,8 @@ internal class GeofenceRepositoryImpl(
         distanceFromAnchor >= config.remoteFetchRefreshTriggerRadius
 
     /** Cache holds regions but none are registered with the OS (e.g. regs lost on sign-out) → re-register. */
-    private fun hasUnregisteredCache(): Boolean =
-        store.getCachedRegions().isNotEmpty() && store.getRegisteredIds().isEmpty()
+    private fun hasUnregisteredCache(cachedRegions: List<GeofenceRegion>): Boolean =
+        cachedRegions.isNotEmpty() && store.getRegisteredIds().isEmpty()
 
     /**
      * Uptime regressed since the last registration → the device rebooted, which wipes GMS geofences
@@ -352,8 +360,15 @@ internal class GeofenceRepositoryImpl(
         // real position than the anchor (only updated on Tier B fetches).
         // Fall back to the anchor if there's no movement-trigger location yet
         // (older cache / first-ever boot restore).
-        val effectiveLocation = store.getLastMovementTriggerLocation()
-            ?: store.getLastApiFetchLocation()
+        val restoreAnchor = store.getLastMovementTriggerLocation()
+        // This path bypasses refreshAction, so it emits its own record. A boot restore is the case
+        // the record exists for and was the one pass that never produced it. Gated: nothing else
+        // here needs the region list, so with diagnostics off it is never read.
+        logger.logStorageLoaded(
+            regionCount = { store.getCachedRegions().size },
+            hasAnchor = restoreAnchor != null
+        )
+        val effectiveLocation = restoreAnchor ?: store.getLastApiFetchLocation()
         if (effectiveLocation == null) {
             logger.logSyncSkipped("no cached state to restore")
             return Result.success(Unit)
@@ -381,8 +396,13 @@ internal class GeofenceRepositoryImpl(
     ): Result<Unit> {
         // The device location lets the backend return the nearby set; the request carries no user
         // identity, so it isn't attributable to a user.
+        val syncStartedAt = clock.elapsedRealtime()
         val fetchLocation = GeofenceLocation(latitude, longitude)
+        val fetchStartedAt = clock.elapsedRealtime()
         val fetchResult = apiService.fetchGeofences(fetchLocation)
+        // Read here, not at the log call: mapping happens in between, and iOS times the request
+        // alone. A cross-platform p95 is meaningless if one side includes the parse.
+        val fetchElapsedMillis = clock.elapsedRealtime() - fetchStartedAt
         return fetchResult.fold(
             onSuccess = { response ->
                 // An unusable response throws (see toDomainRegions) — fail the refresh and
@@ -394,6 +414,13 @@ internal class GeofenceRepositoryImpl(
                     return@fold Result.failure(e)
                 }
                 val (regions, parsedConfig) = mapped
+                // The count off the wire, before local ranking. The gap between what the server
+                // offered and what survived the cap is the thing worth being able to see.
+                logger.logApiFetchResult(
+                    returnedCount = response.geofences.size,
+                    elapsedMillis = fetchElapsedMillis,
+                    regions = regions
+                )
                 // Config preference: server-shipped > last cached > constants.
                 val config = parsedConfig ?: store.getCachedConfigOrFallback()
                 registerNearestAndPersist(
@@ -404,6 +431,7 @@ internal class GeofenceRepositoryImpl(
                     config = config,
                     containmentEpoch = containmentEpoch,
                     fixSource = fixSource,
+                    syncStartedAt = syncStartedAt,
                     // Cache + anchor + timestamp only on remote fetch; Tier A reuses them.
                     // Skip the config save when backend didn't ship one this response —
                     // a null parse must not clobber a previously cached value.
@@ -426,7 +454,7 @@ internal class GeofenceRepositoryImpl(
                 )
             },
             onFailure = { error ->
-                logger.logSyncFailed(error.message)
+                logger.logApiFetchFailed(error.message)
                 Result.failure(error)
             }
         )
@@ -496,7 +524,9 @@ internal class GeofenceRepositoryImpl(
         containmentEpoch: Long,
         fixSource: FixSource,
         register: suspend (List<GeofenceRegion>) -> Result<Unit> = ::registerWithBusinessDiff,
-        onRegistered: (userStateGeneration: Long) -> Unit = {}
+        onRegistered: (userStateGeneration: Long) -> Unit = {},
+        // Measured from the caller's entry so `ms=` spans the same work iOS reports.
+        syncStartedAt: Long = clock.elapsedRealtime()
     ): Result<Unit> {
         // Pure mapping + filter — no shared state, kept outside the lock.
         val nearest = distanceFilter.nearest(
@@ -509,6 +539,23 @@ internal class GeofenceRepositoryImpl(
         // Keep the movement trigger registered even when no regions qualify right now — all beyond
         // maxMonitoringDistance, or the distance-capped /nearest returned none here — so an EXIT
         // re-ranks/re-fetches as the device travels. Only maxBusinessGeofences = 0 means "feature off".
+        logger.logRankEvaluated(
+            candidates = regions.size,
+            selectedCount = nearest.size,
+            selected = { nearest.map { it.id } },
+            evicted = {
+                val nearestIds = nearest.map { it.id }.toSet()
+                regions.map { it.id }.filterNot { it in nearestIds }
+            },
+            // A polygon whose ring never arrived reports no distance, the same reason ranking drops
+            // it, rather than inventing one from its coarse circle. The ring is re-derived rather
+            // than reused from ranking, which only costs anything when diagnostics are enabled.
+            edgeDistances = {
+                nearest.mapNotNull { region ->
+                    region.edgeDistanceToOrNull(latitude, longitude)?.let { region.id to it.toDouble() }
+                }.toMap()
+            }
+        )
         val monitoringEnabled = config.maxBusinessGeofences > 0
         val regionsToRegister = if (!monitoringEnabled) {
             emptyList()
@@ -630,7 +677,27 @@ internal class GeofenceRepositoryImpl(
                         // Leaving the stamp stale sends that refresh down the remote path instead.
                         logger.logSyncSkipped("user changed before routing could be armed")
                     }
-                    logger.logSyncSucceeded(nearest.size, movementTriggerRegistered = monitoringEnabled)
+                    // idsToSave, not `nearest`: when stale removal failed the OS still holds those
+                    // fences, and "what is actually monitored" is the question these records answer.
+                    // The trigger is reported separately, so it must not inflate the business count.
+                    val monitoredBusinessIds = idsToSave.filterNot { it == GeofenceConstants.MOVEMENT_TRIGGER_ID }
+                    logger.logSyncSucceeded(
+                        monitoredBusinessIds.size,
+                        movementTriggerRegistered = monitoringEnabled,
+                        elapsedMillis = clock.elapsedRealtime() - syncStartedAt
+                    )
+                    logger.logRegionsRegisteredIds(
+                        ids = monitoredBusinessIds.sorted(),
+                        movementTriggerId = GeofenceConstants.MOVEMENT_TRIGGER_ID
+                            .takeIf { idsToSave.contains(it) }
+                    )
+                    if (monitoringEnabled) {
+                        logger.logMovementTriggerRegistered(
+                            latitude = latitude,
+                            longitude = longitude,
+                            radiusMeters = config.localRefreshTriggerRadius.toDouble()
+                        )
+                    }
                 }
             }
             // An anchor inside a fence proves nothing about where the device is now, so a record

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceTransitionEmitter.kt
@@ -200,8 +200,6 @@ internal class GeofenceTransitionEmitter(
             logger.logTransitionSuppressed(geofenceId, transition.name, suppressedFor)
             return@withLock Result.SUPPRESSED
         }
-        logger.logTransitionEmitting(geofenceId, transition.name)
-
         val entries = stagedEntries.ifEmpty {
             // One transitionId shared across the per-geoset fan-out.
             val transitionId = UUID.randomUUID().toString()
@@ -241,7 +239,10 @@ internal class GeofenceTransitionEmitter(
             logger.logPersistFailed(geofenceId, transition.name)
             return@withLock Result.PERSIST_FAILED
         }
-        // Only once the rows are durable, so an interrupted write can't suppress its own retry.
+        // Below the write, not above it: logged earlier this could claim an acceptance the write
+        // then failed to make. The same ordering rule covers the cooldown record, so an interrupted
+        // write cannot suppress its own retry.
+        logger.logTransitionAccepted(geofenceId, transition.name, entries.size)
         cooldownFilter.record(userId, geofenceId, transition)
         entries.forEach { entry ->
             // Isolate the scheduler so one failure can't abandon the rest of the batch.

--- a/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/ModuleGeofence.kt
@@ -64,6 +64,11 @@ class ModuleGeofence @JvmOverloads constructor(
             return
         }
 
+        // A cold background wake and a user opening the app run different entry points and behave
+        // very differently, but produced identical logs. This marks the app-start path; the boot
+        // receiver marks its own, and a geofence wake announces itself via os.callback.received.
+        logger.logModuleInitialized(GeofenceLaunchReason.APP_START)
+
         val eventBus = SDKComponent.eventBus
         val sdkAndroid = SDKComponent.android()
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -14,7 +14,9 @@ import io.customer.geofence.worker.GeofenceEventScheduler
 import io.customer.sdk.communication.Event
 import io.customer.sdk.communication.EventBus
 import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.core.util.Clock
+import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.store.SecureUserStore
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -34,9 +36,11 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBeBlank
 import org.amshove.kluent.shouldNotBeNull
 import org.amshove.kluent.shouldNotContain
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -68,6 +72,45 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
     private lateinit var receiver: GeofenceBroadcastReceiver
 
+    /**
+     * Captures what the SDK actually wrote. Asserting the emitted record covers the `ev=` a parser
+     * dispatches on, not merely that some method was called.
+     */
+    private class CapturingLogger : Logger {
+        val messages = mutableListOf<String>()
+        override var logLevel: CioLogLevel = CioLogLevel.DEBUG
+        override fun setLogDispatcher(dispatcher: ((CioLogLevel, String) -> Unit)?) = Unit
+        override fun info(message: String, tag: String?) { messages.add(message) }
+        override fun debug(message: String, tag: String?) { messages.add(message) }
+        override fun error(message: String, tag: String?, throwable: Throwable?) { messages.add(message) }
+    }
+
+    private val capturingLogger = CapturingLogger()
+
+    @After
+    fun resetDiagnostics() {
+        // null, not false: false would pin the gate off for every later test class in this JVM.
+        GeofenceDiagnostics.setEnabledForTesting(null)
+    }
+
+    /**
+     * A broadcast the SDK woke for and could make nothing of must leave a trace, or the capture is
+     * byte-identical to a process the OS never talked to. Asserted on the emitted tail, so deleting
+     * the log line fails the test.
+     */
+    private fun recordFor(ev: String): String? =
+        capturingLogger.messages.firstOrNull { "ev=$ev" in it }
+
+    private fun expectRecorded(ev: String, why: String) {
+        val match = capturingLogger.messages.firstOrNull { "ev=$ev" in it && "why=$why" in it }
+        if (match == null) {
+            throw AssertionError(
+                "expected a record with ev=$ev why=$why; captured:\n" +
+                    capturingLogger.messages.joinToString("\n  ", prefix = "  ")
+            )
+        }
+    }
+
     override fun setup(testConfig: TestConfig) {
         super.setup(
             testConfigurationDefault {
@@ -76,6 +119,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                     sdk {
                         overrideDependency<EventBus>(mockEventBus)
                         overrideDependency<Clock>(mockClock)
+                        overrideDependency<GeofenceLogger>(GeofenceLogger(capturingLogger))
                     }
                     android {
                         overrideDependency<GeofenceEventScheduler>(mockScheduler)
@@ -88,6 +132,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                 }
             }
         )
+        GeofenceDiagnostics.setEnabledForTesting(true)
         // Default: cooldown allows emission. Tests override this to test suppression.
         every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
         every { mockStore.savePendingTransitionEntries(any(), any()) } returns true
@@ -136,6 +181,9 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
+        // A wake the SDK could make nothing of still has to leave a trace, or the capture is
+        // indistinguishable from a process the OS never talked to.
+        expectRecorded("info", "broadcast_unparseable_intent")
     }
 
     @Test
@@ -163,6 +211,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         coVerify(exactly = 0) { mockScheduler.schedule(any()) }
         pendingStore.loadAll() shouldBeEqualTo emptyList()
+        expectRecorded("info", "broadcast_no_triggering_geofences")
     }
 
     @Test
@@ -179,6 +228,25 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
 
         val entry = pendingStore.loadAll().single()
         entry.geofenceId shouldBeEqualTo "biz-1"
+        // No fix to describe, and the record has to say so rather than omit the field.
+        recordFor("os.callback.received").shouldNotBeNull() shouldContain "src=none"
+    }
+
+    @Test
+    fun handleGeofencingEvent_givenTriggeringLocation_expectCallbackRecordedWithTheOsFix() = runTest {
+        // Recorded before any routing decision and before the Location is narrowed to two doubles,
+        // which is the only point where the OS's own fix still exists.
+        val event = buildGeofencingEvent(
+            transition = Geofence.GEOFENCE_TRANSITION_ENTER,
+            geofenceIds = listOf("biz-1"),
+            location = realLocation(37.7749, -122.4194)
+        )
+
+        receiver.handleGeofencingEvent(event)
+
+        val record = recordFor("os.callback.received").shouldNotBeNull()
+        record shouldContain "src=os_trigger"
+        record shouldContain "n=1"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -424,7 +424,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isFailure shouldBeEqualTo true
         result.exceptionOrNull() shouldBeEqualTo error
-        verify { logger.logSyncFailed(match { it?.contains("network down") == true }) }
+        verify { logger.logApiFetchFailed(match { it?.contains("network down") == true }) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         coVerify(exactly = 0) { manager.replaceGeofences(any(), any()) }
@@ -491,7 +491,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify(exactly = 0) { store.saveLastMovementTriggerLocation(any()) }
         verify { store.clearLastMovementTriggerLocation() }
         // Region count alone can't distinguish this from an empty-but-still-monitoring sync.
-        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = false) }
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = false, elapsedMillis = any()) }
     }
 
     @Test
@@ -534,7 +534,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         captured.captured.map { it.id } shouldBeEqualTo listOf(GeofenceConstants.MOVEMENT_TRIGGER_ID)
         verify { store.saveLastMovementTriggerLocation(GeofenceLocation(12.34, 56.78)) }
         verify(exactly = 0) { store.clearLastMovementTriggerLocation() }
-        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = true) }
+        verify { logger.logSyncSucceeded(0, movementTriggerRegistered = true, elapsedMillis = any()) }
     }
 
     @Test
@@ -884,7 +884,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         result.isSuccess shouldBeEqualTo true
         verify { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
         verify { distanceFilter.nearest(any(), 12.34, 56.78, 3, any()) }
-        verify { logger.logSyncSucceeded(filtered.size, movementTriggerRegistered = true) }
+        verify { logger.logSyncSucceeded(filtered.size, movementTriggerRegistered = true, elapsedMillis = any()) }
         // Store holds the IDs of exactly what was registered (movement trigger + business),
         // so the next refresh's stale-cleanup diff is accurate.
         verify { store.saveRegisteredIds(captured.captured.map { it.id }.toSet()) }
@@ -1189,7 +1189,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
             manager.replaceGeofences(any(), any())
             manager.removeGeofencesByIds(any())
         }
-        verify { logger.logSyncSucceeded(1, movementTriggerRegistered = true) }
+        // Two, not one: the stale fence whose removal failed is still monitored by the OS, and
+        // the count answers "what is actually monitored" rather than "what ranking selected".
+        verify { logger.logSyncSucceeded(2, movementTriggerRegistered = true, elapsedMillis = any()) }
         // Persisted set includes the unremoved stale ID — next refresh will retry it.
         persisted.captured shouldContainSame
             setOf(GeofenceConstants.MOVEMENT_TRIGGER_ID, "biz-new", "biz-old")
@@ -1320,7 +1322,7 @@ class GeofenceRepositoryTest : RobolectricTest() {
         coVerify(exactly = 0) { manager.removeGeofencesByIds(any()) }
         verify(exactly = 0) { store.saveRegisteredIds(any()) }
         verify(exactly = 0) { store.saveApiFetchStateIfCurrent(any(), any(), any()) }
-        verify(exactly = 0) { logger.logSyncSucceeded(any(), any()) }
+        verify(exactly = 0) { logger.logSyncSucceeded(any(), any(), any()) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -492,6 +492,8 @@ class GeofenceRepositoryTest : RobolectricTest() {
         verify { store.clearLastMovementTriggerLocation() }
         // Region count alone can't distinguish this from an empty-but-still-monitoring sync.
         verify { logger.logSyncSucceeded(0, movementTriggerRegistered = false, elapsedMillis = any()) }
+        // Nothing is monitoring, so claiming a registered movement trigger would be a false record.
+        verify(exactly = 0) { logger.logMovementTriggerRegistered(any(), any(), any()) }
     }
 
     @Test
@@ -1976,6 +1978,9 @@ class GeofenceRepositoryTest : RobolectricTest() {
 
         result.isSuccess shouldBeEqualTo true
         coVerify { manager.replaceGeofencesForBootRestore(any()) }
+        // This path bypasses refreshAction, so it emits the storage record itself. A boot restore
+        // is the case that record exists for and was the one pass that never produced it.
+        verify { logger.logStorageLoaded(any(), hasAnchor = true) }
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceTransitionEmitterTest.kt
@@ -112,6 +112,42 @@ class GeofenceTransitionEmitterTest : RobolectricTest() {
     }
 
     @Test
+    fun emit_givenPersistSucceeds_expectAcceptedLoggedWithFanoutCount() = runTest {
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
+        every { mockPendingStore.appendAll(any()) } returns true
+
+        emit(geosetIds = listOf("g1", "g2"))
+
+        // `n` is the per-geoset row count, so one crossing reads as one acceptance rather than
+        // being inferred from however many delivery records follow it.
+        verify(exactly = 1) { mockLogger.logTransitionAccepted("biz-1", "ENTER", 2) }
+    }
+
+    @Test
+    fun emit_givenPersistFails_expectNoAcceptedRecord() = runTest {
+        // The record sits below the durable write on purpose: logged above it, a crossing the
+        // write then failed to make would still read as accepted.
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns null
+        every { mockPendingStore.appendAll(any()) } returns false
+
+        emit()
+
+        verify(exactly = 0) { mockLogger.logTransitionAccepted(any(), any(), any()) }
+    }
+
+    @Test
+    fun emit_givenCooldownSuppresses_expectNoAcceptedRecord() = runTest {
+        // A suppressed crossing logs its own record and must not also claim acceptance, or it
+        // counts twice off-device.
+        every { mockCooldownFilter.suppressedForSeconds(any(), any(), any()) } returns 42.0
+
+        emit()
+
+        verify(exactly = 0) { mockLogger.logTransitionAccepted(any(), any(), any()) }
+        verify(exactly = 0) { mockPendingStore.appendAll(any()) }
+    }
+
+    @Test
     fun emit_givenBlankGeosetAlongsideReal_expectBlankDropped() = runTest {
         // A catalog row carrying "" would otherwise persist an entry with an empty geosetId and
         // report two events where iOS reports one, which reads as a platform difference that isn't.


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

## Stack

Bringing `main` into `feature/geofence-polygons`. The merge conflicts in 9 files because both sides rewrote the geofence delivery path, so main's content lands as reviewed PRs first. Correction, added after the merge: this did not shrink the merge (37 hunks became 44). What it bought is that every production conflict resolved to ours, and main's diagnostics arrived already reviewed instead of being ported inside an unreviewed conflict resolution.

- [#851 adopt main's geofence log diagnostics](https://github.com/customerio/customerio-android/pull/851)
- [#852 report the cooldown remainder instead of a boolean](https://github.com/customerio/customerio-android/pull/852)
- [#853 drop blank geoset ids from the transition fan-out](https://github.com/customerio/customerio-android/pull/853)
- 👉 **this PR** — port the remaining diagnostics
- then — `git merge origin/main`, pushed directly so git records the ancestry a squash would lose

## What this is

#851 brought in 14 log methods with no callers. This wires up the 12 that have a place here:

| Where | Records |
|---|---|
| `ModuleGeofence` | app-start entry point |
| `GeofenceBootReceiver` | boot-restore wake |
| `GeofenceBroadcastReceiver` | the OS callback, plus two unparseable-intent cases |
| `GeofenceRepository` | what storage held, what the API returned, how ranking resolved, what ended up registered |
| `GeofenceTransitionEmitter` | an accepted transition, below the durable write |

The receiver's record is placed before any routing decision and before the `Location` is narrowed to two doubles, since that is the only point where the OS's own triggering fix still exists.

## Two adaptations, not straight copies

**Edge distances.** main calls `edgeDistanceTo`, which this branch replaced with the nullable `edgeDistanceToOrNull` for polygons. A polygon whose ring never arrived now reports no distance, matching what ranking already does with it, rather than one derived from its coarse circle. The ring is re-derived rather than reused from ranking, which costs nothing unless diagnostics are enabled.

**API failures.** `logApiFetchFailed` replaces `logSyncFailed` on the fetch branch only. A response-mapping failure still reports as a sync failure, as it does here today.

## One behaviour change worth seeing

`logSyncSucceeded` now counts `idsToSave` minus the movement trigger, rather than `nearest`. When a stale fence's removal fails, the OS is still monitoring it, so it is included.

That flips one existing expectation from 1 to 2, in `refresh_givenAddSucceedsButStaleRemovalFails_expectUnremovedStalePreserved` — a test whose own comment already says the unremoved id is preserved and will be retried. The old number described what ranking selected; the new one describes what is actually monitored.

## Still without callers, deliberately

`logEventInvalidInput` and `logEventWorkerEntryMissing` describe a worker that looks up a single row by key. This branch drains the oldest row in a loop instead, so those paths do not exist here. `logReceiverSkipped` has no production caller on main either.

## Tests

1051 across geofence, core and messagingpush, 0 failures. `lintDebug` 0 issues, `apiCheck` and ktlint clean, no new compiler warnings.

Not exercised on a device.

