### PR TITLE
chore(geofence): catalogue a fence before it can be dropped

### DIFF
--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceCatalogEntry.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceCatalogEntry.kt
@@ -1,0 +1,26 @@
+package io.customer.geofence
+
+import io.customer.geofence.polygon.PolygonCoordinate
+
+/**
+ * One fetched record as the server described it, built before validation decides whether it can be
+ * monitored.
+ *
+ * Deliberately not the mapped region: a malformed record is the one a capture most needs named, and
+ * it never becomes a region. Fields are nullable because this is the wire's account of a fence
+ * rather than a usable one, so a row carries whatever survived and omits the rest.
+ */
+internal data class GeofenceCatalogEntry(
+    val id: String,
+    val name: String?,
+    val geosetIds: List<String>,
+    /** The shape the server claimed, which for an unsupported value is that value verbatim. */
+    val shape: String,
+    val latitude: Double?,
+    val longitude: Double?,
+    /** The backend's own radius — for a polygon its enclosing circle, never the padded one. */
+    val radiusMeters: Double?,
+    /** Canonical ring, or null when the ring does not build; absent beats a ring we cannot trust. */
+    val vertices: List<PolygonCoordinate>?,
+    val transitionTypes: List<String>
+)

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -651,10 +651,15 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     /** Outcome of a nearby-geofence fetch. An **input**: replay feeds the response back. */
+    /**
+     * [catalog] is a lambda for the same reason [logRankEvaluated]'s lists are: building it decodes
+     * and validates every polygon ring a second time, on a background fetch path, and none of that
+     * is wanted unless the rows will actually be written.
+     */
     fun logApiFetchResult(
         returnedCount: Int,
         elapsedMillis: Long?,
-        regions: List<GeofenceRegion> = emptyList()
+        catalog: () -> List<GeofenceCatalogEntry> = { emptyList() }
     ) {
         logger.debug(
             "Fetched $returnedCount nearby geofence(s) from the server" +
@@ -669,11 +674,13 @@ internal class GeofenceLogger(private val logger: Logger) {
                 ),
             tag = TAG
         )
-        logFenceCatalog(regions)
+        logFenceCatalog(catalog)
     }
 
     /**
      * One record per fetched fence, describing the shape the server sent.
+     *
+     * Built from the wire before validation runs, so a record the mapper drops still earns a row.
      *
      * Without this a capture names fences only by opaque id: a replay cannot place them, and nobody
      * reading the log can tell which geoset a crossing belonged to. Re-fetching the geometry from
@@ -683,39 +690,35 @@ internal class GeofenceLogger(private val logger: Logger) {
      * Gated whole rather than relying on `tail()` returning empty, because these records carry no
      * prose worth emitting on their own — with diagnostics off they should not exist at all.
      */
