### PR TITLE
chore(core): keep the pending delivery queue when one row or one read fails

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryClaim.kt
@@ -65,7 +65,7 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
         // A false claim is either another channel taking the entry (now gone) or the removing write
         // failing (still present). Only the former was delivered elsewhere; a still-present entry was
         // claimed by no one, so retry rather than reporting success.
-        return if (get(entry.key) == null) {
+        return if (contains(entry.key) == false) {
             PendingDeliveryResult.AlreadyClaimed
         } else {
             PendingDeliveryResult.Retryable(null)
@@ -109,7 +109,7 @@ suspend fun <T : PendingDeliveryStore.PendingDeliveryEntry> PendingDeliveryStore
     isRetryable: (Throwable?) -> Boolean = { it is IOException },
     send: suspend () -> Result<Unit>
 ): PendingDeliveryResult {
-    if (loadAll().none { it.key == entry.key }) return PendingDeliveryResult.AlreadyClaimed
+    if (contains(entry.key) == false) return PendingDeliveryResult.AlreadyClaimed
 
     val result = send()
     return when {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -10,6 +10,7 @@ import kotlin.concurrent.withLock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 
 /**
  * Disk-backed queue of entries waiting on confirmation that they reached the
@@ -31,15 +32,16 @@ import kotlinx.serialization.json.Json
  * the queue never grows without bound when the primary delivery path is
  * failing.
  *
- * Mutating operations skip the write when nothing actually changed, so a
- * transient read failure (a corrupted file, a brief IO error) cannot silently
- * wipe legitimate entries.
+ * A read that fails is reported as unreadable rather than empty, and every mutating operation
+ * declines to write over it, so a brief IO error cannot silently wipe legitimate entries. Rows that
+ * are readable but cannot be decoded are dropped individually and counted — one bad row costs its
+ * own delivery, not the whole queue.
  */
 @InternalCustomerIOApi
 class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     context: Context,
     fileName: String,
-    elementSerializer: KSerializer<T>,
+    private val elementSerializer: KSerializer<T>,
     private val logger: Logger,
     private val maxEntries: Int = DEFAULT_MAX_ENTRIES
 ) {
@@ -77,7 +79,9 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
             // A caller recovering a staged outbox attempt may append the same stable keys again.
             // Replace those rows atomically instead of duplicating one physical delivery.
             val incomingKeys = entries.mapTo(mutableSetOf(), PendingDeliveryEntry::key)
-            val all = readAll().filterNot { it.key in incomingKeys }.toMutableList()
+            // Entries we could not read are still on disk; writing without them discards them.
+            val current = readAll() ?: return@withLock false
+            val all = current.filterNot { it.key in incomingKeys }.toMutableList()
             all.addAll(entries)
             while (all.size > maxEntries) {
                 all.removeAt(0)
@@ -87,10 +91,18 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     }
 
     /** Returns all pending entries in insertion order. */
-    fun loadAll(): List<T> = lock.withLock { readAll() }
+    fun loadAll(): List<T> = lock.withLock { readAll().orEmpty() }
 
     /** Returns the entry whose [PendingDeliveryEntry.key] equals [key], or null if none is present. */
-    fun get(key: String): T? = lock.withLock { readAll().firstOrNull { it.key == key } }
+    fun get(key: String): T? = lock.withLock { readAll()?.firstOrNull { it.key == key } }
+
+    /**
+     * Whether [key] is present, or `null` when the queue could not be read so presence is unknown.
+     *
+     * A caller deciding whether another channel already delivered an entry must not read unknown as
+     * absent: that reports a delivery which never happened and drops the entry from consideration.
+     */
+    fun contains(key: String): Boolean? = lock.withLock { readAll()?.any { it.key == key } }
 
     /**
      * Remove the entry whose [PendingDeliveryEntry.key] equals [key]. No-op
@@ -104,7 +116,9 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      */
     fun remove(key: String): Boolean {
         return lock.withLock {
-            val entries = readAll()
+            // Unreadable is not absent: reporting removal would mark work done while the row
+            // is still on disk, waiting to be delivered again.
+            val entries = readAll() ?: return@withLock false
             val filtered = entries.filterNot { it.key == key }
             if (filtered.size == entries.size) return@withLock true
             writeAll(filtered)
@@ -126,7 +140,8 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
      * present for the other channel to claim.
      */
     fun claim(key: String): Boolean = lock.withLock {
-        val entries = readAll()
+        // A queue we cannot read yields no claim, leaving the entry for the other channel.
+        val entries = readAll() ?: return@withLock false
         val filtered = entries.filterNot { it.key == key }
         if (filtered.size == entries.size) return@withLock false
         writeAll(filtered)
@@ -141,7 +156,7 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
         if (keys.isEmpty()) return
         val keySet = keys.toSet()
         lock.withLock {
-            val entries = readAll()
+            val entries = readAll() ?: return@withLock
             val filtered = entries.filterNot { it.key in keySet }
             if (filtered.size == entries.size) return@withLock
             writeAll(filtered)
@@ -155,20 +170,55 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
         }
     }
 
-    private fun readAll(): List<T> {
+    /**
+     * Entries on disk, or `null` when the file is there but could not be read.
+     *
+     * Bytes we did read but cannot decode are the opposite case: those rows can never be delivered,
+     * and refusing to write would strand the queue behind them forever, so they are dropped.
+     */
+    private fun readAll(): List<T>? {
         if (!file.exists()) return emptyList()
-        return try {
-            val text = file.readText()
-            if (text.isBlank()) return emptyList()
-            Json.decodeFromString(listSerializer, text)
-        } catch (ex: Exception) {
+        val text = try {
+            file.readText()
+        } catch (ex: IOException) {
             logger.error(
-                "Failed to read pending delivery store ${file.name}; treating as empty",
+                "Could not read pending delivery store ${file.name}; leaving it untouched",
                 tag = TAG,
                 throwable = ex
             )
-            emptyList()
+            return null
         }
+        if (text.isBlank()) return emptyList()
+
+        val rows = try {
+            Json.parseToJsonElement(text).jsonArray
+        } catch (ex: Exception) {
+            // Readable bytes that are not a JSON array at all. Nothing here is recoverable, and
+            // reporting it unreadable would refuse every future write, so give up the contents.
+            logger.error(
+                "Pending delivery store ${file.name} is not a readable queue; dropping its contents",
+                tag = TAG,
+                throwable = ex
+            )
+            return emptyList()
+        }
+
+        var dropped = 0
+        val entries = rows.mapNotNull { row ->
+            try {
+                Json.decodeFromJsonElement(elementSerializer, row)
+            } catch (_: Exception) {
+                dropped++
+                null
+            }
+        }
+        if (dropped > 0) {
+            logger.error(
+                "Dropped $dropped undecodable row(s) from pending delivery store ${file.name}; kept ${entries.size}",
+                tag = TAG
+            )
+        }
+        return entries
     }
 
     private fun writeAll(entries: List<T>): Boolean {

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -180,7 +180,9 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
         if (!file.exists()) return emptyList()
         val text = try {
             file.readText()
-        } catch (ex: IOException) {
+        } catch (ex: Exception) {
+            // Anything that stops us reading means unreadable, not empty. Kept broad because this
+            // never threw before, and a throw here reaches a WorkManager node with no catch.
             logger.error(
                 "Could not read pending delivery store ${file.name}; leaving it untouched",
                 tag = TAG,

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -3,11 +3,13 @@ package io.customer.sdk.data.store
 import io.customer.commontest.core.RobolectricTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.mockk
+import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,15 +18,25 @@ import org.robolectric.RobolectricTestRunner
 class PendingDeliveryClaimTest : RobolectricTest() {
 
     private val mockLogger: Logger = mockk(relaxed = true)
+    private val fileName = "cio_test_claim_send_restore.json"
 
     @Serializable
     private data class TestEntry(val id: String) : PendingDeliveryStore.PendingDeliveryEntry {
         override val key: String get() = id
     }
 
+    private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
+
+    // A test that leaves a directory in the file's place makes every later test in the class fail,
+    // since the store cannot rename over it. One failure should stay one failure.
+    @After
+    fun clearStoreFile() {
+        storeFile().deleteRecursively()
+    }
+
     private fun newStore() = PendingDeliveryStore(
         context = contextMock,
-        fileName = "cio_test_claim_send_restore.json",
+        fileName = fileName,
         elementSerializer = TestEntry.serializer(),
         logger = mockLogger
     ).also { it.removeAll() }
@@ -34,9 +46,8 @@ class PendingDeliveryClaimTest : RobolectricTest() {
         // Exactly-once has no dedup id behind it, so reporting a delivery that never happened
         // loses the entry outright. Unknown presence must defer, never claim success.
         val store = newStore()
-        val file = java.io.File(contextMock.applicationContext.filesDir, "cio_test_claim_send_restore.json")
-        file.delete()
-        file.mkdirs()
+        storeFile().delete()
+        storeFile().mkdirs()
         var sendInvoked = false
 
         val result = store.claimSendRestore(TestEntry("unknown")) {
@@ -46,7 +57,6 @@ class PendingDeliveryClaimTest : RobolectricTest() {
 
         result.shouldBeInstanceOf<PendingDeliveryResult.Retryable>()
         sendInvoked shouldBeEqualTo false
-        file.deleteRecursively()
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryClaimTest.kt
@@ -30,6 +30,26 @@ class PendingDeliveryClaimTest : RobolectricTest() {
     ).also { it.removeAll() }
 
     @Test
+    fun claimSendRestore_givenUnreadableStore_expectRetryableNotAlreadyClaimed() = runBlocking<Unit> {
+        // Exactly-once has no dedup id behind it, so reporting a delivery that never happened
+        // loses the entry outright. Unknown presence must defer, never claim success.
+        val store = newStore()
+        val file = java.io.File(contextMock.applicationContext.filesDir, "cio_test_claim_send_restore.json")
+        file.delete()
+        file.mkdirs()
+        var sendInvoked = false
+
+        val result = store.claimSendRestore(TestEntry("unknown")) {
+            sendInvoked = true
+            Result.success(Unit)
+        }
+
+        result.shouldBeInstanceOf<PendingDeliveryResult.Retryable>()
+        sendInvoked shouldBeEqualTo false
+        file.deleteRecursively()
+    }
+
+    @Test
     fun claimSendRestore_givenEntryNotPresent_expectAlreadyClaimedAndSendNotInvoked() = runBlocking<Unit> {
         val store = newStore()
         val entry = TestEntry("absent")

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -3,6 +3,7 @@ package io.customer.sdk.data.store
 import io.customer.commontest.core.RobolectricTest
 import io.customer.sdk.core.util.Logger
 import io.mockk.mockk
+import io.mockk.verify
 import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -386,6 +387,80 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         store.removeAll(listOf("a", "b"))
 
         storeFile().readText() shouldBeEqualTo corrupted
+    }
+
+    @Test
+    fun loadAll_givenOneUndecodableRow_expectTheOthersSurvive() {
+        val store = newStore()
+        storeFile().writeText(
+            """[{"id":"a","payload":"p-a"},{"unexpected":true},{"id":"c","payload":"p-c"}]"""
+        )
+
+        store.loadAll().map { it.id } shouldBeEqualTo listOf("a", "c")
+    }
+
+    @Test
+    fun append_givenOneUndecodableRow_expectTheOthersKept() {
+        // The whole point: a single bad row used to make the next append rewrite the file
+        // without any of the rows that were still queued behind it.
+        val store = newStore()
+        storeFile().writeText(
+            """[{"id":"a","payload":"p-a"},{"unexpected":true},{"id":"c","payload":"p-c"}]"""
+        )
+
+        store.append(entry("d")).shouldBeTrue()
+
+        store.loadAll().map { it.id } shouldBeEqualTo listOf("a", "c", "d")
+    }
+
+    @Test
+    fun append_givenUnreadableFile_expectRefusedAndNothingWritten() {
+        val store = newStore()
+        store.append(entry("queued")).shouldBeTrue()
+        // A directory in the file's place fails the read the way an IO error would, without
+        // depending on filesystem permissions that vary by machine.
+        storeFile().delete()
+        storeFile().mkdirs()
+
+        store.append(entry("new")) shouldBeEqualTo false
+
+        storeFile().isDirectory.shouldBeTrue()
+        // The refusal has to happen before the write is attempted. Asserting only on the false
+        // return would pass without it too, since renaming over a directory fails anyway — so
+        // assert the write was never tried.
+        verify(exactly = 0) {
+            mockLogger.error(match { it.contains("Failed to write") }, any(), any())
+        }
+    }
+
+    @Test
+    fun remove_givenUnreadableFile_expectNotReportedAsRemoved() {
+        // Reporting true here tells a caller its delivery is done while the row is still on disk.
+        val store = newStore()
+        storeFile().delete()
+        storeFile().mkdirs()
+
+        store.remove("any-id") shouldBeEqualTo false
+    }
+
+    @Test
+    fun contains_givenUnreadableFile_expectUnknownRatherThanAbsent() {
+        // A claim helper reads absent as "another channel delivered it", so unknown must not
+        // collapse to absent — that reports a delivery that never happened.
+        val store = newStore()
+        storeFile().delete()
+        storeFile().mkdirs()
+
+        store.contains("any-id") shouldBeEqualTo null
+    }
+
+    @Test
+    fun contains_givenReadableFile_expectPresenceReported() {
+        val store = newStore()
+        store.append(entry("here"))
+
+        store.contains("here") shouldBeEqualTo true
+        store.contains("absent") shouldBeEqualTo false
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -444,6 +444,17 @@ class PendingDeliveryStoreTest : RobolectricTest() {
     }
 
     @Test
+    fun claim_givenUnreadableFile_expectNotClaimed() {
+        // A claim that succeeds without removing the row lets a second channel claim it too, and
+        // push metrics carry no dedup id, so that double-counts.
+        val store = newStore()
+        storeFile().delete()
+        storeFile().mkdirs()
+
+        store.claim("any-id") shouldBeEqualTo false
+    }
+
+    @Test
     fun contains_givenUnreadableFile_expectUnknownRatherThanAbsent() {
         // A claim helper reads absent as "another channel delivered it", so unknown must not
         // collapse to absent — that reports a delivery that never happened.

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -12,6 +12,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBe
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -43,6 +44,13 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         ).also { it.removeAll() }
 
     private fun storeFile(): File = File(contextMock.applicationContext.filesDir, fileName)
+
+    // Several tests put a directory in the file's place. Without this the next test in the class
+    // fails too, since the store cannot rename over it.
+    @After
+    fun clearStoreFile() {
+        storeFile().deleteRecursively()
+    }
 
     @Test
     fun append_givenSingleEntry_expectLoadAllReturnsIt() {

--- a/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/AsyncGeofenceEventTrackerTest.kt
@@ -46,7 +46,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     @Test
     fun trackEvent_givenPendingEntryAndSuccess_expectSentThenRemoved() = runTest {
         val entry = PendingGeofenceDelivery("biz-1", Event.GeofenceTransition.ENTER, 42L, "user-42", transitionId = "tid-1")
-        every { mockStore.loadAll() } returns listOf(entry)
+        every { mockStore.contains("biz-1_ENTER_tid-1_none") } returns true
         coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
 
         asyncTracker.trackEvent(entry)
@@ -59,7 +59,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     @Test
     fun trackEvent_givenEntryAlreadyDelivered_expectNoSend() = runTest {
         // Foreground flush already delivered + removed this entry: do not re-send.
-        every { mockStore.loadAll() } returns emptyList()
+        every { mockStore.contains(any()) } returns false
         val entry = PendingGeofenceDelivery("biz-3", Event.GeofenceTransition.ENTER, 7L, "user-42", transitionId = "tid-3")
 
         asyncTracker.trackEvent(entry)
@@ -69,11 +69,24 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     }
 
     @Test
+    fun trackEvent_givenPresenceUnknown_expectSentRatherThanAssumedDelivered() = runTest {
+        // An unreadable queue is not proof the entry was delivered elsewhere. Delivery is
+        // at-least-once and deduped backend-side, so sending is the safe direction.
+        val entry = PendingGeofenceDelivery("biz-6", Event.GeofenceTransition.ENTER, 13L, "user-42", transitionId = "tid-6")
+        every { mockStore.contains(any()) } returns null
+        coEvery { mockTracker.trackEvent(any()) } returns Result.success(Unit)
+
+        asyncTracker.trackEvent(entry)
+
+        coVerify(exactly = 1) { mockTracker.trackEvent(entry) }
+    }
+
+    @Test
     fun trackEvent_givenStoreThrows_expectLoggedNotCrashed() = runTest {
         // The fire-and-forget scope has no exception handler — an escaping throw
         // would crash the host. The entry stays in store for the foreground flush.
         val entry = PendingGeofenceDelivery("biz-5", Event.GeofenceTransition.ENTER, 11L, "user-42", transitionId = "tid-5")
-        every { mockStore.loadAll() } throws IllegalStateException("corrupt store")
+        every { mockStore.contains(any()) } throws IllegalStateException("corrupt store")
 
         asyncTracker.trackEvent(entry)
 
@@ -84,7 +97,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
     @Test
     fun trackEvent_givenFailure_expectEntryKeptForFlush() = runTest {
         val entry = PendingGeofenceDelivery("biz-4", Event.GeofenceTransition.ENTER, 9L, "user-42", transitionId = "tid-4")
-        every { mockStore.loadAll() } returns listOf(entry)
+        every { mockStore.contains("biz-4_ENTER_tid-4_none") } returns true
         coEvery { mockTracker.trackEvent(any()) } returns
             Result.failure(IOException("network down"))
 
@@ -102,7 +115,7 @@ class AsyncGeofenceEventTrackerTest : RobolectricTest() {
 
         asyncTracker.trackEvent(entry)
 
-        verify(exactly = 0) { mockStore.loadAll() }
+        verify(exactly = 0) { mockStore.contains(any()) }
         coVerify(exactly = 0) { mockTracker.trackEvent(any()) }
         verify { mockLogger.logEventDeliveryDeferredAnonymous("biz-anon", "ENTER") }
     }


### PR DESCRIPTION
Part of: [MBL-2413](https://linear.app/customerio/issue/MBL-2413/mobile-make-pending-geofence-delivery-resilient-to-corrupt-rows)

`readAll` decoded the file as one list, so a single undecodable row was caught as "treating as empty" and the next `append` rewrote the file without the rows still queued. Rows now decode individually and a bad one is dropped and counted.

A failed read reports unreadable rather than empty, and no mutating operation writes over it. `remove` and `claim` used to return success after such a read, marking a delivery done while its row was still on disk. `contains()` replaces the presence checks in the claim helpers, which had the same conflation.

Pre-existing since #715 and present on main, so messagingpush is exposed the same way via `PendingPushDeliveryMetric`.

Residual: a file that is not valid JSON at all still drops everything, which needs filesystem corruption given the atomic rename. The geofence worker still maps unreadable to empty at its own `loadAll`, so it reports `queue_empty` there — a null-aware `loadAll` is a follow-up.

2043 tests across all modules, ktlint, apiCheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

