### PR TITLE
chore(geofence): drop a dead log method and align the test logger override

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -822,13 +822,13 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
-    fun logEventWorkerEntryMissing(key: String? = null) {
+    fun logEventWorkerEntryMissing() {
         logger.debug(
-            "Geofence event worker skipped: nothing left in the pending queue (already delivered via the analytics pipeline)" +
+            "Geofence event worker woke with nothing to send: an earlier node in the delivery chain drained the queue, or the foreground flush did" +
                 tail(
                     "delivery.sent",
                     GeofenceLogIo.OUTPUT,
-                    listOf("key" to key, "why" to "already_delivered")
+                    listOf("why" to "queue_empty")
                 ),
             tag = TAG
         )

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -983,10 +983,6 @@ internal class GeofenceLogger(private val logger: Logger) {
         logger.debug("Geofence '$geofenceId' transition dropped — registered but routing is not armed for this session; OS registration kept", tag = TAG)
     }
 
-    fun logTransitionEmitting(geofenceId: String, transitionName: String) {
-        logger.debug("Geofence '$geofenceId' $transitionName: queued for at-least-once delivery (WorkManager now, analytics pipeline on next foreground)", tag = TAG)
-    }
-
     fun logUnsupportedGeometryDropped(geofenceId: String, type: String) {
         logger.error(
             "Geofence '$geofenceId' dropped — unsupported geometry type='$type' (only Polygon is understood). Not degraded to a circle; check SDK / backend version alignment.",

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -822,9 +822,9 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
-    fun logEventWorkerEntryMissing(key: String) {
+    fun logEventWorkerEntryMissing(key: String? = null) {
         logger.debug(
-            "Geofence event worker skipped: no pending entry for '$key' (already delivered via the analytics pipeline)" +
+            "Geofence event worker skipped: nothing left in the pending queue (already delivered via the analytics pipeline)" +
                 tail(
                     "delivery.sent",
                     GeofenceLogIo.OUTPUT,

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -77,8 +77,16 @@ internal class GeofenceEventWorker(
         // Every node drains the oldest durable row, not the row that happened to schedule it. This
         // preserves transition order even after retries, foreground handoff, or process death.
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
+        var sawEntry = false
         while (true) {
-            val entry = store.loadAll().firstOrNull() ?: return Result.success()
+            val entry = store.loadAll().firstOrNull() ?: run {
+                // Only when the wake found nothing at all. Draining the queue empty is the normal
+                // success path, and recording that as an already-delivered skip would report a
+                // flush overtaking us on every successful delivery.
+                if (!sawEntry) logger.logEventWorkerEntryMissing()
+                return Result.success()
+            }
+            sawEntry = true
 
             // Shouldn't happen — the receiver drops anonymous transitions before persisting. It is
             // also unrecoverable: the userId was snapshotted at queue time and no later attempt can

--- a/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceBroadcastReceiverTest.kt
@@ -119,7 +119,7 @@ class GeofenceBroadcastReceiverTest : RobolectricTest() {
                     sdk {
                         overrideDependency<EventBus>(mockEventBus)
                         overrideDependency<Clock>(mockClock)
-                        overrideDependency<GeofenceLogger>(GeofenceLogger(capturingLogger))
+                        overrideDependency<Logger>(capturingLogger)
                     }
                     android {
                         overrideDependency<GeofenceEventScheduler>(mockScheduler)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -172,7 +172,7 @@ class GeofenceLogTailTest : RobolectricTest() {
             Row("deliveryDeferredAnonymous", "delivery.queued", listOf("id", "t", "why")) { it.logEventDeliveryDeferredAnonymous("notl_core", "ENTER") },
             Row("eventDelivered", "delivery.sent", listOf("id", "t", "via")) { it.logEventDelivered("notl_core", "ENTER") },
             Row("deliverySkippedAlreadyDelivered", "delivery.sent", listOf("id", "t", "why")) { it.logEventDeliverySkippedAlreadyDelivered("notl_core", "ENTER") },
-            Row("workerEntryMissing", "delivery.sent", listOf("key", "why")) { it.logEventWorkerEntryMissing("notl_core:ENTER") },
+            Row("workerEntryMissing", "delivery.sent", listOf("why")) { it.logEventWorkerEntryMissing() },
             Row("flushSnapshot", "delivery.flush", listOf("n", "phase")) { it.logForegroundFlushSnapshot(3) },
             Row("flushCancelled", "delivery.flush", listOf("id", "t", "why")) { it.logForegroundFlushCancelledWorkManager("notl_core", "ENTER") },
             Row("flushPublished", "delivery.sent", listOf("id", "t", "via")) { it.logForegroundFlushPublished("notl_core", "ENTER") },

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -177,21 +177,18 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
     }
 
-    // logEventDeliverySkippedAlreadyDelivered shares ev and why; only the per-row record carries id.
     private fun emptyQueueRecords(): List<String> =
-        capturing.messages.filter {
-            "ev=delivery.sent" in it && "why=already_delivered" in it && "id=" !in it
-        }
+        capturing.messages.filter { "ev=delivery.sent" in it && "why=queue_empty" in it }
 
     @Test
-    fun doWork_givenEmptyQueueOnWake_expectAlreadyDeliveredRecord() = runTest {
+    fun doWork_givenEmptyQueueOnWake_expectEmptyQueueRecord() = runTest {
         createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
 
         emptyQueueRecords().size shouldBeEqualTo 1
     }
 
     @Test
-    fun doWork_givenQueueDrainedSuccessfully_expectNoAlreadyDeliveredRecord() = runTest {
+    fun doWork_givenQueueDrainedSuccessfully_expectNoEmptyQueueRecord() = runTest {
         // The drain exits through the same empty-queue branch, so without the guard every
         // successful delivery would also report a flush that overtook it.
         seed("biz-1", Event.GeofenceTransition.ENTER)
@@ -202,6 +199,22 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         store.loadAll().isEmpty().shouldBeTrue()
         emptyQueueRecords().shouldBeEmpty()
+    }
+
+    @Test
+    fun doWork_givenSiblingNodeAlreadyDrainedTheChain_expectOneEmptyQueueRecord() = runTest {
+        // A geoset fan-out enqueues one node per row and the first drains them all, so the later
+        // nodes wake to an empty store. This is the common path, not the foreground flush.
+        seed("biz-1", Event.GeofenceTransition.ENTER, transitionId = "tid-fanout", geosetId = "geoset-a")
+        seed("biz-1", Event.GeofenceTransition.ENTER, transitionId = "tid-fanout", geosetId = "geoset-b")
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        coVerify(exactly = 2) { tracker.trackEvent(any()) }
+        emptyQueueRecords().size shouldBeEqualTo 1
+        capturing.messages.none { "ev=delivery.failed" in it }.shouldBeTrue()
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -26,6 +26,7 @@ import java.io.IOException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
@@ -174,6 +175,33 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
+    }
+
+    // logEventDeliverySkippedAlreadyDelivered shares ev and why; only the per-row record carries id.
+    private fun emptyQueueRecords(): List<String> =
+        capturing.messages.filter {
+            "ev=delivery.sent" in it && "why=already_delivered" in it && "id=" !in it
+        }
+
+    @Test
+    fun doWork_givenEmptyQueueOnWake_expectAlreadyDeliveredRecord() = runTest {
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        emptyQueueRecords().size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun doWork_givenQueueDrainedSuccessfully_expectNoAlreadyDeliveredRecord() = runTest {
+        // The drain exits through the same empty-queue branch, so without the guard every
+        // successful delivery would also report a flush that overtook it.
+        seed("biz-1", Event.GeofenceTransition.ENTER)
+        seed("biz-2", Event.GeofenceTransition.EXIT)
+        coEvery { tracker.trackEvent(any()) } returns Result.success(Unit)
+
+        createWorker(Data.EMPTY).doWork() shouldBeEqualTo ListenableWorker.Result.success()
+
+        store.loadAll().isEmpty().shouldBeTrue()
+        emptyQueueRecords().shouldBeEmpty()
     }
 
     @Test


### PR DESCRIPTION
Part of: [MBL-2288](https://linear.app/customerio/issue/MBL-2288/android-implement-wake-scoped-polygon-monitoring)

Post-merge cleanup after `main` landed on `feature/geofence-polygons` (71d3f314).

- `logTransitionEmitting` lost its only caller in #854 when the accepted record moved below the durable write. main never had the method, so the merge could not bring it back.
- The receiver test overrode `GeofenceLogger`; `Logger` is what main's version and the rest of the suite override, and it reaches the same singleton.
- Our worker drains the oldest row rather than a keyed one, so main's already-delivered record lost its call site and an empty-queue wake returned silently. Restored, emitted only when the wake found nothing: a full drain exits through the same branch.

Heads-up for reviewers: `why=queue_empty` is a new token. It does not exist on main or iOS. The old `already_delivered` named the foreground flush, but the common cause is a sibling node in the same chain — the emitter enqueues one node per entry and the worker drains every row, so a geoset fan-out has the first node deliver both.

1058 tests, ktlint, apiCheck and lint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
