### PR TITLE
chore(geofence): stop reading an unreadable delivery queue as an empty one

### DIFF
--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -70,6 +70,13 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
         /** Number of entries snapshotted at the start of the flush (may be 0). */
         open fun onSnapshot(count: Int) {}
 
+        /**
+         * The store could not be read, so this flush did nothing. Distinct from [onSnapshot] with
+         * a count of 0: the rows are still on disk, and without this the failure leaves no trace on
+         * a device where no new entry arrives to wake the worker that would otherwise report it.
+         */
+        open fun onUnreadable() {}
+
         /** The entry's WorkManager unique work was cancelled. */
         open fun onWorkCancelled(entry: T) {}
 
@@ -95,7 +102,12 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
     ) {
         CoroutineScope(dispatchersProvider.background).launch {
             runCatching {
-                val pending = store.loadAll()
+                // Skipped rather than reported as a snapshot of zero: the rows are still on disk,
+                // and the next foreground transition flushes again.
+                val pending = store.loadAllOrNull() ?: run {
+                    callbacks.onUnreadable()
+                    return@runCatching
+                }
                 callbacks.onSnapshot(pending.size)
                 if (pending.isEmpty()) return@runCatching
 

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryFlusher.kt
@@ -71,9 +71,8 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
         open fun onSnapshot(count: Int) {}
 
         /**
-         * The store could not be read, so this flush did nothing. Distinct from [onSnapshot] with
-         * a count of 0: the rows are still on disk, and without this the failure leaves no trace on
-         * a device where no new entry arrives to wake the worker that would otherwise report it.
+         * The store could not be read, so this flush did nothing. Not [onSnapshot] with a count of
+         * 0 — the rows are still on disk, and this is the only path that runs without a new entry.
          */
         open fun onUnreadable() {}
 
@@ -102,8 +101,6 @@ class PendingDeliveryFlusher<T : PendingDeliveryStore.PendingDeliveryEntry>(
     ) {
         CoroutineScope(dispatchersProvider.background).launch {
             runCatching {
-                // Skipped rather than reported as a snapshot of zero: the rows are still on disk,
-                // and the next foreground transition flushes again.
                 val pending = store.loadAllOrNull() ?: run {
                     callbacks.onUnreadable()
                     return@runCatching

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -96,9 +96,8 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
     /**
      * All pending entries in insertion order, or `null` when the queue could not be read.
      *
-     * Same distinction [contains] draws, for a caller that drains rather than asks about one key:
-     * an unreadable queue is not an empty one, and treating it as empty reports the work finished
-     * while the rows are still on disk.
+     * The distinction [contains] draws, for a caller that drains: reading unreadable as empty
+     * reports the work finished while the rows are still on disk.
      */
     fun loadAllOrNull(): List<T>? = lock.withLock { readAll() }
 

--- a/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
+++ b/core/src/main/kotlin/io/customer/sdk/data/store/PendingDeliveryStore.kt
@@ -90,8 +90,17 @@ class PendingDeliveryStore<T : PendingDeliveryStore.PendingDeliveryEntry>(
         }
     }
 
-    /** Returns all pending entries in insertion order. */
+    /** Returns all pending entries in insertion order, reading an unreadable queue as empty. */
     fun loadAll(): List<T> = lock.withLock { readAll().orEmpty() }
+
+    /**
+     * All pending entries in insertion order, or `null` when the queue could not be read.
+     *
+     * Same distinction [contains] draws, for a caller that drains rather than asks about one key:
+     * an unreadable queue is not an empty one, and treating it as empty reports the work finished
+     * while the rows are still on disk.
+     */
+    fun loadAllOrNull(): List<T>? = lock.withLock { readAll() }
 
     /** Returns the entry whose [PendingDeliveryEntry.key] equals [key], or null if none is present. */
     fun get(key: String): T? = lock.withLock { readAll()?.firstOrNull { it.key == key } }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -91,8 +91,8 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
 
     @Test
     fun flush_givenUnreadableStore_expectNoSnapshotRatherThanZero() {
-        // A snapshot of zero is what the empty store reports. Reporting it for a queue we could not
-        // read says the outbox was drained while the rows are still on disk.
+        // A snapshot of zero is what an empty store reports; reporting it here says the outbox
+        // drained while the rows are still on disk.
         val store = newStore()
         store.append(TestEntry("a"))
         val unreadable: PendingDeliveryStore<TestEntry> = spyk(store) {
@@ -106,10 +106,8 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         callbacks.snapshotCount shouldBeEqualTo null
         callbacks.completeCount shouldBeEqualTo null
         publishedKeys shouldBeEqualTo emptyList()
-        // Skipping is the right action, but silence is not the right trace: without this the
-        // failure leaves no record at all on a device where no new entry wakes the worker.
+        // Skipping is the right action; silence is not the right trace.
         callbacks.unreadableCount shouldBeEqualTo 1
-        // The pass is skipped, never destructive: the next foreground transition flushes again.
         store.loadAll().map { it.key } shouldBeEqualTo listOf("a")
     }
 

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryFlusherTest.kt
@@ -9,6 +9,7 @@ import io.customer.sdk.core.util.CustomerIOWorkManagerProvider
 import io.customer.sdk.core.util.Logger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.serialization.Serializable
@@ -60,7 +61,9 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         val published = mutableListOf<String>()
         val failed = mutableListOf<String>()
 
+        var unreadableCount = 0
         override fun onSnapshot(count: Int) { snapshotCount = count }
+        override fun onUnreadable() { unreadableCount++ }
         override fun onWorkCancelled(entry: TestEntry) { cancelled += entry.key }
         override fun onPublished(entry: TestEntry) { published += entry.key }
         override fun onEntryFailed(entry: TestEntry, cause: Throwable) { failed += entry.key }
@@ -80,9 +83,34 @@ class PendingDeliveryFlusherTest : RobolectricTest() {
         newFlusher(store).flush(callbacks) { publishedKeys += it.key }
 
         callbacks.snapshotCount shouldBeEqualTo 0
+        callbacks.unreadableCount shouldBeEqualTo 0
         publishedKeys shouldBeEqualTo emptyList()
         // Mirrors push: an empty store returns before onComplete.
         callbacks.completeCount shouldBeEqualTo null
+    }
+
+    @Test
+    fun flush_givenUnreadableStore_expectNoSnapshotRatherThanZero() {
+        // A snapshot of zero is what the empty store reports. Reporting it for a queue we could not
+        // read says the outbox was drained while the rows are still on disk.
+        val store = newStore()
+        store.append(TestEntry("a"))
+        val unreadable: PendingDeliveryStore<TestEntry> = spyk(store) {
+            every { loadAllOrNull() } returns null
+        }
+        val callbacks = RecordingCallbacks()
+        val publishedKeys = mutableListOf<String>()
+
+        newFlusher(unreadable).flush(callbacks) { publishedKeys += it.key }
+
+        callbacks.snapshotCount shouldBeEqualTo null
+        callbacks.completeCount shouldBeEqualTo null
+        publishedKeys shouldBeEqualTo emptyList()
+        // Skipping is the right action, but silence is not the right trace: without this the
+        // failure leaves no record at all on a device where no new entry wakes the worker.
+        callbacks.unreadableCount shouldBeEqualTo 1
+        // The pass is skipped, never destructive: the next foreground transition flushes again.
+        store.loadAll().map { it.key } shouldBeEqualTo listOf("a")
     }
 
     @Test

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -137,8 +137,7 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         storeFile().delete()
         storeFile().mkdirs()
 
-        // The distinction the caller acts on: loadAll cannot tell these apart, so a drain reports
-        // itself finished while the rows are still on disk.
+        // The distinction a draining caller acts on; loadAll cannot tell these apart.
         store.loadAllOrNull().shouldBeNull()
         store.loadAll().shouldBeEmpty()
     }

--- a/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
+++ b/core/src/test/java/io/customer/sdk/data/store/PendingDeliveryStoreTest.kt
@@ -8,7 +8,9 @@ import java.io.File
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.Serializable
+import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldContain
 import org.amshove.kluent.shouldNotBe
@@ -125,6 +127,35 @@ class PendingDeliveryStoreTest : RobolectricTest() {
         storeFile().mkdirs()
 
         store.appendAll(listOf(entry("a"))) shouldBeEqualTo false
+    }
+
+    @Test
+    fun loadAllOrNull_givenUnreadableFile_expectNullNotEmpty() {
+        val store = newStore()
+        store.append(entry("a"))
+        // A directory in the file's place is the only unreadable state a test can force here.
+        storeFile().delete()
+        storeFile().mkdirs()
+
+        // The distinction the caller acts on: loadAll cannot tell these apart, so a drain reports
+        // itself finished while the rows are still on disk.
+        store.loadAllOrNull().shouldBeNull()
+        store.loadAll().shouldBeEmpty()
+    }
+
+    @Test
+    fun loadAllOrNull_givenReadableQueue_expectEntriesInOrder() {
+        val store = newStore()
+        store.append(entry("a"))
+        store.append(entry("b"))
+
+        store.loadAllOrNull()?.map { it.id } shouldBeEqualTo listOf("a", "b")
+    }
+
+    @Test
+    fun loadAllOrNull_givenNoFile_expectEmptyNotNull() {
+        // Never written is readable and empty, and must not read as a failure.
+        newStore().loadAllOrNull() shouldBeEqualTo emptyList()
     }
 
     @Test

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -55,11 +55,8 @@ internal object GeofenceConstants {
     const val MAX_METADATA_COUNT = 100
     const val MAX_METADATA_PAYLOAD_BYTES = 100 * 1024 // 100 KB
 
-    // Attempts the event worker spends on a queue it cannot read before giving the wake up. The
-    // rows are never written over, so giving up costs nothing but this wake — the next transition
-    // enqueues a fresh worker and the foreground flush retries independently. Sized to span a
-    // transient I/O fault across WorkManager's exponential backoff rather than to outlast a
-    // permanently broken file, which no number of retries recovers.
+    // Attempts on an unreadable queue before the worker gives up the wake. Sized to cover a
+    // transient I/O fault across WorkManager's backoff; no number of retries fixes a broken file.
     const val MAX_UNREADABLE_QUEUE_ATTEMPTS = 5
 
     // GMS `Geofence.Builder().setExpirationDuration()` flag for "never expires".

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceConstants.kt
@@ -55,6 +55,13 @@ internal object GeofenceConstants {
     const val MAX_METADATA_COUNT = 100
     const val MAX_METADATA_PAYLOAD_BYTES = 100 * 1024 // 100 KB
 
+    // Attempts the event worker spends on a queue it cannot read before giving the wake up. The
+    // rows are never written over, so giving up costs nothing but this wake — the next transition
+    // enqueues a fresh worker and the foreground flush retries independently. Sized to span a
+    // transient I/O fault across WorkManager's exponential backoff rather than to outlast a
+    // permanently broken file, which no number of retries recovers.
+    const val MAX_UNREADABLE_QUEUE_ATTEMPTS = 5
+
     // GMS `Geofence.Builder().setExpirationDuration()` flag for "never expires".
     // Our geofences are managed at the application level (we remove explicitly)
     // so OS-side expiration is disabled.

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLifecycleObserver.kt
@@ -39,6 +39,7 @@ internal class GeofenceLifecycleObserver(
         deliveryFlusher.flush(
             callbacks = object : PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>() {
                 override fun onSnapshot(count: Int) = logger.logForegroundFlushSnapshot(count)
+                override fun onUnreadable() = logger.logForegroundFlushQueueUnreadable()
                 override fun onWorkCancelled(entry: PendingGeofenceDelivery) =
                     logger.logForegroundFlushCancelledWorkManager(entry.geofenceId, entry.transition.name)
                 override fun onPublished(entry: PendingGeofenceDelivery) =

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogTail.kt
@@ -8,6 +8,9 @@ import java.util.Locale
 /**
  * Whether a record is something the SDK was told, decided, or neither.
  *
+ * An environment fault the SDK reacts to counts as [INPUT], not [OBSERVATION]: replay has to be fed
+ * the fault to reproduce the decision taken because of it.
+ *
  * Stated explicitly rather than inferred from the event name: replay feeds the `in` records back
  * and compares the `out` records, so a naming convention getting this wrong invalidates a run.
  */

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -914,11 +914,8 @@ internal class GeofenceLogger(private val logger: Logger) {
     }
 
     /**
-     * The queue could not be read, so nothing was sent and nothing was written over.
-     *
-     * Distinct from [logEventWorkerEntryMissing], which names a queue that really was empty. Sharing
-     * one record would report a drained queue for a file we never read. `why=read_failed` matches
-     * iOS, which emits the same token from its own queue.
+     * Distinct from [logEventWorkerEntryMissing], which names a queue that really was empty: one
+     * shared record would report a drain for a file we never read. Token matches iOS.
      */
     fun logEventWorkerQueueUnreadable(attempt: Int, willRetry: Boolean) {
         logger.error(
@@ -933,10 +930,7 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
-    /**
-     * Same failure as [logEventWorkerQueueUnreadable], reached from the foreground flush, which has
-     * no attempt count and no retry decision to report — it simply runs again next foreground.
-     */
+    /** Same failure as [logEventWorkerQueueUnreadable], with no attempt or retry to report. */
     fun logForegroundFlushQueueUnreadable() {
         logger.error(
             "Foreground flush could not read the pending queue; leaving it untouched and retrying on the next foreground" +

--- a/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/GeofenceLogger.kt
@@ -913,6 +913,42 @@ internal class GeofenceLogger(private val logger: Logger) {
         )
     }
 
+    /**
+     * The queue could not be read, so nothing was sent and nothing was written over.
+     *
+     * Distinct from [logEventWorkerEntryMissing], which names a queue that really was empty. Sharing
+     * one record would report a drained queue for a file we never read. `why=read_failed` matches
+     * iOS, which emits the same token from its own queue.
+     */
+    fun logEventWorkerQueueUnreadable(attempt: Int, willRetry: Boolean) {
+        logger.error(
+            "Geofence event worker could not read the pending queue; leaving it untouched and " +
+                (if (willRetry) "retrying on a backoff" else "giving up this wake — the next transition or foreground flush retries") +
+                tail(
+                    "queue.unreadable",
+                    GeofenceLogIo.INPUT,
+                    listOf("why" to "read_failed", "via" to "work_manager", "n" to int(attempt), "retry" to bool(willRetry))
+                ),
+            tag = TAG
+        )
+    }
+
+    /**
+     * Same failure as [logEventWorkerQueueUnreadable], reached from the foreground flush, which has
+     * no attempt count and no retry decision to report — it simply runs again next foreground.
+     */
+    fun logForegroundFlushQueueUnreadable() {
+        logger.error(
+            "Foreground flush could not read the pending queue; leaving it untouched and retrying on the next foreground" +
+                tail(
+                    "queue.unreadable",
+                    GeofenceLogIo.INPUT,
+                    listOf("why" to "read_failed", "via" to "foreground_flush")
+                ),
+            tag = TAG
+        )
+    }
+
     fun logForegroundFlushSnapshot(count: Int) {
         logger.debug(
             "Geofence foreground flush: $count pending transition(s) to hand off to the analytics pipeline" +

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -81,14 +81,9 @@ internal class GeofenceEventWorker(
         var sawEntry = false
         while (true) {
             val queued = store.loadAllOrNull() ?: run {
-                // Unreadable, which is not empty: the rows are still on disk and nothing has been
-                // sent. Reporting success here would say the queue drained.
-                //
-                // Result.failure() is safe here where the delivery paths below avoid it: a terminal
-                // node cancels the chain's dependents, but every one of them would fail this same
-                // read, and the rows they would have sent are untouched on disk for the next
-                // transition or the foreground flush. Retrying past the cap only spins on a file
-                // that no number of attempts recovers.
+                // Unreadable is not empty: nothing was sent, so success would claim a drain.
+                // failure() is safe here where the paths below avoid it — every dependent would
+                // fail this same read, and the rows behind are untouched on disk.
                 val willRetry = runAttemptCount < GeofenceConstants.MAX_UNREADABLE_QUEUE_ATTEMPTS
                 logger.logEventWorkerQueueUnreadable(runAttemptCount, willRetry)
                 return if (willRetry) Result.retry() else Result.failure()

--- a/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
+++ b/geofence/src/main/kotlin/io/customer/geofence/worker/GeofenceEventWorker.kt
@@ -8,6 +8,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
 import androidx.work.await
+import io.customer.geofence.GeofenceConstants
 import io.customer.geofence.di.geofenceEventTracker
 import io.customer.geofence.di.geofenceLogger
 import io.customer.geofence.di.pendingGeofenceDeliveryStore
@@ -79,7 +80,20 @@ internal class GeofenceEventWorker(
         val store = SDKComponent.android().pendingGeofenceDeliveryStore
         var sawEntry = false
         while (true) {
-            val entry = store.loadAll().firstOrNull() ?: run {
+            val queued = store.loadAllOrNull() ?: run {
+                // Unreadable, which is not empty: the rows are still on disk and nothing has been
+                // sent. Reporting success here would say the queue drained.
+                //
+                // Result.failure() is safe here where the delivery paths below avoid it: a terminal
+                // node cancels the chain's dependents, but every one of them would fail this same
+                // read, and the rows they would have sent are untouched on disk for the next
+                // transition or the foreground flush. Retrying past the cap only spins on a file
+                // that no number of attempts recovers.
+                val willRetry = runAttemptCount < GeofenceConstants.MAX_UNREADABLE_QUEUE_ATTEMPTS
+                logger.logEventWorkerQueueUnreadable(runAttemptCount, willRetry)
+                return if (willRetry) Result.retry() else Result.failure()
+            }
+            val entry = queued.firstOrNull() ?: run {
                 // Only when the wake found nothing at all. Draining the queue empty is the normal
                 // success path, and recording that as an already-delivered skip would report a
                 // flush overtaking us on every successful delivery.

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
@@ -45,8 +45,7 @@ class GeofenceLifecycleObserverTest {
 
     @Test
     fun onStart_givenUnreadableQueue_expectTheFailureRecorded() {
-        // The flush is the only path that runs without a new transition, so if it stays silent a
-        // queue that went unreadable leaves no record until something else happens to wake a worker.
+        // The only path that runs without a new transition, so silence here means no record at all.
         val callbacksSlot = slot<PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>>()
         every { mockDeliveryFlusher.flush(capture(callbacksSlot), any(), any()) } returns Unit
 

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLifecycleObserverTest.kt
@@ -44,6 +44,19 @@ class GeofenceLifecycleObserverTest {
     }
 
     @Test
+    fun onStart_givenUnreadableQueue_expectTheFailureRecorded() {
+        // The flush is the only path that runs without a new transition, so if it stays silent a
+        // queue that went unreadable leaves no record until something else happens to wake a worker.
+        val callbacksSlot = slot<PendingDeliveryFlusher.Callbacks<PendingGeofenceDelivery>>()
+        every { mockDeliveryFlusher.flush(capture(callbacksSlot), any(), any()) } returns Unit
+
+        observer.onStart(owner)
+        callbacksSlot.captured.onUnreadable()
+
+        verify(exactly = 1) { mockLogger.logForegroundFlushQueueUnreadable() }
+    }
+
+    @Test
     fun onStart_expectForegroundHookRunOncePerEntry() {
         observer.onStart(owner)
         observer.onStart(owner)

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -602,9 +602,8 @@ class GeofenceLogTailTest : RobolectricTest() {
     fun queueUnreadable_expectViaSeparatesTheTwoPathsSharingTheEv() {
         GeofenceDiagnostics.setEnabledForTesting(true)
 
-        // Both paths file the same failure under one ev, so `via` is the only thing telling a wake
-        // apart from a foreground flush. Collapsed, the flush trace reads as a worker wake and the
-        // path that runs without a new transition becomes invisible again.
+        // One ev for both paths, so `via` is the only thing separating them. Collapsed, the flush
+        // trace reads as a worker wake.
         val worker = CapturingLogger()
         GeofenceLogger(worker).logEventWorkerQueueUnreadable(2, willRetry = true)
         val flush = CapturingLogger()

--- a/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/GeofenceLogTailTest.kt
@@ -179,6 +179,8 @@ class GeofenceLogTailTest : RobolectricTest() {
             Row("eventDelivered", "delivery.sent", listOf("id", "t", "via"), GeofenceLogger::logEventDelivered.name) { it.logEventDelivered("notl_core", "ENTER") },
             Row("deliverySkippedAlreadyDelivered", "delivery.sent", listOf("id", "t", "why"), GeofenceLogger::logEventDeliverySkippedAlreadyDelivered.name) { it.logEventDeliverySkippedAlreadyDelivered("notl_core", "ENTER") },
             Row("workerEntryMissing", "delivery.sent", listOf("why"), GeofenceLogger::logEventWorkerEntryMissing.name) { it.logEventWorkerEntryMissing() },
+            Row("workerQueueUnreadable", "queue.unreadable", listOf("why", "via", "n", "retry"), GeofenceLogger::logEventWorkerQueueUnreadable.name, io = "in") { it.logEventWorkerQueueUnreadable(2, willRetry = true) },
+            Row("flushQueueUnreadable", "queue.unreadable", listOf("why", "via"), GeofenceLogger::logForegroundFlushQueueUnreadable.name, io = "in") { it.logForegroundFlushQueueUnreadable() },
             Row("flushSnapshot", "delivery.flush", listOf("n", "phase"), GeofenceLogger::logForegroundFlushSnapshot.name) { it.logForegroundFlushSnapshot(3) },
             Row("flushCancelled", "delivery.flush", listOf("id", "t", "why"), GeofenceLogger::logForegroundFlushCancelledWorkManager.name) { it.logForegroundFlushCancelledWorkManager("notl_core", "ENTER") },
             Row("flushPublished", "delivery.sent", listOf("id", "t", "via"), GeofenceLogger::logForegroundFlushPublished.name) { it.logForegroundFlushPublished("notl_core", "ENTER") },
@@ -333,6 +335,7 @@ class GeofenceLogTailTest : RobolectricTest() {
             "os.error",
             "permission.changed",
             "polygon.undecided",
+            "queue.unreadable",
             "rank.evaluated",
             "rank.excluded",
             "registration.added",
@@ -593,6 +596,25 @@ class GeofenceLogTailTest : RobolectricTest() {
 
         parseTail(atDecode.messages.last())!!["why"] shouldBeEqualTo "runtime_unsupported"
         parseTail(atRank.messages.last())!!["why"] shouldBeEqualTo "runtime_unsupported"
+    }
+
+    @Test
+    fun queueUnreadable_expectViaSeparatesTheTwoPathsSharingTheEv() {
+        GeofenceDiagnostics.setEnabledForTesting(true)
+
+        // Both paths file the same failure under one ev, so `via` is the only thing telling a wake
+        // apart from a foreground flush. Collapsed, the flush trace reads as a worker wake and the
+        // path that runs without a new transition becomes invisible again.
+        val worker = CapturingLogger()
+        GeofenceLogger(worker).logEventWorkerQueueUnreadable(2, willRetry = true)
+        val flush = CapturingLogger()
+        GeofenceLogger(flush).logForegroundFlushQueueUnreadable()
+
+        parseTail(worker.messages.last())!!["via"] shouldBeEqualTo "work_manager"
+        parseTail(flush.messages.last())!!["via"] shouldBeEqualTo "foreground_flush"
+        // Shared, so a query for the failure itself catches both.
+        parseTail(worker.messages.last())!!["why"] shouldBeEqualTo "read_failed"
+        parseTail(flush.messages.last())!!["why"] shouldBeEqualTo "read_failed"
     }
 
     @Test

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -7,6 +7,7 @@ import io.customer.commontest.config.ApplicationArgument
 import io.customer.commontest.config.TestConfig
 import io.customer.commontest.config.testConfigurationDefault
 import io.customer.commontest.core.RobolectricTest
+import io.customer.geofence.GeofenceConstants
 import io.customer.geofence.GeofenceDiagnostics
 import io.customer.geofence.GeofenceLogger
 import io.customer.geofence.di.pendingGeofenceDeliveryStore
@@ -175,6 +176,50 @@ class GeofenceEventWorkerTest : RobolectricTest() {
 
         result shouldBeEqualTo ListenableWorker.Result.success()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
+    }
+
+    private fun unreadableRecords(): List<String> =
+        capturing.messages.filter { "ev=queue.unreadable" in it }
+
+    @Test
+    fun doWork_givenUnreadableQueue_expectRetryAndNotAnEmptyQueueRecord() = runTest {
+        seed("biz-1", Event.GeofenceTransition.ENTER, 99L)
+        val unreadable = spyk(store) { every { loadAllOrNull() } returns null }
+        SDKComponent.android()
+            .overrideDependency<PendingDeliveryStore<PendingGeofenceDelivery>>(unreadable)
+
+        val result = createWorker(Data.EMPTY).doWork()
+
+        // Retried, not reported drained: the row is still on disk and nothing was sent.
+        result shouldBeEqualTo ListenableWorker.Result.retry()
+        coVerify(exactly = 0) { tracker.trackEvent(any()) }
+        // The distinction this whole change exists for. queue_empty names a cause that was never
+        // established for a file we could not read.
+        emptyQueueRecords().shouldBeEmpty()
+        unreadableRecords().size shouldBeEqualTo 1
+        unreadableRecords().single() shouldContain "why=read_failed"
+        unreadableRecords().single() shouldContain "retry=true"
+        // The wake path, not the foreground flush, which files the same ev.
+        unreadableRecords().single() shouldContain "via=work_manager"
+    }
+
+    @Test
+    fun doWork_givenUnreadableQueueAtAttemptCap_expectGiveUpRatherThanBackoffLoop() = runTest {
+        seed("biz-1", Event.GeofenceTransition.ENTER, 99L)
+        val unreadable = spyk(store) { every { loadAllOrNull() } returns null }
+        SDKComponent.android()
+            .overrideDependency<PendingDeliveryStore<PendingGeofenceDelivery>>(unreadable)
+
+        val worker = TestListenableWorkerBuilder<GeofenceEventWorker>(applicationMock)
+            .setInputData(Data.EMPTY)
+            .setRunAttemptCount(GeofenceConstants.MAX_UNREADABLE_QUEUE_ATTEMPTS)
+            .build()
+
+        // A permanently unreadable file is not recovered by retrying it forever; the rows survive
+        // because nothing is ever written over them.
+        worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
+        unreadableRecords().single() shouldContain "retry=false"
+        store.loadAll().map { it.geofenceId } shouldBeEqualTo listOf("biz-1")
     }
 
     private fun emptyQueueRecords(): List<String> =

--- a/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
+++ b/geofence/src/test/java/io/customer/geofence/worker/GeofenceEventWorkerTest.kt
@@ -193,8 +193,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
         // Retried, not reported drained: the row is still on disk and nothing was sent.
         result shouldBeEqualTo ListenableWorker.Result.retry()
         coVerify(exactly = 0) { tracker.trackEvent(any()) }
-        // The distinction this whole change exists for. queue_empty names a cause that was never
-        // established for a file we could not read.
+        // queue_empty names a cause never established for a file we could not read.
         emptyQueueRecords().shouldBeEmpty()
         unreadableRecords().size shouldBeEqualTo 1
         unreadableRecords().single() shouldContain "why=read_failed"
@@ -215,8 +214,7 @@ class GeofenceEventWorkerTest : RobolectricTest() {
             .setRunAttemptCount(GeofenceConstants.MAX_UNREADABLE_QUEUE_ATTEMPTS)
             .build()
 
-        // A permanently unreadable file is not recovered by retrying it forever; the rows survive
-        // because nothing is ever written over them.
+        // Retrying forever recovers nothing; the rows survive because nothing overwrites them.
         worker.doWork() shouldBeEqualTo ListenableWorker.Result.failure()
         unreadableRecords().single() shouldContain "retry=false"
         store.loadAll().map { it.geofenceId } shouldBeEqualTo listOf("biz-1")

--- a/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/ModuleMessagingPushFCMTest.kt
@@ -113,7 +113,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
         // an FCM-woken background process that initializes the SDK must not flush
         // because background-process network conditions make WorkManager the only
         // credible channel.
-        every { mockPendingStore.loadAll() } returns listOf(
+        every { mockPendingStore.loadAllOrNull() } returns listOf(
             PendingPushDeliveryMetric(deliveryId = "d1", token = "t1")
         )
 
@@ -130,7 +130,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
             PendingPushDeliveryMetric(deliveryId = "d1", token = "t1"),
             PendingPushDeliveryMetric(deliveryId = "d2", token = "t2")
         )
-        every { mockPendingStore.loadAll() } returns entries
+        every { mockPendingStore.loadAllOrNull() } returns entries
         every { mockPendingStore.claim(any()) } returns true
 
         module.handoffPendingPushDeliveryToAnalyticsPipeline()
@@ -167,7 +167,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
         // The WorkManager worker won the race and already claimed (delivered) the
         // entry; the handoff's claim returns false, so it must not publish again.
         val entries = listOf(PendingPushDeliveryMetric(deliveryId = "d1", token = "t1"))
-        every { mockPendingStore.loadAll() } returns entries
+        every { mockPendingStore.loadAllOrNull() } returns entries
         every { mockPendingStore.claim("d1") } returns false
 
         module.handoffPendingPushDeliveryToAnalyticsPipeline()
@@ -179,7 +179,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
 
     @Test
     fun handoff_givenEmptyStore_expectNoCancelNoPublishNoClaim() = runTest {
-        every { mockPendingStore.loadAll() } returns emptyList()
+        every { mockPendingStore.loadAllOrNull() } returns emptyList()
 
         module.handoffPendingPushDeliveryToAnalyticsPipeline()
 
@@ -198,7 +198,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
         val entries = listOf(
             PendingPushDeliveryMetric(deliveryId = "d1", token = "t1")
         )
-        every { mockPendingStore.loadAll() } returns entries
+        every { mockPendingStore.loadAllOrNull() } returns entries
         every { mockPendingStore.claim("d1") } returns true
 
         module.handoffPendingPushDeliveryToAnalyticsPipeline()
@@ -228,7 +228,7 @@ class ModuleMessagingPushFCMTest : IntegrationTest() {
             PendingPushDeliveryMetric(deliveryId = "boom", token = "t1"),
             PendingPushDeliveryMetric(deliveryId = "ok", token = "t2")
         )
-        every { mockPendingStore.loadAll() } returns entries
+        every { mockPendingStore.loadAllOrNull() } returns entries
         every { mockPendingStore.claim("ok") } returns true
         val failingOperation: Operation = mockk(relaxed = true) {
             every { result } returns

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -445,7 +445,9 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         // Foreground handoff already claimed (delivered + removed) this entry, so it's gone.
         every { mockPendingStore.claim(deliveryId) } returns false
-        every { mockPendingStore.get(deliveryId) } returns null
+        // Presence, not the entry: claimSendRestore asks contains(). Stubbed explicitly because a
+        // relaxed mock answers a Boolean? with false, which satisfies the guard for the wrong reason.
+        every { mockPendingStore.contains(deliveryId) } returns false
 
         val worker = createWorker(inputData)
         val result = worker.doWork()

--- a/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
+++ b/messagingpush/src/test/java/io/customer/messagingpush/processor/PushDeliveryMetricsWorkerTest.kt
@@ -445,8 +445,8 @@ class PushDeliveryMetricsWorkerTest : IntegrationTest() {
 
         // Foreground handoff already claimed (delivered + removed) this entry, so it's gone.
         every { mockPendingStore.claim(deliveryId) } returns false
-        // Presence, not the entry: claimSendRestore asks contains(). Stubbed explicitly because a
-        // relaxed mock answers a Boolean? with false, which satisfies the guard for the wrong reason.
+        // claimSendRestore asks contains(). Explicit because a relaxed mock answers Boolean? with
+        // false, satisfying the guard for the wrong reason.
         every { mockPendingStore.contains(deliveryId) } returns false
 
         val worker = createWorker(inputData)


### PR DESCRIPTION
Part of: [MBL-2419](https://linear.app/customerio/issue/MBL-2419/android-improve-geofence-diagnostics-and-queue-failure-handling)

`loadAll()` returns an empty list for a file it could not read. So the event worker emitted `why=queue_empty` — a record asserting an earlier node drained the queue, which was never established — and returned success while the rows sat on disk with nothing coming back for them. The foreground flush had the same defect one layer up, reporting a snapshot of zero for a queue it never read.

`loadAllOrNull()` draws the distinction the store already draws for a single key in `contains()`. The worker retries on it, capped at 5 attempts against `runAttemptCount`, then gives up the wake. Nothing is ever written over, so giving up costs only that wake: the next transition enqueues a fresh worker and the flush retries independently. `Result.failure()` is safe here where the delivery paths below it avoid it, because every dependent in the chain would fail the same read and the rows behind are untouched; the comment says so at the site, since the file argues the opposite case seventy lines down.

The flush reports `onUnreadable()` rather than a false snapshot. Skipping was right as the action but wrong as the trace: the flush is the one path that runs without a new transition, so staying silent meant a queue that went unreadable while the device sat idle left no record at all — the same defect this ticket names, moved up a layer.

Both paths file `ev=queue.unreadable why=read_failed`, with `via` separating a worker wake from a foreground flush. That token is iOS's, agreed cross-platform and already on their `main`.

Also folded in: the test cleanup Shahroz asked for on #856, which merged before it was addressed. `PushDeliveryMetricsWorkerTest` stubbed `get(deliveryId)`, but `claimSendRestore` now asks `contains()`, so the stub was dead and the test passed on a relaxed mock's `Boolean?` default of false.

2063 tests across all modules, ktlint, apiCheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)