### PR TITLE
chore(geofence): catalogue a polygon as a polygon

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
@@ -69,7 +69,7 @@ internal object GeofenceLogTail {
      * The only values that compose the format's separators on purpose. Everything else is treated
      * as an untrusted token: geofence identifiers are workspace-authored and can hold anything.
      */
-    private val COMPOSED_KEYS = setOf("ranked", "evicted", "ids", "gs", "tt")
+    private val COMPOSED_KEYS = setOf("ranked", "evicted", "ids", "gs", "tt", "ring")
 
     /**
      * Applied to every finished value. Only whitespace, which is what separates one `key=value`

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -7,6 +7,7 @@ import io.customer.geofence.GeofenceLogTail.int
 import io.customer.geofence.GeofenceLogTail.list
 import io.customer.geofence.GeofenceLogTail.num
 import io.customer.geofence.GeofenceLogTail.token
+import io.customer.geofence.polygon.PolygonCoordinate
 import io.customer.sdk.core.util.Logger
 
 /**
@@ -650,9 +651,17 @@ internal class GeofenceLogger(private val logger: Logger) {
                             // spaces, commas and `=`, all of which would break the parser's split.
                             "name" to region.name,
                             "gs" to composedList(region.geosetIds),
+                            // Without this a polygon reads as an ordinary circle, and a replay
+                            // places the trigger circle as though it were the fence.
+                            "sh" to if (region.isPolygon) "polygon" else "circle",
                             "lat" to num(region.latitude, 5),
                             "lon" to num(region.longitude, 5),
-                            "rad" to num(region.radius, 0),
+                            // The backend's circle, not the radius we register: a polygon's
+                            // registered radius carries our platform margin, which would read as a
+                            // cross-platform discrepancy that is only padding.
+                            "rad" to num(region.baseRadiusMeters ?: region.radius.toDouble(), 0),
+                            "nv" to int(region.polygonVertices?.size),
+                            "ring" to region.polygonVertices?.let(::ringPairs)?.let(::composedList),
                             "tt" to composedList(region.transitionTypes.map { it.name.lowercase() })
                         )
                     ),
@@ -660,6 +669,20 @@ internal class GeofenceLogger(private val logger: Logger) {
             )
         }
     }
+
+    /**
+     * Outer ring as `lat_lon` pairs in the SDK's order, not the wire's GeoJSON order.
+     *
+     * Capped like any list, so `nv` is the authoritative count and a consumer finding fewer pairs
+     * than vertices must refuse rather than use what it got: a truncated ring is still a
+     * valid-looking polygon, so it answers a membership question confidently and wrongly.
+     */
+    private fun ringPairs(vertices: List<PolygonCoordinate>): List<String> =
+        vertices.mapNotNull { vertex ->
+            val lat = num(vertex.latitude, 5) ?: return@mapNotNull null
+            val lon = num(vertex.longitude, 5) ?: return@mapNotNull null
+            "${lat}_$lon"
+        }
 
     fun logApiFetchFailed(message: String?) {
         logger.error(

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -627,7 +627,7 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     /**
-     * One record per fetched fence, describing the circle the server sent.
+     * One record per fetched fence, describing the shape the server sent.
      *
      * Without this a capture names fences only by opaque id: a replay cannot place them, and nobody
      * reading the log can tell which geoset a crossing belonged to. Re-fetching the geometry from
@@ -659,7 +659,14 @@ internal class GeofenceLogger(private val logger: Logger) {
                             // The backend's circle, not the radius we register: a polygon's
                             // registered radius carries our platform margin, which would read as a
                             // cross-platform discrepancy that is only padding.
-                            "rad" to num(region.baseRadiusMeters ?: region.radius.toDouble(), 0),
+                            // A polygon reports the backend's circle, never the one we register:
+                            // that carries our platform margin and would overstate the fence by a
+                            // kilometre. Absent rather than substituted, so a polygon that somehow
+                            // reaches here without one omits the field instead of lying about it.
+                            "rad" to num(
+                                if (region.isPolygon) region.baseRadiusMeters else region.radius.toDouble(),
+                                0
+                            ),
                             "nv" to int(region.polygonVertices?.size),
                             "ring" to region.polygonVertices?.let(::ringPairs)?.let(::composedList),
                             "tt" to composedList(region.transitionTypes.map { it.name.lowercase() })

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -684,6 +684,21 @@ class GeofenceLogTailTest : RobolectricTest() {
     }
 
     @Test
+    fun fenceCatalog_givenPolygonWithoutBackendRadius_expectRadOmittedNotPadded() {
+        // The mapper drops such a polygon today, so this pins the direction of the failure if that
+        // ever changes: absent is recoverable, the padded radius is the bug this record had.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        val region = polygonCatalogRegion().copy(baseRadiusMeters = null)
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(region))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["sh"] shouldBeEqualTo "polygon"
+        fields["rad"].shouldBeNull()
+    }
+
+    @Test
     fun fenceCatalog_givenCircle_expectShapeCircleAndNoRing() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -4,6 +4,7 @@ import android.location.Location
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.polygon.PolygonCoordinate
 import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.core.util.Logger
 import org.amshove.kluent.shouldBeEqualTo
@@ -585,6 +586,23 @@ class GeofenceLogTailTest : RobolectricTest() {
         regionCountCalls shouldBeEqualTo 1
     }
 
+    private fun polygonCatalogRegion(
+        vertexCount: Int = 4,
+        baseRadiusMeters: Double = 900.0
+    ) = GeofenceRegion(
+        id = "poly-1",
+        latitude = 25.109908,
+        longitude = 55.184004,
+        // What GMS registers: the backend circle plus our platform margin.
+        radius = (baseRadiusMeters + 1_000.0).toFloat(),
+        name = "Polygon Fence",
+        geosetIds = listOf("4471"),
+        polygonVertices = List(vertexCount) { index ->
+            PolygonCoordinate(25.10 + index / 10_000.0, 55.18 + index / 10_000.0)
+        },
+        baseRadiusMeters = baseRadiusMeters
+    )
+
     private fun catalogRegion(
         id: String = "11125",
         name: String? = "Momo Dubai Test"
@@ -634,9 +652,63 @@ class GeofenceLogTailTest : RobolectricTest() {
         fields.shouldNotBeNull()
         fields["ev"] shouldBeEqualTo "fence.cataloged"
         fields["io"] shouldBeEqualTo "in"
-        for (key in listOf("id", "name", "gs", "lat", "lon", "rad", "tt")) {
+        for (key in listOf("id", "name", "gs", "sh", "lat", "lon", "rad", "tt")) {
             if (fields[key] == null) throw AssertionError("missing $key= in '$message'")
         }
+    }
+
+    @Test
+    fun fenceCatalog_givenPolygon_expectShapeVertexCountAndRing() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(vertexCount = 4)))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["sh"] shouldBeEqualTo "polygon"
+        fields["nv"] shouldBeEqualTo "4"
+        // lat_lon pairs in SDK order, comma separated, commas intact.
+        fields["ring"]?.split(",")?.size shouldBeEqualTo 4
+        fields["ring"]?.startsWith("25.10000_55.18000") shouldBeEqualTo true
+    }
+
+    @Test
+    fun fenceCatalog_givenPolygon_expectBackendRadiusNotTheRegisteredOne() {
+        // The registered radius carries our platform margin. Emitting it would read as a
+        // cross-platform discrepancy that is only padding, and overstates the fence by a kilometre.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(baseRadiusMeters = 900.0)))
+
+        parseTail(logger.messages.last())?.get("rad") shouldBeEqualTo "900"
+    }
+
+    @Test
+    fun fenceCatalog_givenCircle_expectShapeCircleAndNoRing() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["sh"] shouldBeEqualTo "circle"
+        fields["nv"].shouldBeNull()
+        fields["ring"].shouldBeNull()
+        fields["rad"] shouldBeEqualTo "150"
+    }
+
+    @Test
+    fun fenceCatalog_givenRingLongerThanTheCap_expectCountStaysAuthoritative() {
+        // A truncated ring still looks like a valid polygon, so the count is what lets a consumer
+        // notice and refuse instead of computing membership against part of the shape.
+        GeofenceDiagnostics.setEnabledForTesting(true)
+        val logger = CapturingLogger()
+        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(vertexCount = 30)))
+
+        val fields = parseTail(logger.messages.last())
+        fields.shouldNotBeNull()
+        fields["nv"] shouldBeEqualTo "30"
+        fields["ring"]?.endsWith(",+5") shouldBeEqualTo true
     }
 
     @Test


### PR DESCRIPTION
Part of: [MBL-2418](https://linear.app/customerio/issue/MBL-2418/mobile-add-structured-diagnostics-for-polygon-geofences)

## Stack
- 👉 [#857 catalogue a polygon as a polygon](https://github.com/customerio/customerio-android/pull/857)
- [#858 give the polygon records a machine-readable tail](https://github.com/customerio/customerio-android/pull/858)
- [#859 catalogue a fence before it can be dropped](https://github.com/customerio/customerio-android/pull/859)

The fence catalog emitted `lat`/`lon`/`rad` straight off the region. For a polygon those describe the registered trigger circle, and that radius is the backend's enclosing circle plus our 1000m platform margin — so every polygon catalogued as a placeable circle a kilometre too big, with nothing marking it as not the fence. A replay placed it and got a confident wrong region rather than a visible gap.

`sh` names the shape, `nv` and `ring` carry the geometry, and `rad` now reports the backend's radius so the field means the same thing on both platforms. A polygon with no backend radius omits `rad` rather than substituting the padded one.

`ring` joins the composed keys: sanitizing folds its commas and runs every coordinate into one token that parses as garbage instead of failing.

`nv` counts the canonical ring — duplicates collapsed, closing vertex dropped — matching what membership is computed against, and stays authoritative against the 25-entry cap so a consumer can detect truncation and refuse.

Field names and semantics agreed with iOS (#1263).

2039 tests across all modules, ktlint, apiCheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