-    private fun logFenceCatalog(regions: List<GeofenceRegion>) {
-        if (regions.isEmpty() || !GeofenceDiagnostics.isEnabled) return
-        for (region in regions) {
+    private fun logFenceCatalog(catalog: () -> List<GeofenceCatalogEntry>) {
+        if (!GeofenceDiagnostics.isEnabled) return
+        val entries = catalog()
+        if (entries.isEmpty()) return
+        for (entry in entries) {
             logger.debug(
-                "Geofence '${region.id}' catalogued" +
+                "Geofence '${entry.id}' catalogued" +
                     tail(
                         "fence.cataloged",
                         GeofenceLogIo.INPUT,
                         listOf(
-                            "id" to region.id,
+                            "id" to entry.id,
                             // Sanitized like any other value: a workspace-authored name can contain
                             // spaces, commas and `=`, all of which would break the parser's split.
-                            "name" to region.name,
-                            "gs" to composedList(region.geosetIds),
+                            "name" to entry.name,
+                            "gs" to composedList(entry.geosetIds),
                             // Without this a polygon reads as an ordinary circle, and a replay
                             // places the trigger circle as though it were the fence.
-                            "sh" to if (region.isPolygon) "polygon" else "circle",
-                            "lat" to num(region.latitude, 5),
-                            "lon" to num(region.longitude, 5),
-                            // The backend's circle, not the radius we register: a polygon's
-                            // registered radius carries our platform margin, which would read as a
-                            // cross-platform discrepancy that is only padding.
+                            "sh" to entry.shape,
+                            "lat" to num(entry.latitude, 5),
+                            "lon" to num(entry.longitude, 5),
                             // A polygon reports the backend's circle, never the one we register:
                             // that carries our platform margin and would overstate the fence by a
                             // kilometre. Absent rather than substituted, so a polygon that somehow
                             // reaches here without one omits the field instead of lying about it.
-                            "rad" to num(
-                                if (region.isPolygon) region.baseRadiusMeters else region.radius.toDouble(),
-                                0
-                            ),
-                            "nv" to int(region.polygonVertices?.size),
-                            "ring" to region.polygonVertices?.let(::ringPairs)?.let(::composedList),
-                            "tt" to composedList(region.transitionTypes.map { it.name.lowercase() })
+                            "rad" to num(entry.radiusMeters, 0),
+                            "nv" to int(entry.vertices?.size),
+                            "ring" to entry.vertices?.let(::ringPairs)?.let(::composedList),
+                            "tt" to composedList(entry.transitionTypes)
                         )
                     ),
                 tag = TAG

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceRepository.kt
@@ -3,6 +3,7 @@ package io.customer.geofence
 import android.Manifest
 import androidx.annotation.RequiresPermission
 import io.customer.geofence.api.GeofenceApiService
+import io.customer.geofence.api.toCatalogEntries
 import io.customer.geofence.api.toDomainConfig
 import io.customer.geofence.api.toDomainRegions
 import io.customer.geofence.store.GeofenceRegionStore
@@ -405,6 +406,14 @@ internal class GeofenceRepositoryImpl(
         val fetchElapsedMillis = clock.elapsedRealtime() - fetchStartedAt
         return fetchResult.fold(
             onSuccess = { response ->
+                // Before mapping: a dropped record still gets catalogued, and a response where
+                // every record drops is still described rather than lost with the failure. The
+                // count is off the wire, so the gap against what survived the cap stays visible.
+                logger.logApiFetchResult(
+                    returnedCount = response.geofences.size,
+                    elapsedMillis = fetchElapsedMillis,
+                    catalog = { response.toCatalogEntries() }
+                )
                 // An unusable response throws (see toDomainRegions) — fail the refresh and
                 // keep current registrations; never let it escape the handler-less scope.
                 val mapped = runCatching {
@@ -414,13 +423,6 @@ internal class GeofenceRepositoryImpl(
                     return@fold Result.failure(e)
                 }
                 val (regions, parsedConfig) = mapped
-                // The count off the wire, before local ranking. The gap between what the server
-                // offered and what survived the cap is the thing worth being able to see.
-                logger.logApiFetchResult(
-                    returnedCount = response.geofences.size,
-                    elapsedMillis = fetchElapsedMillis,
-                    regions = regions
-                )
                 // Config preference: server-shipped > last cached > constants.
                 val config = parsedConfig ?: store.getCachedConfigOrFallback()
                 registerNearestAndPersist(

--- a/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/api/GeofenceApiResponse.kt
@@ -1,5 +1,6 @@
 package io.customer.geofence.api
 
+import io.customer.geofence.GeofenceCatalogEntry
 import io.customer.geofence.GeofenceConfig
 import io.customer.geofence.GeofenceConstants
 import io.customer.geofence.GeofenceRegion
@@ -317,6 +318,36 @@ private fun GeofenceApiRegion.toPolygonRegionOrNull(
     )
 }
 
+/**
+ * Every fetched record, described as the server sent it and before any of them are dropped.
+ *
+ * Deliberately validation-free: the only thing resolved here is the ring, because a ring that does
+ * not build cannot be reported as vertices. Everything else is passed through, so a record the
+ * mapper rejects still produces a catalog row naming the shape it claimed.
+ */
+internal fun GeofenceApiResponse.toCatalogEntries(): List<GeofenceCatalogEntry> =
+    geofences.map { region -> region.toCatalogEntry() }
+
+private fun GeofenceApiRegion.toCatalogEntry(): GeofenceCatalogEntry {
+    val claimedShape = shape?.trim()?.lowercase()?.takeIf(String::isNotEmpty)
+    val isPolygonRecord = claimedShape == POLYGON_SHAPE
+    return GeofenceCatalogEntry(
+        id = id,
+        name = name,
+        geosetIds = geosetIds,
+        // An absent discriminator reads as a circle here for the same reason the mapper reads it
+        // that way, so a legacy response still catalogs as the circle it is.
+        shape = claimedShape ?: CIRCLE_SHAPE,
+        // A polygon's placeable centre is its enclosing circle, never the flat fields: a record
+        // carrying both means them for different shapes.
+        latitude = if (isPolygonRecord) enclosingCircle?.latitude else latitude,
+        longitude = if (isPolygonRecord) enclosingCircle?.longitude else longitude,
+        radiusMeters = if (isPolygonRecord) enclosingCircle?.baseRadiusMeters else radius,
+        vertices = geometry?.toPolygonGeometryOrNull()?.vertices,
+        transitionTypes = transitionTypesOrDefaults(transitionTypes).map { it.name.lowercase() }
+    )
+}
+
 private val GeofenceApiGeometry.isPolygonType: Boolean
     get() = type.equals(POLYGON_GEOMETRY_TYPE, ignoreCase = true)
 
@@ -384,15 +415,20 @@ private fun sanitizeMetadata(raw: JsonElement?): Map<String, JsonElement> {
  * valid + unknown keeps just the valid subset. Each unknown value is logged.
  */
 private fun resolveTransitionTypes(raw: List<String>?): List<GeofenceTransitionType> {
+    raw?.forEach { value ->
+        if (parseTransitionType(value) == null) SDKComponent.geofenceLogger.logUnknownApiTransitionType(value)
+    }
+    return transitionTypesOrDefaults(raw)
+}
+
+/**
+ * The resolution without the reporting, so the catalog can name the same transition types the
+ * mapper will without emitting a second `api.transition.unknown` for every unknown value.
+ */
+private fun transitionTypesOrDefaults(raw: List<String>?): List<GeofenceTransitionType> {
     val defaults = listOf(GeofenceTransitionType.ENTER, GeofenceTransitionType.EXIT)
     if (raw.isNullOrEmpty()) return defaults
-    val parsed = raw.mapNotNull { value ->
-        parseTransitionType(value) ?: run {
-            SDKComponent.geofenceLogger.logUnknownApiTransitionType(value)
-            null
-        }
-    }
-    return parsed.takeIf { it.isNotEmpty() } ?: defaults
+    return raw.mapNotNull(::parseTransitionType).takeIf { it.isNotEmpty() } ?: defaults
 }
 
 private fun parseTransitionType(value: String): GeofenceTransitionType? =

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -694,6 +694,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         var evictedCalls = 0
         var distanceCalls = 0
         var regionCountCalls = 0
+        var catalogCalls = 0
 
         subject.logRankEvaluated(
             candidates = 50,
@@ -703,11 +704,15 @@ class GeofenceLogTailTest : RobolectricTest() {
             edgeDistances = { distanceCalls++; mapOf("alpha" to 120.0) }
         )
         subject.logStorageLoaded(regionCount = { regionCountCalls++; 100 }, hasAnchor = true)
+        subject.logApiFetchResult(1, 10L) { catalogCalls++; listOf(catalogRegion()) }
 
         selectedCalls shouldBeEqualTo 0
         evictedCalls shouldBeEqualTo 0
         distanceCalls shouldBeEqualTo 0
         regionCountCalls shouldBeEqualTo 0
+        // The catalog re-decodes and re-validates every polygon ring the mapper is about to build
+        // anyway; with the gate off that is a background fetch paying twice for rows nobody writes.
+        catalogCalls shouldBeEqualTo 0
 
         // Proves the counts above are zero because of the gate, not because the lambdas are
         // unreachable. logStorageLoaded is diagnostics-only, so it also gains its prose here.
@@ -720,40 +725,47 @@ class GeofenceLogTailTest : RobolectricTest() {
             edgeDistances = { distanceCalls++; mapOf("alpha" to 120.0) }
         )
         subject.logStorageLoaded(regionCount = { regionCountCalls++; 100 }, hasAnchor = true)
+        subject.logApiFetchResult(1, 10L) { catalogCalls++; listOf(catalogRegion()) }
 
         selectedCalls shouldBeEqualTo 1
         evictedCalls shouldBeEqualTo 1
         distanceCalls shouldBeEqualTo 1
         regionCountCalls shouldBeEqualTo 1
+        catalogCalls shouldBeEqualTo 1
     }
 
     private fun polygonCatalogRegion(
         vertexCount: Int = 4,
-        baseRadiusMeters: Double = 900.0
-    ) = GeofenceRegion(
+        baseRadiusMeters: Double? = 900.0
+    ) = GeofenceCatalogEntry(
         id = "poly-1",
-        latitude = 25.109908,
-        longitude = 55.184004,
-        // What GMS registers: the backend circle plus our platform margin.
-        radius = (baseRadiusMeters + 1_000.0).toFloat(),
         name = "Polygon Fence",
         geosetIds = listOf("4471"),
-        polygonVertices = List(vertexCount) { index ->
+        shape = "polygon",
+        latitude = 25.109908,
+        longitude = 55.184004,
+        // The backend's own circle. What GMS registers is this plus our platform margin, and the
+        // catalog must never report that one.
+        radiusMeters = baseRadiusMeters,
+        vertices = List(vertexCount) { index ->
             PolygonCoordinate(25.10 + index / 10_000.0, 55.18 + index / 10_000.0)
         },
-        baseRadiusMeters = baseRadiusMeters
+        transitionTypes = listOf("enter", "exit")
     )
 
     private fun catalogRegion(
         id: String = "11125",
         name: String? = "Momo Dubai Test"
-    ) = GeofenceRegion(
+    ) = GeofenceCatalogEntry(
         id = id,
+        name = name,
+        geosetIds = listOf("4471", "9002"),
+        shape = "circle",
         latitude = 25.109908,
         longitude = 55.184004,
-        radius = 150f,
-        name = name,
-        geosetIds = listOf("4471", "9002")
+        radiusMeters = 150.0,
+        vertices = null,
+        transitionTypes = listOf("enter", "exit")
     )
 
     @Test
@@ -762,7 +774,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         // and `=`. Left raw, `Momo Dubai Test` would split into three bogus fields.
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion(name = "Momo Dubai, Test=1")))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(catalogRegion(name = "Momo Dubai, Test=1")) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -785,7 +797,7 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun fenceCatalog_expectMachineKeyAndReplayClassification() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(catalogRegion()) }
 
         val message = logger.messages.last()
         message.startsWith("[Geofence] ") shouldBeEqualTo true
@@ -802,7 +814,7 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun fenceCatalog_givenPolygon_expectShapeVertexCountAndRing() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(vertexCount = 4)))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(polygonCatalogRegion(vertexCount = 4)) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -819,19 +831,19 @@ class GeofenceLogTailTest : RobolectricTest() {
         // cross-platform discrepancy that is only padding, and overstates the fence by a kilometre.
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(baseRadiusMeters = 900.0)))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(polygonCatalogRegion(baseRadiusMeters = 900.0)) }
 
         parseTail(logger.messages.last())?.get("rad") shouldBeEqualTo "900"
     }
 
     @Test
     fun fenceCatalog_givenPolygonWithoutBackendRadius_expectRadOmittedNotPadded() {
-        // The mapper drops such a polygon today, so this pins the direction of the failure if that
-        // ever changes: absent is recoverable, the padded radius is the bug this record had.
+        // The mapper drops such a polygon, and the catalog now runs before it, so this row is what
+        // a capture actually gets: absent is recoverable, the padded radius is the bug this had.
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        val region = polygonCatalogRegion().copy(baseRadiusMeters = null)
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(region))
+        val region = polygonCatalogRegion().copy(radiusMeters = null)
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(region) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -843,7 +855,7 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun fenceCatalog_givenCircle_expectShapeCircleAndNoRing() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(catalogRegion()) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -859,7 +871,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         // notice and refuse instead of computing membership against part of the shape.
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(polygonCatalogRegion(vertexCount = 30)))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(polygonCatalogRegion(vertexCount = 30)) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -871,11 +883,9 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun fenceCatalog_expectOneRecordPerFence() {
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(
-            3,
-            10L,
+        GeofenceLogger(logger).logApiFetchResult(3, 10L) {
             listOf(catalogRegion(id = "1"), catalogRegion(id = "2"), catalogRegion(id = "3"))
-        )
+        }
         logger.messages.count { it.contains("ev=fence.cataloged") } shouldBeEqualTo 3
     }
 
@@ -885,7 +895,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         // sanitising or the list collapses into one token.
         GeofenceDiagnostics.setEnabledForTesting(true)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(catalogRegion()) }
 
         val fields = parseTail(logger.messages.last())
         fields.shouldNotBeNull()
@@ -901,7 +911,7 @@ class GeofenceLogTailTest : RobolectricTest() {
         // exist at all, not merely lose its tail.
         GeofenceDiagnostics.setEnabledForTesting(false)
         val logger = CapturingLogger()
-        GeofenceLogger(logger).logApiFetchResult(1, 10L, listOf(catalogRegion()))
+        GeofenceLogger(logger).logApiFetchResult(1, 10L) { listOf(catalogRegion()) }
 
         logger.messages.none { it.contains("catalogued") } shouldBeEqualTo true
     }

--- a/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceRepositoryTest.kt
@@ -431,6 +431,36 @@ class GeofenceRepositoryTest : RobolectricTest() {
     }
 
     @Test
+    fun refresh_givenResponseMappingThrows_expectTheFetchStillCatalogued() = runTest {
+        // The catalog runs before mapping, so the response that could not be used at all is still
+        // described. Cataloguing after the mapper is what left the failing fences invisible.
+        every { secureUserStore.getUserId() } returns "user-42"
+        every { store.getLastSyncTimestamp() } returns null
+        coEvery { apiService.fetchGeofences(any()) } returns
+            Result.success(sampleResponse(maxBusinessGeofences = 3))
+        mockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        try {
+            every { any<GeofenceApiResponse>().toDomainRegions() } throws IllegalStateException("mapper defect")
+
+            repository.refresh(latitude = 12.34, longitude = 56.78).isFailure shouldBeEqualTo true
+
+            // Captured rather than matched: the lambda reaching a verify block is mockk's stand-in,
+            // and invoking that throws. The captured one is what production actually passed.
+            val catalog = slot<() -> List<GeofenceCatalogEntry>>()
+            verify {
+                logger.logApiFetchResult(
+                    returnedCount = any(),
+                    elapsedMillis = any(),
+                    catalog = capture(catalog)
+                )
+            }
+            catalog.captured().isNotEmpty() shouldBeEqualTo true
+        } finally {
+            unmockkStatic("io.customer.geofence.api.GeofenceApiResponseKt")
+        }
+    }
+
+    @Test
     fun refresh_givenResponseMappingThrows_expectFailureNotEmptySuccess() = runTest {
         // Unusable response fails the refresh; nothing registered, removed, or persisted.
         every { secureUserStore.getUserId() } returns "user-42"

--- a/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/api/GeofenceApiResponseTest.kt
@@ -1200,6 +1200,181 @@ class GeofenceApiResponseTest : RobolectricTest() {
         }
     """.trimIndent()
 
+    // ---------- catalog: built from the wire, before anything is dropped ----------
+
+    @Test
+    fun toCatalogEntries_expectOneEntryPerWireRecordEvenWhenOneIsDropped() {
+        val response = parseResponse(polygonAndCircleJson())
+
+        // With polygon monitoring off the mapper keeps only the circle. The catalog is the record
+        // of what the server sent, so it must still describe both.
+        response.toDomainRegions().map(GeofenceRegion::id) shouldBeEqualTo listOf("circle")
+        response.toCatalogEntries().map { it.id } shouldBeEqualTo listOf("campus", "circle")
+    }
+
+    @Test
+    fun toCatalogEntries_givenEmptyResponse_expectNoEntries() {
+        parseResponse("""{ "geofences": [] }""").toCatalogEntries().shouldBeEmpty()
+    }
+
+    @Test
+    fun toCatalogEntries_givenPolygon_expectEnclosingCircleAndCanonicalRing() {
+        val entry = parseResponse(polygonOnlyJson()).toCatalogEntries().single()
+
+        entry.shape shouldBeEqualTo "polygon"
+        // The backend's circle, not the padded radius the SDK would register.
+        entry.latitude shouldBeEqualTo 37.775
+        entry.longitude shouldBeEqualTo -122.4194
+        entry.radiusMeters shouldBeEqualTo 100.0
+        // Five wire positions, closing vertex dropped: the count a consumer checks truncation with.
+        entry.vertices?.size shouldBeEqualTo 4
+    }
+
+    @Test
+    fun toCatalogEntries_givenUnbuildableRing_expectRowKeptWithoutVertices() {
+        // The case the catalog exists for: the mapper drops this record entirely, so before this
+        // change the capture had no row naming it at all.
+        val response = parseResponse(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "bad-ring",
+                  "shape": "polygon",
+                  "enclosing_circle": { "latitude": 37.775, "longitude": -122.4194, "base_radius_m": 100 },
+                  "geometry": { "type": "Polygon", "coordinates": [[[-122.42, 37.77], [-122.41, 37.77]]] }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val entry = response.toCatalogEntries().single()
+        entry.id shouldBeEqualTo "bad-ring"
+        entry.shape shouldBeEqualTo "polygon"
+        // Absent, never a ring we could not build: a half-decoded ring answers membership wrongly.
+        entry.vertices.shouldBeNull()
+        entry.radiusMeters shouldBeEqualTo 100.0
+        invoking { response.toDomainRegions(EnabledPolygonSupport) } shouldThrow Exception::class
+    }
+
+    @Test
+    fun toCatalogEntries_givenPolygonWithoutEnclosingCircle_expectPlacementAbsentNotSubstituted() {
+        // The flat fields describe a different shape. Falling back to them would place a polygon at
+        // a circle's centre and radius, which reads as a real fence rather than a missing one.
+        val entry = parseResponse(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "no-circle",
+                  "shape": "polygon",
+                  "latitude": 1.0,
+                  "longitude": 2.0,
+                  "radius": 50,
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                      [-122.4200, 37.7745],
+                      [-122.4188, 37.7745],
+                      [-122.4188, 37.7755],
+                      [-122.4200, 37.7745]
+                    ]]
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        ).toCatalogEntries().single()
+
+        entry.shape shouldBeEqualTo "polygon"
+        entry.latitude.shouldBeNull()
+        entry.longitude.shouldBeNull()
+        entry.radiusMeters.shouldBeNull()
+        // The row still exists, and the ring it did send is still reported.
+        entry.vertices?.size shouldBeEqualTo 3
+    }
+
+    @Test
+    fun toCatalogEntries_givenGeometryWithoutDiscriminator_expectCircleClaimAndTheRing() {
+        // The mis-described record: the mapper drops it as undescribed_shape. The row keeps both
+        // halves of the contradiction — the claim it made and the geometry it actually sent —
+        // because a row saying only "circle" is indistinguishable from a plain circle.
+        val entry = parseResponse(
+            """
+            {
+              "geofences": [
+                {
+                  "id": "mismatched",
+                  "latitude": 1.0,
+                  "longitude": 2.0,
+                  "radius": 50,
+                  "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                      [-122.4200, 37.7745],
+                      [-122.4188, 37.7745],
+                      [-122.4188, 37.7755],
+                      [-122.4200, 37.7745]
+                    ]]
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        ).toCatalogEntries().single()
+
+        entry.shape shouldBeEqualTo "circle"
+        entry.vertices?.size shouldBeEqualTo 3
+        // Read as a circle, so its placement is the flat fields it claimed.
+        entry.latitude shouldBeEqualTo 1.0
+        entry.radiusMeters shouldBeEqualTo 50.0
+    }
+
+    @Test
+    fun toCatalogEntries_givenUnsupportedShape_expectTheClaimVerbatim() {
+        val entry = parseResponse(
+            """
+            { "geofences": [ { "id": "odd", "shape": "Hexagon", "latitude": 1.0, "longitude": 2.0, "radius": 50 } ] }
+            """.trimIndent()
+        ).toCatalogEntries().single()
+
+        // What the server claimed, lowercased but not judged — the drop record carries the verdict.
+        entry.shape shouldBeEqualTo "hexagon"
+        entry.latitude shouldBeEqualTo 1.0
+        entry.radiusMeters shouldBeEqualTo 50.0
+    }
+
+    @Test
+    fun toCatalogEntries_givenLegacyRecord_expectCircleAndResolvedTransitionTypes() {
+        val entry = parseResponse(
+            """
+            { "geofences": [ { "id": "legacy", "latitude": 1.0, "longitude": 2.0, "radius": 50 } ] }
+            """.trimIndent()
+        ).toCatalogEntries().single()
+
+        // No discriminator is how every pre-polygon response looks; it is a circle, not an unknown.
+        entry.shape shouldBeEqualTo "circle"
+        entry.vertices.shouldBeNull()
+        entry.transitionTypes shouldBeEqualTo listOf("enter", "exit")
+    }
+
+    @Test
+    fun toCatalogEntries_givenUnknownTransitionType_expectReportedOnceNotTwice() {
+        val response = parseResponse(
+            """
+            { "geofences": [ { "id": "c", "latitude": 1.0, "longitude": 2.0, "radius": 50, "transition_types": ["dwell"] } ] }
+            """.trimIndent()
+        )
+
+        // Production order: catalog first, then mapping. Both resolve transition types, and only
+        // the mapper may report an unknown one — otherwise every unknown value is counted twice.
+        response.toCatalogEntries()
+        response.toDomainRegions()
+
+        verify(exactly = 1) { mockLogger.logUnknownApiTransitionType("dwell") }
+    }
+
     // ---------- helpers ----------
 
     private val jsonSerializer = GeofenceJsonSerializer()


### PR DESCRIPTION
Part of: [MBL-2419](https://linear.app/customerio/issue/MBL-2419/android-improve-geofence-diagnostics-and-queue-failure-handling)

## Stack
- [#857 catalogue a polygon as a polygon](https://github.com/customerio/customerio-android/pull/857)
- [#858 give the polygon records a machine-readable tail](https://github.com/customerio/customerio-android/pull/858)
- 👉 [#859 catalogue a fence before it can be dropped](https://github.com/customerio/customerio-android/pull/859)

The fence catalog ran on mapped regions, so a record validation rejected produced no row and the capture silently lacked the fence that failed, which is the case the catalog exists to diagnose. A response where every record dropped produced nothing at all: the mapper throws, and the fetch record sat after it.

Now built from the wire. `GeofenceCatalogEntry` describes a record as the server sent it, `toCatalogEntries()` lives in the api package so the logger never sees the wire type, and the fetch record moves above the mapping.

`sh` carries the claim rather than a verdict: an absent discriminator reads as `circle` exactly as the mapper reads it, and an unsupported value comes through verbatim. A record claiming no shape while carrying polygon geometry catalogs as `sh=circle` **and** keeps its ring, so the capture shows a mis-described record instead of a plain circle. `registration.rejected why=undescribed_shape` names the conflict.

For every record the old mapper accepted the emitted fields are unchanged, verified field by field: a polygon's `lat`/`lon` were already the enclosing-circle centre, `rad` the same wire radius, `nv`/`ring` the same canonical vertices.

`resolveTransitionTypes` reported unknown values from inside its own mapping, so the catalog resolving the same list would have double-reported every one. Split into a logging wrapper and a pure resolver, pinned by a test.

The catalog parameter is a lambda evaluated after the diagnostics gate, so a build with diagnostics off no longer decodes and validates every polygon ring a second time per fetch.

2045 tests across all modules, ktlint, apiCheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
